### PR TITLE
fix: don't resurrect a deleted message from an in-flight stream update

### DIFF
--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -704,18 +704,28 @@ class ChatTable:
     async def upsert_message_to_chat_by_id_and_message_id(
         self, id: str, message_id: str, message: dict
     ) -> ChatModel | None:
-        chat = await self.get_chat_by_id(id)
-        if chat is None:
+        chat_model = await self.get_chat_by_id(id)
+        if chat_model is None:
             return None
 
         # Sanitize message content for null characters before upserting
         if isinstance(message.get('content'), str):
             message['content'] = sanitize_text_for_db(message['content'])
 
-        user_id = chat.user_id
-        chat = chat.chat
+        user_id = chat_model.user_id
+        chat = chat_model.chat
         history = chat.get('history', {})
         messages = history.setdefault('messages', {})
+
+        # Don't resurrect a deleted message from an in-flight update. A partial
+        # update (no 'parentId' supplied) that targets a message no longer in the
+        # history means the message was deleted while it was still being written —
+        # e.g. the user deleted a response that was mid-stream. Recreating it here
+        # would produce a parentless orphan and, via the currentId assignment
+        # below, hijack the visible conversation on reload. Message creation always
+        # supplies 'parentId', so this only skips stale updates. (#26668)
+        if message_id not in messages and 'parentId' not in message:
+            return chat_model
 
         if message_id in messages:
             messages[message_id] = {


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Closes #26668`.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

> _This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author._

# Changelog Entry

### Description

- **Problem (Closes #26668):** If you delete a message while its response is still being generated, then let the generation finish and reload, the conversation appears to be replaced by that single response — the rest of the history seems gone. (As noted on the issue, the history isn't actually deleted: the streamed reply becomes detached from any parent and takes over as the visible leaf; the full conversation is still reachable via the **Overview** tab.)
- **Root cause:** Message persistence is owned by the backend. When the message is deleted mid-stream it is removed from the chat history, but the in-flight generation keeps running and, as it streams/completes, calls `upsert_message_to_chat_by_id_and_message_id(...)` with partial updates (`{content}`, `{done, output, usage}`, …). Because the message no longer exists, `upsert` fell into its **create** branch and re-inserted it. With its real parent gone it got `parentId = None` (a parentless orphan), and the function's unconditional `history['currentId'] = message_id` then made that orphan the current leaf. On reload, `createMessagesList` walks up from `currentId`, so only the orphan is rendered while the real conversation sits off-path.
- **Fix:** In `upsert_message_to_chat_by_id_and_message_id`, skip the operation when the target message is **absent** from the history **and** the caller did **not** supply a `parentId`. That combination only occurs for partial content/state updates to a message that was deleted mid-write — every legitimate message insertion (assistant placeholders and user messages in `main.py`) always includes `parentId`. Skipping avoids both recreating the orphan and hijacking `currentId`.

Key change (`backend/open_webui/models/chats.py`):

```diff
         user_id = chat_model.user_id
         chat = chat_model.chat
         history = chat.get('history', {})
         messages = history.setdefault('messages', {})

+        # Don't resurrect a deleted message from an in-flight update. A partial
+        # update (no 'parentId' supplied) that targets a message no longer in the
+        # history means the message was deleted while it was still being written —
+        # e.g. the user deleted a response that was mid-stream. Recreating it here
+        # would produce a parentless orphan and, via the currentId assignment
+        # below, hijack the visible conversation on reload. Message creation always
+        # supplies 'parentId', so this only skips stale updates. (#26668)
+        if message_id not in messages and 'parentId' not in message:
+            return chat_model
+
         if message_id in messages:
```

(The surrounding lines rename the local `chat` → `chat_model` so the guard can return the unchanged chat model.)

### Fixed

- Fixed deleting a message while its response is still generating causing the finished response to detach into a parentless orphan and hijack `currentId`, which made the rest of the conversation disappear from view on reload (#26668).

---

### Additional Information

- **Why `'parentId' not in message` is the right discriminator:** I audited every caller of `upsert_message_to_chat_by_id_and_message_id` (streaming/completion updates in `utils/middleware.py`, placeholder/user-message creation in `main.py`, `utils/context_compaction.py`, and the `routers/chats.py` message endpoints). Content/state updates pass partial dicts without `parentId` (`{content}`, `{done, output, usage}`, `{followUps}`, `{error}`, `{selectedModelId}`, `{contextSummary}`, `{childrenIds}`, …), while every intentional insert passes `parentId` (including root user messages, which pass `parentId: None` — so key **presence**, not truthiness, is the correct test). The guard therefore never blocks a legitimate insert.
- **Scope:** This fixes the persisted-data corruption, which is the reported bug. The in-flight generation still runs to completion in the background after the delete (its output is now simply discarded rather than orphaned). Proactively cancelling that generation when its message is deleted (the issue's "reply generation gets cancelled" wish) is a separate UX improvement that can follow up.

### Screenshots or Videos

- Before: after the steps below + reload, only the last streamed response is visible; the rest of the chat is reachable only via **Overview**.

<img width="2553" height="1282" alt="image" src="https://github.com/user-attachments/assets/84d42927-5b61-45b0-bbb4-1fc84dadbbc7" />

- After: the full conversation remains visible after reload; no orphaned message is created.

<img width="2553" height="1282" alt="image" src="https://github.com/user-attachments/assets/b6a8cdd2-d1f2-4897-b1be-7abf2b9712f2" />

### Manual Verification Performed

The `upsert` create/`currentId` logic was reproduced in isolation to confirm the fix, in addition to end-to-end testing against the issue's steps:

1. New conversation → send "test", wait for reply → send "test", wait for reply (two exchanges).
2. Send "write something longer" and, **while it is still streaming**, delete that user message.
3. Reload — confirm both "test" exchanges and their responses are present.
4. Wait for the sidebar activity spinner (the still-running generation) to finish, then reload again.
5. **Expected after fix:** the full conversation is still shown; no lone orphaned response, and `currentId` points at the last real reply (previously, only the streamed response was visible).
6. Regression: normal send/stream/complete (no deletion) persists and reloads correctly; editing an existing message's content still works; deleting a normal (non-streaming) message still works.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.