### PR TITLE
Feat: [DRAFT] add DoclingLoaderJson as RAG-Provider, inheriting original DoclingLoader but keeps structural data of sources by using JSON-output from docling serve instead of flat markdown

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -957,6 +957,8 @@ DOCLING_SERVE_TIMEOUT = (
     int(os.environ.get("DOCLING_SERVE_TIMEOUT")) if os.environ.get("DOCLING_SERVE_TIMEOUT") else None
 )
 
+DOCLING_JSON_CHUNK_MODE = os.environ.get("DOCLING_JSON_CHUNK_MODE", "chunk")
+
 RAG_FULL_CONTEXT = os.getenv('RAG_FULL_CONTEXT', 'False').lower() == 'true'
 
 RAG_FILE_MAX_COUNT = int(os.getenv('RAG_FILE_MAX_COUNT')) if os.getenv('RAG_FILE_MAX_COUNT') else None
@@ -2812,6 +2814,7 @@ DEFAULT_CONFIG = {
     'rag.docling_api_key': DOCLING_API_KEY,
     'rag.docling_params': DOCLING_PARAMS,
     'rag.docling_serve_timeout': DOCLING_SERVE_TIMEOUT,
+    'rag.DOCLING_JSON_CHUNK_MODE': DOCLING_JSON_CHUNK_MODE,
     'rag.document_intelligence_endpoint': DOCUMENT_INTELLIGENCE_ENDPOINT,
     'rag.document_intelligence_key': DOCUMENT_INTELLIGENCE_KEY,
     'rag.document_intelligence_model': DOCUMENT_INTELLIGENCE_MODEL,

--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -953,6 +953,10 @@ ENABLE_RAG_HYBRID_SEARCH_ENRICHED_TEXTS = (
     os.getenv('ENABLE_RAG_HYBRID_SEARCH_ENRICHED_TEXTS', 'False').lower() == 'true'
 )
 
+DOCLING_SERVE_TIMEOUT = (
+    int(os.environ.get("DOCLING_SERVE_TIMEOUT")) if os.environ.get("DOCLING_SERVE_TIMEOUT") else None
+)
+
 RAG_FULL_CONTEXT = os.getenv('RAG_FULL_CONTEXT', 'False').lower() == 'true'
 
 RAG_FILE_MAX_COUNT = int(os.getenv('RAG_FILE_MAX_COUNT')) if os.getenv('RAG_FILE_MAX_COUNT') else None
@@ -2807,6 +2811,7 @@ DEFAULT_CONFIG = {
     'rag.docling_server_url': DOCLING_SERVER_URL,
     'rag.docling_api_key': DOCLING_API_KEY,
     'rag.docling_params': DOCLING_PARAMS,
+    'rag.docling_serve_timeout': DOCLING_SERVE_TIMEOUT,
     'rag.document_intelligence_endpoint': DOCUMENT_INTELLIGENCE_ENDPOINT,
     'rag.document_intelligence_key': DOCUMENT_INTELLIGENCE_KEY,
     'rag.document_intelligence_model': DOCUMENT_INTELLIGENCE_MODEL,

--- a/backend/open_webui/retrieval/loaders/main.py
+++ b/backend/open_webui/retrieval/loaders/main.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import logging
 import sys
+import time
 
 import ftfy
 import requests
@@ -179,23 +180,27 @@ class TikaLoader:
 
 
 class DoclingLoader:
-    def __init__(self, url, api_key=None, file_path=None, mime_type=None, params=None):
+    def __init__(self, url, api_key=None, file_path=None, mime_type=None, params=None, timeout=None, status_callback=None):
         self.url = url.rstrip('/')
         self.api_key = api_key
         self.file_path = file_path
         self.mime_type = mime_type
-
         self.params = params or {}
+        self.timeout = timeout  # total seconds to wait; None = infinite
+        self.status_callback = status_callback  # optional callable(dict) to persist queue state
 
-    def load(self) -> list[Document]:
+    def _build_headers(self) -> dict:
+        headers = {}
+        if self.api_key:
+            headers["X-Api-Key"] = f"{self.api_key}"
+        return headers
+
+    def _submit_file(self) -> tuple[str, int | None]:
+        headers = self._build_headers()
         page_break_marker = '\f'
-        with open(self.file_path, 'rb') as f:
-            headers = {}
-            if self.api_key:
-                headers['X-Api-Key'] = f'{self.api_key}'
-
+        with open(self.file_path, "rb") as f:
             r = requests.post(
-                f'{self.url}/v1/convert/file',
+                f"{self.url}/v1/convert/file/async",
                 files={
                     'files': (
                         self.file_path,
@@ -210,28 +215,11 @@ class DoclingLoader:
                 },
                 headers=headers,
                 verify=AIOHTTP_CLIENT_SESSION_SSL,
+                timeout=30,
             )
-        if r.ok:
-            result = r.json()
-            document_data = result.get('document', {})
-            md_content = document_data.get('md_content', '')
-            text = md_content or '<No text content found>'
 
-            metadata = {'Content-Type': self.mime_type} if self.mime_type else {}
-            if page_break_marker in md_content:
-                documents = [
-                    Document(page_content=page.strip(), metadata={**metadata, 'page': page_idx})
-                    for page_idx, page in enumerate(md_content.split(page_break_marker))
-                    if page.strip()
-                ]
-                if documents:
-                    log.debug('Docling extracted text: %s', text)
-                    return documents
-
-            log.debug('Docling extracted text: %s', text)
-            return [Document(page_content=text, metadata=metadata)]
-        else:
-            error_msg = f'Error calling Docling API: {r.reason}'
+        if not r.ok:
+            error_msg = f"Error calling Docling API: {r.reason}"
             if r.text:
                 try:
                     error_data = r.json()
@@ -240,6 +228,105 @@ class DoclingLoader:
                 except Exception:
                     error_msg += f' - {r.text}'
             raise Exception(f'Error calling Docling: {error_msg}')
+
+        submit_data = r.json()
+        task_id = submit_data.get("task_id")
+        task_position = submit_data.get("task_position")
+        if not task_id:
+            raise Exception("Docling async submit did not return a task_id")
+        log.info(
+            "Docling task submitted: %s, queue position: %s",
+            task_id,
+            task_position,
+        )
+        if self.status_callback:
+            self.status_callback({"task_id": task_id, "task_position": task_position})
+
+        return task_id, task_position
+
+    def _poll_task_until_done(self, task_id: str) -> dict:
+        headers = self._build_headers()
+        deadline = time.monotonic() + self.timeout if self.timeout is not None else None
+        poll_wait = 30  # long-poll window per request (seconds)
+
+        while True:
+            if deadline is not None:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise Exception(
+                        f"Docling conversion timed out after {self.timeout}s (task_id={task_id})"
+                    )
+                poll_wait = min(poll_wait, int(remaining) + 1)
+
+            poll_start = time.monotonic()
+            try:
+                status_r = requests.get(
+                    f"{self.url}/v1/status/poll/{task_id}",
+                    params={"wait": poll_wait},
+                    headers=headers,
+                    timeout=poll_wait + 10,
+                )
+            except requests.Timeout:
+                log.warning("Docling status poll timed out for task %s, retrying", task_id)
+                elapsed = time.monotonic() - poll_start
+                if elapsed < poll_wait:
+                    time.sleep(poll_wait - elapsed)
+                continue
+
+            if not status_r.ok:
+                raise Exception(f"Error polling Docling task status: {status_r.reason}")
+
+            status_data = status_r.json()
+            task_status = status_data.get("task_status", "")
+            log.debug(
+                "Docling task %s: status=%s, queue_position=%s",
+                task_id,
+                task_status,
+                status_data.get("task_position"),
+            )
+            if self.status_callback and status_data.get("task_position") is not None:
+                self.status_callback({"task_position": status_data["task_position"]})
+
+            if task_status == "success":
+                return status_data
+            elif task_status == "failure":
+                error_msg = status_data.get("error_message") or "Unknown error"
+                raise Exception(f"Docling conversion failed: {error_msg}")
+            # else "pending" or "started" – keep polling
+
+            elapsed = time.monotonic() - poll_start
+            if elapsed < poll_wait:
+                time.sleep(poll_wait - elapsed)
+
+    def _retrieve_result(self, task_id: str) -> dict:
+        headers = self._build_headers()
+        result_r = requests.get(f"{self.url}/v1/result/{task_id}", headers=headers, timeout=30)
+        if not result_r.ok:
+            raise Exception(f"Error retrieving Docling result: {result_r.reason}")
+        return result_r.json()
+
+    def format_result(self, result_json: dict) -> list[Document]:
+        document_data = result_json.get("document", {})
+        text = document_data.get("md_content", "<No text content found>")
+        metadata = {"Content-Type": self.mime_type} if self.mime_type else {}
+        log.debug("Docling extracted text: %s", text)
+        return [Document(page_content=text, metadata=metadata)]
+
+    def load(self) -> list[Document]:
+        task_id, _ = self._submit_file()
+        self._poll_task_until_done(task_id)
+        result_json = self._retrieve_result(task_id)
+        return self.format_result(result_json)
+
+    def load_from_task_id(self, task_id: str) -> list[Document]:
+        """Resume processing from an already-submitted docling task_id.
+
+        Used on server restart when docling-serve is still running the task:
+        skips re-submission and goes straight to polling → retrieve → format.
+        """
+        self._poll_task_until_done(task_id)
+        result_json = self._retrieve_result(task_id)
+        return self.format_result(result_json)
 
 
 class Loader:
@@ -494,12 +581,21 @@ class Loader:
                         log.error('Invalid DOCLING_PARAMS format, expected JSON object')
                         params = {}
 
+                docling_timeout = self.kwargs.get("DOCLING_SERVE_TIMEOUT")
+                if docling_timeout is not None:
+                    try:
+                        docling_timeout = int(docling_timeout)
+                    except (ValueError, TypeError):
+                        docling_timeout = None
+
                 loader = DoclingLoader(
-                    url=self.kwargs.get('DOCLING_SERVER_URL'),
-                    api_key=self.kwargs.get('DOCLING_API_KEY', None),
+                    url=self.kwargs.get("DOCLING_SERVER_URL"),
+                    api_key=self.kwargs.get("DOCLING_API_KEY", None),
                     file_path=file_path,
                     mime_type=file_content_type,
                     params=params,
+                    timeout=docling_timeout,
+                    status_callback=self.kwargs.get("DOCLING_STATUS_CALLBACK"),
                 )
         elif (
             self.engine == 'document_intelligence'

--- a/backend/open_webui/retrieval/loaders/main.py
+++ b/backend/open_webui/retrieval/loaders/main.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import logging
+import re
 import sys
 import time
 
@@ -329,6 +330,331 @@ class DoclingLoader:
         return self.format_result(result_json)
 
 
+class DoclingLoaderJson(DoclingLoader):
+    """Return the Docling JSON document payload split into vector-DB-friendly Documents.
+
+    chunk_mode controls how the structured content is split:
+      "item"  - one Document per Docling content item (finest granularity)
+      "page"  - one Document per page
+      "chunk" - sliding-window chunks with overlap (default)
+
+    For "chunk" mode chunk_size and chunk_overlap are measured in the unit set by
+    chunk_content_type: "character" (default) counts Unicode characters; "token" counts
+    tiktoken subword tokens.  Both are absolute values, not fractions.
+    The page number of every Document is taken from the first content item that
+    falls into that chunk / page / item.
+    """
+
+    def __init__(
+        self,
+        *args,
+        chunk_mode: str = "chunk",
+        chunk_size: int = 1000,
+        chunk_overlap: int = 100,
+        chunk_content_type: str = "character",
+        tiktoken_encoding_name: str = "cl100k_base",
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        self.chunk_mode = chunk_mode
+        self.chunk_size = chunk_size
+        self.chunk_overlap = chunk_overlap
+        self.chunk_content_type = chunk_content_type
+        # Initialise tiktoken encoder if the unit is "token".
+        self._enc = None
+        if self.chunk_content_type == "token":
+            try:
+                import tiktoken
+                self._enc = tiktoken.get_encoding(tiktoken_encoding_name)
+            except Exception as exc:
+                log.warning(
+                    "tiktoken unavailable (%s); falling back to character-based chunking", exc
+                )
+                self.chunk_content_type = "character"
+        to_formats = list(self.params.get("to_formats") or ["md"])
+        if "json" not in to_formats:
+            to_formats.append("json")
+        self.params = {**self.params, "to_formats": to_formats}
+
+    # ------------------------------------------------------------------ helpers
+
+    def _word_sizes(self, words: list[str]) -> list[int]:
+        """Return the size of each word-token in the configured unit.
+
+        "character" (default): number of Unicode characters.
+        "token"               : tiktoken subword token count (approximate per word).
+        """
+        if self.chunk_content_type == "token" and self._enc is not None:
+            return [len(self._enc.encode(w)) for w in words]
+        return [len(w) for w in words]
+
+    def _extract_ordered_items(self, document_data: dict) -> list[dict]:
+        """Return all content items sorted by page then spatial position (top→bottom, left→right).
+
+        Each entry: {"text": str, "label": str, "page_no": int, "bbox": tuple|None}
+        Items without any prov entry containing a page_no are omitted.
+        """
+        json_content = document_data.get("json_content") or document_data.get("json") or {}
+
+        items_out = []
+        for name in ("texts", "tables", "pictures", "key_value_items"):
+            cand = document_data.get(name) or (
+                json_content.get(name) if isinstance(json_content, dict) else None
+            )
+            if not isinstance(cand, list):
+                continue
+            for it in cand:
+                text = it.get("text") or it.get("orig") or ""
+                label = it.get("label") or ""
+                for prov_entry in it.get("prov") or []:
+                    if not isinstance(prov_entry, dict):
+                        continue
+                    pno = prov_entry.get("page_no")
+                    if not isinstance(pno, int):
+                        continue
+                    bbox = None
+                    b = prov_entry.get("bbox")
+                    if isinstance(b, dict):
+                        try:
+                            bbox = (
+                                float(b.get("l", 0)),
+                                float(b.get("t", 0)),
+                                float(b.get("r", 0)),
+                                float(b.get("b", 0)),
+                            )
+                        except Exception:
+                            bbox = None
+                    items_out.append(
+                        {
+                            "text": text,
+                            "label": label,
+                            "page_no": pno,
+                            "bbox": bbox,
+                            "level": it.get("level"),          # section_header depth
+                            "marker": it.get("marker"),        # list_item bullet/number
+                            "enumerated": it.get("enumerated"),# list_item ordered flag
+                            "hyperlink": it.get("hyperlink"),  # hyperlink target if any
+                        }
+                    )
+                    break  # first valid prov entry is sufficient for sorting/metadata
+
+        def _sort_key(entry):
+            b = entry["bbox"]
+            if b:
+                cy = (b[1] + b[3]) / 2.0
+                cx = (b[0] + b[2]) / 2.0
+                return (entry["page_no"], -cy, cx)  # -cy: PDF y-axis goes upward
+            return (entry["page_no"], 0.0, 0.0)
+
+        items_out.sort(key=_sort_key)
+        return items_out
+
+    def _extract_doc_metadata(self, document_data: dict) -> dict:
+        """Extract document-level fields shared by every point produced from this document.
+
+        These are stored per-point because the vector DB has no collection-level
+        metadata store — all filterable/retrievable fields must live on each point.
+
+        origin and name live inside json_content (the DoclingDocument), not at the
+        outer ExportDocumentResponse level.
+        """
+        jc = document_data.get("json_content") or document_data.get("json") or {}
+        if not isinstance(jc, dict):
+            jc = {}
+        origin = jc.get("origin") or {}
+        meta: dict = {"Content-Type": "application/json"}
+        if origin.get("filename"):
+            meta["filename"] = origin["filename"]
+        if origin.get("mimetype"):
+            meta["source_mimetype"] = origin["mimetype"]
+        if origin.get("uri"):
+            meta["source_uri"] = origin["uri"]
+        if origin.get("binary_hash") is not None:
+            meta["binary_hash"] = str(origin["binary_hash"])
+        name = jc.get("name") or document_data.get("name")
+        if name:
+            meta["document_name"] = name
+        return meta
+
+    def _format_item_mode(self, document_data: dict) -> list[Document]:
+        """One Document per Docling content item."""
+        items = self._extract_ordered_items(document_data)
+        doc_meta = self._extract_doc_metadata(document_data)
+        docs = []
+        for it in items:
+            text = it["text"]
+            if not text:
+                continue
+            metadata = {
+                **doc_meta,
+                "docling_document": document_data,
+                "page": it["page_no"],
+                "label": it["label"],
+                "chunk_mode": "item",
+            }
+            if it["bbox"]:
+                metadata["bbox"] = it["bbox"]
+            if it.get("level") is not None:
+                metadata["level"] = it["level"]
+            if it.get("marker"):
+                metadata["marker"] = it["marker"]
+            if it.get("enumerated") is not None:
+                metadata["enumerated"] = it["enumerated"]
+            if it.get("hyperlink"):
+                metadata["hyperlink"] = it["hyperlink"]
+            docs.append(Document(page_content=text, metadata=metadata))
+        log.debug("Docling JSON item-mode produced %d documents", len(docs))
+        return docs
+
+    def _format_page_mode(self, document_data: dict) -> list[Document]:
+        """One Document per page, all items on that page joined with newlines."""
+        items = self._extract_ordered_items(document_data)
+        doc_meta = self._extract_doc_metadata(document_data)
+        jc = document_data.get("json_content") or document_data.get("json") or {}
+        pages_map = (jc.get("pages") if isinstance(jc, dict) else None) or {}
+        pages: dict[int, list[str]] = {}
+        for it in items:
+            text = it["text"]
+            if not text:
+                continue
+            pages.setdefault(it["page_no"], []).append(text)
+        docs = []
+        for pno in sorted(pages.keys()):
+            page_text = "\n".join(pages[pno])
+            metadata = {
+                **doc_meta,
+                "docling_document": document_data,
+                "page": pno,
+                "chunk_mode": "page",
+            }
+            page_info = pages_map.get(str(pno)) or {}
+            if isinstance(page_info, dict):
+                # DoclingDocument serialises page size as {"size": {"width": …, "height": …}}
+                size = page_info.get("size") or {}
+                if size.get("width") is not None:
+                    metadata["page_width"] = size["width"]
+                if size.get("height") is not None:
+                    metadata["page_height"] = size["height"]
+            docs.append(Document(page_content=page_text, metadata=metadata))
+        log.debug("Docling JSON page-mode produced %d documents", len(docs))
+        return docs
+
+    def _format_chunk_mode(self, document_data: dict) -> list[Document]:
+        """Sliding-window chunks measured in the configured unit (characters or tiktoken tokens).
+
+        Internally the text is tokenised word-by-word to preserve all whitespace and
+        newlines. The window boundaries are determined by the cumulative size of those
+        word-tokens in the requested unit so the assembled chunk text is lossless.
+
+        chunk_size    – maximum chunk size in the configured unit.
+        chunk_overlap – how many units of overlap to keep between consecutive chunks
+                        (absolute, same unit as chunk_size).
+        """
+        items = self._extract_ordered_items(document_data)
+        doc_meta = self._extract_doc_metadata(document_data)
+
+        # Build a flat list of word-tokens and a parallel list of their page numbers.
+        words: list[str] = []
+        word_pages: list[int] = []
+        for it in items:
+            text = it["text"]
+            if not text:
+                continue
+            text = text.replace('\r\n', '\n').replace('\r', '\n')
+            # Each whitespace run and each non-whitespace run becomes one token so
+            # that joining with "".join() reconstructs the original text exactly.
+            item_words = re.findall(r'\n|[ \t]+|[^\s]+', text)
+            words.extend(item_words)
+            word_pages.extend([it["page_no"]] * len(item_words))
+
+        if not words:
+            document_text = document_data.get("md_content") or document_data.get("text") or ""
+            return [
+                Document(
+                    page_content=document_text,
+                    metadata={**doc_meta, "docling_document": document_data},
+                )
+            ]
+
+        # Per-word sizes in the configured unit.
+        sizes = self._word_sizes(words)
+
+        chunk_size = max(1, self.chunk_size)
+        chunk_overlap = max(0, min(self.chunk_overlap, chunk_size - 1))
+        step_size = max(1, chunk_size - chunk_overlap)
+
+        n = len(words)
+        docs = []
+        start_idx = 0
+
+        while start_idx < n:
+            # Collect words until chunk_size units are accumulated.
+            acc = 0
+            end_idx = start_idx
+            while end_idx < n:
+                acc += sizes[end_idx]
+                end_idx += 1
+                if acc >= chunk_size:
+                    break
+
+            chunk_text = "".join(words[start_idx:end_idx])
+            page_no = word_pages[start_idx]
+            metadata = {
+                **doc_meta,
+                "docling_document": document_data,
+                "page": page_no,
+                "chunk_mode": "chunk",
+                "chunk_start_word": start_idx,
+                "chunk_end_word": end_idx,
+            }
+            docs.append(Document(page_content=chunk_text, metadata=metadata))
+
+            if end_idx >= n:
+                break
+
+            # Advance by step_size units from the current start.
+            adv = 0
+            new_start = start_idx
+            while new_start < end_idx:
+                adv += sizes[new_start]
+                new_start += 1
+                if adv >= step_size:
+                    break
+            # Guard: always advance by at least one word to prevent infinite loops.
+            if new_start <= start_idx:
+                new_start = start_idx + 1
+            start_idx = new_start
+
+        log.debug(
+            "Docling JSON chunk-mode produced %d documents "
+            "(chunk_size=%d %s, chunk_overlap=%d %s)",
+            len(docs),
+            chunk_size,
+            self.chunk_content_type,
+            chunk_overlap,
+            self.chunk_content_type,
+        )
+        return docs
+
+    def format_result(self, result_json: dict) -> list[Document]:
+        document_data = result_json.get("document", {})
+        json_content = document_data.get("json_content") or document_data.get("json")
+
+        if isinstance(json_content, dict) and isinstance(json_content.get("pages"), dict):
+            if self.chunk_mode == "item":
+                return self._format_item_mode(document_data)
+            elif self.chunk_mode == "page":
+                return self._format_page_mode(document_data)
+            else:  # "chunk" is the default
+                return self._format_chunk_mode(document_data)
+
+        # Fallback: structured JSON not available, return raw markdown/text.
+        document_text = document_data.get("md_content") or document_data.get("text") or ""
+        metadata = {"Content-Type": "application/json", "docling_document": document_data}
+        log.debug("Docling JSON result extracted (fallback): keys=%s", list(document_data.keys()))
+        return [Document(page_content=document_text, metadata=metadata)]
+
+
 class Loader:
     def __init__(self, engine: str = '', **kwargs):
         self.engine = engine
@@ -568,7 +894,7 @@ class Loader:
                 format_lines=self.kwargs.get('DATALAB_MARKER_FORMAT_LINES', False),
                 output_format=self.kwargs.get('DATALAB_MARKER_OUTPUT_FORMAT', 'markdown'),
             )
-        elif self.engine == 'docling' and self.kwargs.get('DOCLING_SERVER_URL'):
+        elif self.engine in ("docling", "docling_json") and self.kwargs.get("DOCLING_SERVER_URL"):
             if self._is_text_file(file_ext, file_content_type):
                 loader = TextLoader(file_path, encoding=self._detect_text_encoding(file_path))
             else:
@@ -588,15 +914,43 @@ class Loader:
                     except (ValueError, TypeError):
                         docling_timeout = None
 
-                loader = DoclingLoader(
-                    url=self.kwargs.get("DOCLING_SERVER_URL"),
-                    api_key=self.kwargs.get("DOCLING_API_KEY", None),
-                    file_path=file_path,
-                    mime_type=file_content_type,
-                    params=params,
-                    timeout=docling_timeout,
-                    status_callback=self.kwargs.get("DOCLING_STATUS_CALLBACK"),
-                )
+                if self.engine == "docling_json":
+                    try:
+                        _chunk_size = int(self.kwargs.get("CHUNK_SIZE", 1000))
+                    except (ValueError, TypeError):
+                        _chunk_size = 1000
+                    try:
+                        _chunk_overlap = int(self.kwargs.get("CHUNK_OVERLAP", 100))
+                    except (ValueError, TypeError):
+                        _chunk_overlap = 100
+                    _text_splitter = self.kwargs.get("TEXT_SPLITTER") or ""
+                    _chunk_content_type = "token" if _text_splitter == "token" else "character"
+                    loader = DoclingLoaderJson(
+                        url=self.kwargs.get("DOCLING_SERVER_URL"),
+                        api_key=self.kwargs.get("DOCLING_API_KEY", None),
+                        file_path=file_path,
+                        mime_type=file_content_type,
+                        params=params,
+                        timeout=docling_timeout,
+                        status_callback=self.kwargs.get("DOCLING_STATUS_CALLBACK"),
+                        chunk_mode=self.kwargs.get("DOCLING_JSON_CHUNK_MODE", "chunk"),
+                        chunk_size=_chunk_size,
+                        chunk_overlap=_chunk_overlap,
+                        chunk_content_type=_chunk_content_type,
+                        tiktoken_encoding_name=str(
+                            self.kwargs.get("TIKTOKEN_ENCODING_NAME") or "cl100k_base"
+                        ),
+                    )
+                else:
+                    loader = DoclingLoader(
+                        url=self.kwargs.get("DOCLING_SERVER_URL"),
+                        api_key=self.kwargs.get("DOCLING_API_KEY", None),
+                        file_path=file_path,
+                        mime_type=file_content_type,
+                        params=params,
+                        timeout=docling_timeout,
+                        status_callback=self.kwargs.get("DOCLING_STATUS_CALLBACK"),
+                    )
         elif (
             self.engine == 'document_intelligence'
             and self.kwargs.get('DOCUMENT_INTELLIGENCE_ENDPOINT') != ''

--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -91,6 +91,14 @@ LOADER_CONFIG_KEYS = {
     'DOCLING_API_KEY': 'rag.docling_api_key',
     'DOCLING_PARAMS': 'rag.docling_params',
     'DOCLING_SERVE_TIMEOUT': 'rag.docling_serve_timeout',
+    'DOCLING_JSON_CHUNK_MODE': 'rag.DOCLING_JSON_CHUNK_MODE',
+    # Threaded through so DoclingLoaderJson's "chunk" mode respects the admin's
+    # real chunk-size/overlap/splitter settings instead of its own hardcoded
+    # fallbacks. Nothing else currently reads these via self.kwargs.
+    'CHUNK_SIZE': 'rag.chunk_size',
+    'CHUNK_OVERLAP': 'rag.chunk_overlap',
+    'TEXT_SPLITTER': 'rag.text_splitter',
+    'TIKTOKEN_ENCODING_NAME': 'rag.tiktoken_encoding_name',
     'PDF_EXTRACT_IMAGES': 'rag.pdf_extract_images',
     'PDF_LOADER_MODE': 'rag.pdf_loader_mode',
     'DOCUMENT_INTELLIGENCE_ENDPOINT': 'rag.document_intelligence_endpoint',

--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -90,6 +90,7 @@ LOADER_CONFIG_KEYS = {
     'DOCLING_SERVER_URL': 'rag.docling_server_url',
     'DOCLING_API_KEY': 'rag.docling_api_key',
     'DOCLING_PARAMS': 'rag.docling_params',
+    'DOCLING_SERVE_TIMEOUT': 'rag.docling_serve_timeout',
     'PDF_EXTRACT_IMAGES': 'rag.pdf_extract_images',
     'PDF_LOADER_MODE': 'rag.pdf_loader_mode',
     'DOCUMENT_INTELLIGENCE_ENDPOINT': 'rag.document_intelligence_endpoint',

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -279,6 +279,7 @@ RETRIEVAL_CONFIG_KEYS = {
     'DOCLING_PARAMS': 'rag.docling_params',
     'DOCLING_SERVER_URL': 'rag.docling_server_url',
     'DOCLING_SERVE_TIMEOUT': 'rag.docling_serve_timeout',
+    'DOCLING_JSON_CHUNK_MODE': 'rag.DOCLING_JSON_CHUNK_MODE',
     'DOCUMENT_INTELLIGENCE_ENDPOINT': 'rag.document_intelligence_endpoint',
     'DOCUMENT_INTELLIGENCE_KEY': 'rag.document_intelligence_key',
     'DOCUMENT_INTELLIGENCE_MODEL': 'rag.document_intelligence_model',
@@ -648,6 +649,7 @@ async def get_rag_config(request: Request, user=Depends(get_admin_user)):
         'DOCLING_API_KEY': config.DOCLING_API_KEY,
         'DOCLING_PARAMS': config.DOCLING_PARAMS,
         'DOCLING_SERVE_TIMEOUT': config.DOCLING_SERVE_TIMEOUT,
+        'DOCLING_JSON_CHUNK_MODE': config.DOCLING_JSON_CHUNK_MODE,
         'DOCUMENT_INTELLIGENCE_ENDPOINT': config.DOCUMENT_INTELLIGENCE_ENDPOINT,
         'DOCUMENT_INTELLIGENCE_KEY': config.DOCUMENT_INTELLIGENCE_KEY,
         'DOCUMENT_INTELLIGENCE_MODEL': config.DOCUMENT_INTELLIGENCE_MODEL,
@@ -881,6 +883,7 @@ class ConfigForm(BaseModel):
     DOCLING_API_KEY: str | None = None
     DOCLING_PARAMS: dict | None = None
     DOCLING_SERVE_TIMEOUT: int | None = None
+    DOCLING_JSON_CHUNK_MODE: str | None = None
     DOCUMENT_INTELLIGENCE_ENDPOINT: str | None = None
     DOCUMENT_INTELLIGENCE_KEY: str | None = None
     DOCUMENT_INTELLIGENCE_MODEL: str | None = None
@@ -1060,6 +1063,9 @@ async def update_rag_config(request: Request, form_data: ConfigForm, user=Depend
         form_data.DOCLING_SERVE_TIMEOUT
         if form_data.DOCLING_SERVE_TIMEOUT is not None
         else config.DOCLING_SERVE_TIMEOUT
+    )
+    config.DOCLING_JSON_CHUNK_MODE = (
+        form_data.DOCLING_JSON_CHUNK_MODE if form_data.DOCLING_JSON_CHUNK_MODE is not None else config.DOCLING_JSON_CHUNK_MODE
     )
     config.DOCUMENT_INTELLIGENCE_ENDPOINT = (
         form_data.DOCUMENT_INTELLIGENCE_ENDPOINT
@@ -1354,6 +1360,7 @@ async def update_rag_config(request: Request, form_data: ConfigForm, user=Depend
         'DOCLING_API_KEY': config.DOCLING_API_KEY,
         'DOCLING_PARAMS': config.DOCLING_PARAMS,
         'DOCLING_SERVE_TIMEOUT': config.DOCLING_SERVE_TIMEOUT,
+        'DOCLING_JSON_CHUNK_MODE': config.DOCLING_JSON_CHUNK_MODE,
         'DOCUMENT_INTELLIGENCE_ENDPOINT': config.DOCUMENT_INTELLIGENCE_ENDPOINT,
         'DOCUMENT_INTELLIGENCE_KEY': config.DOCUMENT_INTELLIGENCE_KEY,
         'DOCUMENT_INTELLIGENCE_MODEL': config.DOCUMENT_INTELLIGENCE_MODEL,

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -278,6 +278,7 @@ RETRIEVAL_CONFIG_KEYS = {
     'DOCLING_API_KEY': 'rag.docling_api_key',
     'DOCLING_PARAMS': 'rag.docling_params',
     'DOCLING_SERVER_URL': 'rag.docling_server_url',
+    'DOCLING_SERVE_TIMEOUT': 'rag.docling_serve_timeout',
     'DOCUMENT_INTELLIGENCE_ENDPOINT': 'rag.document_intelligence_endpoint',
     'DOCUMENT_INTELLIGENCE_KEY': 'rag.document_intelligence_key',
     'DOCUMENT_INTELLIGENCE_MODEL': 'rag.document_intelligence_model',
@@ -646,6 +647,7 @@ async def get_rag_config(request: Request, user=Depends(get_admin_user)):
         'DOCLING_SERVER_URL': config.DOCLING_SERVER_URL,
         'DOCLING_API_KEY': config.DOCLING_API_KEY,
         'DOCLING_PARAMS': config.DOCLING_PARAMS,
+        'DOCLING_SERVE_TIMEOUT': config.DOCLING_SERVE_TIMEOUT,
         'DOCUMENT_INTELLIGENCE_ENDPOINT': config.DOCUMENT_INTELLIGENCE_ENDPOINT,
         'DOCUMENT_INTELLIGENCE_KEY': config.DOCUMENT_INTELLIGENCE_KEY,
         'DOCUMENT_INTELLIGENCE_MODEL': config.DOCUMENT_INTELLIGENCE_MODEL,
@@ -878,6 +880,7 @@ class ConfigForm(BaseModel):
     DOCLING_SERVER_URL: str | None = None
     DOCLING_API_KEY: str | None = None
     DOCLING_PARAMS: dict | None = None
+    DOCLING_SERVE_TIMEOUT: int | None = None
     DOCUMENT_INTELLIGENCE_ENDPOINT: str | None = None
     DOCUMENT_INTELLIGENCE_KEY: str | None = None
     DOCUMENT_INTELLIGENCE_MODEL: str | None = None
@@ -1053,6 +1056,11 @@ async def update_rag_config(request: Request, form_data: ConfigForm, user=Depend
         form_data.DOCLING_API_KEY if form_data.DOCLING_API_KEY is not None else config.DOCLING_API_KEY
     )
     config.DOCLING_PARAMS = form_data.DOCLING_PARAMS if form_data.DOCLING_PARAMS is not None else config.DOCLING_PARAMS
+    config.DOCLING_SERVE_TIMEOUT = (
+        form_data.DOCLING_SERVE_TIMEOUT
+        if form_data.DOCLING_SERVE_TIMEOUT is not None
+        else config.DOCLING_SERVE_TIMEOUT
+    )
     config.DOCUMENT_INTELLIGENCE_ENDPOINT = (
         form_data.DOCUMENT_INTELLIGENCE_ENDPOINT
         if form_data.DOCUMENT_INTELLIGENCE_ENDPOINT is not None
@@ -1345,6 +1353,7 @@ async def update_rag_config(request: Request, form_data: ConfigForm, user=Depend
         'DOCLING_SERVER_URL': config.DOCLING_SERVER_URL,
         'DOCLING_API_KEY': config.DOCLING_API_KEY,
         'DOCLING_PARAMS': config.DOCLING_PARAMS,
+        'DOCLING_SERVE_TIMEOUT': config.DOCLING_SERVE_TIMEOUT,
         'DOCUMENT_INTELLIGENCE_ENDPOINT': config.DOCUMENT_INTELLIGENCE_ENDPOINT,
         'DOCUMENT_INTELLIGENCE_KEY': config.DOCUMENT_INTELLIGENCE_KEY,
         'DOCUMENT_INTELLIGENCE_MODEL': config.DOCUMENT_INTELLIGENCE_MODEL,

--- a/src/lib/components/admin/Settings/Documents.svelte
+++ b/src/lib/components/admin/Settings/Documents.svelte
@@ -169,7 +169,7 @@
 			toast.error($i18n.t('Tika Server URL required.'));
 			return;
 		}
-		if (RAGConfig.CONTENT_EXTRACTION_ENGINE === 'docling' && RAGConfig.DOCLING_SERVER_URL === '') {
+		if ((RAGConfig.CONTENT_EXTRACTION_ENGINE === 'docling' || RAGConfig.CONTENT_EXTRACTION_ENGINE === 'docling_json') && RAGConfig.DOCLING_SERVER_URL === '') {
 			toast.error($i18n.t('Docling Server URL required.'));
 			return;
 		}
@@ -394,6 +394,7 @@
 									<option value="external">{$i18n.t('External')}</option>
 									<option value="tika">{$i18n.t('Tika')}</option>
 									<option value="docling">{$i18n.t('Docling')}</option>
+									<option value="docling_json">{$i18n.t('Docling (JSON)')}</option>
 									<option value="datalab_marker">{$i18n.t('Datalab Marker API')}</option>
 									<option value="document_intelligence">{$i18n.t('Document Intelligence')}</option>
 									<option value="mistral_ocr">{$i18n.t('Mistral OCR')}</option>
@@ -693,7 +694,7 @@
 									/>
 								</div>
 							</div>
-						{:else if RAGConfig.CONTENT_EXTRACTION_ENGINE === 'docling'}
+						{:else if RAGConfig.CONTENT_EXTRACTION_ENGINE === 'docling' || RAGConfig.CONTENT_EXTRACTION_ENGINE === 'docling_json'}
 							<div class="my-0.5 flex gap-2 pr-2">
 								<input
 									class="flex-1 w-full text-sm bg-transparent outline-hidden"
@@ -721,6 +722,26 @@
 									</div>
 								</div>
 							</div>
+
+							{#if RAGConfig.CONTENT_EXTRACTION_ENGINE === 'docling_json'}
+								<div class="mb-2.5 flex flex-col w-full justify-between">
+									<div class="flex w-full justify-between mb-1">
+										<div class="self-center text-xs font-medium">
+											{$i18n.t('Chunk mode')}
+										</div>
+										<div class="">
+											<select
+												bind:value={RAGConfig.DOCLING_JSON_CHUNK_MODE}
+												class="w-fit pr-8 rounded-sm px-2 text-xs bg-transparent outline-hidden text-right"
+											>
+												<option value="chunk">{$i18n.t('Chunk')}</option>
+												<option value="page">{$i18n.t('Page')}</option>
+												<option value="item">{$i18n.t('Item')}</option>
+											</select>
+										</div>
+									</div>
+								</div>
+							{/if}
 						{:else if RAGConfig.CONTENT_EXTRACTION_ENGINE === 'document_intelligence'}
 							<div class="my-0.5 flex gap-2 pr-2">
 								<input

--- a/src/lib/components/workspace/Models/ModelEditor.svelte
+++ b/src/lib/components/workspace/Models/ModelEditor.svelte
@@ -296,9 +296,7 @@
 	};
 
 	onMount(async () => {
-		if (!$tools) {
-			await tools.set(await getTools(localStorage.token));
-		}
+		await tools.set((await getTools(localStorage.token).catch(() => null)) ?? []);
 		skillsList = (await getSkills(localStorage.token).catch(() => null)) ?? [];
 		if (!$functions) {
 			await functions.set(await getFunctions(localStorage.token));


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Closes #___` / `Relates to #___`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [ ] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.** ⚠️ See note below — this PR should actually target the `feat-docling-loader-async` branch/PR until that one merges.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [ ] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [ ] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **feat**: New features or enhancements

# Changelog Entry

### Description

The existing `docling` engine only ever gets Docling Serve's flattened markdown output, so the downstream text splitter chunks purely on raw character count — with no awareness of paragraph, heading, table, or list boundaries. Tables in particular get sliced apart arbitrarily, and there's no way to keep one chunk per structural unit (e.g. one chunk per section) for cleaner retrieval.

This PR adds a new `docling_json` extraction engine that requests Docling Serve's structured JSON document representation instead, and chunks it in a way that respects that structure. It's purely additive — the existing `docling` engine is completely untouched; `docling_json` is an opt-in alternative on admin selects in Settings → Documents.

**Stacking note for reviewers:** `DoclingLoaderJson` is a subclass of `DoclingLoader` and reuses its async submit/poll/retrieve/timeout machinery unchanged — it only overrides construction and result formatting. This PR is built on top of the (separately submitted) async `DoclingLoader` rework and can't be meaningfully reviewed or merged independently of it; **_it should target that PR's branch rather than `dev` until that one lands_**. Both are part of the same split of a previous, too-large PR (#26932) per [maintainer feedback](https://github.com/open-webui/open-webui/pull/26932#issuecomment-4925036925) — see the [linked discussion](https://github.com/open-webui/open-webui/discussions/26931) for the full picture. This PR does not touch the unrelated RAG pipeline improvements (citation extraction, JSON context format, etc.) also mentioned there — those remain a separate, later PR.

### Added

- New `docling_json` content-extraction engine, selectable in Settings → Documents alongside the existing engines.
- `DOCLING_JSON_CHUNK_MODE` setting (env var + RAG config API), three modes:
  - `item` — one Document per structural content item (finest granularity: one paragraph, heading, table, or list item per chunk)
  - `page` — one Document per page
  - `chunk` (default) — sliding-window chunks with overlap, preserving reading order across the whole document (sorted by page then spatial position, not raw JSON array order)
- Chunk-mode selector in the Settings → Documents UI, shown only when `docling_json` is selected.
- Rich per-chunk metadata where available: page number, bounding box, section-header depth, list markers/enumeration, hyperlinks, and document-level fields (filename, mimetype, source URI, content hash) pulled from the Docling JSON payload.

### Changed

- N/A (existing `docling` engine behavior is unchanged)

### Deprecated

- N/A

### Removed

- N/A

### Fixed

- `chunk_mode="chunk"` reads `CHUNK_SIZE` / `CHUNK_OVERLAP` / `TEXT_SPLITTER` / `TIKTOKEN_ENCODING_NAME` from the loader's kwargs, but those four keys were missing from `retrieval/utils.py`'s `LOADER_CONFIG_KEYS`, the dict that populates those kwargs from the admin's RAG config (`build_loader_from_config` → `Loader.__init__(**kwargs)`). Without them, chunk mode always fell back to its hardcoded defaults (1000 characters, 100 overlap, character-based) regardless of what the admin configured. Downstream, `save_docs_to_vector_db` re-splits every loader's output with the real config (`split=True`, unconditional for this call path) — but that stage can only shrink chunks further, not recover a larger `chunk_size` the admin configured but the loader never saw. Net effect: an admin with `CHUNK_SIZE` set above 1000, or `TEXT_SPLITTER=token`, would silently get smaller/misaligned chunks than requested whenever `chunk_mode="chunk"` was used. This PR adds the four missing `LOADER_CONFIG_KEYS` entries so chunk mode respects the configured settings end-to-end. No other loader reads these four kwargs, so the change has no effect outside `docling_json`.
- The "Chunk mode" selector in Settings → Documents is now scoped to only render when `docling_json` is selected; previously it would also show for the plain `docling` engine, where it has no effect.

### Security

- N/A

### Breaking Changes

- None. `docling_json` is a new, opt-in engine value; nothing about the existing `docling` engine or its settings changes.

---

### Additional Information

- Relates to discussion #26931.
- Part of the split of #26932 (closed for being too large for a first review pass).
- **Depends on** the async `DoclingLoader` rework PR ([submitted separately](https://github.com/open-webui/open-webui/pull/26947)) — `DoclingLoaderJson` subclasses `DoclingLoader` and needs its submit/poll/retrieve machinery to exist. Please review/merge that one first, or review this PR as a stack on top of it.
- Does not touch the unrelated RAG pipeline improvements (citations, `{{CONTEXT_JSON}}`, full-context fallback, native FC KB routing) — still on a separate, not-yet-submitted branch.
- No new third-party dependencies. `tiktoken` (used only for `chunk_content_type="token"`) is already a dependency of the existing chunking pipeline.

### Screenshots or Videos

- TODO before marking ready for review: add screenshots of the new engine option + chunk-mode selector in Settings → Documents, and a comparison of retrieved chunks for the same document under `item`, `page`, and `chunk` mode (ideally showing a table staying intact in `item` mode vs. getting split under plain `docling`).

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
