### PR TITLE
fix: chat corruption (openweb-ui#26668)

### DIFF
--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -791,6 +791,11 @@ class ChatTable:
                         parent_id = existing_id
                         break
 
+            if parent_id is None and messages:
+                return await self.get_chat_by_id(id)
+            if parent_id is not None and parent_id not in messages:
+                return await self.get_chat_by_id(id)
+
             parent = messages.get(parent_id) if parent_id else None
             output = message.get('output') or []
             output_role = next(
@@ -816,7 +821,10 @@ class ChatTable:
                 'timestamp': message.get('timestamp') or int(time.time()),
             }
 
-        history['currentId'] = message_id
+        upserted = messages.get(message_id)
+        upserted_parent = upserted.get('parentId') if isinstance(upserted, dict) else None
+        if upserted_parent is None or upserted_parent in messages:
+            history['currentId'] = message_id
 
         chat['history'] = history
 

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -3723,6 +3723,7 @@
 										{continueResponse}
 										{regenerateResponse}
 										{mergeResponses}
+										{stopResponse}
 										{chatActionHandler}
 										{addMessages}
 										topPadding={!embedded}

--- a/src/lib/components/chat/Messages.svelte
+++ b/src/lib/components/chat/Messages.svelte
@@ -36,6 +36,8 @@
 	export let regenerateResponse: Function;
 	export let mergeResponses: Function;
 
+	export let stopResponse: Function = () => {};
+
 	export let chatActionHandler: Function;
 	export let showMessage: Function = () => {};
 	export let submitMessage: Function = () => {};
@@ -433,6 +435,19 @@
 		const messageToDelete = history.messages[messageId];
 		const parentMessageId = messageToDelete.parentId;
 		const childMessageIds = messageToDelete.childrenIds ?? [];
+
+		const deletedIds = [messageId, ...childMessageIds];
+		const activeId = history.currentId;
+		const activeMessage = activeId ? history.messages[activeId] : null;
+		if (
+			activeMessage &&
+			activeMessage.role === 'assistant' &&
+			!activeMessage.done &&
+			deletedIds.includes(activeId)
+		) {
+			await stopResponse(false);
+			await tick();
+		}
 
 		// Collect all grandchildren
 		const grandchildrenIds = childMessageIds.flatMap(


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Closes #___` / `Relates to #___`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [x] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **BREAKING CHANGE**: Changes affecting backward compatibility
  - **build**: Build system or dependency changes
  - **ci**: CI/CD workflow changes
  - **chore**: Refactoring, cleanup, or non-functional changes
  - **docs**: Documentation additions or updates
  - **feat**: New features or enhancements
  - **fix**: Bug fixes or corrections
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvements
  - **refactor**: Code restructuring
  - **style**: Formatting changes (whitespace, semicolons, etc.)
  - **test**: Test additions or corrections
  - **WIP**: Work in progress

# Changelog Entry

### Description

Deleting a user message while its reply was still streaming corrupted the chat: after the generation finished, only the streamed reply survived on reload and the rest of the history became unreachable.

Root cause: deleting a message did not cancel the in-flight generation. The backend task kept running and, on completion, upserted the deleted assistant message with no resolvable parent — recreating it as an orphan root and pointing currentId at it. createMessagesList walks parentId from currentId, so the broken parent chain stranded the prior conversation.

Three fixes:

1. Frontend (Messages.svelte): when the message being deleted (or one of its reply children) is the not-yet-done assistant reply at currentId, call stopResponse(false) first to cancel the backend task. Gate on the message done-state (the codebase's own isGenerating heuristic) rather than the `generating` flag, which is only set in the MoA merge path. stopResponse is threaded through from Chat.svelte as a prop.

2. Backend (chats.py upsert_message_to_chat_by_id_and_message_id): if a stale completion upsert arrives for a message that is no longer in the chat with no resolvable parent (parent deleted, or no surviving message references it in childrenIds), skip the write instead of resurrecting it as an orphan root. Normal flow is unaffected — the user message is persisted before generation, so the assistant upsert resolves a live parent or hits the existing-message merge branch.

3. Backend: only advance currentId to the upserted message when its parentId is None or exists in the messages map, so currentId can never point at a message with a broken parent chain.

### Fixed

- Fixes issue #26668 

---

### Additional Information

- I used AI to fix it, but I reviewed the code and tested it manually

### Screenshots or Videos


https://github.com/user-attachments/assets/ad39a935-6f5c-4a1c-b5e8-7c6752d385dd


### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
