### PR TITLE
perf: avoid O(elapsed-time) rrule walk for sub-daily automation next-run

### DIFF
--- a/backend/open_webui/utils/automations.py
+++ b/backend/open_webui/utils/automations.py
@@ -77,7 +77,13 @@ def _parse_rule(s: str):
 
     if freq in ('MINUTELY', 'HOURLY'):
         epoch = datetime(2000, 1, 1, 0, 0, 0)
-        return rrulestr(s, dtstart=epoch, ignoretz=True)
+        # Snap DTSTART to the most recent point on the fixed epoch grid at or
+        # before now so .after() walks a bounded remainder instead of ~26 years
+        # of steps, while keeping the exact same clock-aligned occurrences. The
+        # 2-day back-off keeps the anchor at or before any caller's local now.
+        step = int(parts.get('INTERVAL', '1')) * (60 if freq == 'MINUTELY' else 3600)
+        k = int((datetime.now() - timedelta(days=2) - epoch).total_seconds() // step)
+        return rrulestr(s, dtstart=epoch + timedelta(seconds=k * step), ignoretz=True)
     return rrulestr(s, ignoretz=True)
 
 


### PR DESCRIPTION
Closes #26954

### Description

MINUTELY/HOURLY automation schedules anchor `dtstart` at a fixed `2000-01-01`, so `rule.after(now)` iterates from the year 2000 to now on every next-run computation — ~6.8M steps for a 2-minute rule (~22s today), growing ~0.85s/year, and re-run on every `validate_rrule` / `next_run_ns` / `next_n_runs_ns` and on each reschedule in `claim_due`.

This snaps `dtstart` to the most recent point on the **same** fixed epoch grid at or before now, so `.after()` walks a bounded remainder (≤ ~a day of steps) instead of ~26 years. Occurrences are identical because the anchor stays on the exact same grid; the 2-day back-off keeps the anchor at or before any caller's local `now`. `FREQ=MINUTELY;INTERVAL=2` drops from ~22s to ~2ms.

### Changed

- `_parse_rule()` snaps the MINUTELY/HOURLY `DTSTART` to the nearest prior point on the fixed epoch grid instead of always starting at 2000-01-01.

### Testing

- Verified next-run output is identical to the year-2000 anchor for intervals 2/5/7/13/90, including a "user timezone behind server" case and the midnight-rollover boundary.
- Timed `FREQ=MINUTELY;INTERVAL=2`: ~22s → ~2ms.

---

- [x] Targets the `dev` branch
- [x] PR title uses the `perf:` prefix
- [x] Changelog entry included above
- [x] Human-reviewed and manually tested
- [x] Self-review performed

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
