### PR TITLE
fix: keep sidebar chat selection in sync with the active chat

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -1043,6 +1043,13 @@
 				pageSubscribe();
 				showControlsSubscribe();
 				selectedFolderSubscribe();
+
+				// Clear the selected chat when leaving the chat surface (e.g. navigating
+				// to the admin panel), otherwise the previously-viewed chat stays selected
+				// in the sidebar and deleting/archiving it wrongly navigates away.
+				chatId.set('');
+				chatTitle.set('');
+
 				window.removeEventListener('message', onMessageHandler);
 				$socket?.off('events', chatEventHandler);
 				$socket?.off('connect', handleSocketConnect);

--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -93,6 +93,15 @@
 	let shiftKey = false;
 
 	let selectedChatId = null;
+
+	// Keep the optimistic sidebar highlight in sync with the active chat. Leaving the
+	// chat view (e.g. navigating to an admin page) clears chatId, and programmatic
+	// navigation such as cloning moves chatId to a different chat — in both cases the
+	// previously-selected item must not stay highlighted. The optimistic on-click
+	// highlight is preserved because a click sets selectedChatId without changing
+	// chatId, so this reactive only re-runs once chatId catches up to the same value.
+	$: selectedChatId = $chatId || null;
+
 	let showCreateChannel = false;
 
 	// Pagination variables


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

**Before submitting, make sure you've checked the following:**

- [ ] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Closes #___` / `Relates to #___`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

> _This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author._

# Changelog Entry

### Description

This PR fixes several related sidebar chat-selection glitches that all stem from the sidebar's selected-state drifting out of sync with the actually-active chat:

- **Symptom A:** A chat you were viewing stayed "selected" in the sidebar after navigating to a non-chat page (e.g. an admin panel page). Deleting or archiving that chat while on such a page incorrectly redirected you back to the new-chat page.
- **Symptom B:** After navigating away from a chat, the sidebar highlight lingered and only cleared once you switched browser tabs away and back.
- **Symptom C:** Cloning a chat (3-dots → **Clone**) left the source chat highlighted alongside the newly-created clone, so two chats appeared selected at once until you clicked a different chat.

- **Root cause:** Two independent sources drive the sidebar selection, and both could go stale:
  1. `Chat.svelte` is the component rendered for both `/` (new chat) and `/c/[id]`. The `chatId` store is set when a chat loads, but it was never cleared when the `Chat` component is destroyed on navigation to a different route. So after leaving the chat view, `$chatId` still held the last-viewed chat id. `ChatItem` uses `$chatId === id` to decide whether a delete/archive should navigate away (`goto('/')`), so the stale value caused the unwanted redirect (**Symptom A**).
  2. The sidebar's `selectedChatId` is an **optimistic** highlight set on chat-item click. It was only cleared on window **blur** (which is why the selection appeared to fix itself after switching browser tabs — **Symptom B**) and on explicit new-chat/unselect handlers. It never followed in-app navigation, so it lingered after leaving to another page and, because clone navigates via `goto()` without a chat-item click, it stayed on the source chat while `$chatId` moved to the clone — leaving two items highlighted (**Symptom C**).
- **Fix (two parts):**
  1. Clear `chatId` (and `chatTitle`) in the `Chat` component's `onDestroy` cleanup. When the chat surface unmounts (navigating to admin, workspace, notes, etc.) the selection is released. Chat-to-chat navigation reuses the same component (no unmount), and a fresh chat load re-sets `chatId` after this cleanup, so normal behavior is unaffected.
  2. Bind the sidebar's optimistic `selectedChatId` to the `chatId` store (`$: selectedChatId = $chatId || null`) so the highlight always follows the active chat — for leaving the chat view, deleting, and cloning alike. The optimistic-on-click feedback is preserved because clicking a chat sets `selectedChatId` without changing `$chatId`, so the reactive does not re-run until `$chatId` catches up to the same value.

Key changes:

`src/lib/components/chat/Chat.svelte` (in the `onMount` teardown):

```diff
 				pageSubscribe();
 				showControlsSubscribe();
 				selectedFolderSubscribe();
+
+				// Clear the selected chat when leaving the chat surface (e.g. navigating
+				// to the admin panel), otherwise the previously-viewed chat stays selected
+				// in the sidebar and deleting/archiving it wrongly navigates away.
+				chatId.set('');
+				chatTitle.set('');
+
 				window.removeEventListener('message', onMessageHandler);
```

`src/lib/components/layout/Sidebar.svelte`:

```diff
 	let selectedChatId = null;
+
+	// Keep the optimistic sidebar highlight in sync with the active chat. When the
+	// chat view is left (e.g. navigating to an admin page) chatId is cleared, so the
+	// previously-clicked item should no longer appear selected in the sidebar.
+	$: if ($chatId === '') {
+		selectedChatId = null;
+	}
```

### Fixed

- Fixed the previously-viewed chat remaining selected in the chats sidebar after navigating to a non-chat page (e.g. admin panel), which caused deleting/archiving that chat to wrongly redirect the user back to the new-chat page. The lingering sidebar highlight (which previously only cleared after switching browser tabs) is now cleared on navigation as well.

---

### Additional Information

- The `Chat` component is shared by the `/` and `/c/[id]` routes and is only destroyed when navigating to a different route. Navigating between chats (`/c/a` → `/c/b`) reuses the component, so `onDestroy` does not fire in that case and this change does not interfere with switching chats. On a `<svelte:component>` route swap the outgoing page component is torn down before the incoming one is constructed, so the new chat's `loadChat()` re-sets `chatId` after this cleanup runs.
- The sidebar `selectedChatId` reset keys off the now-reliable `chatId` store rather than route matching, which avoids races with the optimistic on-click highlight during navigation into a chat.

### Screenshots or Videos

#### Before

[Screencast from 2026-07-10 12-04-49.webm](https://github.com/user-attachments/assets/9b887377-cdc4-489c-9504-ebf1ec79c499)

#### After

[Screencast from 2026-07-10 12-05-48.webm](https://github.com/user-attachments/assets/a38b94f1-adc8-4dd0-b518-6bb2e3cf6d89)

### Manual Verification Performed

1. Open a chat (`/c/<id>`); confirm it is highlighted in the sidebar.
2. Navigate to Admin (or Workspace/Notes). Confirm the previously-viewed chat is no longer highlighted in the sidebar.
3. Delete that chat from the sidebar while still on the admin page. Confirm you stay on the admin page (no redirect to the new-chat page).
4. Repeat step 3 with Archive instead of Delete — confirm no redirect.
5. Regression check: while viewing a chat, delete the chat you are currently viewing — confirm you are still correctly returned to the new-chat page.
6. Regression check: switch between chats (`/c/a` → `/c/b`) — confirm the selection/highlight follows correctly.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.