### PR TITLE
fix: don't use raw user message as retrieval query on empty query list

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -1769,6 +1769,12 @@ async def chat_completion_files_handler(
         all_full_context = all(item.get('context') == 'full' for item in files)
 
         queries = []
+        # When the query-generation LLM returns an empty list, it signals that
+        # no targeted search is needed (e.g. summarise, translate, list all).
+        # In that case we fall back to full-context mode instead of using the
+        # raw user message as a similarity query (which always scores ~0).
+        llm_requested_full_context = False
+
         if not all_full_context:
             try:
                 queries_response = await generate_queries(
@@ -1796,6 +1802,9 @@ async def chat_completion_files_handler(
                     queries_response = {'queries': [queries_response]}
 
                 queries = queries_response.get('queries', [])
+                if len(queries) == 0:
+                    # LLM explicitly decided no search is needed → use full context
+                    llm_requested_full_context = True
             except Exception:
                 pass
 
@@ -1810,7 +1819,9 @@ async def chat_completion_files_handler(
                 }
             )
 
-        if len(queries) == 0:
+        # Only fall back to the raw user message when the LLM did NOT explicitly
+        # return an empty list (i.e. when query generation itself failed/errored).
+        if len(queries) == 0 and not llm_requested_full_context:
             queries = [get_last_user_message(body['messages']) or '']
 
         try:
@@ -1832,7 +1843,7 @@ async def chat_completion_files_handler(
                 r=await Config.get('rag.relevance_threshold'),
                 hybrid_bm25_weight=await Config.get('rag.hybrid_bm25_weight'),
                 hybrid_search=await Config.get('rag.enable_hybrid_search'),
-                full_context=all_full_context or await Config.get('rag.full_context'),
+                full_context=all_full_context or llm_requested_full_context or await Config.get('rag.full_context'),
                 user=user,
             )
         except Exception as e:


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — Originally this has been part of the PR related to the discussion here: https://github.com/open-webui/open-webui/discussions/26931 - though its not relly related to the topic.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [ ] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [ ] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

# Changelog Entry

### Description

`chat_completion_files_handler()` calls `generate_queries()` to turn the conversation into targeted search queries before running vector retrieval over attached files/knowledge bases. When that call fails or returns something unparseable, the code falls back to using the raw last user message as the retrieval query — a reasonable safety net.

The bug: that same fallback also fired when `generate_queries()` succeeded and the LLM correctly returned an empty query list — which is its documented way of signalling "no targeted search needed," e.g. for prompts like "summarize this document" or "translate this text." An empty-but-successful response was indistinguishable from a failed one, so both took the same path: using the raw user message ("summarize this document") as a vector-similarity query. Against real document content, a query like that scores close to zero relevance, so retrieval effectively returned near-random chunks instead of usable context — silently degrading exactly the kind of "whole document" request the empty-query signal was meant to handle better.

### Added

- N/A

### Changed

- `chat_completion_files_handler()` now distinguishes "query generation succeeded with zero queries" from "query generation failed/errored." Only the latter falls back to using the raw user message as the retrieval query. The former now sets `full_context=True` for that retrieval call — the same full-context path already used when a file is explicitly marked `context: 'full'` — so the LLM gets the actual document content instead of a handful of low-relevance chunks.
- **@Reviewer: I am not sure if this is a good behaviour for all cases. It can burn tokens if the full document is huge.**

### Deprecated

- N/A

### Removed

- N/A

### Fixed

- Prompts that make the query-generation LLM correctly return an empty query list (summarization, translation, "list everything in this file", etc.) no longer degrade to near-random chunk retrieval. They now use full document context instead.

### Security

- N/A

### Breaking Changes

- None. This only changes behavior for the specific case where `generate_queries()` succeeds and returns zero queries — previously silently broken, now falls back to full context instead of a low-relevance raw-message query.

---

### Additional Information

- Found while working on a separate, larger RAG-pipeline branch; isolated here as a standalone, minimal fix since it doesn't depend on or relate to the rest of that work.
- No dependency changes.

### Screenshots or Videos

- TODO before marking ready for review: a short before/after showing retrieval sources for a "summarize this document" prompt against an attached file — before: a handful of unrelated low-score chunks; after: full document context.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
