### PR TITLE
feat: add model start form for system prompt variables

### DIFF
--- a/src/lib/apis/index.ts
+++ b/src/lib/apis/index.ts
@@ -1753,6 +1753,9 @@ export interface ModelMeta {
 	description?: string;
 	capabilities?: object;
 	profile_image_url?: string;
+	start_form?: {
+		enabled?: boolean;
+	};
 }
 
 export interface ModelParams {}

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -60,7 +60,9 @@
 		getMessageContentParts,
 		createMessagesList,
 		sanitizeHistory,
+		extractInputVariables,
 		getPromptVariables,
+		renderInputVariables,
 		processDetails,
 		removeAllDetails,
 		getCodeBlockContents,
@@ -111,6 +113,7 @@
 	import WebSearchConfirmDialog from '../common/ConfirmDialog.svelte';
 	import Placeholder from './Placeholder.svelte';
 	import FilesOverlay from './MessageInput/FilesOverlay.svelte';
+	import InputVariablesModal from './MessageInput/InputVariablesModal.svelte';
 	import NotificationToast from '../NotificationToast.svelte';
 	import Spinner from '../common/Spinner.svelte';
 	import Tooltip from '../common/Tooltip.svelte';
@@ -233,6 +236,10 @@
 	let chatFiles = [];
 	let files = [];
 	let params = {};
+	let showStartFormModal = false;
+	let startFormVariables = {};
+	let startFormModalCallback: (values: Record<string, unknown>) => void = () => {};
+	let startFormModalCancel = () => {};
 
 	$: if (chatIdProp) {
 		navigateHandler();
@@ -2126,6 +2133,60 @@
 		await sendMessage(history, userMessageId);
 	};
 
+	const getSelectedPrimaryModel = () => {
+		const modelId = atSelectedModel?.id ?? selectedModels[0];
+		return $models.find((m) => m.id === modelId);
+	};
+
+	const shouldShowStartForm = (model: Model | undefined) => {
+		if (!model || $chatId || history.currentId) {
+			return false;
+		}
+
+		return model?.info?.meta?.start_form?.enabled ?? false;
+	};
+
+	const resolveStartForm = async (model: Model | undefined) => {
+		if (!shouldShowStartForm(model)) {
+			return true;
+		}
+
+		const systemPromptTemplate = params?.system ?? model?.info?.params?.system ?? '';
+		if (!systemPromptTemplate) {
+			return true;
+		}
+
+		const variables = extractInputVariables(systemPromptTemplate);
+		if (Object.keys(variables).length === 0) {
+			return true;
+		}
+
+		startFormVariables = variables;
+		showStartFormModal = true;
+
+		const variableValues = await new Promise<Record<string, unknown> | null>((resolve) => {
+			startFormModalCallback = (values) => {
+				showStartFormModal = false;
+				resolve(values);
+			};
+			startFormModalCancel = () => {
+				showStartFormModal = false;
+				resolve(null);
+			};
+		});
+
+		if (!variableValues) {
+			return false;
+		}
+
+		params = {
+			...params,
+			system: renderInputVariables(systemPromptTemplate, variableValues)
+		};
+
+		return true;
+	};
+
 	const submitHandler = async (userPrompt, { _raw = false } = {}) => {
 		console.log('submitHandler', userPrompt, $chatId);
 
@@ -2147,6 +2208,10 @@
 		}
 		if (selectedModels.includes('')) {
 			toast.error($i18n.t('Model not selected'));
+			return;
+		}
+
+		if (!(await resolveStartForm(getSelectedPrimaryModel()))) {
 			return;
 		}
 
@@ -3094,6 +3159,15 @@
 </svelte:head>
 
 <audio id="audioElement" style="display: none;"></audio>
+
+<InputVariablesModal
+	bind:show={showStartFormModal}
+	title="Start Form"
+	submitLabel="Start Chat"
+	variables={startFormVariables}
+	onSave={startFormModalCallback}
+	onCancel={startFormModalCancel}
+/>
 
 <WebSearchConfirmDialog
 	bind:show={showWebSearchConfirm}

--- a/src/lib/components/chat/MessageInput/InputVariablesModal.svelte
+++ b/src/lib/components/chat/MessageInput/InputVariablesModal.svelte
@@ -16,6 +16,10 @@
 	export let variables = {};
 
 	export let onSave = (e) => {};
+	export let onCancel = () => {};
+	export let title = 'Input Variables';
+	export let submitLabel = 'Save';
+	export let cancelLabel = 'Cancel';
 
 	let loading = true;
 	let variableValues = {};
@@ -67,10 +71,11 @@
 <Modal bind:show size="md">
 	<div>
 		<div class=" flex justify-between dark:text-gray-300 px-5 pt-4 pb-2">
-			<div class=" text-lg font-medium self-center">{$i18n.t('Input Variables')}</div>
+			<div class=" text-lg font-medium self-center">{$i18n.t(title)}</div>
 			<button
 				class="self-center"
 				on:click={() => {
+					onCancel();
 					show = false;
 				}}
 			>
@@ -355,17 +360,18 @@
 							class="px-3.5 py-1.5 text-sm font-medium bg-white hover:bg-gray-100 text-black dark:bg-black dark:text-white dark:hover:bg-gray-900 transition rounded-full"
 							type="button"
 							on:click={() => {
+								onCancel();
 								show = false;
 							}}
 						>
-							{$i18n.t('Cancel')}
+							{$i18n.t(cancelLabel)}
 						</button>
 
 						<button
 							class="px-3.5 py-1.5 text-sm font-medium bg-black hover:bg-gray-900 text-white dark:bg-white dark:text-black dark:hover:bg-gray-100 transition rounded-full"
 							type="submit"
 						>
-							{$i18n.t('Save')}
+							{$i18n.t(submitLabel)}
 						</button>
 					</div>
 				</form>

--- a/src/lib/components/workspace/Models/ModelEditor.svelte
+++ b/src/lib/components/workspace/Models/ModelEditor.svelte
@@ -110,6 +110,7 @@
 	let accessGrants = [];
 	let terminalId = '';
 	let tts = { voice: '' };
+	let startFormEnabled = false;
 	export let suggestionTags: { name: string }[] = [];
 	let voices: { id: string; name?: string }[] = [];
 
@@ -277,6 +278,14 @@
 			}
 		}
 
+		if (startFormEnabled) {
+			info.meta.start_form = { enabled: true };
+		} else {
+			if (info.meta.start_form) {
+				delete info.meta.start_form;
+			}
+		}
+
 		info.params.system = system.trim() === '' ? null : system;
 		info.params.stop = params.stop
 			? (typeof params.stop === 'string' ? params.stop.split(',') : params.stop).filter((s) =>
@@ -388,6 +397,7 @@
 			builtinTools = model?.meta?.builtinTools ?? builtinTools;
 			terminalId = model?.meta?.terminalId ?? '';
 			tts = { voice: model?.meta?.tts?.voice ?? '' };
+			startFormEnabled = model?.meta?.start_form?.enabled ?? false;
 
 			accessGrants = model?.access_grants ?? [];
 
@@ -742,6 +752,23 @@
 										bind:value={system}
 									/>
 								</div>
+							</div>
+
+							<div class="my-2 flex items-start gap-2">
+								<input
+									id="model-start-form-enabled"
+									type="checkbox"
+									class="mt-1 size-3.5 rounded border border-gray-200 dark:border-gray-700"
+									bind:checked={startFormEnabled}
+								/>
+								<label for="model-start-form-enabled" class="flex flex-col gap-1 text-sm">
+									<span class="font-medium">{$i18n.t('Start Form')}</span>
+									<span class="text-xs text-gray-500">
+										{$i18n.t(
+											'Ask for system prompt variables before the first message in a new chat.'
+										)}
+									</span>
+								</label>
 							</div>
 
 							<div class="flex w-full justify-between">

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -1651,6 +1651,18 @@ export const extractInputVariables = (text: string): Record<string, any> => {
 	return variables;
 };
 
+export const renderInputVariables = (text: string, variables: Record<string, unknown>): string => {
+	return text.replace(/{{\s*([^|}\s]+)(?:\s*\|\s*[^}]*)?\s*}}/g, (_, key) => {
+		const value = variables[key.trim()];
+
+		if (value === undefined || value === null) {
+			return '';
+		}
+
+		return String(value);
+	});
+};
+
 export const splitProperties = (str: string, delimiter: string): string[] => {
 	const result: string[] = [];
 	let current = '';


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Relates to #26915.
- [x] **Target branch:** This PR targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has not been added yet; I can follow up in the docs repository if this UX direction is accepted.
- [x] **Dependencies:** No new dependencies.
- [x] **Testing:** `npm run test:frontend`, `npm run build`, and `git diff --check` were run locally. `npm run check` currently reports existing upstream diagnostics unrelated to this PR.
- [x] **No Unchecked AI Code:** The patch has been self-reviewed and locally verified; review is requested for the product/API direction below.
- [x] **Self-Review:** A self-review of the code has been performed.
- [x] **Architecture:** This keeps the implementation small and reuses the existing input variables modal and prompt-variable parsing.
- [x] **Git Hygiene:** The PR is atomic, based on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses the `feat` prefix.

## Review focus

I would especially appreciate maintainer feedback on these decisions before expanding the feature:

- Whether `model.meta.start_form.enabled` is an acceptable opt-in location for model-defined pre-chat forms.
- Whether storing the rendered system prompt in `chat.params.system` is the right persistence point for the first iteration.
- Whether keeping the first version limited to the primary selected model and the first user message is the right scope.

## Description

This implements the small MVP proposed in #26915: a model owner can opt into a pre-chat start form for variables used by that model's system prompt.

The flow is intentionally narrow:

- Model editor adds a `Start Form` toggle.
- The opt-in flag is stored under `model.meta.start_form.enabled`.
- When a new chat sends its first user message, the selected primary model's system prompt is scanned for `{{variable}}` / `{{variable | ...}}` placeholders.
- If variables are present, the existing input variables modal is shown before the message is sent.
- Submitted values are rendered into the system prompt and persisted in the chat params.

This does not add tool routing, generalized metadata transport, backend migrations, new dependencies, or a full template engine.

# Changelog Entry

### Description

- Add a model start form flow for parameterized system prompts.

### Added

- Model-level `Start Form` toggle.
- First-message variable collection for opted-in model system prompts.
- System prompt rendering through the existing `{{variable}}` syntax.

### Changed

- The existing input variables modal can now receive a custom title, submit label, cancel label, and cancel callback.

### Deprecated

- None.

### Removed

- None.

### Fixed

- None.

### Security

- No security-specific changes.

### Breaking Changes

- None.

---

### Additional Information

The diff is limited to frontend UX and model metadata:

- `src/lib/components/workspace/Models/ModelEditor.svelte`
- `src/lib/components/chat/Chat.svelte`
- `src/lib/components/chat/MessageInput/InputVariablesModal.svelte`
- `src/lib/apis/index.ts`
- `src/lib/utils/index.ts`

### Screenshots or Videos

- Not attached yet. The review focus for this PR is the UX/API direction and minimal implementation shape; I can add screenshots or a short recording if that would help review.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
