### PR TITLE
perf: Add covering index on memory (id, user_id)

### DIFF
--- a/backend/open_webui/migrations/versions/55f1302ac17c_add_memory_id_user_id_covering_index.py
+++ b/backend/open_webui/migrations/versions/55f1302ac17c_add_memory_id_user_id_covering_index.py
@@ -1,0 +1,28 @@
+"""Add memory (id, user_id) covering index
+
+Revision ID: 55f1302ac17c
+Revises: 42e2978c7933
+Create Date: 2026-07-09 20:54:25.379896
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = '55f1302ac17c'
+down_revision = '42e2978c7933'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    existing_indexes = {idx['name'] for idx in inspector.get_indexes('memory')}
+
+    if 'ix_memory_id_user_id' not in existing_indexes:
+        op.create_index('ix_memory_id_user_id', 'memory', ['id', 'user_id'])
+
+
+def downgrade():
+    op.drop_index('ix_memory_id_user_id', table_name='memory')

--- a/backend/open_webui/models/memories.py
+++ b/backend/open_webui/models/memories.py
@@ -8,7 +8,7 @@ from typing import Literal
 
 from open_webui.internal.db import Base, get_async_db_context
 from pydantic import BaseModel, ConfigDict
-from sqlalchemy import JSON, BigInteger, Column, String, Text, delete, select
+from sqlalchemy import JSON, BigInteger, Column, Index, String, Text, delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 
@@ -16,6 +16,10 @@ class Memory(Base):  # user memory store
     """Stores user-created memory entries linked to a vector collection."""
 
     __tablename__ = 'memory'
+    __table_args__ = (
+        # Covering index so id-ordered (id, user_id) enumeration stays index-only.
+        Index('ix_memory_id_user_id', 'id', 'user_id'),
+    )
 
     id = Column(String, primary_key=True, unique=True)
     user_id = Column(String, index=True)


### PR DESCRIPTION
Bulk enumeration of memories by id (reconciliation, orphan sweeps, exports) selects only (id, user_id) ordered by id, but no index covers those two columns, so the query reads every full row including the wide content/meta blobs to extract two small columns. The existing ix_memory_user_id index does not apply here, since the scan is ordered by the primary key rather than user_id.

A covering index on (id, user_id) turns the id-ordered scan index-only, skipping the table heap entirely. Measured on SQLite (best of 3), enumerating id + user_id in 5000-row keyset batches:

- 50k memories (57 MB db): 0.165s to 0.019s; plan goes from SEARCH ... USING INDEX sqlite_autoindex_memory_1 to USING COVERING INDEX
- 300k memories (351 MB db): 1.26s to 0.12s (about 10x)

This mirrors the composite performance indexes already added for chat and tag in 018012973d35. The index is created idempotently behind an existence check and declared on the model so fresh databases get it too.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
