### PR TITLE
fix: pass RAG_EMBEDDING_CONTENT_PREFIX when embedding memories

### DIFF
--- a/backend/open_webui/routers/memories.py
+++ b/backend/open_webui/routers/memories.py
@@ -5,13 +5,13 @@ import logging
 from typing import Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
+from open_webui.config import RAG_EMBEDDING_CONTENT_PREFIX, RAG_EMBEDDING_QUERY_PREFIX
 from open_webui.constants import ERROR_MESSAGES
 from open_webui.events import EVENTS, publish_event
 from open_webui.internal.db import get_async_session
 from open_webui.models.config import Config
 from open_webui.models.memories import Memories, MemoryModel
 from open_webui.retrieval.vector.async_client import ASYNC_VECTOR_DB_CLIENT
-from open_webui.config import RAG_EMBEDDING_QUERY_PREFIX
 from open_webui.utils.access_control import has_permission
 from open_webui.utils.auth import get_verified_user
 from open_webui.utils.memory import (
@@ -148,7 +148,11 @@ async def add_memory(
         meta={'created_by': 'manual'},
     )
 
-    vector = await request.app.state.EMBEDDING_FUNCTION(memory_vector_text(memory.content, memory.path), user=user)
+    vector = await request.app.state.EMBEDDING_FUNCTION(
+        memory_vector_text(memory.content, memory.path),
+        RAG_EMBEDDING_CONTENT_PREFIX,
+        user=user,
+    )
 
     await ASYNC_VECTOR_DB_CLIENT.upsert(
         collection_name=f'user-memory-{user.id}',
@@ -208,6 +212,7 @@ async def update_memories(
             if result.get('status') in {'created', 'updated'}:
                 vector = await request.app.state.EMBEDDING_FUNCTION(
                     memory_vector_text(memory.content, memory.path),
+                    RAG_EMBEDDING_CONTENT_PREFIX,
                     user=user,
                 )
                 upsert_items.append(
@@ -407,7 +412,11 @@ async def reset_memory_from_vector_db(
     # Generate vectors in parallel
     vectors = await asyncio.gather(
         *[
-            request.app.state.EMBEDDING_FUNCTION(memory_vector_text(memory.content, memory.path), user=user)
+            request.app.state.EMBEDDING_FUNCTION(
+                memory_vector_text(memory.content, memory.path),
+                RAG_EMBEDDING_CONTENT_PREFIX,
+                user=user,
+            )
             for memory in memories
         ]
     )
@@ -503,7 +512,11 @@ async def update_memory_by_id(
         raise HTTPException(status_code=404, detail=ERROR_MESSAGES.NOT_FOUND)
 
     if form_data.content is not None or form_data.path is not None:
-        vector = await request.app.state.EMBEDDING_FUNCTION(memory_vector_text(memory.content, memory.path), user=user)
+        vector = await request.app.state.EMBEDDING_FUNCTION(
+            memory_vector_text(memory.content, memory.path),
+            RAG_EMBEDDING_CONTENT_PREFIX,
+            user=user,
+        )
 
         await ASYNC_VECTOR_DB_CLIENT.upsert(
             collection_name=f'user-memory-{user.id}',


### PR DESCRIPTION
Relates to #26353

## Problem

When `RAG_EMBEDDING_CONTENT_PREFIX` is configured (e.g., `"search_document: "` for nomic-embed-text), memory content is embedded **without** the prefix while queries correctly use `RAG_EMBEDDING_QUERY_PREFIX`. This creates a vector space mismatch that silently degrades memory retrieval accuracy for asymmetric embedding models.

## Fix

Pass `RAG_EMBEDDING_CONTENT_PREFIX` to all four memory content embedding call sites, aligning them with the established pattern in `save_docs_to_vector_db` (`retrieval.py`):

- `add_memory`
- `update_memories`
- `reset_memory_from_vector_db`
- `update_memory_by_id`

## Notes

- Users with symmetric models where prefix is `None` (default) are completely unaffected
- `query_memory` correctly uses `RAG_EMBEDDING_QUERY_PREFIX` and was intentionally left unchanged
- After this fix, users with asymmetric models should reset their memories to re-embed with the correct prefix

## Changelog

### Fixed
- Pass `RAG_EMBEDDING_CONTENT_PREFIX` when embedding memory content to fix retrieval accuracy degradation for asymmetric embedding models (nomic-embed-text, BGE, UAE, etc.)

---

- [x] **Linked Issue/Discussion:** Relates to #26353
- [x] **Target branch:** Targets `dev`
- [x] **Description:** Provided above
- [x] **No Unchecked AI Code:** Fix is human reviewed and understood
- [x] **Git Hygiene:** Atomic change, one logical fix
- [x] **Title Prefix:** Uses `fix:`

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.