### PR TITLE
 Feat: [DRAFT] add DoclingLoaderJson as RAG-Provider, inheriting original DoclingLoader but keeps structural data of sources by using JSON-output from docling serve instead of flat markdown 

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -970,6 +970,8 @@ DOCLING_SERVE_TIMEOUT = (
     int(os.environ.get("DOCLING_SERVE_TIMEOUT")) if os.environ.get("DOCLING_SERVE_TIMEOUT") else None
 )
 
+DOCLING_JSON_CHUNK_MODE = os.environ.get("DOCLING_JSON_CHUNK_MODE", "chunk")
+
 RAG_FULL_CONTEXT = os.getenv('RAG_FULL_CONTEXT', 'False').lower() == 'true'
 
 RAG_FILE_MAX_COUNT = int(os.getenv('RAG_FILE_MAX_COUNT')) if os.getenv('RAG_FILE_MAX_COUNT') else None
@@ -2865,6 +2867,7 @@ DEFAULT_CONFIG = {
     'rag.docling_api_key': DOCLING_API_KEY,
     'rag.docling_params': DOCLING_PARAMS,
     'rag.docling_serve_timeout': DOCLING_SERVE_TIMEOUT,
+    'rag.DOCLING_JSON_CHUNK_MODE': DOCLING_JSON_CHUNK_MODE,
     'rag.document_intelligence_endpoint': DOCUMENT_INTELLIGENCE_ENDPOINT,
     'rag.document_intelligence_key': DOCUMENT_INTELLIGENCE_KEY,
     'rag.document_intelligence_model': DOCUMENT_INTELLIGENCE_MODEL,

--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -966,6 +966,10 @@ ENABLE_RAG_HYBRID_SEARCH_ENRICHED_TEXTS = (
     os.getenv('ENABLE_RAG_HYBRID_SEARCH_ENRICHED_TEXTS', 'False').lower() == 'true'
 )
 
+DOCLING_SERVE_TIMEOUT = (
+    int(os.environ.get("DOCLING_SERVE_TIMEOUT")) if os.environ.get("DOCLING_SERVE_TIMEOUT") else None
+)
+
 RAG_FULL_CONTEXT = os.getenv('RAG_FULL_CONTEXT', 'False').lower() == 'true'
 
 RAG_FILE_MAX_COUNT = int(os.getenv('RAG_FILE_MAX_COUNT')) if os.getenv('RAG_FILE_MAX_COUNT') else None
@@ -2860,6 +2864,7 @@ DEFAULT_CONFIG = {
     'rag.docling_server_url': DOCLING_SERVER_URL,
     'rag.docling_api_key': DOCLING_API_KEY,
     'rag.docling_params': DOCLING_PARAMS,
+    'rag.docling_serve_timeout': DOCLING_SERVE_TIMEOUT,
     'rag.document_intelligence_endpoint': DOCUMENT_INTELLIGENCE_ENDPOINT,
     'rag.document_intelligence_key': DOCUMENT_INTELLIGENCE_KEY,
     'rag.document_intelligence_model': DOCUMENT_INTELLIGENCE_MODEL,

--- a/backend/open_webui/retrieval/loaders/docling_json.py
+++ b/backend/open_webui/retrieval/loaders/docling_json.py
@@ -1,0 +1,331 @@
+import logging
+import re
+
+from langchain_core.documents import Document
+
+from open_webui.retrieval.loaders.main import DoclingLoader
+
+log = logging.getLogger(__name__)
+
+
+class DoclingLoaderJson(DoclingLoader):
+    """Return the Docling JSON document payload split into vector-DB-friendly Documents.
+
+    chunk_mode controls how the structured content is split:
+      "item"  - one Document per Docling content item (finest granularity)
+      "page"  - one Document per page
+      "chunk" - sliding-window chunks with overlap (default)
+
+    For "chunk" mode chunk_size and chunk_overlap are measured in the unit set by
+    chunk_content_type: "character" (default) counts Unicode characters; "token" counts
+    tiktoken subword tokens.  Both are absolute values, not fractions.
+    The page number of every Document is taken from the first content item that
+    falls into that chunk / page / item.
+    """
+
+    def __init__(
+        self,
+        *args,
+        chunk_mode: str = "chunk",
+        chunk_size: int = 1000,
+        chunk_overlap: int = 100,
+        chunk_content_type: str = "character",
+        tiktoken_encoding_name: str = "cl100k_base",
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        self.chunk_mode = chunk_mode
+        self.chunk_size = chunk_size
+        self.chunk_overlap = chunk_overlap
+        self.chunk_content_type = chunk_content_type
+        # Initialise tiktoken encoder if the unit is "token".
+        self._enc = None
+        if self.chunk_content_type == "token":
+            try:
+                import tiktoken
+                self._enc = tiktoken.get_encoding(tiktoken_encoding_name)
+            except Exception as exc:
+                log.warning(
+                    "tiktoken unavailable (%s); falling back to character-based chunking", exc
+                )
+                self.chunk_content_type = "character"
+        to_formats = list(self.params.get("to_formats") or ["md"])
+        if "json" not in to_formats:
+            to_formats.append("json")
+        self.params = {**self.params, "to_formats": to_formats}
+
+    def _word_sizes(self, words: list[str]) -> list[int]:
+        """Return the size of each word-token in the configured unit.
+
+        "character" (default): number of Unicode characters.
+        "token"               : tiktoken subword token count (approximate per word).
+        """
+        if self.chunk_content_type == "token" and self._enc is not None:
+            return [len(self._enc.encode(w)) for w in words]
+        return [len(w) for w in words]
+
+    def _extract_ordered_items(self, document_data: dict) -> list[dict]:
+        """Return all content items sorted by page then spatial position (top→bottom, left→right).
+
+        Each entry: {"text": str, "label": str, "page_no": int, "bbox": tuple|None}
+        Items without any prov entry containing a page_no are omitted.
+        """
+        json_content = document_data.get("json_content") or document_data.get("json") or {}
+
+        items_out = []
+        for name in ("texts", "tables", "pictures", "key_value_items"):
+            cand = document_data.get(name) or (
+                json_content.get(name) if isinstance(json_content, dict) else None
+            )
+            if not isinstance(cand, list):
+                continue
+            for it in cand:
+                text = it.get("text") or it.get("orig") or ""
+                label = it.get("label") or ""
+                for prov_entry in it.get("prov") or []:
+                    if not isinstance(prov_entry, dict):
+                        continue
+                    pno = prov_entry.get("page_no")
+                    if not isinstance(pno, int):
+                        continue
+                    bbox = None
+                    b = prov_entry.get("bbox")
+                    if isinstance(b, dict):
+                        try:
+                            bbox = (
+                                float(b.get("l", 0)),
+                                float(b.get("t", 0)),
+                                float(b.get("r", 0)),
+                                float(b.get("b", 0)),
+                            )
+                        except Exception:
+                            bbox = None
+                    items_out.append(
+                        {
+                            "text": text,
+                            "label": label,
+                            "page_no": pno,
+                            "bbox": bbox,
+                            "level": it.get("level"),          # section_header depth
+                            "marker": it.get("marker"),        # list_item bullet/number
+                            "enumerated": it.get("enumerated"),# list_item ordered flag
+                            "hyperlink": it.get("hyperlink"),  # hyperlink target if any
+                        }
+                    )
+                    break  # first valid prov entry is sufficient for sorting/metadata
+
+        def _sort_key(entry):
+            b = entry["bbox"]
+            if b:
+                cy = (b[1] + b[3]) / 2.0
+                cx = (b[0] + b[2]) / 2.0
+                return (entry["page_no"], -cy, cx)  # -cy: PDF y-axis goes upward
+            return (entry["page_no"], 0.0, 0.0)
+
+        items_out.sort(key=_sort_key)
+        return items_out
+
+    def _extract_doc_metadata(self, document_data: dict) -> dict:
+        """Extract document-level fields shared by every point produced from this document.
+
+        These are stored per-point because the vector DB has no collection-level
+        metadata store — all filterable/retrievable fields must live on each point.
+
+        origin and name live inside json_content (the DoclingDocument), not at the
+        outer ExportDocumentResponse level.
+        """
+        jc = document_data.get("json_content") or document_data.get("json") or {}
+        if not isinstance(jc, dict):
+            jc = {}
+        origin = jc.get("origin") or {}
+        meta: dict = {"Content-Type": "application/json"}
+        if origin.get("filename"):
+            meta["filename"] = origin["filename"]
+        if origin.get("mimetype"):
+            meta["source_mimetype"] = origin["mimetype"]
+        if origin.get("uri"):
+            meta["source_uri"] = origin["uri"]
+        if origin.get("binary_hash") is not None:
+            meta["binary_hash"] = str(origin["binary_hash"])
+        name = jc.get("name") or document_data.get("name")
+        if name:
+            meta["document_name"] = name
+        return meta
+
+    def _format_item_mode(self, document_data: dict) -> list[Document]:
+        """One Document per Docling content item."""
+        items = self._extract_ordered_items(document_data)
+        doc_meta = self._extract_doc_metadata(document_data)
+        docs = []
+        for it in items:
+            text = it["text"]
+            if not text:
+                continue
+            metadata = {
+                **doc_meta,
+                "docling_document": document_data,
+                "page": it["page_no"],
+                "label": it["label"],
+                "chunk_mode": "item",
+            }
+            if it["bbox"]:
+                metadata["bbox"] = it["bbox"]
+            if it.get("level") is not None:
+                metadata["level"] = it["level"]
+            if it.get("marker"):
+                metadata["marker"] = it["marker"]
+            if it.get("enumerated") is not None:
+                metadata["enumerated"] = it["enumerated"]
+            if it.get("hyperlink"):
+                metadata["hyperlink"] = it["hyperlink"]
+            docs.append(Document(page_content=text, metadata=metadata))
+        log.debug("Docling JSON item-mode produced %d documents", len(docs))
+        return docs
+
+    def _format_page_mode(self, document_data: dict) -> list[Document]:
+        """One Document per page, all items on that page joined with newlines."""
+        items = self._extract_ordered_items(document_data)
+        doc_meta = self._extract_doc_metadata(document_data)
+        jc = document_data.get("json_content") or document_data.get("json") or {}
+        pages_map = (jc.get("pages") if isinstance(jc, dict) else None) or {}
+        pages: dict[int, list[str]] = {}
+        for it in items:
+            text = it["text"]
+            if not text:
+                continue
+            pages.setdefault(it["page_no"], []).append(text)
+        docs = []
+        for pno in sorted(pages.keys()):
+            page_text = "\n".join(pages[pno])
+            metadata = {
+                **doc_meta,
+                "docling_document": document_data,
+                "page": pno,
+                "chunk_mode": "page",
+            }
+            page_info = pages_map.get(str(pno)) or {}
+            if isinstance(page_info, dict):
+                # DoclingDocument serialises page size as {"size": {"width": …, "height": …}}
+                size = page_info.get("size") or {}
+                if size.get("width") is not None:
+                    metadata["page_width"] = size["width"]
+                if size.get("height") is not None:
+                    metadata["page_height"] = size["height"]
+            docs.append(Document(page_content=page_text, metadata=metadata))
+        log.debug("Docling JSON page-mode produced %d documents", len(docs))
+        return docs
+
+    def _format_chunk_mode(self, document_data: dict) -> list[Document]:
+        """Sliding-window chunks measured in the configured unit (characters or tiktoken tokens).
+
+        Internally the text is tokenised word-by-word to preserve all whitespace and
+        newlines. The window boundaries are determined by the cumulative size of those
+        word-tokens in the requested unit so the assembled chunk text is lossless.
+
+        chunk_size    – maximum chunk size in the configured unit.
+        chunk_overlap – how many units of overlap to keep between consecutive chunks
+                        (absolute, same unit as chunk_size).
+        """
+        items = self._extract_ordered_items(document_data)
+        doc_meta = self._extract_doc_metadata(document_data)
+
+        # Build a flat list of word-tokens and a parallel list of their page numbers.
+        words: list[str] = []
+        word_pages: list[int] = []
+        for it in items:
+            text = it["text"]
+            if not text:
+                continue
+            text = text.replace('\r\n', '\n').replace('\r', '\n')
+            # Each whitespace run and each non-whitespace run becomes one token so
+            # that joining with "".join() reconstructs the original text exactly.
+            item_words = re.findall(r'\n|[ \t]+|[^\s]+', text)
+            words.extend(item_words)
+            word_pages.extend([it["page_no"]] * len(item_words))
+
+        if not words:
+            document_text = document_data.get("md_content") or document_data.get("text") or ""
+            return [
+                Document(
+                    page_content=document_text,
+                    metadata={**doc_meta, "docling_document": document_data},
+                )
+            ]
+
+        # Per-word sizes in the configured unit.
+        sizes = self._word_sizes(words)
+
+        chunk_size = max(1, self.chunk_size)
+        chunk_overlap = max(0, min(self.chunk_overlap, chunk_size - 1))
+        step_size = max(1, chunk_size - chunk_overlap)
+
+        n = len(words)
+        docs = []
+        start_idx = 0
+
+        while start_idx < n:
+            # Collect words until chunk_size units are accumulated.
+            acc = 0
+            end_idx = start_idx
+            while end_idx < n:
+                acc += sizes[end_idx]
+                end_idx += 1
+                if acc >= chunk_size:
+                    break
+
+            chunk_text = "".join(words[start_idx:end_idx])
+            page_no = word_pages[start_idx]
+            metadata = {
+                **doc_meta,
+                "docling_document": document_data,
+                "page": page_no,
+                "chunk_mode": "chunk",
+                "chunk_start_word": start_idx,
+                "chunk_end_word": end_idx,
+            }
+            docs.append(Document(page_content=chunk_text, metadata=metadata))
+
+            if end_idx >= n:
+                break
+
+            # Advance by step_size units from the current start.
+            adv = 0
+            new_start = start_idx
+            while new_start < end_idx:
+                adv += sizes[new_start]
+                new_start += 1
+                if adv >= step_size:
+                    break
+            # Guard: always advance by at least one word to prevent infinite loops.
+            if new_start <= start_idx:
+                new_start = start_idx + 1
+            start_idx = new_start
+
+        log.debug(
+            "Docling JSON chunk-mode produced %d documents "
+            "(chunk_size=%d %s, chunk_overlap=%d %s)",
+            len(docs),
+            chunk_size,
+            self.chunk_content_type,
+            chunk_overlap,
+            self.chunk_content_type,
+        )
+        return docs
+
+    def format_result(self, result_json: dict) -> list[Document]:
+        document_data = result_json.get("document", {})
+        json_content = document_data.get("json_content") or document_data.get("json")
+
+        if isinstance(json_content, dict) and isinstance(json_content.get("pages"), dict):
+            if self.chunk_mode == "item":
+                return self._format_item_mode(document_data)
+            elif self.chunk_mode == "page":
+                return self._format_page_mode(document_data)
+            else:  # "chunk" is the default
+                return self._format_chunk_mode(document_data)
+
+        # Fallback: structured JSON not available, return raw markdown/text.
+        document_text = document_data.get("md_content") or document_data.get("text") or ""
+        metadata = {"Content-Type": "application/json", "docling_document": document_data}
+        log.debug("Docling JSON result extracted (fallback): keys=%s", list(document_data.keys()))
+        return [Document(page_content=document_text, metadata=metadata)]

--- a/backend/open_webui/retrieval/loaders/docling_json.py
+++ b/backend/open_webui/retrieval/loaders/docling_json.py
@@ -64,11 +64,50 @@ class DoclingLoaderJson(DoclingLoader):
             return [len(self._enc.encode(w)) for w in words]
         return [len(w) for w in words]
 
+    def _render_table_markdown(self, it: dict) -> str:
+        """Render a Docling TableItem as a GitHub-flavored markdown table.
+
+        TableItem has no "text"/"orig" field at all -- cell content lives in
+        data.table_cells (row/col offsets + text), so without this the table's
+        content is silently dropped (the caller's `if not text: continue` guard
+        would skip it, since it.get("text") is always None for tables).
+
+        Merged cells (row_span/col_span > 1) are placed at their start offset only;
+        the remaining spanned cells stay empty. Row 0 is always treated as the
+        header row for markdown syntax validity, matching common table conventions.
+        """
+        data = it.get('data') or {}
+        num_rows = data.get('num_rows') or 0
+        num_cols = data.get('num_cols') or 0
+        cells = data.get('table_cells') or []
+        if not num_rows or not num_cols or not cells:
+            return ''
+
+        grid = [['' for _ in range(num_cols)] for _ in range(num_rows)]
+        for cell in cells:
+            text = (cell.get('text') or '').replace('\n', ' ').replace('|', '\\|').strip()
+            r = cell.get('start_row_offset_idx')
+            c = cell.get('start_col_offset_idx')
+            if isinstance(r, int) and isinstance(c, int) and 0 <= r < num_rows and 0 <= c < num_cols:
+                grid[r][c] = text
+
+        lines = ['| ' + ' | '.join(grid[0]) + ' |', '| ' + ' | '.join(['---'] * num_cols) + ' |']
+        for row in grid[1:]:
+            lines.append('| ' + ' | '.join(row) + ' |')
+        return '\n'.join(lines)
+
     def _extract_ordered_items(self, document_data: dict) -> list[dict]:
         """Return all content items sorted by page then spatial position (top→bottom, left→right).
 
         Each entry: {"text": str, "label": str, "page_no": int, "bbox": tuple|None}
         Items without any prov entry containing a page_no are omitted.
+
+        Headings and list items are rendered with markdown syntax (# prefix / bullet
+        or number marker) since Docling hands back their raw text unprefixed. Tables
+        are rendered as markdown tables from their cell data (see
+        _render_table_markdown). Furniture-layer items (repeated page headers/footers,
+        background, invisible/notes content) are excluded -- they aren't part of the
+        document's actual content and would otherwise repeat as noise on every page.
         """
         json_content = document_data.get("json_content") or document_data.get("json") or {}
 
@@ -80,8 +119,20 @@ class DoclingLoaderJson(DoclingLoader):
             if not isinstance(cand, list):
                 continue
             for it in cand:
-                text = it.get("text") or it.get("orig") or ""
+                if it.get('content_layer', 'body') != 'body':
+                    continue
                 label = it.get("label") or ""
+                if name == "tables":
+                    text = self._render_table_markdown(it)
+                else:
+                    text = it.get("text") or it.get("orig") or ""
+                    if text:
+                        if label == "section_header":
+                            level = it.get("level") or 1
+                            text = f"{'#' * max(1, level)} {text}"
+                        elif label == "list_item":
+                            marker = it.get("marker") or "-"
+                            text = f"{marker} {text}"
                 for prov_entry in it.get("prov") or []:
                     if not isinstance(prov_entry, dict):
                         continue

--- a/backend/open_webui/retrieval/loaders/docling_json.py
+++ b/backend/open_webui/retrieval/loaders/docling_json.py
@@ -163,7 +163,13 @@ class DoclingLoaderJson(DoclingLoader):
                 continue
             metadata = {
                 **doc_meta,
-                "docling_document": document_data,
+                # The full Docling document (json_content/md_content) is intentionally NOT
+                # attached here: item mode already exposes page/bbox/label/level/marker/etc.
+                # as flat fields below, so the full per-item blob would just duplicate the
+                # entire document's texts/tables/pictures/pages into every single chunk's
+                # Qdrant payload for no benefit (nothing in this codebase reads it back).
+                # Uncomment for local debugging only:
+                # "docling_document": document_data,
                 "page": it["page_no"],
                 "label": it["label"],
                 "chunk_mode": "item",
@@ -199,7 +205,9 @@ class DoclingLoaderJson(DoclingLoader):
             page_text = "\n".join(pages[pno])
             metadata = {
                 **doc_meta,
-                "docling_document": document_data,
+                # Full document (json_content/md_content) intentionally omitted — see the
+                # comment in _format_item_mode. Uncomment for local debugging only:
+                # "docling_document": document_data,
                 "page": pno,
                 "chunk_mode": "page",
             }
@@ -248,7 +256,9 @@ class DoclingLoaderJson(DoclingLoader):
             return [
                 Document(
                     page_content=document_text,
-                    metadata={**doc_meta, "docling_document": document_data},
+                    # Full document intentionally omitted — see _format_item_mode.
+                    # metadata={**doc_meta, "docling_document": document_data},
+                    metadata=doc_meta,
                 )
             ]
 
@@ -277,7 +287,9 @@ class DoclingLoaderJson(DoclingLoader):
             page_no = word_pages[start_idx]
             metadata = {
                 **doc_meta,
-                "docling_document": document_data,
+                # Full document intentionally omitted — see the comment in
+                # _format_item_mode. Uncomment for local debugging only:
+                # "docling_document": document_data,
                 "page": page_no,
                 "chunk_mode": "chunk",
                 "chunk_start_word": start_idx,
@@ -326,6 +338,10 @@ class DoclingLoaderJson(DoclingLoader):
 
         # Fallback: structured JSON not available, return raw markdown/text.
         document_text = document_data.get("md_content") or document_data.get("text") or ""
-        metadata = {"Content-Type": "application/json", "docling_document": document_data}
+        # Full document intentionally omitted here too — document_text above already IS
+        # md_content, so attaching document_data again would duplicate it plus json_content
+        # into metadata for no benefit. Uncomment for local debugging only:
+        # metadata = {"Content-Type": "application/json", "docling_document": document_data}
+        metadata = {"Content-Type": "application/json"}
         log.debug("Docling JSON result extracted (fallback): keys=%s", list(document_data.keys()))
         return [Document(page_content=document_text, metadata=metadata)]

--- a/backend/open_webui/retrieval/loaders/docling_json.py
+++ b/backend/open_webui/retrieval/loaders/docling_json.py
@@ -238,12 +238,22 @@ class DoclingLoaderJson(DoclingLoader):
         doc_meta = self._extract_doc_metadata(document_data)
 
         # Build a flat list of word-tokens and a parallel list of their page numbers.
+        #
+        # Docling hands back each structural item (heading, paragraph, list item, ...)
+        # already stripped of leading/trailing whitespace -- it's structural output, not
+        # flat markdown. Concatenating items back-to-back with nothing in between glues
+        # e.g. a heading directly onto the next paragraph ("HeadingParagraph text...").
+        # Insert an explicit paragraph-break token between items to keep the
+        # reconstructed text readable.
         words: list[str] = []
         word_pages: list[int] = []
         for it in items:
             text = it["text"]
             if not text:
                 continue
+            if words:
+                words.append('\n\n')
+                word_pages.append(it["page_no"])
             text = text.replace('\r\n', '\n').replace('\r', '\n')
             # Each whitespace run and each non-whitespace run becomes one token so
             # that joining with "".join() reconstructs the original text exactly.

--- a/backend/open_webui/retrieval/loaders/main.py
+++ b/backend/open_webui/retrieval/loaders/main.py
@@ -1,8 +1,11 @@
 import asyncio
+import inspect
 import json
 import logging
 import sys
+import time
 
+import aiohttp
 import ftfy
 import requests
 from azure.identity import DefaultAzureCredential
@@ -179,23 +182,60 @@ class TikaLoader:
 
 
 class DoclingLoader:
-    def __init__(self, url, api_key=None, file_path=None, mime_type=None, params=None):
+    """
+    Docling Serve loader with both sync and async support.
+
+    Loads documents by submitting them to Docling Serve's async API
+    (submit → long-poll for status → retrieve), so large/scanned PDFs don't
+    block indefinitely on a single request.
+
+    - `load()` / `load_from_task_id()`: synchronous, using `requests` + `time.sleep()`
+      between polls. Used by callers that already run off the event loop
+      (e.g. the sync URL-content-extraction path), where blocking a thread
+      for the poll duration is expected and harmless.
+    - `aload()` / `aload_from_task_id()`: asynchronous, using `aiohttp` +
+      `await asyncio.sleep()` between polls. Used by the interactive file-upload
+      path so a slow Docling conversion doesn't occupy a worker thread from the
+      shared `asyncio.to_thread` pool for its entire duration.
+    """
+
+    def __init__(
+        self, url, api_key=None, file_path=None, mime_type=None, params=None, timeout=None, status_callback=None
+    ):
         self.url = url.rstrip('/')
         self.api_key = api_key
         self.file_path = file_path
         self.mime_type = mime_type
-
         self.params = params or {}
+        self.timeout = timeout  # total seconds to wait; None = infinite
+        self.status_callback = status_callback  # optional callable(dict) to persist queue state
 
-    def load(self) -> list[Document]:
+    def _build_headers(self) -> dict:
+        headers = {}
+        if self.api_key:
+            headers['X-Api-Key'] = f'{self.api_key}'
+        return headers
+
+    async def _notify_status_async(self, data: dict) -> None:
+        """Invoke status_callback from async code, awaiting it if it's a coroutine function.
+
+        A caller running inside the event loop (like the file-upload path) may
+        reasonably supply an async callback (e.g. one that persists to the DB
+        with `await`). Calling it as a plain function would silently produce an
+        unawaited coroutine that never runs, so this checks and awaits it.
+        """
+        if not self.status_callback:
+            return
+        result = self.status_callback(data)
+        if inspect.isawaitable(result):
+            await result
+
+    def _submit_file(self) -> tuple[str, int | None]:
+        headers = self._build_headers()
         page_break_marker = '\f'
         with open(self.file_path, 'rb') as f:
-            headers = {}
-            if self.api_key:
-                headers['X-Api-Key'] = f'{self.api_key}'
-
             r = requests.post(
-                f'{self.url}/v1/convert/file',
+                f'{self.url}/v1/convert/file/async',
                 files={
                     'files': (
                         self.file_path,
@@ -213,27 +253,10 @@ class DoclingLoader:
                 },
                 headers=headers,
                 verify=AIOHTTP_CLIENT_SESSION_SSL,
+                timeout=30,
             )
-        if r.ok:
-            result = r.json()
-            document_data = result.get('document', {})
-            md_content = document_data.get('md_content', '')
-            text = md_content or '<No text content found>'
 
-            metadata = {'Content-Type': self.mime_type} if self.mime_type else {}
-            if page_break_marker in md_content:
-                documents = [
-                    Document(page_content=page.strip(), metadata={**metadata, 'page': page_idx})
-                    for page_idx, page in enumerate(md_content.split(page_break_marker))
-                    if page.strip()
-                ]
-                if documents:
-                    log.debug('Docling extracted text: %s', text)
-                    return documents
-
-            log.debug('Docling extracted text: %s', text)
-            return [Document(page_content=text, metadata=metadata)]
-        else:
+        if not r.ok:
             error_msg = f'Error calling Docling API: {r.reason}'
             if r.text:
                 try:
@@ -243,6 +266,235 @@ class DoclingLoader:
                 except Exception:
                     error_msg += f' - {r.text}'
             raise Exception(f'Error calling Docling: {error_msg}')
+
+        submit_data = r.json()
+        task_id = submit_data.get('task_id')
+        task_position = submit_data.get('task_position')
+        if not task_id:
+            raise Exception('Docling async submit did not return a task_id')
+        log.info(
+            'Docling task submitted: %s, queue position: %s',
+            task_id,
+            task_position,
+        )
+        if self.status_callback:
+            self.status_callback({'task_id': task_id, 'task_position': task_position})
+
+        return task_id, task_position
+
+    def _poll_task_until_done(self, task_id: str) -> dict:
+        headers = self._build_headers()
+        deadline = time.monotonic() + self.timeout if self.timeout is not None else None
+        poll_wait = 30  # long-poll window per request (seconds)
+
+        while True:
+            if deadline is not None:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise Exception(f'Docling conversion timed out after {self.timeout}s (task_id={task_id})')
+                poll_wait = min(poll_wait, int(remaining) + 1)
+
+            poll_start = time.monotonic()
+            try:
+                status_r = requests.get(
+                    f'{self.url}/v1/status/poll/{task_id}',
+                    params={'wait': poll_wait},
+                    headers=headers,
+                    timeout=poll_wait + 10,
+                )
+            except requests.Timeout:
+                log.warning('Docling status poll timed out for task %s, retrying', task_id)
+                elapsed = time.monotonic() - poll_start
+                if elapsed < poll_wait:
+                    time.sleep(poll_wait - elapsed)
+                continue
+
+            if not status_r.ok:
+                raise Exception(f'Error polling Docling task status: {status_r.reason}')
+
+            status_data = status_r.json()
+            task_status = status_data.get('task_status', '')
+            log.debug(
+                'Docling task %s: status=%s, queue_position=%s',
+                task_id,
+                task_status,
+                status_data.get('task_position'),
+            )
+            if self.status_callback and status_data.get('task_position') is not None:
+                self.status_callback({'task_position': status_data['task_position']})
+
+            if task_status == 'success':
+                return status_data
+            elif task_status == 'failure':
+                error_msg = status_data.get('error_message') or 'Unknown error'
+                raise Exception(f'Docling conversion failed: {error_msg}')
+            # else "pending" or "started" – keep polling
+
+            elapsed = time.monotonic() - poll_start
+            if elapsed < poll_wait:
+                time.sleep(poll_wait - elapsed)
+
+    def _retrieve_result(self, task_id: str) -> dict:
+        headers = self._build_headers()
+        result_r = requests.get(f'{self.url}/v1/result/{task_id}', headers=headers, timeout=30)
+        if not result_r.ok:
+            raise Exception(f'Error retrieving Docling result: {result_r.reason}')
+        return result_r.json()
+
+    def format_result(self, result_json: dict) -> list[Document]:
+        document_data = result_json.get('document', {})
+        text = document_data.get('md_content', '<No text content found>')
+        metadata = {'Content-Type': self.mime_type} if self.mime_type else {}
+        log.debug('Docling extracted text: %s', text)
+        return [Document(page_content=text, metadata=metadata)]
+
+    def load(self) -> list[Document]:
+        task_id, _ = self._submit_file()
+        self._poll_task_until_done(task_id)
+        result_json = self._retrieve_result(task_id)
+        return self.format_result(result_json)
+
+    def load_from_task_id(self, task_id: str) -> list[Document]:
+        """Resume processing from an already-submitted docling task_id.
+
+        Used on server restart when docling-serve is still running the task:
+        skips re-submission and goes straight to polling → retrieve → format.
+        """
+        self._poll_task_until_done(task_id)
+        result_json = self._retrieve_result(task_id)
+        return self.format_result(result_json)
+
+    async def _submit_file_async(self, session: aiohttp.ClientSession) -> tuple[str, int | None]:
+        headers = self._build_headers()
+        page_break_marker = '\f'
+
+        with open(self.file_path, 'rb') as f:
+            writer = aiohttp.MultipartWriter('form-data')
+
+            file_part = writer.append(f, {'Content-Type': self.mime_type or 'application/octet-stream'})
+            file_part.set_content_disposition('form-data', name='files', filename=self.file_path)
+
+            for field_name, value in {
+                'image_export_mode': 'placeholder',
+                'md_page_break_placeholder': page_break_marker,
+                **self.params,
+            }.items():
+                part = writer.append(str(value))
+                part.set_content_disposition('form-data', name=field_name)
+
+            async with session.post(
+                f'{self.url}/v1/convert/file/async',
+                data=writer,
+                headers=headers,
+                ssl=AIOHTTP_CLIENT_SESSION_SSL,
+                timeout=aiohttp.ClientTimeout(total=30),
+            ) as r:
+                if r.status >= 400:
+                    error_msg = f'Error calling Docling API: {r.reason}'
+                    text = await r.text()
+                    if text:
+                        try:
+                            error_data = json.loads(text)
+                            if 'detail' in error_data:
+                                error_msg += f' - {error_data["detail"]}'
+                        except Exception:
+                            error_msg += f' - {text}'
+                    raise Exception(f'Error calling Docling: {error_msg}')
+
+                submit_data = await r.json()
+
+        task_id = submit_data.get('task_id')
+        task_position = submit_data.get('task_position')
+        if not task_id:
+            raise Exception('Docling async submit did not return a task_id')
+        log.info(
+            'Docling task submitted: %s, queue position: %s',
+            task_id,
+            task_position,
+        )
+        await self._notify_status_async({'task_id': task_id, 'task_position': task_position})
+
+        return task_id, task_position
+
+    async def _poll_task_until_done_async(self, session: aiohttp.ClientSession, task_id: str) -> dict:
+        headers = self._build_headers()
+        deadline = time.monotonic() + self.timeout if self.timeout is not None else None
+        poll_wait = 30  # long-poll window per request (seconds)
+
+        while True:
+            if deadline is not None:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise Exception(f'Docling conversion timed out after {self.timeout}s (task_id={task_id})')
+                poll_wait = min(poll_wait, int(remaining) + 1)
+
+            poll_start = time.monotonic()
+            try:
+                async with session.get(
+                    f'{self.url}/v1/status/poll/{task_id}',
+                    params={'wait': poll_wait},
+                    headers=headers,
+                    ssl=AIOHTTP_CLIENT_SESSION_SSL,
+                    timeout=aiohttp.ClientTimeout(total=poll_wait + 10),
+                ) as status_r:
+                    if status_r.status >= 400:
+                        raise Exception(f'Error polling Docling task status: {status_r.reason}')
+                    status_data = await status_r.json()
+            except asyncio.TimeoutError:
+                log.warning('Docling status poll timed out for task %s, retrying', task_id)
+                elapsed = time.monotonic() - poll_start
+                if elapsed < poll_wait:
+                    await asyncio.sleep(poll_wait - elapsed)
+                continue
+
+            task_status = status_data.get('task_status', '')
+            log.debug(
+                'Docling task %s: status=%s, queue_position=%s',
+                task_id,
+                task_status,
+                status_data.get('task_position'),
+            )
+            if status_data.get('task_position') is not None:
+                await self._notify_status_async({'task_position': status_data['task_position']})
+
+            if task_status == 'success':
+                return status_data
+            elif task_status == 'failure':
+                error_msg = status_data.get('error_message') or 'Unknown error'
+                raise Exception(f'Docling conversion failed: {error_msg}')
+            # else "pending" or "started" – keep polling
+
+            elapsed = time.monotonic() - poll_start
+            if elapsed < poll_wait:
+                await asyncio.sleep(poll_wait - elapsed)
+
+    async def _retrieve_result_async(self, session: aiohttp.ClientSession, task_id: str) -> dict:
+        headers = self._build_headers()
+        async with session.get(
+            f'{self.url}/v1/result/{task_id}',
+            headers=headers,
+            ssl=AIOHTTP_CLIENT_SESSION_SSL,
+            timeout=aiohttp.ClientTimeout(total=30),
+        ) as result_r:
+            if result_r.status >= 400:
+                raise Exception(f'Error retrieving Docling result: {result_r.reason}')
+            return await result_r.json()
+
+    async def aload(self) -> list[Document]:
+        async with aiohttp.ClientSession() as session:
+            task_id, _ = await self._submit_file_async(session)
+            await self._poll_task_until_done_async(session, task_id)
+            result_json = await self._retrieve_result_async(session, task_id)
+        return self.format_result(result_json)
+
+    async def aload_from_task_id(self, task_id: str) -> list[Document]:
+        """Async counterpart to `load_from_task_id`: resumes polling and result
+        retrieval for an already-submitted task_id without re-uploading the file.
+        """
+        async with aiohttp.ClientSession() as session:
+            await self._poll_task_until_done_async(session, task_id)
+            result_json = await self._retrieve_result_async(session, task_id)
+        return self.format_result(result_json)
 
 
 class Loader:
@@ -262,11 +514,16 @@ class Loader:
         """
         Async wrapper around `load`.
 
-        Document loaders dispatched by `_get_loader` (PyMuPDF, Unstructured,
+        Most loaders dispatched by `_get_loader` (PyMuPDF, Unstructured,
         python-docx, Tika, etc.) are uniformly synchronous and CPU/IO-bound.
         Calling `load` directly from an async handler would block the event
         loop for the entire parse — minutes for large PDFs. This offloads
         the work to a worker thread so the loop stays responsive.
+
+        `DoclingLoader` is the exception: it has a true async path (`aload`)
+        that uses aiohttp + `asyncio.sleep` for its submit/poll/retrieve cycle,
+        so a slow conversion never ties up a worker thread from the shared
+        `asyncio.to_thread` pool for its entire duration.
         """
         # Group lookup is async-only, so it must happen before `load`
         # is offloaded to a thread without a running event loop.
@@ -275,7 +532,14 @@ class Loader:
                 self.kwargs.get('EXTERNAL_DOCUMENT_LOADER_HEADERS'), self.user
             )
 
-        return await asyncio.to_thread(self.load, filename, file_content_type, file_path)
+        loader = await asyncio.to_thread(self._get_loader, filename, file_content_type, file_path)
+
+        if isinstance(loader, DoclingLoader):
+            docs = await loader.aload()
+        else:
+            docs = await asyncio.to_thread(loader.load)
+
+        return [Document(page_content=ftfy.fix_text(doc.page_content), metadata=doc.metadata) for doc in docs]
 
     def _is_text_file(self, file_ext: str, file_content_type: str) -> bool:
         return file_ext in known_source_ext or (
@@ -513,12 +777,21 @@ class Loader:
                         log.error('Invalid DOCLING_PARAMS format, expected JSON object')
                         params = {}
 
+                docling_timeout = self.kwargs.get('DOCLING_SERVE_TIMEOUT')
+                if docling_timeout is not None:
+                    try:
+                        docling_timeout = int(docling_timeout)
+                    except (ValueError, TypeError):
+                        docling_timeout = None
+
                 loader = DoclingLoader(
                     url=self.kwargs.get('DOCLING_SERVER_URL'),
                     api_key=self.kwargs.get('DOCLING_API_KEY', None),
                     file_path=file_path,
                     mime_type=file_content_type,
                     params=params,
+                    timeout=docling_timeout,
+                    status_callback=self.kwargs.get('DOCLING_STATUS_CALLBACK'),
                 )
         elif (
             self.engine == 'document_intelligence'

--- a/backend/open_webui/retrieval/loaders/main.py
+++ b/backend/open_webui/retrieval/loaders/main.py
@@ -14,6 +14,7 @@ from langchain_community.document_loaders import (
     BSHTMLLoader,
     CSVLoader,
     Docx2txtLoader,
+    OutlookMessageLoader,
     PyPDFLoader,
     TextLoader,
     YoutubeLoader,
@@ -26,10 +27,11 @@ from open_webui.env import (
     REQUESTS_VERIFY,
 )
 from open_webui.retrieval.loaders.datalab_marker import DatalabMarkerLoader
+from open_webui.retrieval.loaders.docling_json import DoclingLoaderJson
 from open_webui.retrieval.loaders.external_document import ExternalDocumentLoader
 from open_webui.retrieval.loaders.mineru import MinerULoader
 from open_webui.retrieval.loaders.mistral import MistralLoader
-from open_webui.retrieval.loaders.paddleocr_vl import PADDLEOCR_VL_SUPPORTED_EXTENSIONS, PaddleOCRVLLoader
+from open_webui.retrieval.loaders.paddleocr_vl import PaddleOCRVLLoader
 from open_webui.utils.headers import get_user_groups_for_custom_headers
 
 logging.basicConfig(stream=sys.stdout, level=GLOBAL_LOG_LEVEL)
@@ -182,26 +184,7 @@ class TikaLoader:
 
 
 class DoclingLoader:
-    """
-    Docling Serve loader with both sync and async support.
-
-    Loads documents by submitting them to Docling Serve's async API
-    (submit → long-poll for status → retrieve), so large/scanned PDFs don't
-    block indefinitely on a single request.
-
-    - `load()` / `load_from_task_id()`: synchronous, using `requests` + `time.sleep()`
-      between polls. Used by callers that already run off the event loop
-      (e.g. the sync URL-content-extraction path), where blocking a thread
-      for the poll duration is expected and harmless.
-    - `aload()` / `aload_from_task_id()`: asynchronous, using `aiohttp` +
-      `await asyncio.sleep()` between polls. Used by the interactive file-upload
-      path so a slow Docling conversion doesn't occupy a worker thread from the
-      shared `asyncio.to_thread` pool for its entire duration.
-    """
-
-    def __init__(
-        self, url, api_key=None, file_path=None, mime_type=None, params=None, timeout=None, status_callback=None
-    ):
+    def __init__(self, url, api_key=None, file_path=None, mime_type=None, params=None, timeout=None, status_callback=None):
         self.url = url.rstrip('/')
         self.api_key = api_key
         self.file_path = file_path
@@ -213,29 +196,15 @@ class DoclingLoader:
     def _build_headers(self) -> dict:
         headers = {}
         if self.api_key:
-            headers['X-Api-Key'] = f'{self.api_key}'
+            headers["X-Api-Key"] = f"{self.api_key}"
         return headers
-
-    async def _notify_status_async(self, data: dict) -> None:
-        """Invoke status_callback from async code, awaiting it if it's a coroutine function.
-
-        A caller running inside the event loop (like the file-upload path) may
-        reasonably supply an async callback (e.g. one that persists to the DB
-        with `await`). Calling it as a plain function would silently produce an
-        unawaited coroutine that never runs, so this checks and awaits it.
-        """
-        if not self.status_callback:
-            return
-        result = self.status_callback(data)
-        if inspect.isawaitable(result):
-            await result
 
     def _submit_file(self) -> tuple[str, int | None]:
         headers = self._build_headers()
         page_break_marker = '\f'
-        with open(self.file_path, 'rb') as f:
+        with open(self.file_path, "rb") as f:
             r = requests.post(
-                f'{self.url}/v1/convert/file/async',
+                f"{self.url}/v1/convert/file/async",
                 files={
                     'files': (
                         self.file_path,
@@ -246,9 +215,6 @@ class DoclingLoader:
                 data={
                     'image_export_mode': 'placeholder',
                     'md_page_break_placeholder': page_break_marker,
-                    # Keep Docling params as user-provided form values. Encoding nested
-                    # values here would make Open WebUI responsible for Docling's API
-                    # quirks and could break when Docling changes its form contract.
                     **self.params,
                 },
                 headers=headers,
@@ -257,7 +223,7 @@ class DoclingLoader:
             )
 
         if not r.ok:
-            error_msg = f'Error calling Docling API: {r.reason}'
+            error_msg = f"Error calling Docling API: {r.reason}"
             if r.text:
                 try:
                     error_data = r.json()
@@ -268,17 +234,17 @@ class DoclingLoader:
             raise Exception(f'Error calling Docling: {error_msg}')
 
         submit_data = r.json()
-        task_id = submit_data.get('task_id')
-        task_position = submit_data.get('task_position')
+        task_id = submit_data.get("task_id")
+        task_position = submit_data.get("task_position")
         if not task_id:
-            raise Exception('Docling async submit did not return a task_id')
+            raise Exception("Docling async submit did not return a task_id")
         log.info(
-            'Docling task submitted: %s, queue position: %s',
+            "Docling task submitted: %s, queue position: %s",
             task_id,
             task_position,
         )
         if self.status_callback:
-            self.status_callback({'task_id': task_id, 'task_position': task_position})
+            self.status_callback({"task_id": task_id, "task_position": task_position})
 
         return task_id, task_position
 
@@ -291,43 +257,45 @@ class DoclingLoader:
             if deadline is not None:
                 remaining = deadline - time.monotonic()
                 if remaining <= 0:
-                    raise Exception(f'Docling conversion timed out after {self.timeout}s (task_id={task_id})')
+                    raise Exception(
+                        f"Docling conversion timed out after {self.timeout}s (task_id={task_id})"
+                    )
                 poll_wait = min(poll_wait, int(remaining) + 1)
 
             poll_start = time.monotonic()
             try:
                 status_r = requests.get(
-                    f'{self.url}/v1/status/poll/{task_id}',
-                    params={'wait': poll_wait},
+                    f"{self.url}/v1/status/poll/{task_id}",
+                    params={"wait": poll_wait},
                     headers=headers,
                     timeout=poll_wait + 10,
                 )
             except requests.Timeout:
-                log.warning('Docling status poll timed out for task %s, retrying', task_id)
+                log.warning("Docling status poll timed out for task %s, retrying", task_id)
                 elapsed = time.monotonic() - poll_start
                 if elapsed < poll_wait:
                     time.sleep(poll_wait - elapsed)
                 continue
 
             if not status_r.ok:
-                raise Exception(f'Error polling Docling task status: {status_r.reason}')
+                raise Exception(f"Error polling Docling task status: {status_r.reason}")
 
             status_data = status_r.json()
-            task_status = status_data.get('task_status', '')
+            task_status = status_data.get("task_status", "")
             log.debug(
-                'Docling task %s: status=%s, queue_position=%s',
+                "Docling task %s: status=%s, queue_position=%s",
                 task_id,
                 task_status,
-                status_data.get('task_position'),
+                status_data.get("task_position"),
             )
-            if self.status_callback and status_data.get('task_position') is not None:
-                self.status_callback({'task_position': status_data['task_position']})
+            if self.status_callback and status_data.get("task_position") is not None:
+                self.status_callback({"task_position": status_data["task_position"]})
 
-            if task_status == 'success':
+            if task_status == "success":
                 return status_data
-            elif task_status == 'failure':
-                error_msg = status_data.get('error_message') or 'Unknown error'
-                raise Exception(f'Docling conversion failed: {error_msg}')
+            elif task_status == "failure":
+                error_msg = status_data.get("error_message") or "Unknown error"
+                raise Exception(f"Docling conversion failed: {error_msg}")
             # else "pending" or "started" – keep polling
 
             elapsed = time.monotonic() - poll_start
@@ -336,16 +304,16 @@ class DoclingLoader:
 
     def _retrieve_result(self, task_id: str) -> dict:
         headers = self._build_headers()
-        result_r = requests.get(f'{self.url}/v1/result/{task_id}', headers=headers, timeout=30)
+        result_r = requests.get(f"{self.url}/v1/result/{task_id}", headers=headers, timeout=30)
         if not result_r.ok:
-            raise Exception(f'Error retrieving Docling result: {result_r.reason}')
+            raise Exception(f"Error retrieving Docling result: {result_r.reason}")
         return result_r.json()
 
     def format_result(self, result_json: dict) -> list[Document]:
-        document_data = result_json.get('document', {})
-        text = document_data.get('md_content', '<No text content found>')
-        metadata = {'Content-Type': self.mime_type} if self.mime_type else {}
-        log.debug('Docling extracted text: %s', text)
+        document_data = result_json.get("document", {})
+        text = document_data.get("md_content", "<No text content found>")
+        metadata = {"Content-Type": self.mime_type} if self.mime_type else {}
+        log.debug("Docling extracted text: %s", text)
         return [Document(page_content=text, metadata=metadata)]
 
     def load(self) -> list[Document]:
@@ -364,144 +332,11 @@ class DoclingLoader:
         result_json = self._retrieve_result(task_id)
         return self.format_result(result_json)
 
-    async def _submit_file_async(self, session: aiohttp.ClientSession) -> tuple[str, int | None]:
-        headers = self._build_headers()
-        page_break_marker = '\f'
-
-        with open(self.file_path, 'rb') as f:
-            writer = aiohttp.MultipartWriter('form-data')
-
-            file_part = writer.append(f, {'Content-Type': self.mime_type or 'application/octet-stream'})
-            file_part.set_content_disposition('form-data', name='files', filename=self.file_path)
-
-            for field_name, value in {
-                'image_export_mode': 'placeholder',
-                'md_page_break_placeholder': page_break_marker,
-                **self.params,
-            }.items():
-                part = writer.append(str(value))
-                part.set_content_disposition('form-data', name=field_name)
-
-            async with session.post(
-                f'{self.url}/v1/convert/file/async',
-                data=writer,
-                headers=headers,
-                ssl=AIOHTTP_CLIENT_SESSION_SSL,
-                timeout=aiohttp.ClientTimeout(total=30),
-            ) as r:
-                if r.status >= 400:
-                    error_msg = f'Error calling Docling API: {r.reason}'
-                    text = await r.text()
-                    if text:
-                        try:
-                            error_data = json.loads(text)
-                            if 'detail' in error_data:
-                                error_msg += f' - {error_data["detail"]}'
-                        except Exception:
-                            error_msg += f' - {text}'
-                    raise Exception(f'Error calling Docling: {error_msg}')
-
-                submit_data = await r.json()
-
-        task_id = submit_data.get('task_id')
-        task_position = submit_data.get('task_position')
-        if not task_id:
-            raise Exception('Docling async submit did not return a task_id')
-        log.info(
-            'Docling task submitted: %s, queue position: %s',
-            task_id,
-            task_position,
-        )
-        await self._notify_status_async({'task_id': task_id, 'task_position': task_position})
-
-        return task_id, task_position
-
-    async def _poll_task_until_done_async(self, session: aiohttp.ClientSession, task_id: str) -> dict:
-        headers = self._build_headers()
-        deadline = time.monotonic() + self.timeout if self.timeout is not None else None
-        poll_wait = 30  # long-poll window per request (seconds)
-
-        while True:
-            if deadline is not None:
-                remaining = deadline - time.monotonic()
-                if remaining <= 0:
-                    raise Exception(f'Docling conversion timed out after {self.timeout}s (task_id={task_id})')
-                poll_wait = min(poll_wait, int(remaining) + 1)
-
-            poll_start = time.monotonic()
-            try:
-                async with session.get(
-                    f'{self.url}/v1/status/poll/{task_id}',
-                    params={'wait': poll_wait},
-                    headers=headers,
-                    ssl=AIOHTTP_CLIENT_SESSION_SSL,
-                    timeout=aiohttp.ClientTimeout(total=poll_wait + 10),
-                ) as status_r:
-                    if status_r.status >= 400:
-                        raise Exception(f'Error polling Docling task status: {status_r.reason}')
-                    status_data = await status_r.json()
-            except asyncio.TimeoutError:
-                log.warning('Docling status poll timed out for task %s, retrying', task_id)
-                elapsed = time.monotonic() - poll_start
-                if elapsed < poll_wait:
-                    await asyncio.sleep(poll_wait - elapsed)
-                continue
-
-            task_status = status_data.get('task_status', '')
-            log.debug(
-                'Docling task %s: status=%s, queue_position=%s',
-                task_id,
-                task_status,
-                status_data.get('task_position'),
-            )
-            if status_data.get('task_position') is not None:
-                await self._notify_status_async({'task_position': status_data['task_position']})
-
-            if task_status == 'success':
-                return status_data
-            elif task_status == 'failure':
-                error_msg = status_data.get('error_message') or 'Unknown error'
-                raise Exception(f'Docling conversion failed: {error_msg}')
-            # else "pending" or "started" – keep polling
-
-            elapsed = time.monotonic() - poll_start
-            if elapsed < poll_wait:
-                await asyncio.sleep(poll_wait - elapsed)
-
-    async def _retrieve_result_async(self, session: aiohttp.ClientSession, task_id: str) -> dict:
-        headers = self._build_headers()
-        async with session.get(
-            f'{self.url}/v1/result/{task_id}',
-            headers=headers,
-            ssl=AIOHTTP_CLIENT_SESSION_SSL,
-            timeout=aiohttp.ClientTimeout(total=30),
-        ) as result_r:
-            if result_r.status >= 400:
-                raise Exception(f'Error retrieving Docling result: {result_r.reason}')
-            return await result_r.json()
-
-    async def aload(self) -> list[Document]:
-        async with aiohttp.ClientSession() as session:
-            task_id, _ = await self._submit_file_async(session)
-            await self._poll_task_until_done_async(session, task_id)
-            result_json = await self._retrieve_result_async(session, task_id)
-        return self.format_result(result_json)
-
-    async def aload_from_task_id(self, task_id: str) -> list[Document]:
-        """Async counterpart to `load_from_task_id`: resumes polling and result
-        retrieval for an already-submitted task_id without re-uploading the file.
-        """
-        async with aiohttp.ClientSession() as session:
-            await self._poll_task_until_done_async(session, task_id)
-            result_json = await self._retrieve_result_async(session, task_id)
-        return self.format_result(result_json)
-
 
 class Loader:
     def __init__(self, engine: str = '', **kwargs):
         self.engine = engine
         self.user = kwargs.get('user', None)
-        self.user_groups = kwargs.get('user_groups', None)
         self.metadata = kwargs.get('metadata', {})
         self.kwargs = kwargs
 
@@ -514,32 +349,13 @@ class Loader:
         """
         Async wrapper around `load`.
 
-        Most loaders dispatched by `_get_loader` (PyMuPDF, Unstructured,
+        Document loaders dispatched by `_get_loader` (PyMuPDF, Unstructured,
         python-docx, Tika, etc.) are uniformly synchronous and CPU/IO-bound.
         Calling `load` directly from an async handler would block the event
         loop for the entire parse — minutes for large PDFs. This offloads
         the work to a worker thread so the loop stays responsive.
-
-        `DoclingLoader` is the exception: it has a true async path (`aload`)
-        that uses aiohttp + `asyncio.sleep` for its submit/poll/retrieve cycle,
-        so a slow conversion never ties up a worker thread from the shared
-        `asyncio.to_thread` pool for its entire duration.
         """
-        # Group lookup is async-only, so it must happen before `load`
-        # is offloaded to a thread without a running event loop.
-        if self.engine == 'external' and self.user_groups is None:
-            self.user_groups = await get_user_groups_for_custom_headers(
-                self.kwargs.get('EXTERNAL_DOCUMENT_LOADER_HEADERS'), self.user
-            )
-
-        loader = await asyncio.to_thread(self._get_loader, filename, file_content_type, file_path)
-
-        if isinstance(loader, DoclingLoader):
-            docs = await loader.aload()
-        else:
-            docs = await asyncio.to_thread(loader.load)
-
-        return [Document(page_content=ftfy.fix_text(doc.page_content), metadata=doc.metadata) for doc in docs]
+        return await asyncio.to_thread(self.load, filename, file_content_type, file_path)
 
     def _is_text_file(self, file_ext: str, file_content_type: str) -> bool:
         return file_ext in known_source_ext or (
@@ -578,20 +394,13 @@ class Loader:
         try:
             raw.decode('utf-8')
             return 'utf-8'
-        except UnicodeDecodeError as e:
-            first_non_utf8 = e.start
+        except UnicodeDecodeError:
+            pass
 
         # Use chardet as a hint, not as ground truth
         import chardet
 
-        # chardet is pure Python (~1.3s/MB), so sample around the first bad byte
-        window = 256 * 1024
-        sample_start = max(0, first_non_utf8 - window // 2)
-        sample = raw[sample_start : sample_start + window]
-        detected = chardet.detect(sample)
-        # A stray byte can sit far from the real payload, leaving the sample with nothing to read
-        if len(sample.translate(None, delete=bytes(range(128)))) < 64 and len(sample) < len(raw):
-            detected = chardet.detect(raw)
+        detected = chardet.detect(raw)
         detected_enc = (detected.get('encoding') or '').lower().replace('-', '').replace('_', '')
 
         # Map chardet's detected encoding to the correct superset codec.
@@ -704,7 +513,6 @@ class Loader:
                 api_key=self.kwargs.get('EXTERNAL_DOCUMENT_LOADER_API_KEY'),
                 mime_type=file_content_type,
                 user=self.user,
-                user_groups=self.user_groups,
                 headers=self.kwargs.get('EXTERNAL_DOCUMENT_LOADER_HEADERS'),
                 metadata={
                     **self.metadata,
@@ -764,7 +572,7 @@ class Loader:
                 format_lines=self.kwargs.get('DATALAB_MARKER_FORMAT_LINES', False),
                 output_format=self.kwargs.get('DATALAB_MARKER_OUTPUT_FORMAT', 'markdown'),
             )
-        elif self.engine == 'docling' and self.kwargs.get('DOCLING_SERVER_URL'):
+        elif self.engine in ("docling", "docling_json") and self.kwargs.get("DOCLING_SERVER_URL"):
             if self._is_text_file(file_ext, file_content_type):
                 loader = TextLoader(file_path, encoding=self._detect_text_encoding(file_path))
             else:
@@ -777,22 +585,50 @@ class Loader:
                         log.error('Invalid DOCLING_PARAMS format, expected JSON object')
                         params = {}
 
-                docling_timeout = self.kwargs.get('DOCLING_SERVE_TIMEOUT')
+                docling_timeout = self.kwargs.get("DOCLING_SERVE_TIMEOUT")
                 if docling_timeout is not None:
                     try:
                         docling_timeout = int(docling_timeout)
                     except (ValueError, TypeError):
                         docling_timeout = None
 
-                loader = DoclingLoader(
-                    url=self.kwargs.get('DOCLING_SERVER_URL'),
-                    api_key=self.kwargs.get('DOCLING_API_KEY', None),
-                    file_path=file_path,
-                    mime_type=file_content_type,
-                    params=params,
-                    timeout=docling_timeout,
-                    status_callback=self.kwargs.get('DOCLING_STATUS_CALLBACK'),
-                )
+                if self.engine == "docling_json":
+                    try:
+                        _chunk_size = int(self.kwargs.get("CHUNK_SIZE", 1000))
+                    except (ValueError, TypeError):
+                        _chunk_size = 1000
+                    try:
+                        _chunk_overlap = int(self.kwargs.get("CHUNK_OVERLAP", 100))
+                    except (ValueError, TypeError):
+                        _chunk_overlap = 100
+                    _text_splitter = self.kwargs.get("TEXT_SPLITTER") or ""
+                    _chunk_content_type = "token" if _text_splitter == "token" else "character"
+                    loader = DoclingLoaderJson(
+                        url=self.kwargs.get("DOCLING_SERVER_URL"),
+                        api_key=self.kwargs.get("DOCLING_API_KEY", None),
+                        file_path=file_path,
+                        mime_type=file_content_type,
+                        params=params,
+                        timeout=docling_timeout,
+                        status_callback=self.kwargs.get("DOCLING_STATUS_CALLBACK"),
+                        chunk_mode=self.kwargs.get("DOCLING_JSON_CHUNK_MODE", "chunk"),
+                        chunk_size=_chunk_size,
+                        chunk_overlap=_chunk_overlap,
+                        chunk_content_type=_chunk_content_type,
+                        tiktoken_encoding_name=str(
+                            self.kwargs.get("TIKTOKEN_ENCODING_NAME") or "cl100k_base"
+                        ),
+                    )
+                else:
+                    loader = DoclingLoader(
+                        url=self.kwargs.get("DOCLING_SERVER_URL"),
+                        api_key=self.kwargs.get("DOCLING_API_KEY", None),
+                        file_path=file_path,
+                        mime_type=file_content_type,
+                        params=params,
+                        timeout=docling_timeout,
+                        status_callback=self.kwargs.get("DOCLING_STATUS_CALLBACK"),
+                    )
         elif (
             self.engine == 'document_intelligence'
             and self.kwargs.get('DOCUMENT_INTELLIGENCE_ENDPOINT') != ''
@@ -846,14 +682,8 @@ class Loader:
                 api_key=self.kwargs.get('MISTRAL_OCR_API_KEY'),
                 file_path=file_path,
                 use_base64=self.kwargs.get('MISTRAL_OCR_USE_BASE64', False),
-                user=self.user,
             )
-        elif (
-            self.engine == 'paddleocr_vl'
-            and self.kwargs.get('PADDLEOCR_VL_BASE_URL')
-            and self.kwargs.get('PADDLEOCR_VL_TOKEN')
-            and file_ext in PADDLEOCR_VL_SUPPORTED_EXTENSIONS
-        ):
+        elif self.engine == 'paddleocr_vl' and self.kwargs.get('PADDLEOCR_VL_TOKEN') != '':
             loader = PaddleOCRVLLoader(
                 api_url=self.kwargs.get('PADDLEOCR_VL_BASE_URL'),
                 token=self.kwargs.get('PADDLEOCR_VL_TOKEN'),
@@ -952,18 +782,7 @@ class Loader:
                     )
                     loader = PptxLoader(file_path)
             elif file_ext == 'msg':
-                try:
-                    from langchain_community.document_loaders import (
-                        UnstructuredEmailLoader,
-                    )
-
-                    # unstructured parses .msg via python-oxmsg; avoids extract_msg's beautifulsoup4<4.14 conflict
-                    loader = UnstructuredEmailLoader(file_path, process_attachments=False)
-                except ImportError:
-                    raise ValueError(
-                        "Processing .msg files requires the 'unstructured' package. "
-                        'Install it with: pip install unstructured'
-                    )
+                loader = OutlookMessageLoader(file_path)
             elif file_ext == 'odt':
                 try:
                     from langchain_community.document_loaders import UnstructuredODTLoader

--- a/backend/open_webui/retrieval/loaders/main.py
+++ b/backend/open_webui/retrieval/loaders/main.py
@@ -27,7 +27,6 @@ from open_webui.env import (
     REQUESTS_VERIFY,
 )
 from open_webui.retrieval.loaders.datalab_marker import DatalabMarkerLoader
-from open_webui.retrieval.loaders.docling_json import DoclingLoaderJson
 from open_webui.retrieval.loaders.external_document import ExternalDocumentLoader
 from open_webui.retrieval.loaders.mineru import MinerULoader
 from open_webui.retrieval.loaders.mistral import MistralLoader
@@ -593,6 +592,8 @@ class Loader:
                         docling_timeout = None
 
                 if self.engine == "docling_json":
+                    from open_webui.retrieval.loaders.docling_json import DoclingLoaderJson
+
                     try:
                         _chunk_size = int(self.kwargs.get("CHUNK_SIZE", 1000))
                     except (ValueError, TypeError):

--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -106,6 +106,7 @@ LOADER_CONFIG_KEYS = {
     'DOCLING_SERVER_URL': 'rag.docling_server_url',
     'DOCLING_API_KEY': 'rag.docling_api_key',
     'DOCLING_PARAMS': 'rag.docling_params',
+    'DOCLING_SERVE_TIMEOUT': 'rag.docling_serve_timeout',
     'PDF_EXTRACT_IMAGES': 'rag.pdf_extract_images',
     'PDF_LOADER_MODE': 'rag.pdf_loader_mode',
     'DOCUMENT_INTELLIGENCE_ENDPOINT': 'rag.document_intelligence_endpoint',

--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -107,6 +107,14 @@ LOADER_CONFIG_KEYS = {
     'DOCLING_API_KEY': 'rag.docling_api_key',
     'DOCLING_PARAMS': 'rag.docling_params',
     'DOCLING_SERVE_TIMEOUT': 'rag.docling_serve_timeout',
+    'DOCLING_JSON_CHUNK_MODE': 'rag.DOCLING_JSON_CHUNK_MODE',
+    # Threaded through so DoclingLoaderJson's "chunk" mode respects the admin's
+    # real chunk-size/overlap/splitter settings instead of its own hardcoded
+    # fallbacks. Nothing else currently reads these via self.kwargs.
+    'CHUNK_SIZE': 'rag.chunk_size',
+    'CHUNK_OVERLAP': 'rag.chunk_overlap',
+    'TEXT_SPLITTER': 'rag.text_splitter',
+    'TIKTOKEN_ENCODING_NAME': 'rag.tiktoken_encoding_name',
     'PDF_EXTRACT_IMAGES': 'rag.pdf_extract_images',
     'PDF_LOADER_MODE': 'rag.pdf_loader_mode',
     'DOCUMENT_INTELLIGENCE_ENDPOINT': 'rag.document_intelligence_endpoint',

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -283,6 +283,7 @@ RETRIEVAL_CONFIG_KEYS = {
     'DOCLING_PARAMS': 'rag.docling_params',
     'DOCLING_SERVER_URL': 'rag.docling_server_url',
     'DOCLING_SERVE_TIMEOUT': 'rag.docling_serve_timeout',
+    'DOCLING_JSON_CHUNK_MODE': 'rag.DOCLING_JSON_CHUNK_MODE',
     'DOCUMENT_INTELLIGENCE_ENDPOINT': 'rag.document_intelligence_endpoint',
     'DOCUMENT_INTELLIGENCE_KEY': 'rag.document_intelligence_key',
     'DOCUMENT_INTELLIGENCE_MODEL': 'rag.document_intelligence_model',
@@ -654,6 +655,7 @@ async def get_rag_config(request: Request, user=Depends(get_admin_user)):
         'DOCLING_API_KEY': config.DOCLING_API_KEY,
         'DOCLING_PARAMS': config.DOCLING_PARAMS,
         'DOCLING_SERVE_TIMEOUT': config.DOCLING_SERVE_TIMEOUT,
+        'DOCLING_JSON_CHUNK_MODE': config.DOCLING_JSON_CHUNK_MODE,
         'DOCUMENT_INTELLIGENCE_ENDPOINT': config.DOCUMENT_INTELLIGENCE_ENDPOINT,
         'DOCUMENT_INTELLIGENCE_KEY': config.DOCUMENT_INTELLIGENCE_KEY,
         'DOCUMENT_INTELLIGENCE_MODEL': config.DOCUMENT_INTELLIGENCE_MODEL,
@@ -890,6 +892,7 @@ class ConfigForm(BaseModel):
     DOCLING_API_KEY: str | None = None
     DOCLING_PARAMS: dict | None = None
     DOCLING_SERVE_TIMEOUT: int | None = None
+    DOCLING_JSON_CHUNK_MODE: str | None = None
     DOCUMENT_INTELLIGENCE_ENDPOINT: str | None = None
     DOCUMENT_INTELLIGENCE_KEY: str | None = None
     DOCUMENT_INTELLIGENCE_MODEL: str | None = None
@@ -1074,6 +1077,9 @@ async def update_rag_config(request: Request, form_data: ConfigForm, user=Depend
         form_data.DOCLING_SERVE_TIMEOUT
         if form_data.DOCLING_SERVE_TIMEOUT is not None
         else config.DOCLING_SERVE_TIMEOUT
+    )
+    config.DOCLING_JSON_CHUNK_MODE = (
+        form_data.DOCLING_JSON_CHUNK_MODE if form_data.DOCLING_JSON_CHUNK_MODE is not None else config.DOCLING_JSON_CHUNK_MODE
     )
     config.DOCUMENT_INTELLIGENCE_ENDPOINT = (
         form_data.DOCUMENT_INTELLIGENCE_ENDPOINT
@@ -1370,6 +1376,7 @@ async def update_rag_config(request: Request, form_data: ConfigForm, user=Depend
         'DOCLING_API_KEY': config.DOCLING_API_KEY,
         'DOCLING_PARAMS': config.DOCLING_PARAMS,
         'DOCLING_SERVE_TIMEOUT': config.DOCLING_SERVE_TIMEOUT,
+        'DOCLING_JSON_CHUNK_MODE': config.DOCLING_JSON_CHUNK_MODE,
         'DOCUMENT_INTELLIGENCE_ENDPOINT': config.DOCUMENT_INTELLIGENCE_ENDPOINT,
         'DOCUMENT_INTELLIGENCE_KEY': config.DOCUMENT_INTELLIGENCE_KEY,
         'DOCUMENT_INTELLIGENCE_MODEL': config.DOCUMENT_INTELLIGENCE_MODEL,

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -282,6 +282,7 @@ RETRIEVAL_CONFIG_KEYS = {
     'DOCLING_API_KEY': 'rag.docling_api_key',
     'DOCLING_PARAMS': 'rag.docling_params',
     'DOCLING_SERVER_URL': 'rag.docling_server_url',
+    'DOCLING_SERVE_TIMEOUT': 'rag.docling_serve_timeout',
     'DOCUMENT_INTELLIGENCE_ENDPOINT': 'rag.document_intelligence_endpoint',
     'DOCUMENT_INTELLIGENCE_KEY': 'rag.document_intelligence_key',
     'DOCUMENT_INTELLIGENCE_MODEL': 'rag.document_intelligence_model',
@@ -652,6 +653,7 @@ async def get_rag_config(request: Request, user=Depends(get_admin_user)):
         'DOCLING_SERVER_URL': config.DOCLING_SERVER_URL,
         'DOCLING_API_KEY': config.DOCLING_API_KEY,
         'DOCLING_PARAMS': config.DOCLING_PARAMS,
+        'DOCLING_SERVE_TIMEOUT': config.DOCLING_SERVE_TIMEOUT,
         'DOCUMENT_INTELLIGENCE_ENDPOINT': config.DOCUMENT_INTELLIGENCE_ENDPOINT,
         'DOCUMENT_INTELLIGENCE_KEY': config.DOCUMENT_INTELLIGENCE_KEY,
         'DOCUMENT_INTELLIGENCE_MODEL': config.DOCUMENT_INTELLIGENCE_MODEL,
@@ -887,6 +889,7 @@ class ConfigForm(BaseModel):
     DOCLING_SERVER_URL: str | None = None
     DOCLING_API_KEY: str | None = None
     DOCLING_PARAMS: dict | None = None
+    DOCLING_SERVE_TIMEOUT: int | None = None
     DOCUMENT_INTELLIGENCE_ENDPOINT: str | None = None
     DOCUMENT_INTELLIGENCE_KEY: str | None = None
     DOCUMENT_INTELLIGENCE_MODEL: str | None = None
@@ -1067,6 +1070,11 @@ async def update_rag_config(request: Request, form_data: ConfigForm, user=Depend
         form_data.DOCLING_API_KEY if form_data.DOCLING_API_KEY is not None else config.DOCLING_API_KEY
     )
     config.DOCLING_PARAMS = form_data.DOCLING_PARAMS if form_data.DOCLING_PARAMS is not None else config.DOCLING_PARAMS
+    config.DOCLING_SERVE_TIMEOUT = (
+        form_data.DOCLING_SERVE_TIMEOUT
+        if form_data.DOCLING_SERVE_TIMEOUT is not None
+        else config.DOCLING_SERVE_TIMEOUT
+    )
     config.DOCUMENT_INTELLIGENCE_ENDPOINT = (
         form_data.DOCUMENT_INTELLIGENCE_ENDPOINT
         if form_data.DOCUMENT_INTELLIGENCE_ENDPOINT is not None
@@ -1361,6 +1369,7 @@ async def update_rag_config(request: Request, form_data: ConfigForm, user=Depend
         'DOCLING_SERVER_URL': config.DOCLING_SERVER_URL,
         'DOCLING_API_KEY': config.DOCLING_API_KEY,
         'DOCLING_PARAMS': config.DOCLING_PARAMS,
+        'DOCLING_SERVE_TIMEOUT': config.DOCLING_SERVE_TIMEOUT,
         'DOCUMENT_INTELLIGENCE_ENDPOINT': config.DOCUMENT_INTELLIGENCE_ENDPOINT,
         'DOCUMENT_INTELLIGENCE_KEY': config.DOCUMENT_INTELLIGENCE_KEY,
         'DOCUMENT_INTELLIGENCE_MODEL': config.DOCUMENT_INTELLIGENCE_MODEL,

--- a/src/lib/components/admin/Settings/Documents.svelte
+++ b/src/lib/components/admin/Settings/Documents.svelte
@@ -28,12 +28,8 @@
 	import Switch from '$lib/components/common/Switch.svelte';
 	import Textarea from '$lib/components/common/Textarea.svelte';
 	import Spinner from '$lib/components/common/Spinner.svelte';
-	import SettingsSelect from '$lib/components/common/SettingsSelect.svelte';
-	import AdminSettingField from './AdminSettingField.svelte';
-	import AdminSettingRow from './AdminSettingRow.svelte';
-	import AdminSettingSection from './AdminSettingSection.svelte';
 
-	const i18n: any = getContext('i18n');
+	const i18n = getContext('i18n');
 
 	let updateEmbeddingModelLoading = false;
 	let updateRerankingModelLoading = false;
@@ -69,13 +65,7 @@
 		hybrid: false
 	};
 
-	let RAGConfig: any = null;
-	const inputClass =
-		'w-full h-7 rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 text-xs text-gray-700 outline-hidden transition-colors placeholder:text-gray-300 focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:placeholder:text-gray-700 dark:focus:border-blue-500';
-	const actionButtonClass =
-		'shrink-0 text-xs text-gray-500 transition-colors hover:text-gray-900 dark:text-gray-500 dark:hover:text-white';
-	const textareaClass =
-		'w-full rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 py-1.5 text-xs text-gray-700 outline-hidden transition-colors placeholder:text-gray-300 focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:placeholder:text-gray-700 dark:focus:border-blue-500';
+	let RAGConfig = null;
 
 	const embeddingModelUpdateHandler = async () => {
 		if (RAG_EMBEDDING_ENGINE === '' && RAG_EMBEDDING_MODEL.split('/').length - 1 > 1) {
@@ -179,7 +169,7 @@
 			toast.error($i18n.t('Tika Server URL required.'));
 			return;
 		}
-		if (RAGConfig.CONTENT_EXTRACTION_ENGINE === 'docling' && RAGConfig.DOCLING_SERVER_URL === '') {
+		if ((RAGConfig.CONTENT_EXTRACTION_ENGINE === 'docling' || RAGConfig.CONTENT_EXTRACTION_ENGINE === 'docling_json') && RAGConfig.DOCLING_SERVER_URL === '') {
 			toast.error($i18n.t('Docling Server URL required.'));
 			return;
 		}
@@ -272,12 +262,6 @@
 				RAGConfig.EXTERNAL_DOCUMENT_LOADER_HEADERS.trim() !== ''
 					? JSON.parse(RAGConfig.EXTERNAL_DOCUMENT_LOADER_HEADERS)
 					: {},
-			CONTENT_EXTRACTION_SUPPORTED_MEDIA_MIME_TYPES:
-				RAGConfig.CONTENT_EXTRACTION_SUPPORTED_MEDIA_MIME_TYPES.trim() === ''
-					? undefined
-					: RAGConfig.CONTENT_EXTRACTION_SUPPORTED_MEDIA_MIME_TYPES.split(',')
-							.map((mimeType: string) => mimeType.trim())
-							.filter((mimeType: string) => mimeType !== ''),
 			MINERU_PARAMS:
 				typeof RAGConfig.MINERU_PARAMS === 'string' && RAGConfig.MINERU_PARAMS.trim() !== ''
 					? JSON.parse(RAGConfig.MINERU_PARAMS)
@@ -334,9 +318,6 @@
 				: config.EXTERNAL_DOCUMENT_LOADER_HEADERS;
 
 		config.MINERU_FILE_EXTENSIONS = (config?.MINERU_FILE_EXTENSIONS ?? ['pdf']).join(', ');
-		config.CONTENT_EXTRACTION_SUPPORTED_MEDIA_MIME_TYPES = (
-			config?.CONTENT_EXTRACTION_SUPPORTED_MEDIA_MIME_TYPES ?? []
-		).join(', ');
 		config.RAG_TOKENIZER_MODEL = config?.RAG_TOKENIZER_MODEL ?? '';
 
 		RAGConfig = config;
@@ -386,1165 +367,1381 @@
 />
 
 <form
-	class="flex h-full flex-col justify-between text-sm"
+	class="flex flex-col h-full justify-between space-y-3 text-sm"
 	on:submit|preventDefault={() => {
 		submitHandler();
 	}}
 >
-	<h2 class="text-sm font-medium text-gray-900 dark:text-white mb-4">{$i18n.t('Documents')}</h2>
-
 	{#if RAGConfig}
-		<div class="flex-1 min-h-0 overflow-y-auto scrollbar-hover pr-1.5">
-			<AdminSettingSection title={$i18n.t('Content Extraction')} first>
-				<AdminSettingRow
-					label={$i18n.t('Content Extraction Engine')}
-					description={$i18n.t('Choose how uploaded documents are parsed before indexing.')}
-				>
-					<SettingsSelect bind:value={RAGConfig.CONTENT_EXTRACTION_ENGINE}>
-						<option value="">{$i18n.t('Default')}</option>
-						<option value="external">{$i18n.t('External')}</option>
-						<option value="tika">{$i18n.t('Tika')}</option>
-						<option value="docling">{$i18n.t('Docling')}</option>
-						<option value="datalab_marker">{$i18n.t('Datalab Marker API')}</option>
-						<option value="document_intelligence">{$i18n.t('Document Intelligence')}</option>
-						<option value="mistral_ocr">{$i18n.t('Mistral OCR')}</option>
-						<option value="paddleocr_vl">{$i18n.t('PaddleOCR-vl')}</option>
-						<option value="mineru">{$i18n.t('MinerU')}</option>
-					</SettingsSelect>
-				</AdminSettingRow>
+		<div class=" space-y-2.5 overflow-y-scroll scrollbar-hidden h-full pr-1.5">
+			<div class="">
+				<div class="mb-3">
+					<div class=" mt-0.5 mb-2.5 text-base font-medium">{$i18n.t('General')}</div>
 
-				<AdminSettingField
-					label={$i18n.t('Supported Media MIME Types')}
-					description={$i18n.t(
-						'Media upload MIME types the content extraction engine may process.'
-					)}
-				>
-					<input
-						class={inputClass}
-						placeholder={$i18n.t('image/*, video/*')}
-						bind:value={RAGConfig.CONTENT_EXTRACTION_SUPPORTED_MEDIA_MIME_TYPES}
-					/>
-				</AdminSettingField>
+					<hr class=" border-gray-100/30 dark:border-gray-850/30 my-2" />
 
-				{#if RAGConfig.CONTENT_EXTRACTION_ENGINE === ''}
-					<AdminSettingRow
-						label={$i18n.t('PDF Extract Images (OCR)')}
-						description={$i18n.t('Extract images from PDFs so OCR can process image-only pages.')}
-						let:labelId
-					>
-						<Switch bind:state={RAGConfig.PDF_EXTRACT_IMAGES} ariaLabelledbyId={labelId} />
-					</AdminSettingRow>
+					<div class="mb-2.5 flex flex-col w-full justify-between">
+						<div class="flex w-full justify-between mb-1">
+							<div class="self-center text-xs font-medium">
+								{$i18n.t('Content Extraction Engine')}
+							</div>
+							<div class="">
+								<select
+									class="w-fit pr-8 rounded-sm px-2 text-xs bg-transparent outline-hidden text-right"
+									bind:value={RAGConfig.CONTENT_EXTRACTION_ENGINE}
+								>
+									<option value="">{$i18n.t('Default')}</option>
+									<option value="external">{$i18n.t('External')}</option>
+									<option value="tika">{$i18n.t('Tika')}</option>
+									<option value="docling">{$i18n.t('Docling')}</option>
+									<option value="docling_json">{$i18n.t('Docling (JSON)')}</option>
+									<option value="datalab_marker">{$i18n.t('Datalab Marker API')}</option>
+									<option value="document_intelligence">{$i18n.t('Document Intelligence')}</option>
+									<option value="mistral_ocr">{$i18n.t('Mistral OCR')}</option>
+									<option value="paddleocr_vl">{$i18n.t('PaddleOCR-vl')}</option>
+									<option value="mineru">{$i18n.t('MinerU')}</option>
+								</select>
+							</div>
+						</div>
 
-					<AdminSettingRow
-						label={$i18n.t('PDF Loader Mode')}
-						description={$i18n.t(
-							'Page mode creates one document per page. Single mode keeps pages together for chunking across boundaries.'
-						)}
-					>
-						<SettingsSelect bind:value={RAGConfig.PDF_LOADER_MODE}>
-							<option value="page">{$i18n.t('Page')}</option>
-							<option value="single">{$i18n.t('Single')}</option>
-						</SettingsSelect>
-					</AdminSettingRow>
-				{:else if RAGConfig.CONTENT_EXTRACTION_ENGINE === 'datalab_marker'}
-					<AdminSettingField
-						label={$i18n.t('API Base URL')}
-						description={$i18n.t('Datalab Marker service endpoint used for document parsing.')}
-					>
-						<input
-							class={inputClass}
-							placeholder={$i18n.t('Enter Datalab Marker API Base URL')}
-							bind:value={RAGConfig.DATALAB_MARKER_API_BASE_URL}
-						/>
-					</AdminSettingField>
+						{#if RAGConfig.CONTENT_EXTRACTION_ENGINE === ''}
+							<div class="flex w-full mt-1">
+								<div class="flex-1 flex justify-between">
+									<div class=" self-center text-xs font-medium">
+										{$i18n.t('PDF Extract Images (OCR)')}
+									</div>
+									<div class="flex items-center relative">
+										<Switch bind:state={RAGConfig.PDF_EXTRACT_IMAGES} />
+									</div>
+								</div>
+							</div>
 
-					<AdminSettingField
-						label={$i18n.t('API Key')}
-						description={$i18n.t('API key used to authenticate with Datalab Marker.')}
-					>
-						<SensitiveInput
-							variant="settings"
-							placeholder={$i18n.t('Enter Datalab Marker API Key')}
-							required={false}
-							bind:value={RAGConfig.DATALAB_MARKER_API_KEY}
-						/>
-					</AdminSettingField>
+							<div class="flex w-full mt-2">
+								<div class="flex-1 flex justify-between">
+									<div class=" self-center text-xs font-medium">
+										<Tooltip
+											content={$i18n.t(
+												'Page mode creates one document per page. Single mode combines all pages into one document for better chunking across page boundaries.'
+											)}
+											placement="top-start"
+										>
+											{$i18n.t('PDF Loader Mode')}
+										</Tooltip>
+									</div>
+									<div class="">
+										<select
+											class="w-fit pr-8 rounded-sm px-2 text-xs bg-transparent outline-hidden text-right"
+											bind:value={RAGConfig.PDF_LOADER_MODE}
+										>
+											<option value="page">{$i18n.t('Page')}</option>
+											<option value="single">{$i18n.t('Single')}</option>
+										</select>
+									</div>
+								</div>
+							</div>
+						{:else if RAGConfig.CONTENT_EXTRACTION_ENGINE === 'datalab_marker'}
+							<div class="my-0.5 flex gap-2 pr-2">
+								<Tooltip
+									content={$i18n.t(
+										'API Base URL for Datalab Marker service. Defaults to: https://www.datalab.to/api/v1/marker'
+									)}
+									placement="top-start"
+									className="w-full"
+								>
+									<input
+										class="flex-1 w-full text-sm bg-transparent outline-hidden"
+										placeholder={$i18n.t('Enter Datalab Marker API Base URL')}
+										bind:value={RAGConfig.DATALAB_MARKER_API_BASE_URL}
+									/>
+								</Tooltip>
+							</div>
+							<div class="my-0.5 flex gap-2 pr-2">
+								<SensitiveInput
+									placeholder={$i18n.t('Enter Datalab Marker API Key')}
+									required={false}
+									bind:value={RAGConfig.DATALAB_MARKER_API_KEY}
+								/>
+							</div>
 
-					<AdminSettingField
-						label={$i18n.t('Additional Config')}
-						description={$i18n.t('JSON options passed to Marker for advanced parsing behavior.')}
-					>
-						<Tooltip
-							content={$i18n.t(
-								'Additional configuration options for marker. This should be a JSON string with key-value pairs. For example, \'{"key": "value"}\'. Supported keys include: disable_links, keep_pageheader_in_output, keep_pagefooter_in_output, filter_blank_pages, drop_repeated_text, layout_coverage_threshold, merge_threshold, height_tolerance, gap_threshold, image_threshold, min_line_length, level_count, default_level'
-							)}
-							placement="top-start"
-							className="w-full"
-						>
-							<Textarea
-								className={textareaClass}
-								bind:value={RAGConfig.DATALAB_MARKER_ADDITIONAL_CONFIG}
-								placeholder={$i18n.t('Enter JSON config (e.g., {"disable_links": true})')}
-							/>
-						</Tooltip>
-					</AdminSettingField>
+							<div class="flex flex-col gap-2 mt-2">
+								<div class=" flex flex-col w-full justify-between">
+									<div class=" mb-1 text-xs font-medium">
+										{$i18n.t('Additional Config')}
+									</div>
+									<div class="flex w-full items-center relative">
+										<Tooltip
+											content={$i18n.t(
+												'Additional configuration options for marker. This should be a JSON string with key-value pairs. For example, \'{"key": "value"}\'. Supported keys include: disable_links, keep_pageheader_in_output, keep_pagefooter_in_output, filter_blank_pages, drop_repeated_text, layout_coverage_threshold, merge_threshold, height_tolerance, gap_threshold, image_threshold, min_line_length, level_count, default_level'
+											)}
+											placement="top-start"
+											className="w-full"
+										>
+											<Textarea
+												bind:value={RAGConfig.DATALAB_MARKER_ADDITIONAL_CONFIG}
+												placeholder={$i18n.t('Enter JSON config (e.g., {"disable_links": true})')}
+											/>
+										</Tooltip>
+									</div>
+								</div>
+							</div>
 
-					<AdminSettingRow
-						label={$i18n.t('Use LLM')}
-						description={$i18n.t(
-							'Use an LLM to improve tables, forms, math, and layout detection.'
-						)}
-						let:labelId
-					>
-						<Switch bind:state={RAGConfig.DATALAB_MARKER_USE_LLM} ariaLabelledbyId={labelId} />
-					</AdminSettingRow>
-					<AdminSettingRow
-						label={$i18n.t('Skip Cache')}
-						description={$i18n.t('Skip cached Marker results and rerun inference.')}
-						let:labelId
-					>
-						<Switch bind:state={RAGConfig.DATALAB_MARKER_SKIP_CACHE} ariaLabelledbyId={labelId} />
-					</AdminSettingRow>
-					<AdminSettingRow
-						label={$i18n.t('Force OCR')}
-						description={$i18n.t('Run OCR on all PDF pages, even pages with embedded text.')}
-						let:labelId
-					>
-						<Switch bind:state={RAGConfig.DATALAB_MARKER_FORCE_OCR} ariaLabelledbyId={labelId} />
-					</AdminSettingRow>
-					<AdminSettingRow
-						label={$i18n.t('Paginate')}
-						description={$i18n.t('Separate output by page with page markers.')}
-						let:labelId
-					>
-						<Switch bind:state={RAGConfig.DATALAB_MARKER_PAGINATE} ariaLabelledbyId={labelId} />
-					</AdminSettingRow>
-					<AdminSettingRow
-						label={$i18n.t('Strip Existing OCR')}
-						description={$i18n.t('Remove existing OCR text and rerun OCR when Force OCR is off.')}
-						let:labelId
-					>
-						<Switch
-							bind:state={RAGConfig.DATALAB_MARKER_STRIP_EXISTING_OCR}
-							ariaLabelledbyId={labelId}
-						/>
-					</AdminSettingRow>
-					<AdminSettingRow
-						label={$i18n.t('Disable Image Extraction')}
-						description={$i18n.t('Do not extract images from PDFs during Marker processing.')}
-						let:labelId
-					>
-						<Switch
-							bind:state={RAGConfig.DATALAB_MARKER_DISABLE_IMAGE_EXTRACTION}
-							ariaLabelledbyId={labelId}
-						/>
-					</AdminSettingRow>
-					<AdminSettingRow
-						label={$i18n.t('Format Lines')}
-						description={$i18n.t('Format lines to detect inline math and styles.')}
-						let:labelId
-					>
-						<Switch bind:state={RAGConfig.DATALAB_MARKER_FORMAT_LINES} ariaLabelledbyId={labelId} />
-					</AdminSettingRow>
-					<AdminSettingRow
-						label={$i18n.t('Output Format')}
-						description={$i18n.t('Text output format returned by Marker.')}
-					>
-						<SettingsSelect bind:value={RAGConfig.DATALAB_MARKER_OUTPUT_FORMAT}>
-							<option value="markdown">{$i18n.t('Markdown')}</option>
-							<option value="json">{$i18n.t('JSON')}</option>
-							<option value="html">{$i18n.t('HTML')}</option>
-						</SettingsSelect>
-					</AdminSettingRow>
-				{:else if RAGConfig.CONTENT_EXTRACTION_ENGINE === 'external'}
-					<div class="grid grid-cols-1 gap-x-3 gap-y-2.5 sm:grid-cols-2">
-						<AdminSettingField
-							label={$i18n.t('Document Loader URL')}
-							description={$i18n.t('External service endpoint used to load document content.')}
-						>
-							<input
-								class={inputClass}
-								placeholder={$i18n.t('Enter External Document Loader URL')}
-								bind:value={RAGConfig.EXTERNAL_DOCUMENT_LOADER_URL}
-							/>
-						</AdminSettingField>
-						<AdminSettingField
-							label={$i18n.t('API Key')}
-							description={$i18n.t('API key sent to the external document loader.')}
-						>
-							<SensitiveInput
-								variant="settings"
-								placeholder={$i18n.t('Enter External Document Loader API Key')}
-								required={false}
-								bind:value={RAGConfig.EXTERNAL_DOCUMENT_LOADER_API_KEY}
-							/>
-						</AdminSettingField>
+							<div class="flex justify-between w-full mt-2">
+								<div class="self-center text-xs font-medium">
+									<Tooltip
+										content={$i18n.t(
+											'Significantly improves accuracy by using an LLM to enhance tables, forms, inline math, and layout detection. Will increase latency. Defaults to False.'
+										)}
+										placement="top-start"
+									>
+										{$i18n.t('Use LLM')}
+									</Tooltip>
+								</div>
+								<div class="flex items-center">
+									<Switch bind:state={RAGConfig.DATALAB_MARKER_USE_LLM} />
+								</div>
+							</div>
+							<div class="flex justify-between w-full mt-2">
+								<div class="self-center text-xs font-medium">
+									<Tooltip
+										content={$i18n.t('Skip the cache and re-run the inference. Defaults to False.')}
+										placement="top-start"
+									>
+										{$i18n.t('Skip Cache')}
+									</Tooltip>
+								</div>
+								<div class="flex items-center">
+									<Switch bind:state={RAGConfig.DATALAB_MARKER_SKIP_CACHE} />
+								</div>
+							</div>
+							<div class="flex justify-between w-full mt-2">
+								<div class="self-center text-xs font-medium">
+									<Tooltip
+										content={$i18n.t(
+											'Force OCR on all pages of the PDF. This can lead to worse results if you have good text in your PDFs. Defaults to False.'
+										)}
+										placement="top-start"
+									>
+										{$i18n.t('Force OCR')}
+									</Tooltip>
+								</div>
+								<div class="flex items-center">
+									<Switch bind:state={RAGConfig.DATALAB_MARKER_FORCE_OCR} />
+								</div>
+							</div>
+							<div class="flex justify-between w-full mt-2">
+								<div class="self-center text-xs font-medium">
+									<Tooltip
+										content={$i18n.t(
+											'Whether to paginate the output. Each page will be separated by a horizontal rule and page number. Defaults to False.'
+										)}
+										placement="top-start"
+									>
+										{$i18n.t('Paginate')}
+									</Tooltip>
+								</div>
+								<div class="flex items-center">
+									<Switch bind:state={RAGConfig.DATALAB_MARKER_PAGINATE} />
+								</div>
+							</div>
+							<div class="flex justify-between w-full mt-2">
+								<div class="self-center text-xs font-medium">
+									<Tooltip
+										content={$i18n.t(
+											'Strip existing OCR text from the PDF and re-run OCR. Ignored if Force OCR is enabled. Defaults to False.'
+										)}
+										placement="top-start"
+									>
+										{$i18n.t('Strip Existing OCR')}
+									</Tooltip>
+								</div>
+								<div class="flex items-center">
+									<Switch bind:state={RAGConfig.DATALAB_MARKER_STRIP_EXISTING_OCR} />
+								</div>
+							</div>
+							<div class="flex justify-between w-full mt-2">
+								<div class="self-center text-xs font-medium">
+									<Tooltip
+										content={$i18n.t(
+											'Disable image extraction from the PDF. If Use LLM is enabled, images will be automatically captioned. Defaults to False.'
+										)}
+										placement="top-start"
+									>
+										{$i18n.t('Disable Image Extraction')}
+									</Tooltip>
+								</div>
+								<div class="flex items-center">
+									<Switch bind:state={RAGConfig.DATALAB_MARKER_DISABLE_IMAGE_EXTRACTION} />
+								</div>
+							</div>
+							<div class="flex justify-between w-full mt-2">
+								<div class="self-center text-xs font-medium">
+									<Tooltip
+										content={$i18n.t(
+											'Format the lines in the output. Defaults to False. If set to True, the lines will be formatted to detect inline math and styles.'
+										)}
+										placement="top-start"
+									>
+										{$i18n.t('Format Lines')}
+									</Tooltip>
+								</div>
+								<div class="flex items-center">
+									<Switch bind:state={RAGConfig.DATALAB_MARKER_FORMAT_LINES} />
+								</div>
+							</div>
+							<div class="flex justify-between w-full mt-2">
+								<div class="self-center text-xs font-medium">
+									<Tooltip
+										content={$i18n.t(
+											"The output format for the text. Can be 'json', 'markdown', or 'html'. Defaults to 'markdown'."
+										)}
+										placement="top-start"
+									>
+										{$i18n.t('Output Format')}
+									</Tooltip>
+								</div>
+								<div class="">
+									<select
+										class="w-fit pr-8 rounded-sm px-2 text-xs bg-transparent outline-hidden text-right"
+										bind:value={RAGConfig.DATALAB_MARKER_OUTPUT_FORMAT}
+									>
+										<option value="markdown">{$i18n.t('Markdown')}</option>
+										<option value="json">{$i18n.t('JSON')}</option>
+										<option value="html">{$i18n.t('HTML')}</option>
+									</select>
+								</div>
+							</div>
+						{:else if RAGConfig.CONTENT_EXTRACTION_ENGINE === 'external'}
+							<div class="my-0.5 flex flex-col gap-2 pr-2">
+								<div class="flex gap-2">
+									<input
+										class="flex-1 w-full text-sm bg-transparent outline-hidden"
+										placeholder={$i18n.t('Enter External Document Loader URL')}
+										bind:value={RAGConfig.EXTERNAL_DOCUMENT_LOADER_URL}
+									/>
+									<SensitiveInput
+										placeholder={$i18n.t('Enter External Document Loader API Key')}
+										required={false}
+										bind:value={RAGConfig.EXTERNAL_DOCUMENT_LOADER_API_KEY}
+									/>
+								</div>
+								<div class="flex flex-col">
+									<div class="mb-0.5 text-xs text-gray-500">{$i18n.t('Headers')}</div>
+									<Tooltip
+										content={$i18n.t(
+											'Enter additional headers in JSON format (e.g. {"X-Custom-Header": "value"}'
+										)}
+									>
+										<Textarea
+											className="w-full text-sm outline-hidden"
+											bind:value={RAGConfig.EXTERNAL_DOCUMENT_LOADER_HEADERS}
+											placeholder={$i18n.t('Enter additional headers in JSON format')}
+											required={false}
+										/>
+									</Tooltip>
+									<button
+										type="button"
+										class="mt-1 flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition w-fit"
+										on:click={() =>
+											(showExternalDocumentLoaderHeadersHint =
+												!showExternalDocumentLoaderHeadersHint)}
+									>
+										<svg
+											xmlns="http://www.w3.org/2000/svg"
+											viewBox="0 0 20 20"
+											fill="currentColor"
+											class="w-3 h-3 transition-transform {showExternalDocumentLoaderHeadersHint
+												? 'rotate-90'
+												: ''}"
+										>
+											<path
+												fill-rule="evenodd"
+												d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z"
+												clip-rule="evenodd"
+											/>
+										</svg>
+										{$i18n.t('Header variables')}
+									</button>
+									{#if showExternalDocumentLoaderHeadersHint}
+										<div class="mt-1 text-xs text-gray-500 dark:text-gray-400 leading-5">
+											<div>
+												{$i18n.t('No additional headers are sent unless configured.')}
+											</div>
+											<div>
+												{$i18n.t('Example')}:
+												<code class="text-gray-700 dark:text-gray-300"
+													>{'{"X-OpenWebUI-File-Id": "{{FILE_ID}}"}'}</code
+												>
+											</div>
+											<div>
+												{$i18n.t('Available variables')}:
+												<code class="text-gray-700 dark:text-gray-300">{'{{FILE_ID}}'}</code>,
+												<code class="text-gray-700 dark:text-gray-300">{'{{FILE_NAME}}'}</code>,
+												<code class="text-gray-700 dark:text-gray-300"
+													>{'{{FILE_CONTENT_TYPE}}'}</code
+												>
+											</div>
+										</div>
+									{/if}
+								</div>
+							</div>
+						{:else if RAGConfig.CONTENT_EXTRACTION_ENGINE === 'tika'}
+							<div class="flex w-full mt-1">
+								<div class="flex-1 mr-2">
+									<input
+										class="flex-1 w-full text-sm bg-transparent outline-hidden"
+										placeholder={$i18n.t('Enter Tika Server URL')}
+										bind:value={RAGConfig.TIKA_SERVER_URL}
+									/>
+								</div>
+							</div>
+						{:else if RAGConfig.CONTENT_EXTRACTION_ENGINE === 'docling' || RAGConfig.CONTENT_EXTRACTION_ENGINE === 'docling_json'}
+							<div class="my-0.5 flex gap-2 pr-2">
+								<input
+									class="flex-1 w-full text-sm bg-transparent outline-hidden"
+									placeholder={$i18n.t('Enter Docling Server URL')}
+									bind:value={RAGConfig.DOCLING_SERVER_URL}
+								/>
+								<SensitiveInput
+									placeholder={$i18n.t('Enter Docling API Key')}
+									bind:value={RAGConfig.DOCLING_API_KEY}
+									required={false}
+								/>
+							</div>
+
+							<div class="flex flex-col gap-2 mt-2">
+								<div class=" flex flex-col w-full justify-between">
+									<div class=" mb-1 text-xs font-medium">
+										{$i18n.t('Parameters')}
+									</div>
+									<div class="flex w-full items-center relative">
+										<Textarea
+											bind:value={RAGConfig.DOCLING_PARAMS}
+											placeholder={$i18n.t('Enter additional parameters in JSON format')}
+											minSize={100}
+										/>
+									</div>
+								</div>
+							</div>
+
+							{#if RAGConfig.CONTENT_EXTRACTION_ENGINE === 'docling_json'}
+								<div class="mb-2.5 flex flex-col w-full justify-between">
+									<div class="flex w-full justify-between mb-1">
+										<div class="self-center text-xs font-medium">
+											{$i18n.t('Chunk mode')}
+										</div>
+										<div class="">
+											<select
+												bind:value={RAGConfig.DOCLING_JSON_CHUNK_MODE}
+												class="w-fit pr-8 rounded-sm px-2 text-xs bg-transparent outline-hidden text-right"
+											>
+												<option value="chunk">{$i18n.t('Chunk')}</option>
+												<option value="page">{$i18n.t('Page')}</option>
+												<option value="item">{$i18n.t('Item')}</option>
+											</select>
+										</div>
+									</div>
+								</div>
+							{/if}
+						{:else if RAGConfig.CONTENT_EXTRACTION_ENGINE === 'document_intelligence'}
+							<div class="my-0.5 flex gap-2 pr-2">
+								<input
+									class="flex-1 w-full text-sm bg-transparent outline-hidden"
+									placeholder={$i18n.t('Enter Document Intelligence Endpoint')}
+									bind:value={RAGConfig.DOCUMENT_INTELLIGENCE_ENDPOINT}
+								/>
+								<SensitiveInput
+									placeholder={$i18n.t('Enter Document Intelligence Key')}
+									bind:value={RAGConfig.DOCUMENT_INTELLIGENCE_KEY}
+									required={false}
+								/>
+							</div>
+							<div class="my-0.5 flex flex-col w-full">
+								<div class=" mb-1 text-xs font-medium">
+									{$i18n.t('Document Intelligence Model')}
+								</div>
+								<div class="flex w-full">
+									<div class="flex-1 mr-2">
+										<input
+											class="flex-1 w-full text-sm bg-transparent outline-hidden"
+											placeholder={$i18n.t('Enter Document Intelligence Model')}
+											bind:value={RAGConfig.DOCUMENT_INTELLIGENCE_MODEL}
+										/>
+									</div>
+								</div>
+							</div>
+						{:else if RAGConfig.CONTENT_EXTRACTION_ENGINE === 'mistral_ocr'}
+							<div class="my-0.5 flex gap-2 pr-2">
+								<input
+									class="flex-1 w-full text-sm bg-transparent outline-hidden"
+									placeholder={$i18n.t('Enter Mistral API Base URL')}
+									bind:value={RAGConfig.MISTRAL_OCR_API_BASE_URL}
+								/>
+								<SensitiveInput
+									placeholder={$i18n.t('Enter Mistral API Key')}
+									bind:value={RAGConfig.MISTRAL_OCR_API_KEY}
+								/>
+							</div>
+							<div class="flex justify-between w-full mt-2 pr-2">
+								<div class="self-center text-xs font-medium">
+									<Tooltip
+										content={$i18n.t(
+											'Send the PDF as a base64 data URL instead of uploading it first.'
+										)}
+										placement="top-start"
+									>
+										{$i18n.t('Use Base64')}
+									</Tooltip>
+								</div>
+								<div class="flex items-center">
+									<Switch bind:state={RAGConfig.MISTRAL_OCR_USE_BASE64} />
+								</div>
+							</div>
+						{:else if RAGConfig.CONTENT_EXTRACTION_ENGINE === 'paddleocr_vl'}
+							<div class="my-0.5 flex gap-2 pr-2">
+								<input
+									class="flex-1 w-full text-sm bg-transparent outline-hidden"
+									placeholder={$i18n.t('Enter PaddleOCR-vl API Base URL')}
+									bind:value={RAGConfig.PADDLEOCR_VL_BASE_URL}
+								/>
+								<SensitiveInput
+									placeholder={$i18n.t('Enter PaddleOCR-vl API Token')}
+									bind:value={RAGConfig.PADDLEOCR_VL_TOKEN}
+									required={false}
+								/>
+							</div>
+						{:else if RAGConfig.CONTENT_EXTRACTION_ENGINE === 'mineru'}
+							<!-- API Mode Selection -->
+							<div class="flex w-full mt-2">
+								<div class="flex-1 flex justify-between">
+									<div class="self-center text-xs font-medium">
+										{$i18n.t('API Mode')}
+									</div>
+									<select
+										class="w-fit pr-8 rounded-sm px-2 text-xs bg-transparent outline-hidden"
+										bind:value={RAGConfig.MINERU_API_MODE}
+										on:change={() => {
+											// Auto-update URL when switching modes if it's empty or matches the opposite mode's default
+											const cloudUrl = 'https://mineru.net/api/v4';
+											const localUrl = 'http://localhost:8000';
+
+											if (RAGConfig.MINERU_API_MODE === 'cloud') {
+												if (!RAGConfig.MINERU_API_URL || RAGConfig.MINERU_API_URL === localUrl) {
+													RAGConfig.MINERU_API_URL = cloudUrl;
+												}
+											} else {
+												if (!RAGConfig.MINERU_API_URL || RAGConfig.MINERU_API_URL === cloudUrl) {
+													RAGConfig.MINERU_API_URL = localUrl;
+												}
+											}
+										}}
+									>
+										<option value="local">{$i18n.t('local')}</option>
+										<option value="cloud">{$i18n.t('cloud')}</option>
+									</select>
+								</div>
+							</div>
+
+							<!-- API URL -->
+							<div class="flex w-full mt-2">
+								<input
+									class="flex-1 w-full text-sm bg-transparent outline-hidden"
+									placeholder={RAGConfig.MINERU_API_MODE === 'cloud'
+										? $i18n.t('https://mineru.net/api/v4')
+										: $i18n.t('http://localhost:8000')}
+									bind:value={RAGConfig.MINERU_API_URL}
+								/>
+							</div>
+
+							<div class="flex w-full mt-2">
+								<SensitiveInput
+									placeholder={$i18n.t('Enter MinerU API Key')}
+									bind:value={RAGConfig.MINERU_API_KEY}
+								/>
+							</div>
+
+							<div class="flex w-full mt-2">
+								<div class="flex-1 flex justify-between">
+									<div class="self-center text-xs font-medium">
+										{$i18n.t('API Timeout')}
+									</div>
+									<input
+										class="w-16 text-sm bg-transparent outline-hidden text-right"
+										type="number"
+										min="1"
+										bind:value={RAGConfig.MINERU_API_TIMEOUT}
+										placeholder="60"
+									/>
+								</div>
+							</div>
+
+							<!-- Parameters -->
+							<div class="flex flex-col justify-between w-full mt-2">
+								<div class="text-xs font-medium">
+									<Tooltip
+										content={$i18n.t(
+											'Advanced parameters for MinerU parsing (enable_ocr, enable_formula, enable_table, language, model_version, page_ranges)'
+										)}
+										placement="top-start"
+									>
+										{$i18n.t('Parameters')}
+									</Tooltip>
+								</div>
+								<div class="mt-1.5">
+									<Textarea
+										bind:value={RAGConfig.MINERU_PARAMS}
+										placeholder={`{\n  "enable_ocr": false,\n  "enable_formula": true,\n  "enable_table": true,\n  "language": "en",\n  "model_version": "pipeline",\n  "page_ranges": ""\n}`}
+										minSize={100}
+									/>
+								</div>
+							</div>
+
+							<!-- File Extensions -->
+							<div class="flex flex-col justify-between w-full mt-2">
+								<div class="text-xs font-medium mb-1">
+									<Tooltip
+										content={$i18n.t(
+											'Comma-separated list of file extensions MinerU will handle (e.g. pdf, docx, pptx, xlsx)'
+										)}
+										placement="top-start"
+									>
+										{$i18n.t('File Extensions')}
+									</Tooltip>
+								</div>
+								<input
+									class="flex-1 w-full text-sm bg-transparent outline-hidden"
+									placeholder={$i18n.t('pdf, docx, pptx, xlsx')}
+									bind:value={RAGConfig.MINERU_FILE_EXTENSIONS}
+								/>
+							</div>
+						{/if}
 					</div>
 
-					<AdminSettingField
-						label={$i18n.t('Headers')}
-						description={$i18n.t('Additional JSON headers sent to the external document loader.')}
-					>
-						<Tooltip
-							content={$i18n.t(
-								'Enter additional headers in JSON format (e.g. {"X-Custom-Header": "value"}'
-							)}
-						>
-							<Textarea
-								className={textareaClass}
-								bind:value={RAGConfig.EXTERNAL_DOCUMENT_LOADER_HEADERS}
-								placeholder={$i18n.t('Enter additional headers in JSON format')}
-								required={false}
-							/>
-						</Tooltip>
-						<button
-							type="button"
-							class="mt-1 text-[0.6875rem] text-gray-400 transition-colors hover:text-gray-700 dark:text-gray-600 dark:hover:text-gray-300"
-							on:click={() =>
-								(showExternalDocumentLoaderHeadersHint = !showExternalDocumentLoaderHeadersHint)}
-						>
-							{$i18n.t('Header variables')}
-						</button>
-						{#if showExternalDocumentLoaderHeadersHint}
-							<div class="mt-1 text-[0.6875rem] leading-5 text-gray-500 dark:text-gray-400">
-								<div>{$i18n.t('No additional headers are sent unless configured.')}</div>
-								<div>
-									{$i18n.t('Example')}:
-									<code class="text-gray-700 dark:text-gray-300"
-										>{'{"X-OpenWebUI-File-Id": "{{FILE_ID}}"}'}</code
-									>
+					<div class="  mb-2.5 flex w-full justify-between">
+						<div class=" self-center text-xs font-medium">
+							<Tooltip content={$i18n.t('Full Context Mode')} placement="top-start">
+								{$i18n.t('Bypass Embedding and Retrieval')}
+							</Tooltip>
+						</div>
+						<div class="flex items-center relative">
+							<Tooltip
+								content={RAGConfig.BYPASS_EMBEDDING_AND_RETRIEVAL
+									? $i18n.t(
+											'Inject the entire content as context for comprehensive processing, this is recommended for complex queries.'
+										)
+									: $i18n.t(
+											'Default to segmented retrieval for focused and relevant content extraction, this is recommended for most cases.'
+										)}
+							>
+								<Switch bind:state={RAGConfig.BYPASS_EMBEDDING_AND_RETRIEVAL} />
+							</Tooltip>
+						</div>
+					</div>
+
+					{#if !RAGConfig.BYPASS_EMBEDDING_AND_RETRIEVAL}
+						<div class="  mb-2.5 flex w-full justify-between">
+							<div class=" self-center text-xs font-medium">{$i18n.t('Text Splitter')}</div>
+							<div class="flex items-center relative">
+								<select
+									class="w-fit pr-8 rounded-sm px-2 text-xs bg-transparent outline-hidden text-right"
+									bind:value={RAGConfig.TEXT_SPLITTER}
+								>
+									<option value="">{$i18n.t('Default')} ({$i18n.t('Character')})</option>
+									<option value="token">{$i18n.t('Token')} ({$i18n.t('Tiktoken')})</option>
+									<option value="token_transformers">
+										{$i18n.t('Token')} ({$i18n.t('Transformers')})
+									</option>
+								</select>
+							</div>
+						</div>
+
+						{#if RAGConfig.TEXT_SPLITTER === 'token_transformers'}
+							<div class="mb-2.5 flex flex-col w-full justify-between">
+								<div class="self-center text-xs font-medium min-w-fit mb-1 w-full">
+									{$i18n.t('Tokenizer Model')}
 								</div>
-								<div>
-									{$i18n.t('Available variables')}:
-									<code class="text-gray-700 dark:text-gray-300">{'{{FILE_ID}}'}</code>,
-									<code class="text-gray-700 dark:text-gray-300">{'{{FILE_NAME}}'}</code>,
-									<code class="text-gray-700 dark:text-gray-300">{'{{FILE_CONTENT_TYPE}}'}</code>
+								<div class="self-center w-full">
+									<input
+										class="w-full rounded-lg py-1.5 px-4 text-sm bg-gray-50 dark:text-gray-300 dark:bg-gray-850 outline-hidden"
+										placeholder={$i18n.t('Enter Tokenizer Model')}
+										bind:value={RAGConfig.RAG_TOKENIZER_MODEL}
+										autocomplete="off"
+										required={RAG_EMBEDDING_ENGINE !== ''}
+									/>
 								</div>
 							</div>
 						{/if}
-					</AdminSettingField>
-				{:else if RAGConfig.CONTENT_EXTRACTION_ENGINE === 'tika'}
-					<AdminSettingField
-						label={$i18n.t('Tika Server URL')}
-						description={$i18n.t('Tika server endpoint used for content extraction.')}
-					>
-						<input
-							class={inputClass}
-							placeholder={$i18n.t('Enter Tika Server URL')}
-							bind:value={RAGConfig.TIKA_SERVER_URL}
-						/>
-					</AdminSettingField>
-				{:else if RAGConfig.CONTENT_EXTRACTION_ENGINE === 'docling'}
-					<div class="grid grid-cols-1 gap-x-3 gap-y-2.5 sm:grid-cols-2">
-						<AdminSettingField
-							label={$i18n.t('Docling Server URL')}
-							description={$i18n.t('Docling service endpoint used for parsing.')}
-						>
-							<input
-								class={inputClass}
-								placeholder={$i18n.t('Enter Docling Server URL')}
-								bind:value={RAGConfig.DOCLING_SERVER_URL}
-							/>
-						</AdminSettingField>
-						<AdminSettingField
-							label={$i18n.t('API Key')}
-							description={$i18n.t('API key sent to Docling.')}
-						>
-							<SensitiveInput
-								variant="settings"
-								placeholder={$i18n.t('Enter Docling API Key')}
-								bind:value={RAGConfig.DOCLING_API_KEY}
-								required={false}
-							/>
-						</AdminSettingField>
-					</div>
 
-					<AdminSettingField
-						label={$i18n.t('Parameters')}
-						description={$i18n.t('Additional Docling parameters in JSON format.')}
-					>
-						<Textarea
-							className={textareaClass}
-							bind:value={RAGConfig.DOCLING_PARAMS}
-							placeholder={$i18n.t('Enter additional parameters in JSON format')}
-							minSize={100}
-						/>
-					</AdminSettingField>
-				{:else if RAGConfig.CONTENT_EXTRACTION_ENGINE === 'document_intelligence'}
-					<div class="grid grid-cols-1 gap-x-3 gap-y-2.5 sm:grid-cols-2">
-						<AdminSettingField
-							label={$i18n.t('Endpoint')}
-							description={$i18n.t('Document Intelligence endpoint used for parsing.')}
-						>
-							<input
-								class={inputClass}
-								placeholder={$i18n.t('Enter Document Intelligence Endpoint')}
-								bind:value={RAGConfig.DOCUMENT_INTELLIGENCE_ENDPOINT}
-							/>
-						</AdminSettingField>
-						<AdminSettingField
-							label={$i18n.t('Key')}
-							description={$i18n.t('Credential used for Document Intelligence.')}
-						>
-							<SensitiveInput
-								variant="settings"
-								placeholder={$i18n.t('Enter Document Intelligence Key')}
-								bind:value={RAGConfig.DOCUMENT_INTELLIGENCE_KEY}
-								required={false}
-							/>
-						</AdminSettingField>
-					</div>
-
-					<AdminSettingField
-						label={$i18n.t('Document Intelligence Model')}
-						description={$i18n.t('Model name used by Document Intelligence.')}
-					>
-						<input
-							class={inputClass}
-							placeholder={$i18n.t('Enter Document Intelligence Model')}
-							bind:value={RAGConfig.DOCUMENT_INTELLIGENCE_MODEL}
-						/>
-					</AdminSettingField>
-				{:else if RAGConfig.CONTENT_EXTRACTION_ENGINE === 'mistral_ocr'}
-					<div class="grid grid-cols-1 gap-x-3 gap-y-2.5 sm:grid-cols-2">
-						<AdminSettingField
-							label={$i18n.t('API Base URL')}
-							description={$i18n.t('Mistral OCR service endpoint.')}
-						>
-							<input
-								class={inputClass}
-								placeholder={$i18n.t('Enter Mistral API Base URL')}
-								bind:value={RAGConfig.MISTRAL_OCR_API_BASE_URL}
-							/>
-						</AdminSettingField>
-						<AdminSettingField
-							label={$i18n.t('API Key')}
-							description={$i18n.t('API key sent to Mistral OCR.')}
-						>
-							<SensitiveInput
-								variant="settings"
-								placeholder={$i18n.t('Enter Mistral API Key')}
-								bind:value={RAGConfig.MISTRAL_OCR_API_KEY}
-							/>
-						</AdminSettingField>
-					</div>
-					<AdminSettingRow
-						label={$i18n.t('Use Base64')}
-						description={$i18n.t('Send PDFs as base64 data URLs instead of uploading first.')}
-						let:labelId
-					>
-						<Switch bind:state={RAGConfig.MISTRAL_OCR_USE_BASE64} ariaLabelledbyId={labelId} />
-					</AdminSettingRow>
-				{:else if RAGConfig.CONTENT_EXTRACTION_ENGINE === 'paddleocr_vl'}
-					<div class="grid grid-cols-1 gap-x-3 gap-y-2.5 sm:grid-cols-2">
-						<AdminSettingField
-							label={$i18n.t('API Base URL')}
-							description={$i18n.t('PaddleOCR-vl service endpoint.')}
-						>
-							<input
-								class={inputClass}
-								placeholder={$i18n.t('Enter PaddleOCR-vl API Base URL')}
-								bind:value={RAGConfig.PADDLEOCR_VL_BASE_URL}
-							/>
-						</AdminSettingField>
-						<AdminSettingField
-							label={$i18n.t('API Token')}
-							description={$i18n.t('API token sent to PaddleOCR-vl.')}
-						>
-							<SensitiveInput
-								variant="settings"
-								placeholder={$i18n.t('Enter PaddleOCR-vl API Token')}
-								bind:value={RAGConfig.PADDLEOCR_VL_TOKEN}
-								required={false}
-							/>
-						</AdminSettingField>
-					</div>
-				{:else if RAGConfig.CONTENT_EXTRACTION_ENGINE === 'mineru'}
-					<AdminSettingRow
-						label={$i18n.t('API Mode')}
-						description={$i18n.t('Choose the local or cloud MinerU API mode.')}
-					>
-						<SettingsSelect
-							bind:value={RAGConfig.MINERU_API_MODE}
-							on:change={() => {
-								const cloudUrl = 'https://mineru.net/api/v4';
-								const localUrl = 'http://localhost:8000';
-
-								if (RAGConfig.MINERU_API_MODE === 'cloud') {
-									if (!RAGConfig.MINERU_API_URL || RAGConfig.MINERU_API_URL === localUrl) {
-										RAGConfig.MINERU_API_URL = cloudUrl;
-									}
-								} else {
-									if (!RAGConfig.MINERU_API_URL || RAGConfig.MINERU_API_URL === cloudUrl) {
-										RAGConfig.MINERU_API_URL = localUrl;
-									}
-								}
-							}}
-						>
-							<option value="local">{$i18n.t('local')}</option>
-							<option value="cloud">{$i18n.t('cloud')}</option>
-						</SettingsSelect>
-					</AdminSettingRow>
-
-					<AdminSettingField
-						label={$i18n.t('API URL')}
-						description={$i18n.t('MinerU API endpoint for the selected mode.')}
-					>
-						<input
-							class={inputClass}
-							placeholder={RAGConfig.MINERU_API_MODE === 'cloud'
-								? $i18n.t('https://mineru.net/api/v4')
-								: $i18n.t('http://localhost:8000')}
-							bind:value={RAGConfig.MINERU_API_URL}
-						/>
-					</AdminSettingField>
-
-					<AdminSettingField
-						label={$i18n.t('API Key')}
-						description={$i18n.t('API key used for MinerU cloud mode.')}
-					>
-						<SensitiveInput
-							variant="settings"
-							placeholder={$i18n.t('Enter MinerU API Key')}
-							bind:value={RAGConfig.MINERU_API_KEY}
-						/>
-					</AdminSettingField>
-
-					<AdminSettingRow
-						label={$i18n.t('API Timeout')}
-						description={$i18n.t('Maximum time in seconds to wait for MinerU API responses.')}
-					>
-						<input
-							class="w-16 rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 text-right text-xs text-gray-700 outline-hidden transition-colors focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:focus:border-blue-500"
-							type="number"
-							min="1"
-							bind:value={RAGConfig.MINERU_API_TIMEOUT}
-							placeholder="60"
-						/>
-					</AdminSettingRow>
-
-					<AdminSettingField
-						label={$i18n.t('Parameters')}
-						description={$i18n.t('Advanced MinerU parsing parameters in JSON format.')}
-					>
-						<Textarea
-							className={textareaClass}
-							bind:value={RAGConfig.MINERU_PARAMS}
-							placeholder={`{\n  "enable_ocr": false,\n  "enable_formula": true,\n  "enable_table": true,\n  "language": "en",\n  "model_version": "pipeline",\n  "page_ranges": ""\n}`}
-							minSize={100}
-						/>
-					</AdminSettingField>
-
-					<AdminSettingField
-						label={$i18n.t('File Extensions')}
-						description={$i18n.t('Comma-separated extensions MinerU should handle.')}
-					>
-						<input
-							class={inputClass}
-							placeholder={$i18n.t('pdf, docx, pptx, xlsx')}
-							bind:value={RAGConfig.MINERU_FILE_EXTENSIONS}
-						/>
-					</AdminSettingField>
-				{/if}
-
-				<AdminSettingRow
-					label={$i18n.t('Bypass Embedding and Retrieval')}
-					description={RAGConfig.BYPASS_EMBEDDING_AND_RETRIEVAL
-						? $i18n.t('Inject the entire content as context for comprehensive processing.')
-						: $i18n.t('Use segmented retrieval for focused and relevant context.')}
-					let:labelId
-				>
-					<Switch
-						bind:state={RAGConfig.BYPASS_EMBEDDING_AND_RETRIEVAL}
-						ariaLabelledbyId={labelId}
-					/>
-				</AdminSettingRow>
-
-				{#if !RAGConfig.BYPASS_EMBEDDING_AND_RETRIEVAL}
-					<AdminSettingRow
-						label={$i18n.t('Text Splitter')}
-						description={$i18n.t('Choose how extracted text is split before indexing.')}
-					>
-						<SettingsSelect bind:value={RAGConfig.TEXT_SPLITTER}>
-							<option value="">{$i18n.t('Default')} ({$i18n.t('Character')})</option>
-							<option value="token">{$i18n.t('Token')} ({$i18n.t('Tiktoken')})</option>
-							<option value="token_transformers">
-								{$i18n.t('Token')} ({$i18n.t('Transformers')})
-							</option>
-						</SettingsSelect>
-					</AdminSettingRow>
-
-					{#if RAGConfig.TEXT_SPLITTER === 'token_transformers'}
-						<AdminSettingField
-							label={$i18n.t('Tokenizer Model')}
-							description={$i18n.t('Tokenizer model used for transformer token splitting.')}
-						>
-							<input
-								class={inputClass}
-								placeholder={$i18n.t('Enter Tokenizer Model')}
-								bind:value={RAGConfig.RAG_TOKENIZER_MODEL}
-								autocomplete="off"
-								required={RAG_EMBEDDING_ENGINE !== ''}
-							/>
-						</AdminSettingField>
-					{/if}
-
-					<AdminSettingRow
-						label={$i18n.t('Markdown Header Text Splitter')}
-						description={$i18n.t(
-							'Split documents by markdown headers before character or token splitting.'
-						)}
-						let:labelId
-					>
-						<Switch
-							bind:state={RAGConfig.ENABLE_MARKDOWN_HEADER_TEXT_SPLITTER}
-							ariaLabelledbyId={labelId}
-						/>
-					</AdminSettingRow>
-
-					<div class="grid grid-cols-1 gap-x-3 gap-y-2.5 sm:grid-cols-2">
-						<AdminSettingField
-							label={$i18n.t('Chunk Size')}
-							description={$i18n.t('Maximum size for each text chunk.')}
-						>
-							<input
-								class={inputClass}
-								type="number"
-								placeholder={$i18n.t('Enter Chunk Size')}
-								bind:value={RAGConfig.CHUNK_SIZE}
-								autocomplete="off"
-								min="0"
-							/>
-						</AdminSettingField>
-						<AdminSettingField
-							label={$i18n.t('Chunk Overlap')}
-							description={$i18n.t('Overlap preserved between neighboring chunks.')}
-						>
-							<input
-								class={inputClass}
-								type="number"
-								placeholder={$i18n.t('Enter Chunk Overlap')}
-								bind:value={RAGConfig.CHUNK_OVERLAP}
-								autocomplete="off"
-								min="0"
-							/>
-						</AdminSettingField>
-					</div>
-
-					{#if RAGConfig.ENABLE_MARKDOWN_HEADER_TEXT_SPLITTER}
-						<AdminSettingField
-							label={$i18n.t('Chunk Min Size Target')}
-							description={$i18n.t(
-								'Merge chunks smaller than this threshold when possible. Set to 0 to disable merging.'
-							)}
-						>
-							<input
-								class={inputClass}
-								type="number"
-								placeholder={$i18n.t('Enter Chunk Min Size Target')}
-								bind:value={RAGConfig.CHUNK_MIN_SIZE_TARGET}
-								autocomplete="off"
-								min="0"
-							/>
-						</AdminSettingField>
-					{/if}
-				{/if}
-			</AdminSettingSection>
-
-			{#if !RAGConfig.BYPASS_EMBEDDING_AND_RETRIEVAL}
-				<AdminSettingSection title={$i18n.t('Embedding')}>
-					<AdminSettingRow
-						label={$i18n.t('Embedding Model Engine')}
-						description={$i18n.t('Provider used to generate document embeddings.')}
-					>
-						<SettingsSelect
-							bind:value={RAG_EMBEDDING_ENGINE}
-							placeholder={$i18n.t('Select an embedding model engine')}
-							on:change={(e) => {
-								if (e.target.value === 'ollama') {
-									RAG_EMBEDDING_MODEL = '';
-								} else if (e.target.value === 'openai') {
-									RAG_EMBEDDING_MODEL = 'text-embedding-3-small';
-								} else if (e.target.value === 'azure_openai') {
-									RAG_EMBEDDING_MODEL = 'text-embedding-3-small';
-								} else if (e.target.value === '') {
-									RAG_EMBEDDING_MODEL = 'sentence-transformers/all-MiniLM-L6-v2';
-								}
-							}}
-						>
-							<option value="">{$i18n.t('Default (SentenceTransformers)')}</option>
-							<option value="ollama">{$i18n.t('Ollama')}</option>
-							<option value="openai">{$i18n.t('OpenAI')}</option>
-							<option value="azure_openai">{$i18n.t('Azure OpenAI')}</option>
-						</SettingsSelect>
-					</AdminSettingRow>
-
-					{#if RAG_EMBEDDING_ENGINE === 'openai'}
-						<div class="grid grid-cols-1 gap-x-3 gap-y-2.5 sm:grid-cols-2">
-							<AdminSettingField
-								label={$i18n.t('API Base URL')}
-								description={$i18n.t('OpenAI-compatible embeddings endpoint.')}
-							>
-								<input
-									class={inputClass}
-									placeholder={$i18n.t('API Base URL')}
-									bind:value={OpenAIUrl}
-									required
-								/>
-							</AdminSettingField>
-							<AdminSettingField
-								label={$i18n.t('API Key')}
-								description={$i18n.t('API key for embedding requests.')}
-							>
-								<SensitiveInput
-									variant="settings"
-									placeholder={$i18n.t('API Key')}
-									bind:value={OpenAIKey}
-									required={false}
-								/>
-							</AdminSettingField>
-						</div>
-					{:else if RAG_EMBEDDING_ENGINE === 'ollama'}
-						<div class="grid grid-cols-1 gap-x-3 gap-y-2.5 sm:grid-cols-2">
-							<AdminSettingField
-								label={$i18n.t('API Base URL')}
-								description={$i18n.t('Ollama endpoint used for embeddings.')}
-							>
-								<input
-									class={inputClass}
-									placeholder={$i18n.t('API Base URL')}
-									bind:value={OllamaUrl}
-									required
-								/>
-							</AdminSettingField>
-							<AdminSettingField
-								label={$i18n.t('API Key')}
-								description={$i18n.t('Optional API key for Ollama requests.')}
-							>
-								<SensitiveInput
-									variant="settings"
-									placeholder={$i18n.t('API Key')}
-									bind:value={OllamaKey}
-									required={false}
-								/>
-							</AdminSettingField>
-						</div>
-					{:else if RAG_EMBEDDING_ENGINE === 'azure_openai'}
-						<div class="grid grid-cols-1 gap-x-3 gap-y-2.5 sm:grid-cols-2">
-							<AdminSettingField
-								label={$i18n.t('API Base URL')}
-								description={$i18n.t('Azure OpenAI endpoint used for embeddings.')}
-							>
-								<input
-									class={inputClass}
-									placeholder={$i18n.t('API Base URL')}
-									bind:value={AzureOpenAIUrl}
-									required
-								/>
-							</AdminSettingField>
-							<AdminSettingField
-								label={$i18n.t('API Key')}
-								description={$i18n.t('Azure OpenAI API key.')}
-							>
-								<SensitiveInput
-									variant="settings"
-									placeholder={$i18n.t('API Key')}
-									bind:value={AzureOpenAIKey}
-								/>
-							</AdminSettingField>
-							<AdminSettingField
-								label={$i18n.t('Version')}
-								description={$i18n.t('Azure OpenAI API version.')}
-							>
-								<input
-									class={inputClass}
-									placeholder={$i18n.t('Version')}
-									bind:value={AzureOpenAIVersion}
-									required
-								/>
-							</AdminSettingField>
-						</div>
-					{/if}
-
-					<AdminSettingField
-						label={$i18n.t('Embedding Model')}
-						description={$i18n.t(
-							'Model used to generate embeddings. Reindex knowledge after changing this.'
-						)}
-					>
-						<div class="flex w-full gap-2">
-							<input
-								class={inputClass}
-								placeholder={RAG_EMBEDDING_ENGINE === 'ollama'
-									? $i18n.t('Set embedding model')
-									: $i18n.t('Set embedding model (e.g. {{model}})', {
-											model: RAG_EMBEDDING_MODEL.slice(-40)
-										})}
-								bind:value={RAG_EMBEDDING_MODEL}
-								required={RAG_EMBEDDING_ENGINE === 'ollama'}
-							/>
-
-							{#if RAG_EMBEDDING_ENGINE === ''}
-								<button
-									class="flex size-7 shrink-0 items-center justify-center rounded-lg text-gray-500 transition-colors hover:bg-black/5 hover:text-gray-900 dark:text-gray-500 dark:hover:bg-white/5 dark:hover:text-white"
-									type="button"
-									on:click={() => {
-										embeddingModelUpdateHandler();
-									}}
-									disabled={updateEmbeddingModelLoading}
-									aria-label={$i18n.t('Update embedding model')}
+						<div class="  mb-2.5 flex w-full justify-between">
+							<div class=" self-center text-xs font-medium">
+								<Tooltip
+									placement="top-start"
+									content={$i18n.t(
+										'Split documents by markdown headers before applying character/token splitting.'
+									)}
 								>
-									{#if updateEmbeddingModelLoading}
-										<Spinner />
-									{:else}
-										<svg
-											xmlns="http://www.w3.org/2000/svg"
-											viewBox="0 0 16 16"
-											fill="currentColor"
-											class="size-4"
-										>
-											<path
-												d="M8.75 2.75a.75.75 0 0 0-1.5 0v5.69L5.03 6.22a.75.75 0 0 0-1.06 1.06l3.5 3.5a.75.75 0 0 0 1.06 0l3.5-3.5a.75.75 0 0 0-1.06-1.06L8.75 8.44V2.75Z"
-											/>
-											<path
-												d="M3.5 9.75a.75.75 0 0 0-1.5 0v1.5A2.75 2.75 0 0 0 4.75 14h6.5A2.75 2.75 0 0 0 14 11.25v-1.5a.75.75 0 0 0-1.5 0v1.5c0 .69-.56 1.25-1.25 1.25h-6.5c-.69 0-1.25-.56-1.25-1.25v-1.5Z"
-											/>
-										</svg>
-									{/if}
-								</button>
-							{/if}
+									{$i18n.t('Markdown Header Text Splitter')}
+								</Tooltip>
+							</div>
+							<div class="flex items-center relative">
+								<Switch bind:state={RAGConfig.ENABLE_MARKDOWN_HEADER_TEXT_SPLITTER} />
+							</div>
 						</div>
-						<div class="mt-1 text-[0.6875rem] text-gray-400 dark:text-gray-600">
-							{$i18n.t(
-								'After changing the embedding model, reindex the knowledge base for changes to take effect.'
-							)}
-						</div>
-					</AdminSettingField>
 
-					<AdminSettingRow
-						label={$i18n.t('Embedding Batch Size')}
-						description={$i18n.t('Number of items processed per embedding batch.')}
-					>
-						<input
-							bind:value={RAG_EMBEDDING_BATCH_SIZE}
-							type="number"
-							class="w-14 bg-transparent text-center text-xs outline-none"
-							min="-2"
-							max="16000"
-							step="1"
-						/>
-					</AdminSettingRow>
-
-					{#if RAG_EMBEDDING_ENGINE === 'ollama' || RAG_EMBEDDING_ENGINE === 'openai' || RAG_EMBEDDING_ENGINE === 'azure_openai'}
-						<AdminSettingRow
-							label={$i18n.t('Async Embedding Processing')}
-							description={$i18n.t('Run embedding tasks concurrently to speed up processing.')}
-							let:labelId
-						>
-							<Switch bind:state={ENABLE_ASYNC_EMBEDDING} ariaLabelledbyId={labelId} />
-						</AdminSettingRow>
-						<AdminSettingRow
-							label={$i18n.t('Embedding Concurrent Requests')}
-							description={$i18n.t(
-								'Maximum concurrent embedding requests. Set to 0 for unlimited.'
-							)}
-						>
-							<input
-								bind:value={RAG_EMBEDDING_CONCURRENT_REQUESTS}
-								type="number"
-								class="w-14 bg-transparent text-center text-xs outline-none"
-								min="0"
-								step="1"
-							/>
-						</AdminSettingRow>
-					{/if}
-				</AdminSettingSection>
-			{/if}
-
-			<AdminSettingSection title={$i18n.t('Retrieval')}>
-				{#if !RAGConfig.BYPASS_EMBEDDING_AND_RETRIEVAL}
-					<AdminSettingRow
-						label={$i18n.t('Full Context Mode')}
-						description={RAGConfig.RAG_FULL_CONTEXT
-							? $i18n.t('Inject entire documents as context for comprehensive processing.')
-							: $i18n.t('Use segmented retrieval for focused context.')}
-						let:labelId
-					>
-						<Switch bind:state={RAGConfig.RAG_FULL_CONTEXT} ariaLabelledbyId={labelId} />
-					</AdminSettingRow>
-
-					{#if !RAGConfig.RAG_FULL_CONTEXT}
-						<AdminSettingRow
-							label={$i18n.t('Hybrid Search')}
-							description={$i18n.t('Combine semantic and keyword retrieval.')}
-							let:labelId
-						>
-							<Switch bind:state={RAGConfig.ENABLE_RAG_HYBRID_SEARCH} ariaLabelledbyId={labelId} />
-						</AdminSettingRow>
-
-						{#if RAGConfig.ENABLE_RAG_HYBRID_SEARCH === true}
-							<AdminSettingRow
-								label={$i18n.t('Enrich Hybrid Search Text')}
-								description={$i18n.t(
-									'Add filenames, titles, sections, and snippets to improve lexical recall.'
-								)}
-								let:labelId
-							>
-								<Switch
-									bind:state={RAGConfig.ENABLE_RAG_HYBRID_SEARCH_ENRICHED_TEXTS}
-									ariaLabelledbyId={labelId}
-								/>
-							</AdminSettingRow>
-
-							<AdminSettingRow
-								label={$i18n.t('Reranking Engine')}
-								description={$i18n.t('Provider used to rerank hybrid search results.')}
-							>
-								<SettingsSelect
-									bind:value={RAGConfig.RAG_RERANKING_ENGINE}
-									placeholder={$i18n.t('Select a reranking model engine')}
-									on:change={(e) => {
-										if (e.target.value === 'external') {
-											RAGConfig.RAG_RERANKING_MODEL = '';
-										} else if (e.target.value === '') {
-											RAGConfig.RAG_RERANKING_MODEL = 'BAAI/bge-reranker-v2-m3';
-										}
-									}}
-								>
-									<option value="">{$i18n.t('Default (SentenceTransformers)')}</option>
-									<option value="external">{$i18n.t('External')}</option>
-								</SettingsSelect>
-							</AdminSettingRow>
-
-							{#if RAGConfig.RAG_RERANKING_ENGINE === 'external'}
-								<div class="grid grid-cols-1 gap-x-3 gap-y-2.5 sm:grid-cols-2">
-									<AdminSettingField
-										label={$i18n.t('API Base URL')}
-										description={$i18n.t('External reranker endpoint.')}
-									>
+						<div class="  mb-2.5 flex w-full justify-between">
+							<div class=" flex gap-1.5 w-full">
+								<div class="  w-full justify-between">
+									<div class="self-center text-xs font-medium min-w-fit mb-1">
+										{$i18n.t('Chunk Size')}
+									</div>
+									<div class="self-center">
 										<input
-											class={inputClass}
+											class=" w-full rounded-lg py-1.5 px-4 text-sm bg-gray-50 dark:text-gray-300 dark:bg-gray-850 outline-hidden"
+											type="number"
+											placeholder={$i18n.t('Enter Chunk Size')}
+											bind:value={RAGConfig.CHUNK_SIZE}
+											autocomplete="off"
+											min="0"
+										/>
+									</div>
+								</div>
+
+								<div class="w-full">
+									<div class=" self-center text-xs font-medium min-w-fit mb-1">
+										{$i18n.t('Chunk Overlap')}
+									</div>
+
+									<div class="self-center">
+										<input
+											class="w-full rounded-lg py-1.5 px-4 text-sm bg-gray-50 dark:text-gray-300 dark:bg-gray-850 outline-hidden"
+											type="number"
+											placeholder={$i18n.t('Enter Chunk Overlap')}
+											bind:value={RAGConfig.CHUNK_OVERLAP}
+											autocomplete="off"
+											min="0"
+										/>
+									</div>
+								</div>
+							</div>
+						</div>
+
+						{#if RAGConfig.ENABLE_MARKDOWN_HEADER_TEXT_SPLITTER}
+							<div class="  mb-2.5 flex w-full justify-between">
+								<div class=" flex gap-1.5 w-full">
+									<div class="w-full">
+										<div class="self-center text-xs font-medium min-w-fit mb-1">
+											<Tooltip
+												placement="top-start"
+												content={$i18n.t(
+													'Chunks smaller than this threshold will be merged with neighboring chunks when possible. Set to 0 to disable merging.'
+												)}
+											>
+												{$i18n.t('Chunk Min Size Target')}
+											</Tooltip>
+										</div>
+										<div class="self-center">
+											<input
+												class="w-full rounded-lg py-1.5 px-4 text-sm bg-gray-50 dark:text-gray-300 dark:bg-gray-850 outline-hidden"
+												type="number"
+												placeholder={$i18n.t('Enter Chunk Min Size Target')}
+												bind:value={RAGConfig.CHUNK_MIN_SIZE_TARGET}
+												autocomplete="off"
+												min="0"
+											/>
+										</div>
+									</div>
+								</div>
+							</div>
+						{/if}
+					{/if}
+				</div>
+
+				{#if !RAGConfig.BYPASS_EMBEDDING_AND_RETRIEVAL}
+					<div class="mb-3">
+						<div class=" mt-0.5 mb-2.5 text-base font-medium">{$i18n.t('Embedding')}</div>
+
+						<hr class=" border-gray-100/30 dark:border-gray-850/30 my-2" />
+
+						<div class="  mb-2.5 flex flex-col w-full justify-between">
+							<div class="flex w-full justify-between">
+								<div class=" self-center text-xs font-medium">
+									{$i18n.t('Embedding Model Engine')}
+								</div>
+								<div class="flex items-center relative">
+									<select
+										class="w-fit pr-8 rounded-sm px-2 p-1 text-xs bg-transparent outline-hidden text-right"
+										bind:value={RAG_EMBEDDING_ENGINE}
+										placeholder={$i18n.t('Select an embedding model engine')}
+										on:change={(e) => {
+											if (e.target.value === 'ollama') {
+												RAG_EMBEDDING_MODEL = '';
+											} else if (e.target.value === 'openai') {
+												RAG_EMBEDDING_MODEL = 'text-embedding-3-small';
+											} else if (e.target.value === 'azure_openai') {
+												RAG_EMBEDDING_MODEL = 'text-embedding-3-small';
+											} else if (e.target.value === '') {
+												RAG_EMBEDDING_MODEL = 'sentence-transformers/all-MiniLM-L6-v2';
+											}
+										}}
+									>
+										<option value="">{$i18n.t('Default (SentenceTransformers)')}</option>
+										<option value="ollama">{$i18n.t('Ollama')}</option>
+										<option value="openai">{$i18n.t('OpenAI')}</option>
+										<option value="azure_openai">{$i18n.t('Azure OpenAI')}</option>
+									</select>
+								</div>
+							</div>
+
+							{#if RAG_EMBEDDING_ENGINE === 'openai'}
+								<div class="my-0.5 flex gap-2 pr-2">
+									<input
+										class="flex-1 w-full text-sm bg-transparent outline-hidden"
+										placeholder={$i18n.t('API Base URL')}
+										bind:value={OpenAIUrl}
+										required
+									/>
+
+									<SensitiveInput
+										placeholder={$i18n.t('API Key')}
+										bind:value={OpenAIKey}
+										required={false}
+									/>
+								</div>
+							{:else if RAG_EMBEDDING_ENGINE === 'ollama'}
+								<div class="my-0.5 flex gap-2 pr-2">
+									<input
+										class="flex-1 w-full text-sm bg-transparent outline-hidden"
+										placeholder={$i18n.t('API Base URL')}
+										bind:value={OllamaUrl}
+										required
+									/>
+
+									<SensitiveInput
+										placeholder={$i18n.t('API Key')}
+										bind:value={OllamaKey}
+										required={false}
+									/>
+								</div>
+							{:else if RAG_EMBEDDING_ENGINE === 'azure_openai'}
+								<div class="my-0.5 flex flex-col gap-2 pr-2 w-full">
+									<div class="flex gap-2">
+										<input
+											class="flex-1 w-full text-sm bg-transparent outline-hidden"
 											placeholder={$i18n.t('API Base URL')}
-											bind:value={RAGConfig.RAG_EXTERNAL_RERANKER_URL}
+											bind:value={AzureOpenAIUrl}
 											required
 										/>
-									</AdminSettingField>
-									<AdminSettingField
-										label={$i18n.t('API Key')}
-										description={$i18n.t('API key sent to the external reranker.')}
-									>
-										<SensitiveInput
-											variant="settings"
-											placeholder={$i18n.t('API Key')}
-											bind:value={RAGConfig.RAG_EXTERNAL_RERANKER_API_KEY}
-											required={false}
+										<SensitiveInput placeholder={$i18n.t('API Key')} bind:value={AzureOpenAIKey} />
+									</div>
+									<div class="flex gap-2">
+										<input
+											class="flex-1 w-full text-sm bg-transparent outline-hidden"
+											placeholder={$i18n.t('Version')}
+											bind:value={AzureOpenAIVersion}
+											required
 										/>
-									</AdminSettingField>
+									</div>
+								</div>
+							{/if}
+						</div>
+
+						<div class="  mb-2.5 flex flex-col w-full">
+							<div class=" mb-1 text-xs font-medium">{$i18n.t('Embedding Model')}</div>
+
+							<div class="">
+								{#if RAG_EMBEDDING_ENGINE === 'ollama'}
+									<div class="flex w-full">
+										<div class="flex-1 mr-2">
+											<input
+												class="flex-1 w-full text-sm bg-transparent outline-hidden"
+												bind:value={RAG_EMBEDDING_MODEL}
+												placeholder={$i18n.t('Set embedding model')}
+												required
+											/>
+										</div>
+									</div>
+								{:else}
+									<div class="flex w-full">
+										<div class="flex-1 mr-2">
+											<input
+												class="flex-1 w-full text-sm bg-transparent outline-hidden"
+												placeholder={$i18n.t('Set embedding model (e.g. {{model}})', {
+													model: RAG_EMBEDDING_MODEL.slice(-40)
+												})}
+												bind:value={RAG_EMBEDDING_MODEL}
+											/>
+										</div>
+
+										{#if RAG_EMBEDDING_ENGINE === ''}
+											<button
+												class="px-2.5 bg-transparent text-gray-800 dark:bg-transparent dark:text-gray-100 rounded-lg transition"
+												on:click={() => {
+													embeddingModelUpdateHandler();
+												}}
+												disabled={updateEmbeddingModelLoading}
+											>
+												{#if updateEmbeddingModelLoading}
+													<div class="self-center">
+														<Spinner />
+													</div>
+												{:else}
+													<svg
+														xmlns="http://www.w3.org/2000/svg"
+														viewBox="0 0 16 16"
+														fill="currentColor"
+														class="w-4 h-4"
+													>
+														<path
+															d="M8.75 2.75a.75.75 0 0 0-1.5 0v5.69L5.03 6.22a.75.75 0 0 0-1.06 1.06l3.5 3.5a.75.75 0 0 0 1.06 0l3.5-3.5a.75.75 0 0 0-1.06-1.06L8.75 8.44V2.75Z"
+														/>
+														<path
+															d="M3.5 9.75a.75.75 0 0 0-1.5 0v1.5A2.75 2.75 0 0 0 4.75 14h6.5A2.75 2.75 0 0 0 14 11.25v-1.5a.75.75 0 0 0-1.5 0v1.5c0 .69-.56 1.25-1.25 1.25h-6.5c-.69 0-1.25-.56-1.25-1.25v-1.5Z"
+														/>
+													</svg>
+												{/if}
+											</button>
+										{/if}
+									</div>
+								{/if}
+							</div>
+
+							<div class="mt-1 mb-1 text-xs text-gray-400 dark:text-gray-500">
+								{$i18n.t(
+									'After updating or changing the embedding model, you must reindex the knowledge base for the changes to take effect. You can do this using the "Reindex" button below.'
+								)}
+							</div>
+						</div>
+
+						<div class="  mb-2.5 flex w-full justify-between">
+							<div class=" self-center text-xs font-medium">
+								{$i18n.t('Embedding Batch Size')}
+							</div>
+
+							<div class="">
+								<input
+									bind:value={RAG_EMBEDDING_BATCH_SIZE}
+									type="number"
+									class=" bg-transparent text-center w-14 outline-none"
+									min="-2"
+									max="16000"
+									step="1"
+								/>
+							</div>
+						</div>
+
+						{#if RAG_EMBEDDING_ENGINE === 'ollama' || RAG_EMBEDDING_ENGINE === 'openai' || RAG_EMBEDDING_ENGINE === 'azure_openai'}
+							<div class="  mb-2.5 flex w-full justify-between">
+								<div class="self-center text-xs font-medium">
+									<Tooltip
+										content={$i18n.t(
+											'Runs embedding tasks concurrently to speed up processing. Turn off if rate limits become an issue.'
+										)}
+										placement="top-start"
+									>
+										{$i18n.t('Async Embedding Processing')}
+									</Tooltip>
+								</div>
+								<div class="flex items-center relative">
+									<Switch bind:state={ENABLE_ASYNC_EMBEDDING} />
+								</div>
+							</div>
+
+							<div class="  mb-2.5 flex w-full justify-between">
+								<div class="self-center text-xs font-medium">
+									<Tooltip
+										content={$i18n.t(
+											'Limits the number of concurrent embedding requests. Set to 0 for unlimited.'
+										)}
+										placement="top-start"
+									>
+										{$i18n.t('Embedding Concurrent Requests')}
+									</Tooltip>
+								</div>
+								<div class="">
+									<input
+										bind:value={RAG_EMBEDDING_CONCURRENT_REQUESTS}
+										type="number"
+										class=" bg-transparent text-center w-14 outline-none"
+										min="0"
+										step="1"
+									/>
+								</div>
+							</div>
+						{/if}
+					</div>
+				{/if}
+
+				<div class="mb-3">
+					<div class=" mt-0.5 mb-2.5 text-base font-medium">{$i18n.t('Retrieval')}</div>
+
+					<hr class=" border-gray-100/30 dark:border-gray-850/30 my-2" />
+
+					{#if !RAGConfig.BYPASS_EMBEDDING_AND_RETRIEVAL}
+						<div class="  mb-2.5 flex w-full justify-between">
+							<div class=" self-center text-xs font-medium">{$i18n.t('Full Context Mode')}</div>
+							<div class="flex items-center relative">
+								<Tooltip
+									content={RAGConfig.RAG_FULL_CONTEXT
+										? $i18n.t(
+												'Inject the entire content as context for comprehensive processing, this is recommended for complex queries.'
+											)
+										: $i18n.t(
+												'Default to segmented retrieval for focused and relevant content extraction, this is recommended for most cases.'
+											)}
+								>
+									<Switch bind:state={RAGConfig.RAG_FULL_CONTEXT} />
+								</Tooltip>
+							</div>
+						</div>
+
+						{#if !RAGConfig.RAG_FULL_CONTEXT}
+							<div class="  mb-2.5 flex w-full justify-between">
+								<div class=" self-center text-xs font-medium">{$i18n.t('Hybrid Search')}</div>
+								<div class="flex items-center relative">
+									<Switch bind:state={RAGConfig.ENABLE_RAG_HYBRID_SEARCH} />
+								</div>
+							</div>
+
+							{#if RAGConfig.ENABLE_RAG_HYBRID_SEARCH === true}
+								<div class="mb-2.5 flex w-full justify-between">
+									<div class="self-center text-xs font-medium">
+										{$i18n.t('Enrich Hybrid Search Text')}
+									</div>
+									<div class="flex items-center relative">
+										<Tooltip
+											content={$i18n.t(
+												'Adds filenames, titles, sections, and snippets into the BM25 text to improve lexical recall.'
+											)}
+										>
+											<Switch bind:state={RAGConfig.ENABLE_RAG_HYBRID_SEARCH_ENRICHED_TEXTS} />
+										</Tooltip>
+									</div>
+								</div>
+
+								<div class="  mb-2.5 flex flex-col w-full justify-between">
+									<div class="flex w-full justify-between">
+										<div class=" self-center text-xs font-medium">
+											{$i18n.t('Reranking Engine')}
+										</div>
+										<div class="flex items-center relative">
+											<select
+												class="w-fit pr-8 rounded-sm px-2 p-1 text-xs bg-transparent outline-hidden text-right"
+												bind:value={RAGConfig.RAG_RERANKING_ENGINE}
+												placeholder={$i18n.t('Select a reranking model engine')}
+												on:change={(e) => {
+													if (e.target.value === 'external') {
+														RAGConfig.RAG_RERANKING_MODEL = '';
+													} else if (e.target.value === '') {
+														RAGConfig.RAG_RERANKING_MODEL = 'BAAI/bge-reranker-v2-m3';
+													}
+												}}
+											>
+												<option value="">{$i18n.t('Default (SentenceTransformers)')}</option>
+												<option value="external">{$i18n.t('External')}</option>
+											</select>
+										</div>
+									</div>
+
+									{#if RAGConfig.RAG_RERANKING_ENGINE === 'external'}
+										<div class="my-0.5 flex gap-2 pr-2">
+											<input
+												class="flex-1 w-full text-sm bg-transparent outline-hidden"
+												placeholder={$i18n.t('API Base URL')}
+												bind:value={RAGConfig.RAG_EXTERNAL_RERANKER_URL}
+												required
+											/>
+
+											<SensitiveInput
+												placeholder={$i18n.t('API Key')}
+												bind:value={RAGConfig.RAG_EXTERNAL_RERANKER_API_KEY}
+												required={false}
+											/>
+										</div>
+									{/if}
+								</div>
+
+								<div class="  mb-2.5 flex flex-col w-full">
+									<div class=" mb-1 text-xs font-medium">{$i18n.t('Reranking Model')}</div>
+
+									<div class="">
+										<div class="flex w-full">
+											<div class="flex-1 mr-2">
+												<input
+													class="flex-1 w-full text-sm bg-transparent outline-hidden"
+													placeholder={$i18n.t('Set reranking model (e.g. {{model}})', {
+														model: 'BAAI/bge-reranker-v2-m3'
+													})}
+													bind:value={RAGConfig.RAG_RERANKING_MODEL}
+												/>
+											</div>
+										</div>
+									</div>
 								</div>
 							{/if}
 
-							<AdminSettingField
-								label={$i18n.t('Reranking Model')}
-								description={$i18n.t('Model used to rerank retrieved results.')}
-							>
-								<input
-									class={inputClass}
-									placeholder={$i18n.t('Set reranking model (e.g. {{model}})', {
-										model: 'BAAI/bge-reranker-v2-m3'
-									})}
-									bind:value={RAGConfig.RAG_RERANKING_MODEL}
-								/>
-							</AdminSettingField>
+							<div class="  mb-2.5 flex w-full justify-between">
+								<div class=" self-center text-xs font-medium">
+									{$i18n.t('Reranking Batch Size')}
+								</div>
+
+								<div class="">
+									<input
+										bind:value={RAGConfig.RAG_RERANKING_BATCH_SIZE}
+										type="number"
+										class=" bg-transparent text-center w-14 outline-none"
+										min="1"
+										max="16000"
+										step="1"
+									/>
+								</div>
+							</div>
+
+							<div class="  mb-2.5 flex w-full justify-between">
+								<div class=" self-center text-xs font-medium">{$i18n.t('Top K')}</div>
+								<div class="flex items-center relative">
+									<input
+										class="flex-1 w-full text-sm bg-transparent outline-hidden"
+										type="number"
+										placeholder={$i18n.t('Enter Top K')}
+										bind:value={RAGConfig.TOP_K}
+										autocomplete="off"
+										min="0"
+									/>
+								</div>
+							</div>
+
+							{#if RAGConfig.ENABLE_RAG_HYBRID_SEARCH === true}
+								<div class="mb-2.5 flex w-full justify-between">
+									<div class="self-center text-xs font-medium">{$i18n.t('Top K Reranker')}</div>
+									<div class="flex items-center relative">
+										<input
+											class="flex-1 w-full text-sm bg-transparent outline-hidden"
+											type="number"
+											placeholder={$i18n.t('Enter Top K Reranker')}
+											bind:value={RAGConfig.TOP_K_RERANKER}
+											autocomplete="off"
+											min="0"
+										/>
+									</div>
+								</div>
+							{/if}
+
+							{#if RAGConfig.ENABLE_RAG_HYBRID_SEARCH === true}
+								<div class="  mb-2.5 flex flex-col w-full justify-between">
+									<div class=" flex w-full justify-between">
+										<div class=" self-center text-xs font-medium">
+											{$i18n.t('Relevance Threshold')}
+										</div>
+										<div class="flex items-center relative">
+											<input
+												class="flex-1 w-full text-sm bg-transparent outline-hidden"
+												type="number"
+												step="0.01"
+												placeholder={$i18n.t('Enter Score')}
+												bind:value={RAGConfig.RELEVANCE_THRESHOLD}
+												autocomplete="off"
+												min="0.0"
+												title={$i18n.t(
+													'The score should be a value between 0.0 (0%) and 1.0 (100%).'
+												)}
+											/>
+										</div>
+									</div>
+									<div class="mt-1 text-xs text-gray-400 dark:text-gray-500">
+										{$i18n.t(
+											'Note: If you set a minimum score, the search will only return documents with a score greater than or equal to the minimum score.'
+										)}
+									</div>
+								</div>
+							{/if}
+
+							{#if RAGConfig.ENABLE_RAG_HYBRID_SEARCH === true}
+								<div class=" mb-2.5 py-0.5 w-full justify-between">
+									<Tooltip
+										content={$i18n.t(
+											'The Weight of BM25 Hybrid Search. 0 more semantic, 1 more lexical. Default 0.5'
+										)}
+										placement="top-start"
+										className="inline-tooltip"
+									>
+										<div class="flex w-full justify-between">
+											<div class=" self-center text-xs font-medium">
+												{$i18n.t('BM25 Weight')}
+											</div>
+											<button
+												class="p-1 px-3 text-xs flex rounded-sm transition shrink-0 outline-hidden"
+												type="button"
+												on:click={() => {
+													RAGConfig.HYBRID_BM25_WEIGHT =
+														(RAGConfig?.HYBRID_BM25_WEIGHT ?? null) === null ? 0.5 : null;
+												}}
+											>
+												{#if (RAGConfig?.HYBRID_BM25_WEIGHT ?? null) === null}
+													<span class="ml-2 self-center"> {$i18n.t('Default')} </span>
+												{:else}
+													<span class="ml-2 self-center"> {$i18n.t('Custom')} </span>
+												{/if}
+											</button>
+										</div>
+									</Tooltip>
+
+									{#if (RAGConfig?.HYBRID_BM25_WEIGHT ?? null) !== null}
+										<div class="flex mt-0.5 space-x-2">
+											<div class=" flex-1">
+												<input
+													id="steps-range"
+													type="range"
+													min="0"
+													max="1"
+													step="0.05"
+													bind:value={RAGConfig.HYBRID_BM25_WEIGHT}
+													class="w-full h-2 rounded-lg appearance-none cursor-pointer dark:bg-gray-700"
+												/>
+
+												<div class="py-0.5">
+													<div class="flex w-full justify-between">
+														<div class=" text-left text-xs font-small">
+															{$i18n.t('semantic')}
+														</div>
+														<div class=" text-right text-xs font-small">
+															{$i18n.t('lexical')}
+														</div>
+													</div>
+												</div>
+											</div>
+											<div>
+												<input
+													bind:value={RAGConfig.HYBRID_BM25_WEIGHT}
+													type="number"
+													class=" bg-transparent text-center w-14"
+													min="0"
+													max="1"
+													step="any"
+												/>
+											</div>
+										</div>
+									{/if}
+								</div>
+							{/if}
 						{/if}
+					{/if}
 
-						<AdminSettingRow
-							label={$i18n.t('Reranking Batch Size')}
-							description={$i18n.t('Number of results processed per reranking batch.')}
-						>
-							<input
-								bind:value={RAGConfig.RAG_RERANKING_BATCH_SIZE}
-								type="number"
-								class="w-14 bg-transparent text-center text-xs outline-none"
-								min="1"
-								max="16000"
-								step="1"
-							/>
-						</AdminSettingRow>
+					<div class="  mb-2.5 flex flex-col w-full justify-between">
+						<div class=" mb-1 text-xs font-medium">{$i18n.t('RAG Template')}</div>
+						<div class="flex w-full items-center relative">
+							<Tooltip
+								content={$i18n.t('Leave empty to use the default prompt, or enter a custom prompt')}
+								placement="top-start"
+								className="w-full"
+							>
+								<Textarea
+									bind:value={RAGConfig.RAG_TEMPLATE}
+									placeholder={$i18n.t(
+										'Leave empty to use the default prompt, or enter a custom prompt'
+									)}
+								/>
+							</Tooltip>
+						</div>
 
-						<AdminSettingField
-							label={$i18n.t('Top K')}
-							description={$i18n.t('Maximum number of retrieved chunks returned to the model.')}
-						>
-							<input
-								class={inputClass}
-								type="number"
-								placeholder={$i18n.t('Enter Top K')}
-								bind:value={RAGConfig.TOP_K}
-								autocomplete="off"
-								min="0"
-							/>
-						</AdminSettingField>
+						{#if RAGConfig.RAG_TEMPLATE && (RAGConfig.RAG_TEMPLATE.match(/\[context\]/g) || []).length + (RAGConfig.RAG_TEMPLATE.match(/\{\{CONTEXT\}\}/g) || []).length > 1}
+							<div class="mt-1 text-xs text-gray-400 dark:text-gray-500">
+								{$i18n.t(
+									'This template contains multiple context placeholders ([context] or {{CONTEXT}}). Context will be injected at each occurrence.'
+								)}
+							</div>
+						{/if}
+					</div>
+				</div>
 
-						{#if RAGConfig.ENABLE_RAG_HYBRID_SEARCH === true}
-							<AdminSettingField
-								label={$i18n.t('Top K Reranker')}
-								description={$i18n.t('Maximum number of hybrid results sent to the reranker.')}
+				<div class="mb-3">
+					<div class=" mt-0.5 mb-2.5 text-base font-medium">{$i18n.t('Files')}</div>
+
+					<hr class=" border-gray-100/30 dark:border-gray-850/30 my-2" />
+
+					<div class="  mb-2.5 flex w-full justify-between">
+						<div class=" self-center text-xs font-medium">{$i18n.t('Allowed File Extensions')}</div>
+						<div class="flex items-center relative">
+							<Tooltip
+								content={$i18n.t(
+									'Allowed file extensions for upload. Separate multiple extensions with commas. Leave empty for all file types.'
+								)}
+								placement="top-start"
 							>
 								<input
-									class={inputClass}
+									class="flex-1 w-full text-sm bg-transparent outline-hidden"
+									type="text"
+									placeholder={$i18n.t('e.g. pdf, docx, txt')}
+									bind:value={RAGConfig.ALLOWED_FILE_EXTENSIONS}
+									autocomplete="off"
+								/>
+							</Tooltip>
+						</div>
+					</div>
+
+					<div class="  mb-2.5 flex w-full justify-between">
+						<div class=" self-center text-xs font-medium">{$i18n.t('Max Upload Size')}</div>
+						<div class="flex items-center relative">
+							<Tooltip
+								content={$i18n.t(
+									'The maximum file size in MB. If the file size exceeds this limit, the file will not be uploaded.'
+								)}
+								placement="top-start"
+							>
+								<input
+									class="flex-1 w-full text-sm bg-transparent outline-hidden"
 									type="number"
-									placeholder={$i18n.t('Enter Top K Reranker')}
-									bind:value={RAGConfig.TOP_K_RERANKER}
+									placeholder={$i18n.t('Leave empty for unlimited')}
+									bind:value={RAGConfig.FILE_MAX_SIZE}
 									autocomplete="off"
 									min="0"
 								/>
-							</AdminSettingField>
+							</Tooltip>
+						</div>
+					</div>
 
-							<AdminSettingField
-								label={$i18n.t('Relevance Threshold')}
-								description={$i18n.t(
-									'Only return documents with a score greater than or equal to this value.'
+					<div class="  mb-2.5 flex w-full justify-between">
+						<div class=" self-center text-xs font-medium">{$i18n.t('Max Upload Count')}</div>
+						<div class="flex items-center relative">
+							<Tooltip
+								content={$i18n.t(
+									'The maximum number of files that can be used at once in chat. If the number of files exceeds this limit, the files will not be uploaded.'
 								)}
+								placement="top-start"
 							>
 								<input
-									class={inputClass}
+									class="flex-1 w-full text-sm bg-transparent outline-hidden"
 									type="number"
-									step="0.01"
-									placeholder={$i18n.t('Enter Score')}
-									bind:value={RAGConfig.RELEVANCE_THRESHOLD}
+									placeholder={$i18n.t('Leave empty for unlimited')}
+									bind:value={RAGConfig.FILE_MAX_COUNT}
 									autocomplete="off"
-									min="0.0"
-									title={$i18n.t('The score should be a value between 0.0 (0%) and 1.0 (100%).')}
+									min="0"
 								/>
-							</AdminSettingField>
-
-							<AdminSettingRow
-								label={$i18n.t('BM25 Weight')}
-								description={$i18n.t('Balance semantic and lexical weighting for hybrid search.')}
-							>
-								<button
-									class={actionButtonClass}
-									type="button"
-									on:click={() => {
-										RAGConfig.HYBRID_BM25_WEIGHT =
-											(RAGConfig?.HYBRID_BM25_WEIGHT ?? null) === null ? 0.5 : null;
-									}}
-								>
-									{(RAGConfig?.HYBRID_BM25_WEIGHT ?? null) === null
-										? $i18n.t('Default')
-										: $i18n.t('Custom')}
-								</button>
-							</AdminSettingRow>
-
-							{#if (RAGConfig?.HYBRID_BM25_WEIGHT ?? null) !== null}
-								<div class="flex items-center gap-2">
-									<div class="flex-1">
-										<input
-											id="steps-range"
-											type="range"
-											min="0"
-											max="1"
-											step="0.05"
-											bind:value={RAGConfig.HYBRID_BM25_WEIGHT}
-											class="h-2 w-full cursor-pointer appearance-none rounded-lg dark:bg-gray-700"
-										/>
-										<div
-											class="flex justify-between py-0.5 text-[0.6875rem] text-gray-400 dark:text-gray-600"
-										>
-											<div>{$i18n.t('semantic')}</div>
-											<div>{$i18n.t('lexical')}</div>
-										</div>
-									</div>
-									<input
-										bind:value={RAGConfig.HYBRID_BM25_WEIGHT}
-										type="number"
-										class="w-14 bg-transparent text-center text-xs outline-none"
-										min="0"
-										max="1"
-										step="any"
-									/>
-								</div>
-							{/if}
-						{/if}
-					{/if}
-				{/if}
-
-				<AdminSettingField
-					label={$i18n.t('RAG Template')}
-					description={$i18n.t('Prompt template used when retrieved context is injected.')}
-				>
-					<Tooltip
-						content={$i18n.t('Leave empty to use the default prompt, or enter a custom prompt')}
-						placement="top-start"
-						className="w-full"
-					>
-						<Textarea
-							className={textareaClass}
-							bind:value={RAGConfig.RAG_TEMPLATE}
-							placeholder={$i18n.t(
-								'Leave empty to use the default prompt, or enter a custom prompt'
-							)}
-						/>
-					</Tooltip>
-
-					{#if RAGConfig.RAG_TEMPLATE && (RAGConfig.RAG_TEMPLATE.match(/\[context\]/g) || []).length + (RAGConfig.RAG_TEMPLATE.match(/\{\{CONTEXT\}\}/g) || []).length > 1}
-						<div class="mt-1 text-[0.6875rem] text-gray-400 dark:text-gray-600">
-							{$i18n.t(
-								'This template contains multiple context placeholders ([context] or {{CONTEXT}}). Context will be injected at each occurrence.'
-							)}
+							</Tooltip>
 						</div>
-					{/if}
-				</AdminSettingField>
-			</AdminSettingSection>
+					</div>
 
-			<AdminSettingSection title={$i18n.t('Files')}>
-				<AdminSettingField
-					label={$i18n.t('Allowed File Extensions')}
-					description={$i18n.t(
-						'Comma-separated upload extensions. Leave empty for all file types.'
-					)}
-				>
-					<input
-						class={inputClass}
-						type="text"
-						placeholder={$i18n.t('e.g. pdf, docx, txt')}
-						bind:value={RAGConfig.ALLOWED_FILE_EXTENSIONS}
-						autocomplete="off"
-					/>
-				</AdminSettingField>
+					<div class="  mb-2.5 flex w-full justify-between">
+						<div class=" self-center text-xs font-medium">{$i18n.t('Image Compression Width')}</div>
+						<div class="flex items-center relative">
+							<Tooltip
+								content={$i18n.t(
+									'The width in pixels to compress images to. Leave empty for no compression.'
+								)}
+								placement="top-start"
+							>
+								<input
+									class="flex-1 w-full text-sm bg-transparent outline-hidden"
+									type="number"
+									placeholder={$i18n.t('Leave empty for no compression')}
+									bind:value={RAGConfig.FILE_IMAGE_COMPRESSION_WIDTH}
+									autocomplete="off"
+									min="0"
+								/>
+							</Tooltip>
+						</div>
+					</div>
 
-				<div class="grid grid-cols-1 gap-x-3 gap-y-2.5 sm:grid-cols-2">
-					<AdminSettingField
-						label={$i18n.t('Max Upload Size')}
-						description={$i18n.t('Maximum file size in MB. Leave empty for unlimited.')}
-					>
-						<input
-							class={inputClass}
-							type="number"
-							placeholder={$i18n.t('Leave empty for unlimited')}
-							bind:value={RAGConfig.FILE_MAX_SIZE}
-							autocomplete="off"
-							min="0"
-						/>
-					</AdminSettingField>
-					<AdminSettingField
-						label={$i18n.t('Max Upload Count')}
-						description={$i18n.t('Maximum number of files that can be used at once in chat.')}
-					>
-						<input
-							class={inputClass}
-							type="number"
-							placeholder={$i18n.t('Leave empty for unlimited')}
-							bind:value={RAGConfig.FILE_MAX_COUNT}
-							autocomplete="off"
-							min="0"
-						/>
-					</AdminSettingField>
+					<div class="  mb-2.5 flex w-full justify-between">
+						<div class=" self-center text-xs font-medium">
+							{$i18n.t('Image Compression Height')}
+						</div>
+						<div class="flex items-center relative">
+							<Tooltip
+								content={$i18n.t(
+									'The height in pixels to compress images to. Leave empty for no compression.'
+								)}
+								placement="top-start"
+							>
+								<input
+									class="flex-1 w-full text-sm bg-transparent outline-hidden"
+									type="number"
+									placeholder={$i18n.t('Leave empty for no compression')}
+									bind:value={RAGConfig.FILE_IMAGE_COMPRESSION_HEIGHT}
+									autocomplete="off"
+									min="0"
+								/>
+							</Tooltip>
+						</div>
+					</div>
 				</div>
 
-				<div class="grid grid-cols-1 gap-x-3 gap-y-2.5 sm:grid-cols-2">
-					<AdminSettingField
-						label={$i18n.t('Image Compression Width')}
-						description={$i18n.t(
-							'Width in pixels to compress images to. Leave empty for no compression.'
-						)}
-					>
-						<input
-							class={inputClass}
-							type="number"
-							placeholder={$i18n.t('Leave empty for no compression')}
-							bind:value={RAGConfig.FILE_IMAGE_COMPRESSION_WIDTH}
-							autocomplete="off"
-							min="0"
-						/>
-					</AdminSettingField>
-					<AdminSettingField
-						label={$i18n.t('Image Compression Height')}
-						description={$i18n.t(
-							'Height in pixels to compress images to. Leave empty for no compression.'
-						)}
-					>
-						<input
-							class={inputClass}
-							type="number"
-							placeholder={$i18n.t('Leave empty for no compression')}
-							bind:value={RAGConfig.FILE_IMAGE_COMPRESSION_HEIGHT}
-							autocomplete="off"
-							min="0"
-						/>
-					</AdminSettingField>
+				<div class="mb-3">
+					<div class=" mt-0.5 mb-2.5 text-base font-medium">{$i18n.t('Integration')}</div>
+
+					<hr class=" border-gray-100/30 dark:border-gray-850/30 my-2" />
+
+					<div class="  mb-2.5 flex w-full justify-between">
+						<div class=" self-center text-xs font-medium">{$i18n.t('Google Drive')}</div>
+						<div class="flex items-center relative">
+							<Switch bind:state={RAGConfig.ENABLE_GOOGLE_DRIVE_INTEGRATION} />
+						</div>
+					</div>
+
+					<div class="  mb-2.5 flex w-full justify-between">
+						<div class=" self-center text-xs font-medium">{$i18n.t('OneDrive')}</div>
+						<div class="flex items-center relative">
+							<Switch bind:state={RAGConfig.ENABLE_ONEDRIVE_INTEGRATION} />
+						</div>
+					</div>
 				</div>
-			</AdminSettingSection>
 
-			<AdminSettingSection title={$i18n.t('Integration')}>
-				<AdminSettingRow
-					label={$i18n.t('Google Drive')}
-					description={$i18n.t('Allow Google Drive as a document source.')}
-					let:labelId
-				>
-					<Switch
-						bind:state={RAGConfig.ENABLE_GOOGLE_DRIVE_INTEGRATION}
-						ariaLabelledbyId={labelId}
-					/>
-				</AdminSettingRow>
-				<AdminSettingRow
-					label={$i18n.t('OneDrive')}
-					description={$i18n.t('Allow OneDrive as a document source.')}
-					let:labelId
-				>
-					<Switch bind:state={RAGConfig.ENABLE_ONEDRIVE_INTEGRATION} ariaLabelledbyId={labelId} />
-				</AdminSettingRow>
-			</AdminSettingSection>
+				<div class="mb-3">
+					<div class=" mt-0.5 mb-2.5 text-base font-medium">{$i18n.t('Danger Zone')}</div>
 
-			<AdminSettingSection title={$i18n.t('Danger Zone')}>
-				<AdminSettingRow
-					label={$i18n.t('Reset Upload Directory')}
-					description={$i18n.t('Delete uploaded files from the upload directory.')}
-				>
-					<button
-						class={actionButtonClass}
-						type="button"
-						on:click={() => {
-							showResetUploadDirConfirm = true;
-						}}
-					>
-						{$i18n.t('Reset')}
-					</button>
-				</AdminSettingRow>
-				<AdminSettingRow
-					label={$i18n.t('Reset Vector Storage/Knowledge')}
-					description={$i18n.t('Clear vector storage and knowledge indexing data.')}
-				>
-					<button
-						class={actionButtonClass}
-						type="button"
-						on:click={() => {
-							showResetConfirm = true;
-						}}
-					>
-						{$i18n.t('Reset')}
-					</button>
-				</AdminSettingRow>
-				<AdminSettingRow
-					label={$i18n.t('Reindex Knowledge Base Vectors')}
-					description={$i18n.t('Rebuild vectors for existing knowledge files.')}
-				>
-					<button
-						class={actionButtonClass}
-						type="button"
-						on:click={() => {
-							showReindexConfirm = true;
-						}}
-					>
-						{$i18n.t('Reindex')}
-					</button>
-				</AdminSettingRow>
-			</AdminSettingSection>
+					<hr class=" border-gray-100/30 dark:border-gray-850/30 my-2" />
+
+					<div class="  mb-2.5 flex w-full justify-between">
+						<div class=" self-center text-xs font-medium">{$i18n.t('Reset Upload Directory')}</div>
+						<div class="flex items-center relative">
+							<button
+								class="text-xs"
+								type="button"
+								on:click={() => {
+									showResetUploadDirConfirm = true;
+								}}
+							>
+								{$i18n.t('Reset')}
+							</button>
+						</div>
+					</div>
+
+					<div class="  mb-2.5 flex w-full justify-between">
+						<div class=" self-center text-xs font-medium">
+							{$i18n.t('Reset Vector Storage/Knowledge')}
+						</div>
+						<div class="flex items-center relative">
+							<button
+								class="text-xs"
+								type="button"
+								on:click={() => {
+									showResetConfirm = true;
+								}}
+							>
+								{$i18n.t('Reset')}
+							</button>
+						</div>
+					</div>
+					<div class="  mb-2.5 flex w-full justify-between">
+						<div class=" self-center text-xs font-medium">
+							{$i18n.t('Reindex Knowledge Base Vectors')}
+						</div>
+						<div class="flex items-center relative">
+							<button
+								class="text-xs"
+								type="button"
+								on:click={() => {
+									showReindexConfirm = true;
+								}}
+							>
+								{$i18n.t('Reindex')}
+							</button>
+						</div>
+					</div>
+				</div>
+			</div>
 		</div>
-
-		<div class="flex justify-end pt-6 text-sm font-normal">
+		<div class="flex justify-end pt-3 text-sm font-medium">
 			<button
-				class="px-3.5 py-1.5 text-sm font-normal bg-black hover:bg-gray-900 text-white dark:bg-white dark:text-black dark:hover:bg-gray-100 transition rounded-full"
+				class="px-3.5 py-1.5 text-sm font-medium bg-black hover:bg-gray-900 text-white dark:bg-white dark:text-black dark:hover:bg-gray-100 transition rounded-full"
 				type="submit"
 			>
 				{$i18n.t('Save')}


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Closes #___` / `Relates to #___`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.** ⚠️ See note below — **this PR should actually target the `feat-docling-loader-async` branch/PR until that one merges.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **feat**: New features or enhancements

# Changelog Entry

### Description

The existing `docling` engine only ever gets Docling Serve's flattened markdown output, so the downstream text splitter chunks purely on raw character count — with no awareness of paragraph, heading, table, or list boundaries. Tables in particular get sliced apart arbitrarily, and there's no way to keep one chunk per structural unit (e.g. one chunk per section) for cleaner retrieval.

This PR adds a new `docling_json` extraction engine that requests Docling Serve's structured JSON document representation instead, and chunks it in a way that respects that structure. It's purely additive — the existing `docling` engine is completely untouched; `docling_json` is an opt-in alternative on admin selects in Settings → Documents.

**Stacking note for reviewers:** `DoclingLoaderJson` is a subclass of `DoclingLoader` and reuses its async submit/poll/retrieve/timeout machinery unchanged — it only overrides construction and result formatting. This PR is built on top of the ([separately submitted](https://github.com/open-webui/open-webui/pull/26947)) async `DoclingLoader` rework and can't be meaningfully reviewed or merged independently of it; **_it should target that PR's branch rather than `dev` until that one lands_**. Both are part of the same split of a previous, too-large PR (#26932) per [maintainer feedback](https://github.com/open-webui/open-webui/pull/26932#issuecomment-4925036925) — see the [linked discussion](https://github.com/open-webui/open-webui/discussions/26931) for the full picture. This PR does not touch the unrelated RAG pipeline improvements (citation extraction, JSON context format, etc.) also mentioned there — those remain a separate, later PR.

### Added

- New `docling_json` content-extraction engine, selectable in Settings → Documents alongside the existing engines.
- `DOCLING_JSON_CHUNK_MODE` setting (env var + RAG config API), three modes:
  - `item` — one Document per structural content item (finest granularity: one paragraph, heading, table, or list item per chunk)
  - `page` — one Document per page
  - `chunk` (default) — sliding-window chunks with overlap, preserving reading order across the whole document (sorted by page then spatial position, not raw JSON array order)
- Chunk-mode selector in the Settings → Documents UI, shown only when `docling_json` is selected.
- Rich per-chunk metadata where available: page number, bounding box, section-header depth, list markers/enumeration, hyperlinks, and document-level fields (filename, mimetype, source URI, content hash) pulled from the Docling JSON payload.

### Changed

- N/A (existing `docling` engine behavior is unchanged)

### Deprecated

- N/A

### Removed

- N/A

### Fixed

- `chunk_mode="chunk"` reads `CHUNK_SIZE` / `CHUNK_OVERLAP` / `TEXT_SPLITTER` / `TIKTOKEN_ENCODING_NAME` from the loader's kwargs, but those four keys were missing from `retrieval/utils.py`'s `LOADER_CONFIG_KEYS`, the dict that populates those kwargs from the admin's RAG config (`build_loader_from_config` → `Loader.__init__(**kwargs)`). Without them, chunk mode always fell back to its hardcoded defaults (1000 characters, 100 overlap, character-based) regardless of what the admin configured. Downstream, `save_docs_to_vector_db` re-splits every loader's output with the real config (`split=True`, unconditional for this call path) — but that stage can only shrink chunks further, not recover a larger `chunk_size` the admin configured but the loader never saw. Net effect: an admin with `CHUNK_SIZE` set above 1000, or `TEXT_SPLITTER=token`, would silently get smaller/misaligned chunks than requested whenever `chunk_mode="chunk"` was used. This PR adds the four missing `LOADER_CONFIG_KEYS` entries so chunk mode respects the configured settings end-to-end. No other loader reads these four kwargs, so the change has no effect outside `docling_json`.
- The "Chunk mode" selector in Settings → Documents is now scoped to only render when `docling_json` is selected; previously it would also show for the plain `docling` engine, where it has no effect.

### Security

- N/A

### Breaking Changes

- None. `docling_json` is a new, opt-in engine value; nothing about the existing `docling` engine or its settings changes.

---

### Additional Information

- Relates to discussion #26931.
- Part of the split of #26932 (closed for being too large for a first review pass).
- **Depends on** the async `DoclingLoader` rework PR ([submitted separately](https://github.com/open-webui/open-webui/pull/26947)) — `DoclingLoaderJson` subclasses `DoclingLoader` and needs its submit/poll/retrieve machinery to exist. Please review/merge that one first, or review this PR as a stack on top of it.
- Does not touch the unrelated RAG pipeline improvements (citations, `{{CONTEXT_JSON}}`, full-context fallback, native FC KB routing) — still on a separate, not-yet-submitted branch.
- No new third-party dependencies. `tiktoken` (used only for `chunk_content_type="token"`) is already a dependency of the existing chunking pipeline.

### Screenshots or Videos

- TODO before marking ready for review: add screenshots of the new engine option + chunk-mode selector in Settings → Documents, and a comparison of retrieved chunks for the same document under `item`, `page`, and `chunk` mode (ideally showing a table staying intact in `item` mode vs. getting split under plain `docling`).

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
