### PR TITLE
feat: track knowledge file processing status and recover in-flight up…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ FROM --platform=$BUILDPLATFORM node:22-alpine3.20 AS build
 ARG BUILD_HASH
 
 # Set Node.js options (heap limit Allocation failed - JavaScript heap out of memory)
-# ENV NODE_OPTIONS="--max-old-space-size=4096"
+ENV NODE_OPTIONS="--max-old-space-size=6144"
 
 WORKDIR /app
 

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -132,6 +132,7 @@ from open_webui.models.access_grants import AccessGrants
 from open_webui.models.channels import Channels
 from open_webui.models.chats import ChatForm, Chats
 from open_webui.models.config import Config
+from open_webui.models.files import Files
 from open_webui.models.functions import Functions
 from open_webui.models.messages import Messages
 from open_webui.models.models import Models
@@ -342,6 +343,11 @@ async def lifespan(app: FastAPI):
     await seed_registered_defaults()
     await initialize_runtime_config(app)
     await migrate_legacy_webhook_config()
+
+    n_reset = await Files.reset_stuck_processing_files()
+    if n_reset:
+        log.info('Reset %d stuck file(s) to failed state', n_reset)
+
     await publish_event(app, EVENTS.SYSTEM_STARTUP_STARTED, source='system')
 
     license_task = None

--- a/backend/open_webui/models/files.py
+++ b/backend/open_webui/models/files.py
@@ -251,6 +251,31 @@ class FilesTable:
             result = await db.execute(select(File).filter_by(user_id=user_id))
             return [FileModel.model_validate(file) for file in result.scalars().all()]
 
+    async def get_pending_files_by_knowledge_id(
+        self,
+        knowledge_id: str,
+        user_id: str | None = None,
+        db: AsyncSession | None = None,
+    ) -> list['FileModelResponse']:
+        """Return files that reference knowledge_id in their meta.data and are
+        still being processed (status pending or processing).  Used to surface
+        in-flight uploads after a page refresh, before the background task has
+        finished and linked the file to the knowledge base."""
+        async with get_async_db_context(db) as db:
+            stmt = select(File).filter(
+                File.data['status'].as_string().in_(['pending', 'processing']),
+                File.meta['data']['knowledge_id'].as_string() == knowledge_id,
+            )
+            if user_id:
+                stmt = stmt.filter_by(user_id=user_id)
+
+            result = await db.execute(stmt.order_by(File.created_at.desc()))
+            files = result.scalars().all()
+
+            return [
+                FileModelResponse.model_validate(f, from_attributes=True) for f in files
+            ]
+
     async def get_file_list(
         self,
         user_id: str | None = None,
@@ -366,6 +391,34 @@ class FilesTable:
                 return FileModel.model_validate(file)
             except Exception:
                 return None
+
+    async def reset_stuck_processing_files(self, db: AsyncSession | None = None) -> int:
+        """Mark all files whose status is 'pending' or 'processing' as 'failed'.
+
+        Called once at application startup to clean up orphaned background
+        tasks left behind by a previous server crash or restart. Returns the
+        number of files updated."""
+        import time as _time
+        async with get_async_db_context(db) as db:
+            try:
+                stmt = select(File).filter(
+                    File.data['status'].as_string().in_(['pending', 'processing'])
+                )
+                result = await db.execute(stmt)
+                rows = result.scalars().all()
+                now = int(_time.time())
+                for f in rows:
+                    f.data = {
+                        **(f.data or {}),
+                        'status': 'failed',
+                        'error': 'Processing was interrupted by a server restart.',
+                    }
+                    f.updated_at = now
+                await db.commit()
+                return len(rows)
+            except Exception as exc:
+                log.warning('reset_stuck_processing_files failed: %s', exc)
+                return 0
 
     async def update_file_data_by_id(self, id: str, data: dict, db: AsyncSession | None = None) -> FileModel | None:
         async with get_async_db_context(db) as db:

--- a/backend/open_webui/models/files.py
+++ b/backend/open_webui/models/files.py
@@ -251,31 +251,6 @@ class FilesTable:
             result = await db.execute(select(File).filter_by(user_id=user_id))
             return [FileModel.model_validate(file) for file in result.scalars().all()]
 
-    async def get_pending_files_by_knowledge_id(
-        self,
-        knowledge_id: str,
-        user_id: str | None = None,
-        db: AsyncSession | None = None,
-    ) -> list['FileModelResponse']:
-        """Return files that reference knowledge_id in their meta.data and are
-        still being processed (status pending or processing).  Used to surface
-        in-flight uploads after a page refresh, before the background task has
-        finished and linked the file to the knowledge base."""
-        async with get_async_db_context(db) as db:
-            stmt = select(File).filter(
-                File.data['status'].as_string().in_(['pending', 'processing']),
-                File.meta['data']['knowledge_id'].as_string() == knowledge_id,
-            )
-            if user_id:
-                stmt = stmt.filter_by(user_id=user_id)
-
-            result = await db.execute(stmt.order_by(File.created_at.desc()))
-            files = result.scalars().all()
-
-            return [
-                FileModelResponse.model_validate(f, from_attributes=True) for f in files
-            ]
-
     async def get_file_list(
         self,
         user_id: str | None = None,
@@ -398,7 +373,6 @@ class FilesTable:
         Called once at application startup to clean up orphaned background
         tasks left behind by a previous server crash or restart. Returns the
         number of files updated."""
-        import time as _time
         async with get_async_db_context(db) as db:
             try:
                 stmt = select(File).filter(
@@ -406,7 +380,7 @@ class FilesTable:
                 )
                 result = await db.execute(stmt)
                 rows = result.scalars().all()
-                now = int(_time.time())
+                now = int(time.time())
                 for f in rows:
                     f.data = {
                         **(f.data or {}),

--- a/backend/open_webui/routers/files.py
+++ b/backend/open_webui/routers/files.py
@@ -257,6 +257,36 @@ async def process_uploaded_file(
                 },
                 db=db_session,
             )
+            return  # Do not attempt knowledge linking after a processing failure
+
+        # After successful processing: if the file was dropped directly into a
+        # Knowledge base (metadata carries knowledge_id), link it here inside
+        # the background task.  This ensures the file lands even when the browser
+        # tab is closed before the SSE stream delivers the completed status to
+        # the frontend's addFileHandler — the true "drop-and-forget" guarantee.
+        knowledge_id = file_metadata.get('knowledge_id') if file_metadata else None
+        if knowledge_id:
+            try:
+                async with get_async_db_context() as kg_session:
+                    # Skip if the frontend already linked it (idempotency).
+                    if not await Knowledges.has_file(knowledge_id=knowledge_id, file_id=file_item.id, db=kg_session):
+                        await process_file(
+                            request,
+                            ProcessFileForm(file_id=file_item.id, collection_name=knowledge_id),
+                            user=user,
+                            db=kg_session,
+                        )
+                        await Knowledges.add_file_to_knowledge_by_id(
+                            knowledge_id=knowledge_id,
+                            file_id=file_item.id,
+                            user_id=user.id,
+                            db=kg_session,
+                        )
+                        log.info(f'Auto-linked file {file_item.id} to knowledge {knowledge_id}')
+                    else:
+                        log.debug(f'File {file_item.id} already linked to knowledge {knowledge_id}, skipping auto-link')
+            except Exception as kg_err:
+                log.error(f'Failed to auto-link file {file_item.id} to knowledge {knowledge_id}: {kg_err}')
 
     try:
         if db:

--- a/backend/open_webui/routers/files.py
+++ b/backend/open_webui/routers/files.py
@@ -45,6 +45,11 @@ from open_webui.routers.audio import transcribe
 from open_webui.routers.retrieval import ProcessFileForm, process_file
 from open_webui.storage.provider import Storage
 from open_webui.utils.auth import get_admin_user, get_verified_user
+from open_webui.utils.file_processing import (
+    FileProcessingCancelled,
+    register_processing,
+    unregister_processing,
+)
 from open_webui.utils.misc import strict_match_mime_type
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -134,6 +139,10 @@ async def process_uploaded_file(
     user,
     db: Optional[AsyncSession] = None,
 ):
+    def _cancelled(result) -> bool:
+        """process_file() reports a user-requested abort instead of raising."""
+        return isinstance(result, dict) and result.get('reason') == 'cancelled'
+
     async def _process_handler(db_session):
         try:
             content_type = file.content_type
@@ -158,12 +167,15 @@ async def process_uploaded_file(
                     file_metadata,
                     user,
                 )
-                await process_file(
-                    request,
-                    ProcessFileForm(file_id=file_item.id, content=result.get('text', '')),
-                    user=user,
-                    db=db_session,
-                )
+                if _cancelled(
+                    await process_file(
+                        request,
+                        ProcessFileForm(file_id=file_item.id, content=result.get('text', '')),
+                        user=user,
+                        db=db_session,
+                    )
+                ):
+                    return
 
             elif (
                 content_type
@@ -191,12 +203,15 @@ async def process_uploaded_file(
                 # configured content extraction engine.
                 if not content_type:
                     log.info(f'File type {file.content_type} is not provided, but trying to process anyway')
-                await process_file(
-                    request,
-                    ProcessFileForm(file_id=file_item.id),
-                    user=user,
-                    db=db_session,
-                )
+                if _cancelled(
+                    await process_file(
+                        request,
+                        ProcessFileForm(file_id=file_item.id),
+                        user=user,
+                        db=db_session,
+                    )
+                ):
+                    return
 
             # Auto-link to Knowledge Collection when uploaded from one (#24807).
             # Mirrors POST /knowledge/{id}/file/add so linking doesn't depend
@@ -227,12 +242,16 @@ async def process_uploaded_file(
                         # Keep the generic file status stream open until the
                         # KB-specific vector write and durable link both finish.
                         await Files.update_file_data_by_id(file_item.id, {'status': 'processing'}, db=db_session)
-                        await process_file(
-                            request,
-                            ProcessFileForm(file_id=file_item.id, collection_name=knowledge_id),
-                            user=user,
-                            db=db_session,
-                        )
+                        if _cancelled(
+                            await process_file(
+                                request,
+                                ProcessFileForm(file_id=file_item.id, collection_name=knowledge_id),
+                                user=user,
+                                db=db_session,
+                            )
+                        ):
+                            # Never link a file the user deleted mid-flight.
+                            return
                         knowledge_file = await Knowledges.add_file_to_knowledge_by_id(
                             knowledge_id=knowledge_id,
                             file_id=file_item.id,
@@ -247,6 +266,12 @@ async def process_uploaded_file(
                     log.warning(f'Failed to link file {file_item.id} to knowledge {knowledge_id}: {e}')
                     raise
 
+        except FileProcessingCancelled:
+            # The file was deleted while we were processing it. Nothing left to
+            # report to — and nothing left to link.
+            log.info(f'Upload processing for {file_item.id} was cancelled by the user')
+            return
+
         except Exception as e:
             log.error(f'Error processing file: {file_item.id}')
             await Files.update_file_data_by_id(
@@ -258,6 +283,9 @@ async def process_uploaded_file(
                 db=db_session,
             )
 
+    # Announce the job so a delete arriving while it runs can interrupt it
+    # instead of waiting for extraction and embedding to finish.
+    register_processing(file_item.id)
     try:
         if db:
             await _process_handler(db)
@@ -265,6 +293,7 @@ async def process_uploaded_file(
             async with get_async_db_context() as db_session:
                 await _process_handler(db_session)
     finally:
+        unregister_processing(file_item.id)
         _cleanup_local_cache(file_path)
 
 

--- a/backend/open_webui/routers/files.py
+++ b/backend/open_webui/routers/files.py
@@ -257,36 +257,6 @@ async def process_uploaded_file(
                 },
                 db=db_session,
             )
-            return  # Do not attempt knowledge linking after a processing failure
-
-        # After successful processing: if the file was dropped directly into a
-        # Knowledge base (metadata carries knowledge_id), link it here inside
-        # the background task.  This ensures the file lands even when the browser
-        # tab is closed before the SSE stream delivers the completed status to
-        # the frontend's addFileHandler — the true "drop-and-forget" guarantee.
-        knowledge_id = file_metadata.get('knowledge_id') if file_metadata else None
-        if knowledge_id:
-            try:
-                async with get_async_db_context() as kg_session:
-                    # Skip if the frontend already linked it (idempotency).
-                    if not await Knowledges.has_file(knowledge_id=knowledge_id, file_id=file_item.id, db=kg_session):
-                        await process_file(
-                            request,
-                            ProcessFileForm(file_id=file_item.id, collection_name=knowledge_id),
-                            user=user,
-                            db=kg_session,
-                        )
-                        await Knowledges.add_file_to_knowledge_by_id(
-                            knowledge_id=knowledge_id,
-                            file_id=file_item.id,
-                            user_id=user.id,
-                            db=kg_session,
-                        )
-                        log.info(f'Auto-linked file {file_item.id} to knowledge {knowledge_id}')
-                    else:
-                        log.debug(f'File {file_item.id} already linked to knowledge {knowledge_id}, skipping auto-link')
-            except Exception as kg_err:
-                log.error(f'Failed to auto-link file {file_item.id} to knowledge {knowledge_id}: {kg_err}')
 
     try:
         if db:

--- a/backend/open_webui/routers/knowledge.py
+++ b/backend/open_webui/routers/knowledge.py
@@ -1358,6 +1358,51 @@ async def get_knowledge_files_by_id(
 
 
 ############################
+# GetPendingFilesByKnowledgeId
+############################
+
+
+@router.get('/{id}/files/pending', response_model=list[FileModelResponse])
+async def get_pending_files_by_knowledge_id(
+    id: str,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Return files that are still being processed (pending/processing) for
+    this knowledge base.  These have not yet been linked to the knowledge base
+    but carry knowledge_id in their meta.data so they can be shown in the UI
+    after a page refresh."""
+    knowledge = await Knowledges.get_knowledge_by_id(id=id, db=db)
+    if not knowledge:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=ERROR_MESSAGES.NOT_FOUND,
+        )
+
+    if not (
+        user.role == 'admin'
+        or knowledge.user_id == user.id
+        or await AccessGrants.has_access(
+            user_id=user.id,
+            resource_type='knowledge',
+            resource_id=knowledge.id,
+            permission='read',
+            db=db,
+        )
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
+        )
+
+    return await Files.get_pending_files_by_knowledge_id(
+        knowledge_id=id,
+        user_id=None if user.role == 'admin' else user.id,
+        db=db,
+    )
+
+
+############################
 # AddFileToKnowledge
 ############################
 
@@ -1418,6 +1463,17 @@ async def add_file_to_knowledge_by_id(
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
+            )
+
+    # Idempotency: if the background task already linked this file (e.g. the
+    # browser was open long enough after all), skip the expensive re-embedding
+    # and just return the current knowledge state.
+    if await Knowledges.has_file(knowledge_id=id, file_id=form_data.file_id, db=db):
+        log.debug(f'File {form_data.file_id} already in knowledge {id}, skipping re-embed')
+        if knowledge:
+            return KnowledgeFilesResponse(
+                **knowledge.model_dump(),
+                files=await Knowledges.get_file_metadatas_by_id(knowledge.id, db=db),
             )
 
     # Add content to the vector database

--- a/backend/open_webui/routers/knowledge.py
+++ b/backend/open_webui/routers/knowledge.py
@@ -43,6 +43,11 @@ from open_webui.storage.provider import Storage
 from open_webui.utils.access_control import filter_allowed_access_grants, has_permission
 from open_webui.utils.access_control.files import has_access_to_file
 from open_webui.utils.auth import get_admin_user, get_verified_user
+from open_webui.utils.file_processing import (
+    register_processing,
+    request_cancellation,
+    unregister_processing,
+)
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -1432,27 +1437,49 @@ async def add_file_to_knowledge_by_id(
             )
 
     # Add content to the vector database
+    register_processing(form_data.file_id)
     try:
-        await process_file(
+        result = await process_file(
             request,
             ProcessFileForm(file_id=form_data.file_id, collection_name=id),
             user=user,
             db=db,
         )
 
-        # Add file to knowledge base
-        await Knowledges.add_file_to_knowledge_by_id(
-            knowledge_id=id,
-            file_id=form_data.file_id,
-            user_id=user.id,
-            directory_id=form_data.directory_id,
-            db=db,
-        )
+        # process_file reports a delete that arrived mid-embedding instead of
+        # raising; such a file must not be linked.
+        cancelled = isinstance(result, dict) and result.get('reason') == 'cancelled'
+
+        if not cancelled:
+            # Add file to knowledge base
+            await Knowledges.add_file_to_knowledge_by_id(
+                knowledge_id=id,
+                file_id=form_data.file_id,
+                user_id=user.id,
+                directory_id=form_data.directory_id,
+                db=db,
+            )
     except Exception as e:
         log.debug(e)
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(e),
+        )
+    finally:
+        unregister_processing(form_data.file_id)
+
+    if cancelled:
+        # Not an error: the user deleted the file while it was being added, and
+        # the knowledge base as it now stands is the honest answer.
+        log.info(f'File {form_data.file_id} was deleted while being added to knowledge {id}')
+        if not knowledge:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=ERROR_MESSAGES.NOT_FOUND,
+            )
+        return KnowledgeFilesResponse(
+            **knowledge.model_dump(),
+            files=await Knowledges.get_file_metadatas_by_id(knowledge.id, db=db),
         )
 
     if knowledge:
@@ -1605,11 +1632,34 @@ async def remove_file_from_knowledge_by_id(
             detail=ERROR_MESSAGES.NOT_FOUND,
         )
 
-    # Validate the file actually belongs to this knowledge base
-    if not await Knowledges.has_file(knowledge_id=id, file_id=form_data.file_id, db=db):
+    # Validate the file actually belongs to this knowledge base. A file that is
+    # still being processed is not linked yet, but it is shown in this knowledge
+    # base (see GET /{id}/files/pending) and must be deletable from here too —
+    # otherwise a slow extraction would leave the user with an undeletable row.
+    is_linked = await Knowledges.has_file(knowledge_id=id, file_id=form_data.file_id, db=db)
+    file_status = (file.data or {}).get('status')
+    is_in_flight_here = (
+        not is_linked
+        and ((file.meta or {}).get('data') or {}).get('knowledge_id') == id
+        and file_status in ('pending', 'processing', 'failed')
+    )
+
+    if not is_linked and not is_in_flight_here:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=ERROR_MESSAGES.NOT_FOUND,
+        )
+
+    # Stop the pipeline before tearing anything down, so a background task
+    # cannot write vectors or a 'completed' status for a file we just removed.
+    # The DB status is the cross-process half of the signal; see
+    # utils/file_processing.py.
+    if file_status in ('pending', 'processing'):
+        interrupted = request_cancellation(form_data.file_id)
+        await Files.update_file_data_by_id(form_data.file_id, {'status': 'cancelled'}, db=db)
+        log.info(
+            f'Cancelling processing of file {form_data.file_id} '
+            f'({"signalled in-process" if interrupted else "via database flag"})'
         )
 
     await Knowledges.remove_file_from_knowledge_by_id(knowledge_id=id, file_id=form_data.file_id, db=db)
@@ -1642,6 +1692,24 @@ async def remove_file_from_knowledge_by_id(
 
         # Delete file from database
         await Files.delete_file_by_id(form_data.file_id, db=db)
+
+        # ... and the stored blob, so cancelling a long extraction really does
+        # leave nothing of the file behind.
+        if file.path:
+            try:
+                await asyncio.to_thread(Storage.delete_file, file.path)
+            except Exception as e:
+                log.warning(f'Failed to delete stored file for {form_data.file_id}: {e}')
+
+    elif is_in_flight_here:
+        # The caller may remove the file from this knowledge base but not delete
+        # the record itself (not the owner, or delete_file=false). Detach it from
+        # the knowledge base so it stops showing up as an in-flight upload here.
+        await Files.update_file_metadata_by_id(
+            form_data.file_id,
+            {'data': {**(((file.meta or {}).get('data')) or {}), 'knowledge_id': None}},
+            db=db,
+        )
 
     if knowledge:
         response = KnowledgeFilesResponse(

--- a/backend/open_webui/routers/knowledge.py
+++ b/backend/open_webui/routers/knowledge.py
@@ -1358,51 +1358,6 @@ async def get_knowledge_files_by_id(
 
 
 ############################
-# GetPendingFilesByKnowledgeId
-############################
-
-
-@router.get('/{id}/files/pending', response_model=list[FileModelResponse])
-async def get_pending_files_by_knowledge_id(
-    id: str,
-    user=Depends(get_verified_user),
-    db: AsyncSession = Depends(get_async_session),
-):
-    """Return files that are still being processed (pending/processing) for
-    this knowledge base.  These have not yet been linked to the knowledge base
-    but carry knowledge_id in their meta.data so they can be shown in the UI
-    after a page refresh."""
-    knowledge = await Knowledges.get_knowledge_by_id(id=id, db=db)
-    if not knowledge:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=ERROR_MESSAGES.NOT_FOUND,
-        )
-
-    if not (
-        user.role == 'admin'
-        or knowledge.user_id == user.id
-        or await AccessGrants.has_access(
-            user_id=user.id,
-            resource_type='knowledge',
-            resource_id=knowledge.id,
-            permission='read',
-            db=db,
-        )
-    ):
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
-        )
-
-    return await Files.get_pending_files_by_knowledge_id(
-        knowledge_id=id,
-        user_id=None if user.role == 'admin' else user.id,
-        db=db,
-    )
-
-
-############################
 # AddFileToKnowledge
 ############################
 

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -7,9 +7,9 @@ import mimetypes
 import os
 import re
 import shutil
+import time
 import uuid
 from datetime import datetime
-import time
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Callable, Iterator, Optional, Sequence, Union
@@ -1929,7 +1929,7 @@ async def process_file(
                     # UI polling loop can show meaningful status information.
                     await Files.update_file_data_by_id(
                         file.id,
-                        {"status": "processing", "started_at": int(time.time())},
+                        {'status': 'processing', 'started_at': int(time.time())},
                         db=db,
                     )
 
@@ -2041,8 +2041,8 @@ async def process_file(
                         async with get_async_db() as _guard_session:
                             if await Files.get_file_by_id(file.id, db=_guard_session) is None:
                                 log.warning(
-                                    "File %s was deleted during processing; "
-                                    "discarding embeddings to prevent orphaned vectors.",
+                                    'File %s was deleted during processing; '
+                                    'discarding embeddings to prevent orphaned vectors.',
                                     file.id,
                                 )
                                 try:
@@ -2050,21 +2050,19 @@ async def process_file(
                                         # Shared knowledge collection – remove only this file's chunks
                                         VECTOR_DB_CLIENT.delete(
                                             collection_name=collection_name,
-                                            filter={"file_id": file.id},
+                                            filter={'file_id': file.id},
                                         )
                                     else:
                                         # Private file collection – drop entirely
-                                        VECTOR_DB_CLIENT.delete_collection(
-                                            collection_name=collection_name
-                                        )
+                                        VECTOR_DB_CLIENT.delete_collection(collection_name=collection_name)
                                 except Exception as _cleanup_err:
                                     log.debug(
-                                        "Vector DB cleanup after user-delete: %s",
+                                        'Vector DB cleanup after user-delete: %s',
                                         _cleanup_err,
                                     )
                                 return {
-                                    "status": False,
-                                    "reason": "file_deleted_during_processing",
+                                    'status': False,
+                                    'reason': 'file_deleted_during_processing',
                                 }
                         # Fresh session for the final update.
                         async with get_async_db() as session:

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -9,6 +9,7 @@ import re
 import shutil
 import uuid
 from datetime import datetime
+import time
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Callable, Iterator, Optional, Sequence, Union
@@ -1923,6 +1924,24 @@ async def process_file(
                 file_path = file.path
                 if file_path:
                     file_path = await asyncio.to_thread(Storage.get_file, file_path)
+
+                    # Mark as actively processing and record start time so the
+                    # UI polling loop can show meaningful status information.
+                    await Files.update_file_data_by_id(
+                        file.id,
+                        {"status": "processing", "started_at": int(time.time())},
+                        db=db,
+                    )
+
+                    # Callback used by DoclingLoader to persist queue position
+                    # and task_id so they appear in the UI tooltip.
+                    _file_id_for_callback = file.id
+
+                    async def _docling_status_callback(data: dict) -> None:
+                        await Files.update_file_data_by_id(
+                            _file_id_for_callback, data, db=db
+                        )
+
                     loader_config = await get_loader_config()
                     loader = build_loader_from_config(request, loader_config)
                     loader.user = user
@@ -1931,6 +1950,7 @@ async def process_file(
                         'file_name': file.filename,
                         'file_content_type': file.meta.get('content_type'),
                     }
+                    loader.kwargs['DOCLING_STATUS_CALLBACK'] = _docling_status_callback
                     docs = await loader.aload(file.filename, file.meta.get('content_type'), file_path)
 
                     docs = [
@@ -2015,6 +2035,37 @@ async def process_file(
                     log.info(f'added {len(docs)} items to collection {collection_name}')
 
                     if result:
+                        # Guard: check that the file record still exists before
+                        # committing the final status.  The user may have pressed
+                        # the delete button while docling/embedding was running.
+                        async with get_async_db() as _guard_session:
+                            if await Files.get_file_by_id(file.id, db=_guard_session) is None:
+                                log.warning(
+                                    "File %s was deleted during processing; "
+                                    "discarding embeddings to prevent orphaned vectors.",
+                                    file.id,
+                                )
+                                try:
+                                    if form_data.collection_name:
+                                        # Shared knowledge collection – remove only this file's chunks
+                                        VECTOR_DB_CLIENT.delete(
+                                            collection_name=collection_name,
+                                            filter={"file_id": file.id},
+                                        )
+                                    else:
+                                        # Private file collection – drop entirely
+                                        VECTOR_DB_CLIENT.delete_collection(
+                                            collection_name=collection_name
+                                        )
+                                except Exception as _cleanup_err:
+                                    log.debug(
+                                        "Vector DB cleanup after user-delete: %s",
+                                        _cleanup_err,
+                                    )
+                                return {
+                                    "status": False,
+                                    "reason": "file_deleted_during_processing",
+                                }
                         # Fresh session for the final update.
                         async with get_async_db() as session:
                             await Files.update_file_metadata_by_id(

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -120,6 +120,12 @@ from open_webui.storage.provider import Storage
 from open_webui.utils.access_control import has_permission
 from open_webui.utils.access_control.files import has_access_to_file
 from open_webui.utils.auth import get_admin_user, get_verified_user
+from open_webui.utils.file_processing import (
+    FileProcessingCancelled,
+    is_cancelled,
+    raise_if_cancelled,
+    run_cancellable,
+)
 from open_webui.utils.misc import (
     calculate_sha256_string,
     sanitize_text_for_db,
@@ -1834,6 +1840,24 @@ class ProcessFileForm(BaseModel):
     collection_name: str | None = None
 
 
+async def _discard_vectors(collection_name: str, file_id: str, shared_collection: bool) -> None:
+    """Undo a vector write for a file that is being deleted.
+
+    A shared knowledge collection holds other files too, so only this file's
+    chunks may go; a private ``file-{id}`` collection is dropped whole.
+    """
+    try:
+        if shared_collection:
+            await ASYNC_VECTOR_DB_CLIENT.delete(
+                collection_name=collection_name,
+                filter={'file_id': file_id},
+            )
+        else:
+            await ASYNC_VECTOR_DB_CLIENT.delete_collection(collection_name=collection_name)
+    except Exception as e:
+        log.debug('Vector DB cleanup after cancelled processing: %s', e)
+
+
 @router.post('/process/file')
 async def process_file(
     request: Request,
@@ -1923,6 +1947,10 @@ async def process_file(
                 # Usage: /files/
                 file_path = file.path
                 if file_path:
+                    # Nothing expensive has happened yet — if the user already
+                    # asked for this file to go away, stop right here.
+                    await raise_if_cancelled(file.id)
+
                     file_path = await asyncio.to_thread(Storage.get_file, file_path)
 
                     # Mark as actively processing and record start time so the
@@ -1951,7 +1979,14 @@ async def process_file(
                         'file_content_type': file.meta.get('content_type'),
                     }
                     loader.kwargs['DOCLING_STATUS_CALLBACK'] = _docling_status_callback
-                    docs = await loader.aload(file.filename, file.meta.get('content_type'), file_path)
+
+                    # Content extraction is the longest leg of the pipeline
+                    # (minutes to hours for a large PDF). Wait for it in a way
+                    # that a delete request can interrupt.
+                    docs = await run_cancellable(
+                        loader.aload(file.filename, file.meta.get('content_type'), file_path),
+                        file.id,
+                    )
 
                     docs = [
                         Document(
@@ -1982,6 +2017,11 @@ async def process_file(
                 text_content = ' '.join([doc.page_content for doc in docs])
 
             log.debug('text_content: %s', text_content)
+
+            # Extraction may have run for a long time; don't persist its result
+            # for a file the user has meanwhile deleted.
+            await raise_if_cancelled(file.id)
+
             await Files.update_file_data_by_id(
                 file.id,
                 {'content': text_content},
@@ -2018,6 +2058,13 @@ async def process_file(
                     # calls asyncio.run_coroutine_threadsafe(..., main_loop).result()
                     # which blocks the calling thread.  We MUST run it in a
                     # worker thread to avoid deadlocking the event loop.
+                    await raise_if_cancelled(file.id)
+
+                    # Deliberately *not* cancellable: abandoning this wait would
+                    # not stop the worker thread, and its vector write could then
+                    # land after the cleanup and leave orphans behind. Embedding
+                    # is the short leg, and the guard below removes whatever it
+                    # wrote if the file was deleted meanwhile.
                     result = await run_in_threadpool(
                         save_docs_to_vector_db,
                         request,
@@ -2035,35 +2082,20 @@ async def process_file(
                     log.info(f'added {len(docs)} items to collection {collection_name}')
 
                     if result:
-                        # Guard: check that the file record still exists before
-                        # committing the final status.  The user may have pressed
-                        # the delete button while docling/embedding was running.
-                        async with get_async_db() as _guard_session:
-                            if await Files.get_file_by_id(file.id, db=_guard_session) is None:
-                                log.warning(
-                                    'File %s was deleted during processing; '
-                                    'discarding embeddings to prevent orphaned vectors.',
-                                    file.id,
-                                )
-                                try:
-                                    if form_data.collection_name:
-                                        # Shared knowledge collection – remove only this file's chunks
-                                        VECTOR_DB_CLIENT.delete(
-                                            collection_name=collection_name,
-                                            filter={'file_id': file.id},
-                                        )
-                                    else:
-                                        # Private file collection – drop entirely
-                                        VECTOR_DB_CLIENT.delete_collection(collection_name=collection_name)
-                                except Exception as _cleanup_err:
-                                    log.debug(
-                                        'Vector DB cleanup after user-delete: %s',
-                                        _cleanup_err,
-                                    )
-                                return {
-                                    'status': False,
-                                    'reason': 'file_deleted_during_processing',
-                                }
+                        # Guard: the delete may have landed between the last
+                        # checkpoint and the vector write, in which case those
+                        # vectors are already orphaned.
+                        if await is_cancelled(file.id):
+                            log.warning(
+                                'File %s was deleted during processing; '
+                                'discarding embeddings to prevent orphaned vectors.',
+                                file.id,
+                            )
+                            await _discard_vectors(collection_name, file.id, bool(form_data.collection_name))
+                            return {
+                                'status': False,
+                                'reason': 'cancelled',
+                            }
                         # Fresh session for the final update.
                         async with get_async_db() as session:
                             await Files.update_file_metadata_by_id(
@@ -2099,6 +2131,17 @@ async def process_file(
                         raise Exception('Error saving document to vector database')
                 except Exception as e:
                     raise e
+
+        except FileProcessingCancelled:
+            # The user deleted this file mid-flight. Not an error: no 'failed'
+            # status is written (the record is normally gone anyway), and any
+            # vectors written before the checkpoint are removed.
+            log.info('Processing of file %s cancelled by user; cleaning up', file.id)
+            await _discard_vectors(collection_name, file.id, bool(form_data.collection_name))
+            return {
+                'status': False,
+                'reason': 'cancelled',
+            }
 
         except Exception as e:
             log.exception(e)

--- a/backend/open_webui/utils/file_processing.py
+++ b/backend/open_webui/utils/file_processing.py
@@ -1,0 +1,156 @@
+"""Cooperative cancellation for long-running file processing.
+
+A knowledge file can spend minutes (sometimes hours) in content extraction and
+embedding.  When a user deletes such a file while it is still being processed,
+the delete has to take effect immediately and the background pipeline has to
+stop instead of writing vectors and status updates for a file that no longer
+exists.
+
+Two mechanisms cooperate here:
+
+* an in-process registry of ``asyncio.Event`` objects, so a delete served by
+  this worker interrupts the pipeline within ``POLL_INTERVAL`` seconds — even
+  while it is blocked waiting on a loader thread, and
+* a database fallback (the file row is gone, or carries ``status: cancelled``)
+  which also covers a delete served by a different worker process.
+
+Nothing here can abort a blocking third-party call: a Docling conversion keeps
+running in its worker thread until the remote server answers.  What the
+pipeline does is stop waiting for it and discard the result, which is what the
+user actually observes.
+"""
+
+import asyncio
+import logging
+from typing import Awaitable, TypeVar
+
+from open_webui.internal.db import get_async_db_context
+from open_webui.models.files import Files
+
+log = logging.getLogger(__name__)
+
+T = TypeVar('T')
+
+# How often a cancellable wait wakes up to look for a cancellation request, and
+# how many of those ticks pass before the (more expensive) database fallback is
+# consulted.
+POLL_INTERVAL = 5.0
+DB_POLL_EVERY = 6
+
+_cancel_events: dict[str, asyncio.Event] = {}
+# How many nested/parallel jobs share an event. The upload background task and a
+# concurrent POST /file/add can both be working on the same file; the signal has
+# to survive until the last of them is done with it.
+_registrations: dict[str, int] = {}
+
+
+class FileProcessingCancelled(Exception):
+    """Raised inside the processing pipeline once a delete request arrives."""
+
+    def __init__(self, file_id: str):
+        self.file_id = file_id
+        super().__init__(f'Processing of file {file_id} was cancelled')
+
+
+def register_processing(file_id: str) -> asyncio.Event:
+    """Announce that `file_id` is being processed by this worker."""
+    event = _cancel_events.get(file_id)
+    if event is None:
+        event = asyncio.Event()
+        _cancel_events[file_id] = event
+    _registrations[file_id] = _registrations.get(file_id, 0) + 1
+    return event
+
+
+def unregister_processing(file_id: str) -> None:
+    remaining = _registrations.get(file_id, 0) - 1
+    if remaining > 0:
+        _registrations[file_id] = remaining
+        return
+
+    _registrations.pop(file_id, None)
+    _cancel_events.pop(file_id, None)
+
+
+def request_cancellation(file_id: str) -> bool:
+    """Ask a running pipeline to stop.
+
+    Returns True when processing for this file is registered in *this* worker;
+    a False result does not mean nothing is running — the pipeline may live in
+    another process and will then pick the request up via the database.
+    """
+    event = _cancel_events.get(file_id)
+    if event is None:
+        return False
+    event.set()
+    return True
+
+
+def is_cancellation_requested(file_id: str) -> bool:
+    event = _cancel_events.get(file_id)
+    return event is not None and event.is_set()
+
+
+async def is_cancelled(file_id: str) -> bool:
+    """Check both the in-process registry and the database."""
+    if is_cancellation_requested(file_id):
+        return True
+
+    try:
+        async with get_async_db_context() as db:
+            file = await Files.get_file_by_id(file_id, db=db)
+    except Exception as e:
+        # A failing check must not abort a healthy job.
+        log.debug('Cancellation check for %s failed: %s', file_id, e)
+        return False
+
+    if file is None:
+        # The record was deleted while we were processing it.
+        return True
+    return (file.data or {}).get('status') == 'cancelled'
+
+
+async def raise_if_cancelled(file_id: str) -> None:
+    if await is_cancelled(file_id):
+        raise FileProcessingCancelled(file_id)
+
+
+def _abandon(task: 'asyncio.Future') -> None:
+    """Drop a task we are no longer interested in, without a noisy traceback."""
+    task.cancel()
+
+    def _swallow(finished: 'asyncio.Future') -> None:
+        if not finished.cancelled():
+            finished.exception()
+
+    task.add_done_callback(_swallow)
+
+
+async def run_cancellable(awaitable: Awaitable[T], file_id: str) -> T:
+    """Await `awaitable`, giving up as soon as the file's deletion is requested.
+
+    Raises FileProcessingCancelled instead of returning in that case.  The
+    abandoned work keeps running if it sits in a worker thread — threads cannot
+    be interrupted — but its result is never used.
+
+    Only wrap work whose result is held in memory (content extraction).  Work
+    that writes to the vector database must be awaited normally, otherwise its
+    write can land after the caller has already cleaned up.
+    """
+    work = asyncio.ensure_future(awaitable)
+    ticks = 0
+
+    while True:
+        done, _ = await asyncio.wait({work}, timeout=POLL_INTERVAL)
+        if work in done:
+            return work.result()
+
+        ticks += 1
+        cancelled = is_cancellation_requested(file_id)
+        if not cancelled and ticks % DB_POLL_EVERY == 0:
+            cancelled = await is_cancelled(file_id)
+
+        if cancelled:
+            log.info('Abandoning in-flight processing of file %s on user request', file_id)
+            _abandon(work)
+            raise FileProcessingCancelled(file_id)

--- a/src/lib/apis/files/index.ts
+++ b/src/lib/apis/files/index.ts
@@ -6,6 +6,10 @@ export const uploadFile = async (
 	file: File,
 	metadata?: object | null,
 	process?: boolean | null,
+	onProgress?: (data: { status: string; error?: string }) => void,
+	/** Called immediately after the file record is created, with the new file id.
+	 *  Use this to update local placeholders before the SSE stream finishes. */
+	onUploaded?: (id: string) => void,
 	stream: boolean = true
 ) => {
 	const data = new FormData();
@@ -44,6 +48,12 @@ export const uploadFile = async (
 	}
 
 	if (res && stream) {
+		// Fire immediately so callers can associate the real file id with their
+		// local placeholder before the (potentially very long) SSE stream runs.
+		if (onUploaded) {
+			onUploaded(res.id);
+		}
+
 		const status = await getFileProcessStatus(token, res.id);
 
 		if (status && status.ok) {
@@ -77,6 +87,10 @@ export const uploadFile = async (
 
 								if (res?.data) {
 									res.data = data;
+								}
+
+								if (onProgress) {
+									onProgress(data);
 								}
 							}
 						}

--- a/src/lib/apis/knowledge/index.ts
+++ b/src/lib/apis/knowledge/index.ts
@@ -646,6 +646,34 @@ export const updateKnowledgeById = async (token: string, id: string, form: Knowl
 	return res;
 };
 
+export const getPendingFilesByKnowledgeId = async (token: string, id: string) => {
+	let error = null;
+
+	const res = await fetch(`${WEBUI_API_BASE_URL}/knowledge/${id}/files/pending`, {
+		method: 'GET',
+		headers: {
+			Accept: 'application/json',
+			'Content-Type': 'application/json',
+			authorization: `Bearer ${token}`
+		}
+	})
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			error = err.detail;
+			console.error(err);
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
+
+	return res;
+};
+
 export const updateKnowledgeAccessGrants = async (
 	token: string,
 	id: string,

--- a/src/lib/apis/knowledge/index.ts
+++ b/src/lib/apis/knowledge/index.ts
@@ -646,34 +646,6 @@ export const updateKnowledgeById = async (token: string, id: string, form: Knowl
 	return res;
 };
 
-export const getPendingFilesByKnowledgeId = async (token: string, id: string) => {
-	let error = null;
-
-	const res = await fetch(`${WEBUI_API_BASE_URL}/knowledge/${id}/files/pending`, {
-		method: 'GET',
-		headers: {
-			Accept: 'application/json',
-			'Content-Type': 'application/json',
-			authorization: `Bearer ${token}`
-		}
-	})
-		.then(async (res) => {
-			if (!res.ok) throw await res.json();
-			return res.json();
-		})
-		.catch((err) => {
-			error = err.detail;
-			console.error(err);
-			return null;
-		});
-
-	if (error) {
-		throw error;
-	}
-
-	return res;
-};
-
 export const updateKnowledgeAccessGrants = async (
 	token: string,
 	id: string,

--- a/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
+++ b/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
@@ -38,6 +38,7 @@
 		updateKnowledgeById,
 		updateKnowledgeAccessGrants,
 		searchKnowledgeFilesById,
+		getPendingFilesByKnowledgeId,
 		createKnowledgeDirectory,
 		updateKnowledgeDirectory,
 		deleteKnowledgeDirectory,
@@ -133,6 +134,30 @@
 	let fileItems = null;
 	let fileItemsTotal = null;
 
+	// Poll every 15 s while any file is still being processed, so the UI
+	// reflects status changes (pending → processing → completed / failed)
+	// without requiring a manual page refresh.
+	let pollingInterval: ReturnType<typeof setInterval> | null = null;
+
+	$: {
+		const hasPendingFiles = fileItems?.some(
+			(f) =>
+				f?.data?.status === 'pending' ||
+				f?.data?.status === 'processing' ||
+				f?.status === 'uploading'
+		);
+		if (hasPendingFiles && pollingInterval === null) {
+			pollingInterval = setInterval(() => {
+				getItemsPage(true);
+			}, 15_000);
+		} else if (fileItems !== null && !hasPendingFiles && pollingInterval !== null) {
+			// Only stop polling once we have a real result — not while fileItems is
+			// momentarily null during a refresh, which would kill the interval early.
+			clearInterval(pollingInterval);
+			pollingInterval = null;
+		}
+	}
+
 	// Directory state
 	let currentDirectoryId: string | null = null;
 	let directoryItems = [];
@@ -185,32 +210,74 @@
 		getItemsPage();
 	}
 
-	const getItemsPage = async () => {
+	$: if (
+		query !== undefined &&
+		viewOption !== undefined &&
+		sortKey !== undefined &&
+		direction !== undefined
+	) {
+		reset();
+	}
+
+	// silent=true preserves the current list while refreshing (used by the
+	// polling interval) so files don't flash away every 15 seconds.
+	const getItemsPage = async (silent = false) => {
 		if (knowledgeId === null) return;
 
-		fileItems = null;
-		fileItemsTotal = null;
+		if (!silent) {
+			fileItems = null;
+			fileItemsTotal = null;
+		}
 
 		if (sortKey === null) {
 			direction = null;
 		}
 
-		const res = await searchKnowledgeFilesById(
-			localStorage.token,
-			knowledge.id,
-			query,
-			viewOption,
-			sortKey,
-			direction,
-			currentPage,
-			currentDirectoryId,
-			includeContent
-		).catch(() => {
-			return null;
-		});
+		const [res, pendingFromServer] = await Promise.all([
+			searchKnowledgeFilesById(
+				localStorage.token,
+				knowledge.id,
+				query,
+				viewOption,
+				sortKey,
+				direction,
+				currentPage,
+				currentDirectoryId,
+				includeContent
+			).catch(() => {
+				return null;
+			}),
+			getPendingFilesByKnowledgeId(
+				localStorage.token,
+				knowledge.id
+			).catch(() => [])
+		]);
 
 		if (res) {
-			fileItems = res.items;
+			const linkedIds = new Set(res.items.map((f) => f.id).filter(Boolean));
+
+			// Pending files from the server that are not yet in the linked list.
+			const serverPending = (pendingFromServer ?? []).filter((f) => !linkedIds.has(f.id));
+
+			if (silent && fileItems !== null) {
+				// During a polling refresh, also preserve local-only in-flight
+				// placeholders (e.g. files uploading in this tab right now) that
+				// aren't reflected in the server responses yet.
+				const serverIds = new Set([
+					...linkedIds,
+					...serverPending.map((f) => f.id).filter(Boolean)
+				]);
+				const localInFlight = fileItems.filter(
+					(f) =>
+						(f.status === 'uploading' ||
+							f?.data?.status === 'pending' ||
+							f?.data?.status === 'processing') &&
+						!serverIds.has(f.id)
+				);
+				fileItems = [...localInFlight, ...serverPending, ...res.items];
+			} else {
+				fileItems = [...serverPending, ...res.items];
+			}
 			fileItemsTotal = res.total;
 			directoryItems = res.directories ?? [];
 			breadcrumbs = res.breadcrumbs ?? [];
@@ -348,6 +415,18 @@
 					const uploadedFile = await uploadFile(localStorage.token, file, {
 						knowledge_id: knowledge.id,
 						directory_id: currentDirectoryId
+					}, null, (statusData) => {
+						fileItems = fileItems.map((item) =>
+							item.itemId === fileItem.itemId
+								? { ...item, data: { ...(item.data ?? {}), ...statusData } }
+								: item
+						);
+					}, (fileId) => {
+						// Set the real id immediately so polling deduplication works
+						// before the SSE stream finishes.
+						fileItems = fileItems.map((item) =>
+							item.itemId === fileItem.itemId ? { ...item, id: fileId } : item
+						);
 					}).catch((e) => {
 						toast.error(`${e}`);
 						return null;
@@ -436,7 +515,28 @@
 					: {})
 			};
 
-			const uploadedFile = await uploadFile(localStorage.token, file, metadata).catch((e) => {
+			const uploadedFile = await uploadFile(
+				localStorage.token,
+				file,
+				metadata,
+				null,
+				(statusData) => {
+					// Update the local placeholder item with the server-side status so
+					// the tooltip (and spinner) reflect real progress while we wait.
+					fileItems = fileItems.map((item) =>
+						item.itemId === fileItem.itemId
+							? { ...item, data: { ...(item.data ?? {}), ...statusData } }
+							: item
+					);
+				},
+				(fileId) => {
+					// Set the real id immediately so polling deduplication works
+					// before the SSE stream finishes.
+					fileItems = fileItems.map((item) =>
+						item.itemId === fileItem.itemId ? { ...item, id: fileId } : item
+					);
+				}
+			).catch((e) => {
 				toast.error(`${e}`);
 				return null;
 			});
@@ -1133,6 +1233,7 @@
 
 	onDestroy(() => {
 		clearTimeout(searchDebounceTimer);
+		if (pollingInterval !== null) clearInterval(pollingInterval);
 		if (pendingPollTimer) {
 			clearInterval(pendingPollTimer);
 			pendingPollTimer = null;

--- a/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
+++ b/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
@@ -38,7 +38,6 @@
 		updateKnowledgeById,
 		updateKnowledgeAccessGrants,
 		searchKnowledgeFilesById,
-		getPendingFilesByKnowledgeId,
 		createKnowledgeDirectory,
 		updateKnowledgeDirectory,
 		deleteKnowledgeDirectory,
@@ -134,30 +133,6 @@
 	let fileItems = null;
 	let fileItemsTotal = null;
 
-	// Poll every 15 s while any file is still being processed, so the UI
-	// reflects status changes (pending → processing → completed / failed)
-	// without requiring a manual page refresh.
-	let pollingInterval: ReturnType<typeof setInterval> | null = null;
-
-	$: {
-		const hasPendingFiles = fileItems?.some(
-			(f) =>
-				f?.data?.status === 'pending' ||
-				f?.data?.status === 'processing' ||
-				f?.status === 'uploading'
-		);
-		if (hasPendingFiles && pollingInterval === null) {
-			pollingInterval = setInterval(() => {
-				getItemsPage(true);
-			}, 15_000);
-		} else if (fileItems !== null && !hasPendingFiles && pollingInterval !== null) {
-			// Only stop polling once we have a real result — not while fileItems is
-			// momentarily null during a refresh, which would kill the interval early.
-			clearInterval(pollingInterval);
-			pollingInterval = null;
-		}
-	}
-
 	// Directory state
 	let currentDirectoryId: string | null = null;
 	let directoryItems = [];
@@ -210,17 +185,8 @@
 		getItemsPage();
 	}
 
-	$: if (
-		query !== undefined &&
-		viewOption !== undefined &&
-		sortKey !== undefined &&
-		direction !== undefined
-	) {
-		reset();
-	}
-
-	// silent=true preserves the current list while refreshing (used by the
-	// polling interval) so files don't flash away every 15 seconds.
+	// silent=true refreshes in place instead of blanking the list first, so the
+	// poll below can pick up status changes without the rows flashing away.
 	const getItemsPage = async (silent = false) => {
 		if (knowledgeId === null) return;
 
@@ -233,51 +199,30 @@
 			direction = null;
 		}
 
-		const [res, pendingFromServer] = await Promise.all([
-			searchKnowledgeFilesById(
-				localStorage.token,
-				knowledge.id,
-				query,
-				viewOption,
-				sortKey,
-				direction,
-				currentPage,
-				currentDirectoryId,
-				includeContent
-			).catch(() => {
-				return null;
-			}),
-			getPendingFilesByKnowledgeId(
-				localStorage.token,
-				knowledge.id
-			).catch(() => [])
-		]);
+		const res = await searchKnowledgeFilesById(
+			localStorage.token,
+			knowledge.id,
+			query,
+			viewOption,
+			sortKey,
+			direction,
+			currentPage,
+			currentDirectoryId,
+			includeContent
+		).catch(() => {
+			return null;
+		});
 
 		if (res) {
-			const linkedIds = new Set(res.items.map((f) => f.id).filter(Boolean));
+			// Uploads started in this tab have no file id until the POST returns,
+			// so the server cannot report them yet. A silent refresh must not drop
+			// those rows.
+			const localInFlight =
+				silent && fileItems !== null
+					? fileItems.filter((f) => f.status === 'uploading' && !f.id)
+					: [];
 
-			// Pending files from the server that are not yet in the linked list.
-			const serverPending = (pendingFromServer ?? []).filter((f) => !linkedIds.has(f.id));
-
-			if (silent && fileItems !== null) {
-				// During a polling refresh, also preserve local-only in-flight
-				// placeholders (e.g. files uploading in this tab right now) that
-				// aren't reflected in the server responses yet.
-				const serverIds = new Set([
-					...linkedIds,
-					...serverPending.map((f) => f.id).filter(Boolean)
-				]);
-				const localInFlight = fileItems.filter(
-					(f) =>
-						(f.status === 'uploading' ||
-							f?.data?.status === 'pending' ||
-							f?.data?.status === 'processing') &&
-						!serverIds.has(f.id)
-				);
-				fileItems = [...localInFlight, ...serverPending, ...res.items];
-			} else {
-				fileItems = [...serverPending, ...res.items];
-			}
+			fileItems = [...localInFlight, ...res.items];
 			fileItemsTotal = res.total;
 			directoryItems = res.directories ?? [];
 			breadcrumbs = res.breadcrumbs ?? [];
@@ -296,21 +241,18 @@
 						}));
 					if (newPending.length > 0) {
 						fileItems = [...newPending, ...fileItems];
-
-						// Start polling for completion (if not already polling)
-						if (!pendingPollTimer) {
-							pendingPollTimer = setInterval(async () => {
-								try {
-									const still = await getPendingKnowledgeFiles(localStorage.token, knowledgeId);
-									if (!still || still.length === 0) {
-										clearInterval(pendingPollTimer);
-										pendingPollTimer = null;
-										init();
-									}
-								} catch {}
-							}, 5000);
-						}
 					}
+
+					// Keep refreshing while anything is in flight. A silent refresh
+					// also re-reads the pending list, so this loop both surfaces
+					// status changes (queued → processing → failed) and retires
+					// itself once the last file has landed.
+					if (!pendingPollTimer) {
+						pendingPollTimer = setInterval(() => getItemsPage(true), 5000);
+					}
+				} else if (pendingPollTimer) {
+					clearInterval(pendingPollTimer);
+					pendingPollTimer = null;
 				}
 			} catch (e) {
 				console.warn('Failed to fetch pending files:', e);
@@ -1233,7 +1175,6 @@
 
 	onDestroy(() => {
 		clearTimeout(searchDebounceTimer);
-		if (pollingInterval !== null) clearInterval(pollingInterval);
 		if (pendingPollTimer) {
 			clearInterval(pendingPollTimer);
 			pendingPollTimer = null;

--- a/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
+++ b/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
@@ -133,6 +133,11 @@
 	let fileItems = null;
 	let fileItemsTotal = null;
 
+	// Files deleted in this tab. An upload in progress and the pending poll both
+	// re-add rows from sources that can lag a few seconds behind the deletion,
+	// so every merge below filters against this set.
+	let deletedFileIds = new Set<string>();
+
 	// Directory state
 	let currentDirectoryId: string | null = null;
 	let directoryItems = [];
@@ -222,7 +227,9 @@
 					? fileItems.filter((f) => f.status === 'uploading' && !f.id)
 					: [];
 
-			fileItems = [...localInFlight, ...res.items];
+			fileItems = [...localInFlight, ...res.items].filter(
+				(f) => !(f?.id && deletedFileIds.has(f.id))
+			);
 			fileItemsTotal = res.total;
 			directoryItems = res.directories ?? [];
 			breadcrumbs = res.breadcrumbs ?? [];
@@ -233,7 +240,7 @@
 				if (pendingFiles && pendingFiles.length > 0) {
 					const existingIds = new Set(fileItems.map((f) => f.id));
 					const newPending = pendingFiles
-						.filter((f) => !existingIds.has(f.id))
+						.filter((f) => !existingIds.has(f.id) && !deletedFileIds.has(f.id))
 						.map((f) => ({
 							...f,
 							name: f.meta?.name ?? f.filename,
@@ -336,6 +343,12 @@
 		fileItems = [...newFileItems, ...(fileItems ?? [])];
 
 		for (const fileItem of newFileItems) {
+			// See uploadFileHandler: once the id is known the row can be deleted
+			// while we are still awaiting its processing stream.
+			let uploadedFileId: string | null = null;
+			const wasDeletedDuringUpload = () =>
+				uploadedFileId !== null && deletedFileIds.has(uploadedFileId);
+
 			try {
 				console.log(fileItem);
 				const res = await processWeb(localStorage.token, '', fileItem.url, false).catch((e) => {
@@ -366,13 +379,20 @@
 					}, (fileId) => {
 						// Set the real id immediately so polling deduplication works
 						// before the SSE stream finishes.
+						uploadedFileId = fileId;
 						fileItems = fileItems.map((item) =>
 							item.itemId === fileItem.itemId ? { ...item, id: fileId } : item
 						);
 					}).catch((e) => {
-						toast.error(`${e}`);
+						if (!wasDeletedDuringUpload()) {
+							toast.error(`${e}`);
+						}
 						return null;
 					});
+
+					if (wasDeletedDuringUpload()) {
+						continue;
+					}
 
 					if (uploadedFile) {
 						console.log(uploadedFile);
@@ -402,7 +422,9 @@
 			} catch (e) {
 				// remove the item from fileItems
 				fileItems = fileItems.filter((item) => item.itemId !== fileItem.itemId);
-				toast.error(`${e}`);
+				if (!wasDeletedDuringUpload()) {
+					toast.error(`${e}`);
+				}
 			}
 		}
 	};
@@ -444,6 +466,14 @@
 		}
 
 		fileItems = [fileItem, ...(fileItems ?? [])];
+
+		// The server-side id, known as soon as the upload request returns. From
+		// that point on the user can delete the file, which aborts the stream we
+		// are still awaiting below.
+		let uploadedFileId: string | null = null;
+		const wasDeletedDuringUpload = () =>
+			uploadedFileId !== null && deletedFileIds.has(uploadedFileId);
+
 		try {
 			let metadata = {
 				knowledge_id: knowledge.id,
@@ -474,14 +504,23 @@
 				(fileId) => {
 					// Set the real id immediately so polling deduplication works
 					// before the SSE stream finishes.
+					uploadedFileId = fileId;
 					fileItems = fileItems.map((item) =>
 						item.itemId === fileItem.itemId ? { ...item, id: fileId } : item
 					);
 				}
 			).catch((e) => {
-				toast.error(`${e}`);
+				// A file deleted mid-upload aborts its own processing stream —
+				// that is the outcome the user asked for, not a failure.
+				if (!wasDeletedDuringUpload()) {
+					toast.error(`${e}`);
+				}
 				return null;
 			});
+
+			if (wasDeletedDuringUpload()) {
+				return;
+			}
 
 			if (uploadedFile) {
 				console.log(uploadedFile);
@@ -504,7 +543,9 @@
 				toast.error($i18n.t('Failed to upload file.'));
 			}
 		} catch (e) {
-			toast.error(`${e}`);
+			if (!wasDeletedDuringUpload()) {
+				toast.error(`${e}`);
+			}
 		}
 	};
 
@@ -905,21 +946,32 @@
 		}
 	};
 
-	const deleteFileHandler = async (fileId) => {
-		try {
-			console.log('Starting file deletion process for:', fileId);
+	const deleteFileHandler = async (fileId, wasProcessing = false) => {
+		if (!fileId) return;
 
-			// Remove from knowledge base only
+		// A file that is still being processed is deleted server-side too — the
+		// backend cancels the running extraction/embedding first. Remember the id
+		// so neither the pending poll nor this tab's own upload handler can put
+		// the row back while that unwinds.
+		deletedFileIds.add(fileId);
+		fileItems = (fileItems ?? []).filter((item) => item.id !== fileId);
+
+		try {
 			const res = await removeFileFromKnowledgeById(localStorage.token, id, fileId);
-			console.log('Knowledge base updated:', res);
 
 			if (res) {
-				toast.success($i18n.t('File removed successfully.'));
+				toast.success(
+					wasProcessing
+						? $i18n.t('Processing stopped and file deleted.')
+						: $i18n.t('File removed successfully.')
+				);
 				await init();
 			}
 		} catch (e) {
 			console.error('Error in deleteFileHandler:', e);
+			deletedFileIds.delete(fileId);
 			toast.error(`${e}`);
+			await init();
 		}
 	};
 
@@ -1624,13 +1676,13 @@
 														}
 													}
 												}}
-												onDelete={(fileId) => {
+												onDelete={(fileId, wasProcessing) => {
 													selectedFileId = null;
 													selectedFile = null;
 													selectedFileContent = '';
 													loadingFileContent = false;
 
-													deleteFileHandler(fileId);
+													deleteFileHandler(fileId, wasProcessing);
 												}}
 												onRename={(fileId, name) => renameFileHandler(fileId, name)}
 												onNavigateDirectory={(dirId) => navigateToDirectory(dirId)}

--- a/src/lib/components/workspace/Knowledge/KnowledgeBase/Files.svelte
+++ b/src/lib/components/workspace/Knowledge/KnowledgeBase/Files.svelte
@@ -58,6 +58,55 @@
 	const cancelRename = () => {
 		editingFileId = null;
 	};
+
+	/** Build the HTML tooltip for files that are pending, processing, or failed. */
+	function getStatusTooltip(file: any): string {
+		// Local upload-in-progress item — data is not yet populated from server
+		if (file?.status === 'uploading') {
+			// If the SSE stream has already delivered a server-side status (e.g.
+			// 'processing' once docling picks up the job), show that instead of
+			// the generic "Uploading…" so the tooltip stays meaningful.
+			const serverStatus = file?.data?.status;
+			if (!serverStatus || serverStatus === 'pending') {
+				return '<strong>Uploading…</strong>';
+			}
+			// fall through: real server status available, show it below
+		}
+
+		const status = file?.data?.status;
+		if (!status || status === 'completed') return '';
+
+		const parts: string[] = [];
+
+		if (status === 'pending') {
+			parts.push('<strong>Queued for processing</strong>');
+		} else if (status === 'processing') {
+			parts.push('<strong>Processing…</strong>');
+		} else if (status === 'failed') {
+			parts.push('<strong style="color:#f87171">Processing failed</strong>');
+		}
+
+		// started_at is written by process_file() just before loader.load()
+		if (file?.data?.started_at) {
+			parts.push(`Started: ${dayjs(file.data.started_at * 1000).fromNow()}`);
+		} else if (status === 'pending' && file?.created_at) {
+			parts.push(`Uploaded: ${dayjs(file.created_at * 1000).fromNow()}`);
+		}
+
+		// Docling-specific fields written by the status_callback during polling
+		if (file?.data?.task_position != null) {
+			parts.push(`Queue position: ${file.data.task_position}`);
+		}
+		if (file?.data?.task_id) {
+			parts.push(`Task ID: ${String(file.data.task_id).slice(0, 8)}…`);
+		}
+
+		if (status === 'failed' && file?.data?.error) {
+			parts.push(`<span style="color:#f87171">${file.data.error}</span>`);
+		}
+
+		return parts.join('<br>');
+	}
 </script>
 
 <div class=" max-h-full flex flex-col w-full gap-[0.5px]">
@@ -76,6 +125,11 @@
 
 	<!-- Files -->
 	{#each files as file (file?.id ?? file?.itemId ?? file?.tempId)}
+		{@const fileStatus = file?.data?.status}
+		{@const isInFlight =
+			file?.status === 'uploading' || fileStatus === 'pending' || fileStatus === 'processing'}
+		{@const isFailed = fileStatus === 'failed'}
+		{@const statusTooltip = getStatusTooltip(file)}
 		<div
 			class=" flex cursor-pointer w-full px-2 bg-transparent dark:hover:bg-gray-850/50 hover:bg-white rounded-xl transition {selectedFileId
 				? ''
@@ -89,28 +143,58 @@
 			}}
 		>
 			<div class="flex items-center">
-				{#if file?.status !== 'uploading'}
-					<button
-						class="p-1 rounded-full transition"
-						type="button"
-						on:click={() => {
-							let fileId = file?.id ?? file?.tempId;
-							onClick(fileId);
-						}}
-					>
-						<DocumentPage className="size-3.5" />
-					</button>
+				{#if file?.status === 'uploading' && (!file?.data?.status || file?.data?.status === 'pending')}
+					<!-- No file ID yet — show spinner with status tooltip, no link -->
+					<Tooltip content={statusTooltip} placement="top-start">
+						<div class="p-1">
+							<Spinner className="size-3.5" />
+						</div>
+					</Tooltip>
+				{:else if isInFlight || isFailed}
+					<!-- File exists but still processing / failed — link to PDF, carry status tooltip -->
+					<Tooltip content={statusTooltip} placement="top-start">
+						<button
+							class="p-1 rounded-full hover:bg-gray-100 dark:hover:bg-gray-850 transition {isFailed
+								? 'text-red-500 dark:text-red-400'
+								: ''}"
+							type="button"
+							on:click={() => {
+								let fileId = file?.id ?? file?.tempId;
+								if (fileId) window.open(`${WEBUI_BASE_URL}/api/v1/files/${fileId}/content`, '_blank');
+							}}
+						>
+							{#if isInFlight}
+								<Spinner className="size-3.5" />
+							{:else}
+								<DocumentPage className="size-3.5" />
+							{/if}
+						</button>
+					</Tooltip>
 				{:else}
-					<Spinner className="size-3.5" />
+					<Tooltip content={$i18n.t('Open file')}>
+						<button
+							class="p-1 rounded-full hover:bg-gray-100 dark:hover:bg-gray-850 transition"
+							type="button"
+							on:click={() => {
+								let fileId = file?.id ?? file?.tempId;
+								window.open(`${WEBUI_BASE_URL}/api/v1/files/${fileId}/content`, '_blank');
+							}}
+						>
+							<DocumentPage className="size-3.5" />
+						</button>
+					</Tooltip>
 				{/if}
 			</div>
 
 			<button
-				class="relative flex items-center gap-1 rounded-xl p-2 text-left flex-1 justify-between"
+				class="relative group flex items-center gap-1 rounded-xl p-2 text-left flex-1 justify-between {isFailed
+					? 'text-red-500 dark:text-red-400'
+					: ''}"
 				type="button"
-				on:click={() => {
+				on:click={async () => {
 					if (editingFileId) return;
-					onClick(file?.id ?? file?.tempId);
+					if (isInFlight || !file?.id) return;
+					onClick(file.id);
 				}}
 				on:dblclick={() => {
 					if (knowledge?.write_access) startRename(file);

--- a/src/lib/components/workspace/Knowledge/KnowledgeBase/Files.svelte
+++ b/src/lib/components/workspace/Knowledge/KnowledgeBase/Files.svelte
@@ -30,7 +30,7 @@
 	export let directories = [];
 
 	export let onClick = (fileId) => {};
-	export let onDelete = (fileId) => {};
+	export let onDelete = (fileId, wasProcessing = false) => {};
 	export let onRename = (fileId: string, name: string) => {};
 	export let onNavigateDirectory = (directoryId: string) => {};
 	export let onRenameDirectory = (id: string, name: string) => {};
@@ -130,6 +130,11 @@
 			file?.status === 'uploading' || fileStatus === 'pending' || fileStatus === 'processing'}
 		{@const isFailed = fileStatus === 'failed'}
 		{@const statusTooltip = getStatusTooltip(file)}
+		<!-- Deleting needs a server-side file id. It exists from the moment the
+		     upload request returns, so this only greys out the brief window in
+		     which the bytes are still on the wire. Once processing has started,
+		     deleting cancels it. -->
+		{@const canDelete = Boolean(file?.id)}
 		<div
 			class=" flex cursor-pointer w-full px-2 bg-transparent dark:hover:bg-gray-850/50 hover:bg-white rounded-xl transition {selectedFileId
 				? ''
@@ -291,16 +296,27 @@
 									<Download className="size-3.5" />
 									{$i18n.t('Download')}
 								</button>
-								<button
-									type="button"
-									class="select-none flex h-[1.6875rem] w-full cursor-pointer items-center gap-2 rounded-xl bg-transparent px-2 text-xs transition hover:text-gray-900 dark:hover:text-gray-100"
-									on:click={() => {
-										onDelete(file?.id ?? file?.tempId);
-									}}
+								<Tooltip
+									content={canDelete
+										? ''
+										: $i18n.t('Available once the upload has been received.')}
+									className="w-full"
 								>
-									<GarbageBin className="size-3.5" />
-									{$i18n.t('Delete')}
-								</button>
+									<button
+										type="button"
+										disabled={!canDelete}
+										class="select-none flex h-[1.6875rem] w-full items-center gap-2 rounded-xl bg-transparent px-2 text-xs transition {canDelete
+											? 'cursor-pointer hover:text-gray-900 dark:hover:text-gray-100'
+											: 'cursor-not-allowed opacity-50'}"
+										on:click={() => {
+											if (!canDelete) return;
+											onDelete(file.id, isInFlight);
+										}}
+									>
+										<GarbageBin className="size-3.5" />
+										{isInFlight ? $i18n.t('Stop & Delete') : $i18n.t('Delete')}
+									</button>
+								</Tooltip>
 							</DropdownMenu>
 						</div>
 					</Dropdown>


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Closes #___` / [Relates to #26931](https://github.com/open-webui/open-webui/discussions/26931). If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [ ] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [ ] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [ ] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [ ] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **feat**: New features or enhancements

> **Why four boxes are unticked.** The delete-during-processing support in this revision is new and so far verified on the backend only (full application import, cancellation checks); it has not been exercised in the browser yet, and the recording below predates it. Testing, self-review and the human-review attestation stay unticked until that is done. Git Hygiene is unticked because this revision adds a second logical change on top of the status tracking — see the note under **Description**.

# Changelog Entry

### Description

Knowledge base file processing (embedding) can take anywhere from seconds to minutes, and today the UI has no way to reflect that: a file's state is invisible once upload starts, ~~a page refresh loses track of anything still in flight,~~ and a server restart mid-embedding leaves the file stuck in `pending`/`processing` forever with no recovery path. ~~If the browser tab is closed while a background task is still running, the file can also silently fail to get linked to its knowledge base.~~ For as long as a file is in that state it also cannot be deleted, which is precisely when a user is most likely to want to.

*(Struck-through problems above are now solved in `dev` itself — see the revision note below.)*

This is a split-out of a previous, too-large PR (#26932) per [maintainer feedback](https://github.com/open-webui/open-webui/pull/26932#issuecomment-4925036925) asking for smaller, atomic, independently reviewable changes. This PR contains **only** the status-tracking/recovery piece ~~— no extraction-engine changes, no RAG pipeline changes, and (per the same feedback) no translation file edits.~~ **and the delete support that piece turns out to require** — no extraction-engine changes, no RAG pipeline changes, and (per the same feedback) no translation file edits. A separate PR/discussion will follow for the `docling_json` extraction provider and related RAG pipeline improvements described in the [linked discussion](https://github.com/open-webui/open-webui/discussions/26931).

The delete support is included here rather than split off again because it is not separable in practice: this PR is what puts in-flight files on screen, and a row that cannot be acted on is arguably worse than no row. The PR also already carried the server-side half of it (discarding embeddings for a file deleted mid-processing) without the half that makes it reachable. Happy to split it out if you would still prefer that.

> **Revision note (this update).** After rebasing onto 0.11 `dev`, several parts of this PR turned out to duplicate functionality `dev` had grown in the meantime. Because the two implementations never touched the same lines, the rebase kept both — including a second `GET /{id}/files/pending` route that FastAPI never reached. Everything `dev` already provides has been dropped in favour of upstream's version; the diff against `dev` shrank from 456 to 266 lines with no loss of functionality. Revised claims below are struck through with the reason given.
>
> The same update also completes one item that this PR previously only half-addressed: it already discarded embeddings for a file deleted mid-processing, but the delete itself was impossible to trigger for exactly those files. That is now fixed — see *Deleting a file while it is being processed* under **Added**.

### Added

- ~~`GET /api/v1/knowledge/{id}/files/pending` endpoint returning files still in `pending`/`processing` status for a knowledge base, so the UI can recover in-flight uploads after a page refresh (with the same owner/admin/access-grant checks as the rest of the knowledge API).~~ **Dropped:** `dev` ships this endpoint itself (`get_pending_knowledge_files`), with an additional SSE streaming mode and a query that also excludes files already linked. This PR now uses upstream's version; the duplicate route it had added was unreachable anyway, since FastAPI matches the first registration for a path.
- Startup cleanup pass (`Files.reset_stuck_processing_files`) that marks any file still `pending`/`processing` as `failed` on server boot, so a crash or restart no longer leaves files stuck in limbo indefinitely.
- Idempotency guard in `add_file_to_knowledge`: if a background task already linked the file (e.g. the browser stayed open long enough after all), the endpoint returns the current state instead of re-embedding.
- ~~"Drop-and-forget" auto-link: if a file is uploaded directly into a knowledge base, the background processing task links it to the KB itself, so the file still lands correctly even if the tab is closed before the SSE stream completes.~~ **Dropped:** `dev` already links uploaded files to their knowledge base from within the background task, gated by an explicit write-access check. This PR now uses upstream's version.
- `status: processing` together with a `started_at` timestamp is written when content extraction begins. `dev` only marks a file `processing` once it reaches the knowledge-base embedding step, so the long extraction phase was indistinguishable from "queued"; the UI can now tell the two apart and show how long a file has been running.
- Knowledge base file list shows a status tooltip (queued / processing / failed + error message) with a spinner/badge per file, and keeps local, not-yet-confirmed upload placeholders visible across refreshes. ~~now polls while any file is pending/processing~~ — **revised:** the polling is upstream's existing `pendingPollTimer`, not a second interval alongside it (see **Changed**).
- ~~Guard against orphaned vector-DB entries: if a file is deleted by the user while it's still being embedded, the (now pointless) embeddings are discarded instead of being committed.~~ **Superseded** by full delete support, below — the guard alone was unreachable in practice, because deleting such a file was rejected before processing could ever observe it.
- **Deleting a file while it is being processed.** Extraction and embedding can run for minutes or hours, and the delete button did nothing for a file in that state: it is not linked to the knowledge base yet, so `POST /knowledge/{id}/file/remove` rejected it with `400 NOT_FOUND` — even though the row is on screen via the pending endpoint. Deleting now works in every state, stops the running job instead of letting it finish into a deleted file, and removes everything belonging to it: knowledge-base link, vectors in both the shared and the per-file collection, database record and the stored blob. In the UI the action reads "Stop & Delete" while a file is processing; it is greyed out only in the brief window before the upload request has returned an id, since there is nothing to address server-side yet.
- `open_webui/utils/file_processing.py`: cooperative cancellation for long-running file processing. An in-process registry of `asyncio.Event`s interrupts a pipeline served by the same worker within seconds, and a database fallback (record gone, or `status: cancelled`) covers a delete served by a different worker process. `process_file` checks it before the storage read, after extraction and before embedding, and waits for the extraction step through a cancellable wrapper so a delete no longer has to wait for the loader. Embedding is deliberately left uncancellable: abandoning that wait would not stop the worker thread, and its vector write could then land after the cleanup — it completes instead, and the existing guard discards the result.

### Changed

- `add_file_to_knowledge` performs the idempotency check described above before doing any (potentially expensive) re-embedding work.
- Upstream's `pendingPollTimer` now refreshes the file list in place instead of only asking "is anything still pending?" and calling `init()` once the last file has landed. Intermediate status changes (queued → processing → failed) become visible while they happen, rather than only the end result, and the timer retires itself when nothing is in flight. Rows for uploads this tab started are preserved across such a refresh, since the server cannot report them until the upload request returns.
- `POST /knowledge/{id}/file/remove` accepts a file that is not yet linked to the knowledge base, provided it is in flight for that knowledge base. See **Breaking Changes** for the exact condition.

### Fixed

- Files stuck in `pending`/`processing` after a server crash/restart are no longer invisible/unrecoverable — they're marked `failed` with an explanatory message on next boot.
- The delete button is no longer inert for a file that is still being processed — the case where a user is most likely to want it, because that is when they notice a file was uploaded by mistake or is taking far too long.
- ~~Uploads in progress are no longer "lost" from the UI on page refresh.~~ **Dropped:** fixed in `dev` by the endpoint this PR no longer adds.
- ~~Files uploaded and processed while the browser tab is closed are no longer silently missing from the knowledge base.~~ **Dropped:** fixed in `dev` by the auto-link this PR no longer adds.

### Deprecated

- N/A

### Removed

- N/A

### Security

- N/A

### Breaking Changes

- ~~None. All changes are additive (new endpoint, new file-status values that default gracefully, new UI states); existing behavior for already-completed files is unchanged.~~ **Revised:** still none for already-completed files, and there is no new endpoint any more, but three behaviour changes are worth naming explicitly rather than filing under "additive":
  - `POST /knowledge/{id}/file/remove` no longer requires the file to be linked to the knowledge base. It also accepts a file whose `meta.data.knowledge_id` points at this knowledge base and whose status is `pending`, `processing` or `failed`; anything else is still rejected with `400 NOT_FOUND` as before. Write access to the knowledge base is checked exactly as before.
  - When that endpoint deletes the file record (owner or admin, `delete_file=true`), it now also deletes the stored blob. Previously the row disappeared and the file stayed in storage. A caller who may unlink but not delete the record now has the file detached from the knowledge base instead, so it stops appearing there as an in-flight upload.
  - The frontend `uploadFile()` helper gained two optional callbacks (`onProgress`, `onUploaded`) *before* its existing trailing `stream` parameter. No caller in the tree passes `stream` positionally, so nothing in-tree breaks, but out-of-tree callers that do would need adjusting.

---

### Additional Information

- Relates to discussion #26931.
- Supersedes #26932, which was closed for being too large for a first review pass. This PR is the first of the planned split — see the discussion for the full picture, including the still-to-come `docling_json` extraction provider and RAG pipeline improvement PRs.
- No dependency changes.
- No translation/i18n files are touched in this PR, per review feedback on #26932. The three new UI strings are in place as English `$i18n.t()` source strings only.
- Rebased onto current `dev`. The branch now carries three commits: the original feature, a `refactor:` commit removing everything `dev` had grown in the meantime, and the delete-during-processing support. Squashing the first two on merge is fine if preferred — they are only kept apart so the deduplication is reviewable on its own.
- Known limitation of the cancellation: a Docling conversion that has already been handed to the server keeps running there. The loader posts synchronously from a worker thread, which cannot be interrupted, and without a task id there is nothing to cancel remotely. The pipeline stops waiting and discards the result, so the user sees an immediate delete; the remote job finishes unobserved. Cancelling it properly needs Docling's async task API and is out of scope here. See: https://github.com/docling-project/docling-serve/issues/401

### Screenshots or Videos

https://github.com/user-attachments/assets/b92e0d63-1cde-4698-a5fd-57637320460b

> The recording above predates this revision and shows the status tracking only, not the delete-while-processing behaviour.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
