### PR TITLE
fix: close sidebar on mobile when opening Calendar from user menu

### DIFF
--- a/src/lib/components/layout/Sidebar/UserMenu.svelte
+++ b/src/lib/components/layout/Sidebar/UserMenu.svelte
@@ -337,6 +337,10 @@
 							e.preventDefault();
 							show = false;
 							goto('/calendar');
+							if ($mobile) {
+								await tick();
+								showSidebar.set(false);
+							}
 						}}
 					>
 						<div class="self-center">


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions/27172) — `Closes #___` / `Relates to #___`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

# Changelog Entry

### Description

- **Problem:** On mobile, opening the **Calendar** page from the user menu (the account menu at the bottom of the chats sidebar) did not automatically close the sidebar, leaving it open on top of the Calendar page. Every other navigation entry in that menu closes the sidebar on mobile after navigating.
- **Root cause:** Each navigation entry in `UserMenu.svelte` closes the sidebar on mobile with an `if ($mobile) { await tick(); showSidebar.set(false); }` block in its click handler. The **Calendar** entry was the only one missing this block — it navigated with `goto('/calendar')` but never collapsed the sidebar.
- **Fix:** Add the same mobile guard used by the sibling entries (Notes, Automations, Playground, Workspace) to the Calendar click handler so it collapses the sidebar on mobile after navigating. This is a behavioral parity fix — no new logic or patterns are introduced.

Key change (`src/lib/components/layout/Sidebar/UserMenu.svelte`, in the Calendar entry's click handler):

```diff
 							e.preventDefault();
 							show = false;
 							goto('/calendar');
+							if ($mobile) {
+								await tick();
+								showSidebar.set(false);
+							}
 						}}
```

### Fixed

- Fixed the chats sidebar not closing on mobile when navigating to the Calendar page from the user menu, bringing it in line with the other user-menu navigation entries.

---

### Additional Information

- The click handler is already `async`, and `tick`, `mobile`, and `showSidebar` are already imported in this component, so no additional imports were required.
- The added block is byte-for-byte identical to the handling already used by the Notes, Automations, Playground, and Workspace entries in the same menu.

### Manual Verification Performed

1. On a mobile viewport (or a real mobile device such as an iPhone), open the user menu at the bottom of the chats sidebar.
2. Tap **Calendar**. Confirm the app navigates to the Calendar page **and** the sidebar automatically closes (as it does for Notes, Automations, Playground, etc.).
3. Regression check (desktop): confirm the Calendar entry still navigates correctly and the sidebar is unaffected (the `$mobile` guard means desktop behavior is unchanged).
4. Regression check: confirm `Cmd/Ctrl/Shift+click` and middle-click on the Calendar entry still open the page without the click handler interfering (the early-return guard is untouched).

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.