### PR TITLE
perf: coalesce streaming markdown parses

### DIFF
--- a/src/lib/components/chat/Messages/Markdown.svelte
+++ b/src/lib/components/chat/Messages/Markdown.svelte
@@ -35,6 +35,7 @@
 	import { user } from '$lib/stores';
 
 	import MarkdownTokens from './Markdown/MarkdownTokens.svelte';
+	import { createMarkdownUpdateScheduler } from './markdown-update-scheduler';
 
 	export let id = '';
 	export let content;
@@ -59,7 +60,6 @@
 	export let onTaskClick = () => {};
 
 	let tokens = [];
-	let pendingUpdate = null;
 	let lastContent = '';
 	let lastParsedContent = '';
 
@@ -74,21 +74,12 @@
 		tokens = marked.lexer(processed);
 	};
 
-	const updateHandler = (content) => {
-		if (content && !pendingUpdate) {
-			pendingUpdate = requestAnimationFrame(() => {
-				pendingUpdate = null;
-				parseTokens();
-			});
-		}
-	};
+	const updateScheduler = createMarkdownUpdateScheduler(parseTokens);
 
-	$: updateHandler(content);
+	$: updateScheduler.update(content);
 
 	// Throttle parsing to once per animation frame while streaming
-	onDestroy(() => {
-		cancelAnimationFrame(pendingUpdate);
-	});
+	onDestroy(updateScheduler.cancel);
 </script>
 
 {#key id}

--- a/src/lib/components/chat/Messages/Markdown.svelte
+++ b/src/lib/components/chat/Messages/Markdown.svelte
@@ -75,17 +75,11 @@
 	};
 
 	const updateHandler = (content) => {
-		if (content) {
-			if (done) {
-				cancelAnimationFrame(pendingUpdate);
+		if (content && !pendingUpdate) {
+			pendingUpdate = requestAnimationFrame(() => {
 				pendingUpdate = null;
 				parseTokens();
-			} else if (!pendingUpdate) {
-				pendingUpdate = requestAnimationFrame(() => {
-					pendingUpdate = null;
-					parseTokens();
-				});
-			}
+			});
 		}
 	};
 

--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -65,6 +65,7 @@
 	import FullHeightIframe from '$lib/components/common/FullHeightIframe.svelte';
 	import OutputEditView from './OutputEditView.svelte';
 	import { getOutputText, replaceOutputMessageText, type OutputItem } from './structuredOutput';
+	import { resolveMarkdownDone } from './markdown-update-scheduler';
 
 	interface MessageType {
 		id: string;
@@ -839,9 +840,7 @@
 									preview={!readOnly}
 									{editCodeBlock}
 									{topPadding}
-									done={($settings?.chatFadeStreamingText ?? true)
-										? (message?.done ?? false)
-										: true}
+									done={resolveMarkdownDone($settings?.chatFadeStreamingText, message?.done)}
 									{model}
 									onTaskClick={async (e) => {
 										console.log(e);

--- a/src/lib/components/chat/Messages/markdown-update-scheduler.test.ts
+++ b/src/lib/components/chat/Messages/markdown-update-scheduler.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createMarkdownUpdateScheduler, resolveMarkdownDone } from './markdown-update-scheduler';
+
+describe('createMarkdownUpdateScheduler', () => {
+	it('coalesces the fade-disabled done path onto the pending frame', () => {
+		let content = '';
+		let done = resolveMarkdownDone(false, false);
+		const parsed: Array<{ content: string; done: boolean }> = [];
+		const frames: FrameRequestCallback[] = [];
+		const requestFrame = vi.fn((callback: FrameRequestCallback) => {
+			frames.push(callback);
+			return frames.length;
+		});
+		const scheduler = createMarkdownUpdateScheduler(
+			() => parsed.push({ content, done }),
+			requestFrame,
+			vi.fn()
+		);
+
+		scheduler.update(content);
+		expect(requestFrame).not.toHaveBeenCalled();
+
+		content = 'partial';
+		scheduler.update(content);
+		content = 'final';
+		done = resolveMarkdownDone(false, true);
+		scheduler.update(content);
+
+		expect(requestFrame).toHaveBeenCalledTimes(1);
+		expect(parsed).toEqual([]);
+
+		frames[0](16);
+		expect(parsed).toEqual([{ content: 'final', done: true }]);
+	});
+
+	it('cancels a pending frame on teardown', () => {
+		const cancelFrame = vi.fn();
+		const scheduler = createMarkdownUpdateScheduler(
+			vi.fn(),
+			vi.fn(() => 42),
+			cancelFrame
+		);
+
+		scheduler.update('streaming');
+		scheduler.cancel();
+		scheduler.cancel();
+
+		expect(cancelFrame).toHaveBeenCalledOnce();
+		expect(cancelFrame).toHaveBeenCalledWith(42);
+	});
+});
+
+describe('resolveMarkdownDone', () => {
+	it.each([
+		{ fadeStreamingText: false, messageDone: false, expected: true },
+		{ fadeStreamingText: false, messageDone: true, expected: true },
+		{ fadeStreamingText: true, messageDone: false, expected: false },
+		{ fadeStreamingText: true, messageDone: true, expected: true },
+		{ fadeStreamingText: undefined, messageDone: false, expected: false }
+	])(
+		'returns $expected when fadeStreamingText=$fadeStreamingText and messageDone=$messageDone',
+		({ fadeStreamingText, messageDone, expected }) => {
+			expect(resolveMarkdownDone(fadeStreamingText, messageDone)).toBe(expected);
+		}
+	);
+});

--- a/src/lib/components/chat/Messages/markdown-update-scheduler.ts
+++ b/src/lib/components/chat/Messages/markdown-update-scheduler.ts
@@ -1,0 +1,35 @@
+type RequestFrame = (callback: FrameRequestCallback) => number;
+type CancelFrame = (handle: number) => void;
+
+const requestBrowserFrame: RequestFrame = (callback) => requestAnimationFrame(callback);
+const cancelBrowserFrame: CancelFrame = (handle) => cancelAnimationFrame(handle);
+
+export const resolveMarkdownDone = (
+	fadeStreamingText: boolean | null | undefined,
+	messageDone: boolean | null | undefined
+) => ((fadeStreamingText ?? true) ? (messageDone ?? false) : true);
+
+export const createMarkdownUpdateScheduler = (
+	parseTokens: () => void,
+	requestFrame: RequestFrame = requestBrowserFrame,
+	cancelFrame: CancelFrame = cancelBrowserFrame
+) => {
+	let pendingUpdate: number | null = null;
+
+	return {
+		update(content: unknown) {
+			if (!content || pendingUpdate !== null) return;
+
+			pendingUpdate = requestFrame(() => {
+				pendingUpdate = null;
+				parseTokens();
+			});
+		},
+		cancel() {
+			if (pendingUpdate === null) return;
+
+			cancelFrame(pendingUpdate);
+			pendingUpdate = null;
+		}
+	};
+};


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Relates to #20878 and restores the behavior previously merged in #23868.
- [x] **Target branch:** This pull request targets `dev`.
- [x] **Description:** The change and its motivation are described below.
- [x] **Changelog:** A changelog entry is included below.
- [x] **Documentation:** No documentation update is needed because this restores existing internal scheduling behavior without changing user-facing configuration.
- [x] **Dependencies:** No dependencies are added or changed.
- [x] **Testing:** Focused Vitest coverage and the fade-disabled browser replay both pass.
- [x] **No Unchecked AI Code:** The final patch was manually validated and independently reviewed.
- [x] **Self-Review:** The diff is limited to the markdown streaming scheduler, its call site, and focused tests.
- [x] **Architecture:** This restores the existing display-aligned scheduling policy and adds no setting or persistent state.
- [x] **Git Hygiene:** The branch is based on current `dev` and contains only focused changes.
- [x] **Title Prefix:** The title uses the `perf` prefix.

## Summary

When **Fade Effect for Streaming Text** is disabled, `ResponseMessage` passes `done={true}` to suppress token fade animations. The current markdown scheduler also interprets `done=true` as a reason to parse synchronously, so it runs the full markdown lexer for every streamed content update.

Always scheduling the parse through `requestAnimationFrame` coalesces updates to the display cadence while preserving the `done` value passed to child renderers. This restores the behavior previously merged in #23868, which was lost from the current `dev` implementation.

## Performance

A browser replay delivered 504 deterministic content updates at 5 ms intervals with the fade-disabled `done=true` path:

| | Markdown parses |
| --- | ---: |
| Current `dev` | 499 |
| This PR, 3 runs | 165-172 |

That is a **65.5-66.9% reduction** in full markdown parses. First render remained between 3.4 and 12.8 ms, and the largest observed render gap was 33.9 ms.

The replay also verifies exact final content, identical streamed and one-shot DOM/text, syntax highlighting, math rendering or safe fallback, tool-call order, and tool expansion.

Supplementary autoresearch: [public dashboard](https://dashboard.weco.ai/share/CxSXNMXQZzDmH6xtp-azm2vXjMpJv9o_).

## Validation

- `npm run test:frontend -- --run src/lib/components/chat/Messages/markdown-update-scheduler.test.ts` (7 tests passed)
- Targeted ESLint for the scheduler, its test, and `Markdown.svelte`
- Prettier for all four changed files
- `git diff --check`
- Browser replay described above, repeated three times

# Changelog Entry

### Description

- Restore frame-coalesced markdown parsing while assistant responses stream.

### Added

- Focused regression coverage for frame coalescing, fade-setting semantics, and teardown cancellation.

### Changed

- Streamed markdown updates are parsed at most once per animation frame, including when text fade is disabled.

### Deprecated

- None.

### Removed

- None.

### Fixed

- Prevent synchronous markdown parsing on every streamed chunk when **Fade Effect for Streaming Text** is disabled.

### Security

- None.

### Breaking Changes

- None.

---

### Additional Information

- Relates to #20878.
- Restores the scheduling behavior from #23868.

### Screenshots or Videos

- Not applicable; this change has no intended visual effect.

### Contributor License Agreement

<!--
DO NOT DELETE THE TEXT BELOW.
Keep the Contributor License Agreement confirmation text intact.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.