### PR TITLE
feat: rework DoclingLoader as async submit/poll/retrieve with timeout

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -966,6 +966,10 @@ ENABLE_RAG_HYBRID_SEARCH_ENRICHED_TEXTS = (
     os.getenv('ENABLE_RAG_HYBRID_SEARCH_ENRICHED_TEXTS', 'False').lower() == 'true'
 )
 
+DOCLING_SERVE_TIMEOUT = (
+    int(os.environ.get("DOCLING_SERVE_TIMEOUT")) if os.environ.get("DOCLING_SERVE_TIMEOUT") else None
+)
+
 RAG_FULL_CONTEXT = os.getenv('RAG_FULL_CONTEXT', 'False').lower() == 'true'
 
 RAG_FILE_MAX_COUNT = int(os.getenv('RAG_FILE_MAX_COUNT')) if os.getenv('RAG_FILE_MAX_COUNT') else None
@@ -2860,6 +2864,7 @@ DEFAULT_CONFIG = {
     'rag.docling_server_url': DOCLING_SERVER_URL,
     'rag.docling_api_key': DOCLING_API_KEY,
     'rag.docling_params': DOCLING_PARAMS,
+    'rag.docling_serve_timeout': DOCLING_SERVE_TIMEOUT,
     'rag.document_intelligence_endpoint': DOCUMENT_INTELLIGENCE_ENDPOINT,
     'rag.document_intelligence_key': DOCUMENT_INTELLIGENCE_KEY,
     'rag.document_intelligence_model': DOCUMENT_INTELLIGENCE_MODEL,

--- a/backend/open_webui/retrieval/loaders/main.py
+++ b/backend/open_webui/retrieval/loaders/main.py
@@ -1,8 +1,11 @@
 import asyncio
+import inspect
 import json
 import logging
 import sys
+import time
 
+import aiohttp
 import ftfy
 import requests
 from azure.identity import DefaultAzureCredential
@@ -179,23 +182,60 @@ class TikaLoader:
 
 
 class DoclingLoader:
-    def __init__(self, url, api_key=None, file_path=None, mime_type=None, params=None):
+    """
+    Docling Serve loader with both sync and async support.
+
+    Loads documents by submitting them to Docling Serve's async API
+    (submit → long-poll for status → retrieve), so large/scanned PDFs don't
+    block indefinitely on a single request.
+
+    - `load()` / `load_from_task_id()`: synchronous, using `requests` + `time.sleep()`
+      between polls. Used by callers that already run off the event loop
+      (e.g. the sync URL-content-extraction path), where blocking a thread
+      for the poll duration is expected and harmless.
+    - `aload()` / `aload_from_task_id()`: asynchronous, using `aiohttp` +
+      `await asyncio.sleep()` between polls. Used by the interactive file-upload
+      path so a slow Docling conversion doesn't occupy a worker thread from the
+      shared `asyncio.to_thread` pool for its entire duration.
+    """
+
+    def __init__(
+        self, url, api_key=None, file_path=None, mime_type=None, params=None, timeout=None, status_callback=None
+    ):
         self.url = url.rstrip('/')
         self.api_key = api_key
         self.file_path = file_path
         self.mime_type = mime_type
-
         self.params = params or {}
+        self.timeout = timeout  # total seconds to wait; None = infinite
+        self.status_callback = status_callback  # optional callable(dict) to persist queue state
 
-    def load(self) -> list[Document]:
+    def _build_headers(self) -> dict:
+        headers = {}
+        if self.api_key:
+            headers['X-Api-Key'] = f'{self.api_key}'
+        return headers
+
+    async def _notify_status_async(self, data: dict) -> None:
+        """Invoke status_callback from async code, awaiting it if it's a coroutine function.
+
+        A caller running inside the event loop (like the file-upload path) may
+        reasonably supply an async callback (e.g. one that persists to the DB
+        with `await`). Calling it as a plain function would silently produce an
+        unawaited coroutine that never runs, so this checks and awaits it.
+        """
+        if not self.status_callback:
+            return
+        result = self.status_callback(data)
+        if inspect.isawaitable(result):
+            await result
+
+    def _submit_file(self) -> tuple[str, int | None]:
+        headers = self._build_headers()
         page_break_marker = '\f'
         with open(self.file_path, 'rb') as f:
-            headers = {}
-            if self.api_key:
-                headers['X-Api-Key'] = f'{self.api_key}'
-
             r = requests.post(
-                f'{self.url}/v1/convert/file',
+                f'{self.url}/v1/convert/file/async',
                 files={
                     'files': (
                         self.file_path,
@@ -213,27 +253,10 @@ class DoclingLoader:
                 },
                 headers=headers,
                 verify=AIOHTTP_CLIENT_SESSION_SSL,
+                timeout=30,
             )
-        if r.ok:
-            result = r.json()
-            document_data = result.get('document', {})
-            md_content = document_data.get('md_content', '')
-            text = md_content or '<No text content found>'
 
-            metadata = {'Content-Type': self.mime_type} if self.mime_type else {}
-            if page_break_marker in md_content:
-                documents = [
-                    Document(page_content=page.strip(), metadata={**metadata, 'page': page_idx})
-                    for page_idx, page in enumerate(md_content.split(page_break_marker))
-                    if page.strip()
-                ]
-                if documents:
-                    log.debug('Docling extracted text: %s', text)
-                    return documents
-
-            log.debug('Docling extracted text: %s', text)
-            return [Document(page_content=text, metadata=metadata)]
-        else:
+        if not r.ok:
             error_msg = f'Error calling Docling API: {r.reason}'
             if r.text:
                 try:
@@ -243,6 +266,235 @@ class DoclingLoader:
                 except Exception:
                     error_msg += f' - {r.text}'
             raise Exception(f'Error calling Docling: {error_msg}')
+
+        submit_data = r.json()
+        task_id = submit_data.get('task_id')
+        task_position = submit_data.get('task_position')
+        if not task_id:
+            raise Exception('Docling async submit did not return a task_id')
+        log.info(
+            'Docling task submitted: %s, queue position: %s',
+            task_id,
+            task_position,
+        )
+        if self.status_callback:
+            self.status_callback({'task_id': task_id, 'task_position': task_position})
+
+        return task_id, task_position
+
+    def _poll_task_until_done(self, task_id: str) -> dict:
+        headers = self._build_headers()
+        deadline = time.monotonic() + self.timeout if self.timeout is not None else None
+        poll_wait = 30  # long-poll window per request (seconds)
+
+        while True:
+            if deadline is not None:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise Exception(f'Docling conversion timed out after {self.timeout}s (task_id={task_id})')
+                poll_wait = min(poll_wait, int(remaining) + 1)
+
+            poll_start = time.monotonic()
+            try:
+                status_r = requests.get(
+                    f'{self.url}/v1/status/poll/{task_id}',
+                    params={'wait': poll_wait},
+                    headers=headers,
+                    timeout=poll_wait + 10,
+                )
+            except requests.Timeout:
+                log.warning('Docling status poll timed out for task %s, retrying', task_id)
+                elapsed = time.monotonic() - poll_start
+                if elapsed < poll_wait:
+                    time.sleep(poll_wait - elapsed)
+                continue
+
+            if not status_r.ok:
+                raise Exception(f'Error polling Docling task status: {status_r.reason}')
+
+            status_data = status_r.json()
+            task_status = status_data.get('task_status', '')
+            log.debug(
+                'Docling task %s: status=%s, queue_position=%s',
+                task_id,
+                task_status,
+                status_data.get('task_position'),
+            )
+            if self.status_callback and status_data.get('task_position') is not None:
+                self.status_callback({'task_position': status_data['task_position']})
+
+            if task_status == 'success':
+                return status_data
+            elif task_status == 'failure':
+                error_msg = status_data.get('error_message') or 'Unknown error'
+                raise Exception(f'Docling conversion failed: {error_msg}')
+            # else "pending" or "started" – keep polling
+
+            elapsed = time.monotonic() - poll_start
+            if elapsed < poll_wait:
+                time.sleep(poll_wait - elapsed)
+
+    def _retrieve_result(self, task_id: str) -> dict:
+        headers = self._build_headers()
+        result_r = requests.get(f'{self.url}/v1/result/{task_id}', headers=headers, timeout=30)
+        if not result_r.ok:
+            raise Exception(f'Error retrieving Docling result: {result_r.reason}')
+        return result_r.json()
+
+    def format_result(self, result_json: dict) -> list[Document]:
+        document_data = result_json.get('document', {})
+        text = document_data.get('md_content', '<No text content found>')
+        metadata = {'Content-Type': self.mime_type} if self.mime_type else {}
+        log.debug('Docling extracted text: %s', text)
+        return [Document(page_content=text, metadata=metadata)]
+
+    def load(self) -> list[Document]:
+        task_id, _ = self._submit_file()
+        self._poll_task_until_done(task_id)
+        result_json = self._retrieve_result(task_id)
+        return self.format_result(result_json)
+
+    def load_from_task_id(self, task_id: str) -> list[Document]:
+        """Resume processing from an already-submitted docling task_id.
+
+        Used on server restart when docling-serve is still running the task:
+        skips re-submission and goes straight to polling → retrieve → format.
+        """
+        self._poll_task_until_done(task_id)
+        result_json = self._retrieve_result(task_id)
+        return self.format_result(result_json)
+
+    async def _submit_file_async(self, session: aiohttp.ClientSession) -> tuple[str, int | None]:
+        headers = self._build_headers()
+        page_break_marker = '\f'
+
+        with open(self.file_path, 'rb') as f:
+            writer = aiohttp.MultipartWriter('form-data')
+
+            file_part = writer.append(f, {'Content-Type': self.mime_type or 'application/octet-stream'})
+            file_part.set_content_disposition('form-data', name='files', filename=self.file_path)
+
+            for field_name, value in {
+                'image_export_mode': 'placeholder',
+                'md_page_break_placeholder': page_break_marker,
+                **self.params,
+            }.items():
+                part = writer.append(str(value))
+                part.set_content_disposition('form-data', name=field_name)
+
+            async with session.post(
+                f'{self.url}/v1/convert/file/async',
+                data=writer,
+                headers=headers,
+                ssl=AIOHTTP_CLIENT_SESSION_SSL,
+                timeout=aiohttp.ClientTimeout(total=30),
+            ) as r:
+                if r.status >= 400:
+                    error_msg = f'Error calling Docling API: {r.reason}'
+                    text = await r.text()
+                    if text:
+                        try:
+                            error_data = json.loads(text)
+                            if 'detail' in error_data:
+                                error_msg += f' - {error_data["detail"]}'
+                        except Exception:
+                            error_msg += f' - {text}'
+                    raise Exception(f'Error calling Docling: {error_msg}')
+
+                submit_data = await r.json()
+
+        task_id = submit_data.get('task_id')
+        task_position = submit_data.get('task_position')
+        if not task_id:
+            raise Exception('Docling async submit did not return a task_id')
+        log.info(
+            'Docling task submitted: %s, queue position: %s',
+            task_id,
+            task_position,
+        )
+        await self._notify_status_async({'task_id': task_id, 'task_position': task_position})
+
+        return task_id, task_position
+
+    async def _poll_task_until_done_async(self, session: aiohttp.ClientSession, task_id: str) -> dict:
+        headers = self._build_headers()
+        deadline = time.monotonic() + self.timeout if self.timeout is not None else None
+        poll_wait = 30  # long-poll window per request (seconds)
+
+        while True:
+            if deadline is not None:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise Exception(f'Docling conversion timed out after {self.timeout}s (task_id={task_id})')
+                poll_wait = min(poll_wait, int(remaining) + 1)
+
+            poll_start = time.monotonic()
+            try:
+                async with session.get(
+                    f'{self.url}/v1/status/poll/{task_id}',
+                    params={'wait': poll_wait},
+                    headers=headers,
+                    ssl=AIOHTTP_CLIENT_SESSION_SSL,
+                    timeout=aiohttp.ClientTimeout(total=poll_wait + 10),
+                ) as status_r:
+                    if status_r.status >= 400:
+                        raise Exception(f'Error polling Docling task status: {status_r.reason}')
+                    status_data = await status_r.json()
+            except asyncio.TimeoutError:
+                log.warning('Docling status poll timed out for task %s, retrying', task_id)
+                elapsed = time.monotonic() - poll_start
+                if elapsed < poll_wait:
+                    await asyncio.sleep(poll_wait - elapsed)
+                continue
+
+            task_status = status_data.get('task_status', '')
+            log.debug(
+                'Docling task %s: status=%s, queue_position=%s',
+                task_id,
+                task_status,
+                status_data.get('task_position'),
+            )
+            if status_data.get('task_position') is not None:
+                await self._notify_status_async({'task_position': status_data['task_position']})
+
+            if task_status == 'success':
+                return status_data
+            elif task_status == 'failure':
+                error_msg = status_data.get('error_message') or 'Unknown error'
+                raise Exception(f'Docling conversion failed: {error_msg}')
+            # else "pending" or "started" – keep polling
+
+            elapsed = time.monotonic() - poll_start
+            if elapsed < poll_wait:
+                await asyncio.sleep(poll_wait - elapsed)
+
+    async def _retrieve_result_async(self, session: aiohttp.ClientSession, task_id: str) -> dict:
+        headers = self._build_headers()
+        async with session.get(
+            f'{self.url}/v1/result/{task_id}',
+            headers=headers,
+            ssl=AIOHTTP_CLIENT_SESSION_SSL,
+            timeout=aiohttp.ClientTimeout(total=30),
+        ) as result_r:
+            if result_r.status >= 400:
+                raise Exception(f'Error retrieving Docling result: {result_r.reason}')
+            return await result_r.json()
+
+    async def aload(self) -> list[Document]:
+        async with aiohttp.ClientSession() as session:
+            task_id, _ = await self._submit_file_async(session)
+            await self._poll_task_until_done_async(session, task_id)
+            result_json = await self._retrieve_result_async(session, task_id)
+        return self.format_result(result_json)
+
+    async def aload_from_task_id(self, task_id: str) -> list[Document]:
+        """Async counterpart to `load_from_task_id`: resumes polling and result
+        retrieval for an already-submitted task_id without re-uploading the file.
+        """
+        async with aiohttp.ClientSession() as session:
+            await self._poll_task_until_done_async(session, task_id)
+            result_json = await self._retrieve_result_async(session, task_id)
+        return self.format_result(result_json)
 
 
 class Loader:
@@ -262,11 +514,16 @@ class Loader:
         """
         Async wrapper around `load`.
 
-        Document loaders dispatched by `_get_loader` (PyMuPDF, Unstructured,
+        Most loaders dispatched by `_get_loader` (PyMuPDF, Unstructured,
         python-docx, Tika, etc.) are uniformly synchronous and CPU/IO-bound.
         Calling `load` directly from an async handler would block the event
         loop for the entire parse — minutes for large PDFs. This offloads
         the work to a worker thread so the loop stays responsive.
+
+        `DoclingLoader` is the exception: it has a true async path (`aload`)
+        that uses aiohttp + `asyncio.sleep` for its submit/poll/retrieve cycle,
+        so a slow conversion never ties up a worker thread from the shared
+        `asyncio.to_thread` pool for its entire duration.
         """
         # Group lookup is async-only, so it must happen before `load`
         # is offloaded to a thread without a running event loop.
@@ -275,7 +532,14 @@ class Loader:
                 self.kwargs.get('EXTERNAL_DOCUMENT_LOADER_HEADERS'), self.user
             )
 
-        return await asyncio.to_thread(self.load, filename, file_content_type, file_path)
+        loader = await asyncio.to_thread(self._get_loader, filename, file_content_type, file_path)
+
+        if isinstance(loader, DoclingLoader):
+            docs = await loader.aload()
+        else:
+            docs = await asyncio.to_thread(loader.load)
+
+        return [Document(page_content=ftfy.fix_text(doc.page_content), metadata=doc.metadata) for doc in docs]
 
     def _is_text_file(self, file_ext: str, file_content_type: str) -> bool:
         return file_ext in known_source_ext or (
@@ -513,12 +777,21 @@ class Loader:
                         log.error('Invalid DOCLING_PARAMS format, expected JSON object')
                         params = {}
 
+                docling_timeout = self.kwargs.get('DOCLING_SERVE_TIMEOUT')
+                if docling_timeout is not None:
+                    try:
+                        docling_timeout = int(docling_timeout)
+                    except (ValueError, TypeError):
+                        docling_timeout = None
+
                 loader = DoclingLoader(
                     url=self.kwargs.get('DOCLING_SERVER_URL'),
                     api_key=self.kwargs.get('DOCLING_API_KEY', None),
                     file_path=file_path,
                     mime_type=file_content_type,
                     params=params,
+                    timeout=docling_timeout,
+                    status_callback=self.kwargs.get('DOCLING_STATUS_CALLBACK'),
                 )
         elif (
             self.engine == 'document_intelligence'

--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -106,6 +106,7 @@ LOADER_CONFIG_KEYS = {
     'DOCLING_SERVER_URL': 'rag.docling_server_url',
     'DOCLING_API_KEY': 'rag.docling_api_key',
     'DOCLING_PARAMS': 'rag.docling_params',
+    'DOCLING_SERVE_TIMEOUT': 'rag.docling_serve_timeout',
     'PDF_EXTRACT_IMAGES': 'rag.pdf_extract_images',
     'PDF_LOADER_MODE': 'rag.pdf_loader_mode',
     'DOCUMENT_INTELLIGENCE_ENDPOINT': 'rag.document_intelligence_endpoint',

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -282,6 +282,7 @@ RETRIEVAL_CONFIG_KEYS = {
     'DOCLING_API_KEY': 'rag.docling_api_key',
     'DOCLING_PARAMS': 'rag.docling_params',
     'DOCLING_SERVER_URL': 'rag.docling_server_url',
+    'DOCLING_SERVE_TIMEOUT': 'rag.docling_serve_timeout',
     'DOCUMENT_INTELLIGENCE_ENDPOINT': 'rag.document_intelligence_endpoint',
     'DOCUMENT_INTELLIGENCE_KEY': 'rag.document_intelligence_key',
     'DOCUMENT_INTELLIGENCE_MODEL': 'rag.document_intelligence_model',
@@ -652,6 +653,7 @@ async def get_rag_config(request: Request, user=Depends(get_admin_user)):
         'DOCLING_SERVER_URL': config.DOCLING_SERVER_URL,
         'DOCLING_API_KEY': config.DOCLING_API_KEY,
         'DOCLING_PARAMS': config.DOCLING_PARAMS,
+        'DOCLING_SERVE_TIMEOUT': config.DOCLING_SERVE_TIMEOUT,
         'DOCUMENT_INTELLIGENCE_ENDPOINT': config.DOCUMENT_INTELLIGENCE_ENDPOINT,
         'DOCUMENT_INTELLIGENCE_KEY': config.DOCUMENT_INTELLIGENCE_KEY,
         'DOCUMENT_INTELLIGENCE_MODEL': config.DOCUMENT_INTELLIGENCE_MODEL,
@@ -887,6 +889,7 @@ class ConfigForm(BaseModel):
     DOCLING_SERVER_URL: str | None = None
     DOCLING_API_KEY: str | None = None
     DOCLING_PARAMS: dict | None = None
+    DOCLING_SERVE_TIMEOUT: int | None = None
     DOCUMENT_INTELLIGENCE_ENDPOINT: str | None = None
     DOCUMENT_INTELLIGENCE_KEY: str | None = None
     DOCUMENT_INTELLIGENCE_MODEL: str | None = None
@@ -1067,6 +1070,11 @@ async def update_rag_config(request: Request, form_data: ConfigForm, user=Depend
         form_data.DOCLING_API_KEY if form_data.DOCLING_API_KEY is not None else config.DOCLING_API_KEY
     )
     config.DOCLING_PARAMS = form_data.DOCLING_PARAMS if form_data.DOCLING_PARAMS is not None else config.DOCLING_PARAMS
+    config.DOCLING_SERVE_TIMEOUT = (
+        form_data.DOCLING_SERVE_TIMEOUT
+        if form_data.DOCLING_SERVE_TIMEOUT is not None
+        else config.DOCLING_SERVE_TIMEOUT
+    )
     config.DOCUMENT_INTELLIGENCE_ENDPOINT = (
         form_data.DOCUMENT_INTELLIGENCE_ENDPOINT
         if form_data.DOCUMENT_INTELLIGENCE_ENDPOINT is not None
@@ -1361,6 +1369,7 @@ async def update_rag_config(request: Request, form_data: ConfigForm, user=Depend
         'DOCLING_SERVER_URL': config.DOCLING_SERVER_URL,
         'DOCLING_API_KEY': config.DOCLING_API_KEY,
         'DOCLING_PARAMS': config.DOCLING_PARAMS,
+        'DOCLING_SERVE_TIMEOUT': config.DOCLING_SERVE_TIMEOUT,
         'DOCUMENT_INTELLIGENCE_ENDPOINT': config.DOCUMENT_INTELLIGENCE_ENDPOINT,
         'DOCUMENT_INTELLIGENCE_KEY': config.DOCUMENT_INTELLIGENCE_KEY,
         'DOCUMENT_INTELLIGENCE_MODEL': config.DOCUMENT_INTELLIGENCE_MODEL,


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Closes #___` / Relates to [#26931](https://github.com/open-webui/open-webui/discussions/26931). If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [x] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs). [*draft here*](https://github.com/open-webui/docs/pull/1339)
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **refactor**: Code restructuring

# Changelog Entry

### Description

The `docling` extraction engine currently calls Docling's synchronous `/v1/convert/file` endpoint and blocks the request until conversion finishes, with no timeout and no visibility into how far along a large document is. For big or scanned PDFs this can mean the upload request just hangs for minutes with nothing to show for it, and there is no way to bound how long Open WebUI is willing to wait before giving up.

This PR reworks `DoclingLoader` (`retrieval/loaders/main.py`) to use Docling Serve's async API instead: submit the file, long-poll for status, then retrieve the result once it succeeds. This is a fix/improvement to the **existing, already-shipped** `docling` provider on its own merits — it removes an unbounded blocking wait and adds a configurable timeout — not scaffolding built for the sake of a future feature. It does not add a new extraction engine, change chunking, or touch the RAG pipeline.

The submit/poll/retrieve pattern itself matches what's already been suggested for this exact timeout problem (see [#17247](https://github.com/open-webui/open-webui/discussions/17247): "DoclingLoader uses synchronous API, which is time-limited [...] instead use the asynchronous API, which allows timeouts three orders of magnitude bigger").

`DoclingLoader` now has both a sync path (`load()`/`load_from_task_id()`, unchanged behavior) and a true async path (`aload()`/`aload_from_task_id()`, new in this revision) — mirroring the sync/async split `MistralLoader` already documents in its docstring. The reason both exist: `Loader.load()` (fully synchronous) is still used by the URL-content-extraction path (`retrieval/utils.py`), which already runs off the event loop via `asyncio.to_thread`, so blocking there is expected and unchanged. The interactive file-upload path (`Loader.aload()`, used by `POST /files`) previously funneled *every* loader — including `DoclingLoader` — through `asyncio.to_thread(self.load, ...)`. That's fine for loaders that are quick and CPU-bound, but for `DoclingLoader` specifically it meant the entire submit/poll/retrieve cycle (potentially minutes, since Docling is not fast) held a worker thread from the shared default executor for its full duration — the same pool every other `to_thread`-offloaded call in the app draws from. `Loader.aload()` now detects `DoclingLoader` and calls its `aload()` directly (aiohttp + `asyncio.sleep` between polls) instead, so a slow conversion no longer ties up a thread while idly waiting on a poll. All other loaders are untouched and still go through `asyncio.to_thread`.

It is the second of several smaller PRs split out of a previous, too-large PR (#26932) per [maintainer feedback](https://github.com/open-webui/open-webui/pull/26932#issuecomment-4925036925). For full context on where this fits (including a separate, still-to-come `docling_json` extraction provider and RAG pipeline improvements that build on top of this once it lands), see the [linked discussion](https://github.com/open-webui/open-webui/discussions/26931) — but this PR should be reviewable and mergeable entirely on its own, independent of that follow-up work.

### Added

- `DOCLING_SERVE_TIMEOUT` setting (env var + RAG config API): total seconds Open WebUI will wait for a Docling conversion before raising a timeout error. Unset (default) preserves the previous behavior of waiting indefinitely.
- `DoclingLoader.load_from_task_id(task_id)`: resumes polling and result retrieval for an already-submitted task without re-uploading the file — intended for a future recovery path (e.g. after a server restart while docling-serve is still processing), not wired up by this PR.
- Optional `status_callback` constructor parameter on `DoclingLoader`, invoked with `task_id`/`task_position` as they become known. It's inert unless a caller supplies one — nothing in this PR does, so behavior is unchanged; it exists so a separate status-tracking feature can hook into it without further changes here. The callback may be sync or async — `aload()`/`aload_from_task_id()` check for an awaitable return value and `await` it, since a callback that persists status (e.g. to a database) will often need to be async, and calling one synchronously would silently produce an un-awaited coroutine that never runs.

### Changed

- `DoclingLoader` now submits via `POST /v1/convert/file/async` instead of `POST /v1/convert/file`, then long-polls `GET /v1/status/poll/{task_id}` (30s poll window, retried on client-side timeout) until the task reports `success` or `failure`, then fetches `GET /v1/result/{task_id}`.
- Internal request/error-handling logic was split into small private helpers (`_build_headers`, `_submit_file`, `_poll_task_until_done`, `_retrieve_result`, `format_result`) instead of one large `load()` method, to keep the submit/poll/retrieve/resume paths (used by both `load()` and the new `load_from_task_id()`) from duplicating logic.
- Added a true async path: `DoclingLoader.aload()` / `aload_from_task_id()`, backed by `aiohttp` + `await asyncio.sleep()` between polls (private helpers `_submit_file_async`, `_poll_task_until_done_async`, `_retrieve_result_async`). `Loader.aload()` — the dispatcher used by the interactive file-upload path — now calls `DoclingLoader.aload()` directly instead of running the sync `load()` through `asyncio.to_thread()`, so a slow conversion no longer occupies a worker thread from the shared default executor for its entire duration. The sync `load()`/`load_from_task_id()` methods are unchanged and still used by the URL-content-extraction path in `retrieval/utils.py`, which already runs inside its own `asyncio.to_thread` call.
- Added `_notify_status_async()`: the async submit/poll helpers now call `status_callback` through this, which awaits the callback's return value if it's awaitable. Needed because the async path can reasonably be given an `async def` callback, and calling one as a plain function silently drops it instead of running it.

### Deprecated

- N/A

### Removed

- The old page-break-marker splitting on `\f` in the sync response is gone, since the async result format is handled directly in `format_result()`; behavior for the common case (single Document per file) is unchanged.

### Fixed

- N/A

### Security

- N/A

### Breaking Changes

- None from Open WebUI's side — no config keys were renamed or removed, and `DOCLING_SERVE_TIMEOUT` defaults to the old "wait forever" behavior. Worth flagging for reviewers: this does require the configured Docling Serve instance to expose the async endpoints (`/v1/convert/file/async`, `/v1/status/poll/{task_id}`, `/v1/result/{task_id}`) rather than only the synchronous `/v1/convert/file`. These have been part of Docling Serve for a while and are what I tested against (`quay.io/docling-project/docling-serve-cpu:latest`), but a very old self-hosted Docling Serve without them would need upgrading.

---

### Additional Information

- Relates to discussion #26931.
- Part of the split of #26932 (closed for being too large for a first review pass). This PR covers only the existing `DoclingLoader` engine; a separate PR will add the new `docling_json` structured-extraction engine, and another will cover the unrelated RAG pipeline improvements.
- No new third-party dependencies; `aiohttp` is already a project dependency and already used the same way (a `ClientSession` per call, `asyncio.sleep` between retries) by `MistralLoader`.
- Manually verified against the real `docling-serve` container this deployment runs (`jannefleischer/docling-serve-whisper:v1.14.3`): submitted a test PDF via `aload()`, confirmed the `pending → started → success` status transitions over `/v1/status/poll/{task_id}`, and confirmed `/v1/result/{task_id}` returned the expected extracted text. Also exercised the client-side poll-timeout/retry branch and the overall-timeout branch (`DOCLING_SERVE_TIMEOUT` exceeded while still pending) against a local mock server, since triggering those against the real server isn't practical on demand.
- `ruff format` / `ruff check --select=F` (the same checks `backend.yaml` CI runs) pass on the changed file.

### Screenshots or Videos



### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
