### PR TITLE
fix: persist modelIdx so duplicate side-by-side models don't collapse on reload

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -1225,7 +1225,7 @@ async def chat_completion(
                         target_model_id = entry['model_id']
                         assistant_message_id = entry['message_id']
                         if assistant_message_id:
-                            history_messages[assistant_message_id] = {
+                            assistant_message = {
                                 'id': assistant_message_id,
                                 'parentId': user_message_id,
                                 'childrenIds': [],
@@ -1235,6 +1235,11 @@ async def chat_completion(
                                 'model': target_model_id,
                                 'timestamp': int(time.time()),
                             }
+                            # Preserve the side-by-side column index so duplicate
+                            # models don't collapse into one another on reload.
+                            if entry.get('modelIdx') is not None:
+                                assistant_message['modelIdx'] = entry['modelIdx']
+                            history_messages[assistant_message_id] = assistant_message
 
                     await Chats.insert_new_chat(
                         chat_id,
@@ -1433,19 +1438,24 @@ async def chat_completion(
                         target_model_id = entry['model_id']
                         assistant_message_id = entry['message_id']
                         if assistant_message_id:
+                            assistant_message = {
+                                'id': assistant_message_id,
+                                'parentId': user_message_id,
+                                'childrenIds': [],
+                                'role': 'assistant',
+                                'content': '',
+                                'done': False,
+                                'model': target_model_id,
+                                'timestamp': int(time.time()),
+                            }
+                            # Preserve the side-by-side column index so duplicate
+                            # models don't collapse into one another on reload.
+                            if entry.get('modelIdx') is not None:
+                                assistant_message['modelIdx'] = entry['modelIdx']
                             await Chats.upsert_message_to_chat_by_id_and_message_id(
                                 chat_id,
                                 assistant_message_id,
-                                {
-                                    'id': assistant_message_id,
-                                    'parentId': user_message_id,
-                                    'childrenIds': [],
-                                    'role': 'assistant',
-                                    'content': '',
-                                    'done': False,
-                                    'model': target_model_id,
-                                    'timestamp': int(time.time()),
-                                },
+                                assistant_message,
                             )
                             await publish_event(
                                 request,

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -2258,9 +2258,11 @@
 				: selectedModels;
 
 		// Create response messages for each selected model
-		// Build message_ids list: [{model_id, message_id}, ...]
+		// Build message_ids list: [{model_id, message_id, modelIdx}, ...]
 		// Uses an array instead of a dict to support duplicate model IDs in side-by-side chat.
-		const messageIdsList: Array<{ model_id: string; message_id: string }> = [];
+		// modelIdx identifies each side-by-side column so the backend can persist it; without
+		// it, duplicate models collapse into one another when the chat is reloaded.
+		const messageIdsList: Array<{ model_id: string; message_id: string; modelIdx: number }> = [];
 		for (const [_modelIdx, modelId] of selectedModelIds.entries()) {
 			const model = $models.filter((m) => m.id === modelId).at(0);
 
@@ -2292,7 +2294,11 @@
 				}
 
 				responseMessageIds[`${modelId}-${modelIdx ? modelIdx : _modelIdx}`] = responseMessageId;
-				messageIdsList.push({ model_id: modelId, message_id: responseMessageId });
+				messageIdsList.push({
+					model_id: modelId,
+					message_id: responseMessageId,
+					modelIdx: modelIdx ? modelIdx : _modelIdx
+				});
 			}
 		}
 		history = history;
@@ -2354,7 +2360,11 @@
 					primaryResponseMessageId,
 					_chatId,
 					{
-						messageIdsList: selectedModelIds.length > 1 ? messageIdsList : undefined,
+						// Always forward the message_ids list (not just for multi-model sends) so the
+						// backend persists each response's modelIdx — including single-column
+						// regenerations in a duplicate-model chat, which would otherwise lose their
+						// column identity and collapse on reload.
+						messageIdsList: messageIdsList.length > 0 ? messageIdsList : undefined,
 						regenerationPrompt
 					}
 				);


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

**Before submitting, make sure you've checked the following:**

- [ ] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Closes #___` / `Relates to #___`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

> _This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author._

# Changelog Entry

### Description

- **Problem:** When the **same model** is added more than once to a side-by-side chat, each query correctly produces a unique response per column while generating. But after the responses (and follow-ups) finish and the page is **reloaded**, every column collapses to show the **first** response duplicated, and each column grows a bogus `1/N` pager. The unique responses are effectively lost from view.
- **Root cause:** Each side-by-side response is created with a distinct `modelIdx` (0, 1, 2, …) that identifies its column. The backend now owns message persistence, but when it builds the assistant placeholders (both for a new chat and when appending to an existing chat) it wrote them **without the `modelIdx` field**. So `modelIdx` was never saved. On reload, `MultiResponseMessages.svelte` groups responses by `modelIdx`, and only when `modelIdx` is missing does it fall back to grouping by **model id**. With duplicate models that fallback matches every response for every column, so all columns render the current leaf — the first response — and report `1/N` siblings.
- **Fix:** Send `modelIdx` with each `message_ids` entry from the frontend, and persist it on the assistant placeholders in both backend paths (new-chat history build and existing-chat placeholder upsert). The `message_ids` list is now forwarded on **every** send (not only multi-model ones), so single-column **regenerations** in a duplicate-model chat also keep their column identity across reloads. Grouping by `modelIdx` then keeps the columns distinct after reload. The value is only written when the client provides it, so older clients are unaffected and non-duplicate (distinct-model) chats keep working exactly as before.

Key changes:

`src/lib/components/chat/Chat.svelte` — include `modelIdx` in each `message_ids` entry, and forward the list on every send:

```diff
-				messageIdsList.push({ model_id: modelId, message_id: responseMessageId });
+				messageIdsList.push({
+					model_id: modelId,
+					message_id: responseMessageId,
+					modelIdx: modelIdx ? modelIdx : _modelIdx
+				});
```

```diff
-						messageIdsList: selectedModelIds.length > 1 ? messageIdsList : undefined,
+						messageIdsList: messageIdsList.length > 0 ? messageIdsList : undefined,
```

`backend/open_webui/main.py` — persist `modelIdx` on the assistant placeholders (shown for the new-chat path; the same guard is added to the existing-chat `upsert_message_to_chat_by_id_and_message_id` placeholder):

```diff
-                            history_messages[assistant_message_id] = {
+                            assistant_message = {
                                 'id': assistant_message_id,
                                 'parentId': user_message_id,
                                 'childrenIds': [],
                                 'role': 'assistant',
                                 'content': '',
                                 'done': False,
                                 'model': target_model_id,
                                 'timestamp': int(time.time()),
                             }
+                            # Preserve the side-by-side column index so duplicate
+                            # models don't collapse into one another on reload.
+                            if entry.get('modelIdx') is not None:
+                                assistant_message['modelIdx'] = entry['modelIdx']
+                            history_messages[assistant_message_id] = assistant_message
```

Because `upsert_message_to_chat_by_id_and_message_id` merges (`{**existing, **incoming}`), the `modelIdx` set on the placeholder survives the streamed content updates that follow.

### Fixed

- Fixed side-by-side chats that use the **same model** more than once collapsing every response into the first one (with a false `1/N` pager) after the page is reloaded. The per-column `modelIdx` is now persisted so each duplicate-model column keeps its own response across reloads.

---

### Additional Information

- The `modelIdx` values match the order of the `message_ids` list the frontend already sends, and are written verbatim by the backend — no reindexing or guessing.
- Non-duplicate (distinct-model) side-by-side chats and single-model chats are unaffected: they either already grouped correctly by model id, or now additionally have an explicit `modelIdx` that resolves to the same layout.
- Backward compatible: the backend only sets `modelIdx` when the client sends it, so older frontends behave exactly as before.

### Screenshots or Videos

#### Before: after reload, all four columns show the first response and a `1/4` pager.

[Screencast from 2026-07-10 13-10-20.webm](https://github.com/user-attachments/assets/7a6ad35c-f9c6-4409-bb55-13d6b09243ba)

#### After: after reload, each column keeps its own unique response with no false pager.

[Screencast from 2026-07-10 13-11-38.webm](https://github.com/user-attachments/assets/cb6d81c0-1d93-4382-b8c8-e7cdbe3c49e4)

### Manual Verification Performed

The frontend grouping logic in `MultiResponseMessages.svelte` was reproduced in isolation to confirm the fix, in addition to end-to-end testing:

1. Add the **same model** 3–4 times to a new chat and send a prompt. Confirm each column streams a unique response (unchanged behavior).
2. Wait for the responses and follow-up suggestions to finish.
3. **Reload the page.** Confirm each column still shows its **own** unique response and there is **no** `1/N` pager on the columns.
4. Repeat in an **existing** chat (send a second prompt to the same duplicate-model setup, then reload) to cover the existing-chat persistence path.
5. Duplicate-model **regeneration**: in a duplicate-model chat, regenerate a single column's response, wait, then reload. Confirm the regenerated response stays in its own column (as a `1/2` sibling) instead of collapsing or reverting to the pre-regeneration response.
6. Regression — distinct models: add two or three **different** models side by side, send, reload; confirm each column shows the correct model's response.
7. Regression — single model: send a normal single-model message and reload; confirm it renders normally, and that regenerating a response still produces a normal `1/N` sibling pager.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.