### PR TITLE
feat: add a master OAuth / OIDC enable toggle in Authentication settings

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -2429,6 +2429,11 @@ if JWT_EXPIRES_IN == '-1':
 # OAuth config
 ####################################
 
+# Master switch for OAuth/OIDC sign-in. Defaults to enabled so existing
+# deployments that already have a provider configured keep working; admins can
+# turn it off to disable OAuth login without clearing their provider settings.
+ENABLE_OAUTH = os.getenv('ENABLE_OAUTH', 'True').lower() == 'true'
+
 ENABLE_OAUTH_SIGNUP = os.getenv('ENABLE_OAUTH_SIGNUP', 'False').lower() == 'true'
 
 OAUTH_AUTO_REDIRECT = os.getenv('OAUTH_AUTO_REDIRECT', 'False').lower() == 'true'
@@ -3091,6 +3096,7 @@ DEFAULT_CONFIG = {
     'auth.api_key.endpoint_restrictions': ENABLE_API_KEYS_ENDPOINT_RESTRICTIONS,
     'auth.api_key.allowed_endpoints': API_KEYS_ALLOWED_ENDPOINTS,
     'auth.jwt_expiry': JWT_EXPIRES_IN,
+    'oauth.enable': ENABLE_OAUTH,
     'oauth.enable_signup': ENABLE_OAUTH_SIGNUP,
     'oauth.auto_redirect': OAUTH_AUTO_REDIRECT,
     'oauth.refresh_token.include_scope': OAUTH_REFRESH_TOKEN_INCLUDE_SCOPE,

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -1998,6 +1998,7 @@ async def get_app_config(request: Request):
     license_metadata = getattr(app.state, 'LICENSE_METADATA', None)
     user_count = await Users.get_num_users() if license_metadata else None
     config = await Config.get_many(
+        'oauth.enable',
         'oauth.auto_redirect',
         'ldap.enable',
         'ui.enable_signup',
@@ -2052,7 +2053,13 @@ async def get_app_config(request: Request):
         'version': VERSION,
         'default_locale': str(DEFAULT_LOCALE),
         'oauth': {
-            'providers': {name: config.get('name', name) for name, config in OAUTH_PROVIDERS.items()},
+            # Hide providers (and thus the login buttons / auto-redirect) when OAuth
+            # is disabled, without clearing the admin's provider configuration.
+            'providers': (
+                {name: provider.get('name', name) for name, provider in OAUTH_PROVIDERS.items()}
+                if config.get('oauth.enable', True)
+                else {}
+            ),
             'auto_redirect': config.get('oauth.auto_redirect'),
         },
         'features': {

--- a/backend/open_webui/routers/auths.py
+++ b/backend/open_webui/routers/auths.py
@@ -1304,6 +1304,7 @@ class OAuthConfigForm(BaseModel):
     """All OAuth/OIDC settings exposed to the admin panel."""
 
     # General OAuth
+    ENABLE_OAUTH: bool | None = None
     ENABLE_OAUTH_SIGNUP: bool | None = None
     OAUTH_MERGE_ACCOUNTS_BY_EMAIL: bool | None = None
     OAUTH_AUTO_REDIRECT: bool | None = None
@@ -1359,6 +1360,7 @@ OAUTH_COMMA_LIST_FIELDS = {
 
 
 OAUTH_CONFIG_KEYS = {
+    'ENABLE_OAUTH': 'oauth.enable',
     'ENABLE_OAUTH_SIGNUP': 'oauth.enable_signup',
     'OAUTH_MERGE_ACCOUNTS_BY_EMAIL': 'oauth.merge_accounts_by_email',
     'OAUTH_AUTO_REDIRECT': 'oauth.auto_redirect',

--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -35,6 +35,7 @@ from mcp.shared.auth import (
 from open_webui.config import (
     DEFAULT_USER_ROLE,
     ENABLE_OAUTH_GROUP_CREATION,
+    ENABLE_OAUTH,
     ENABLE_OAUTH_GROUP_MANAGEMENT,
     ENABLE_OAUTH_ROLE_MANAGEMENT,
     ENABLE_OAUTH_SIGNUP,
@@ -120,6 +121,7 @@ OAUTH_RESOURCE_PARAMETER_MODES = {'auto', 'include', 'omit'}
 
 OAUTH_RUNTIME_CONFIG = {
     'DEFAULT_USER_ROLE': ('ui.default_user_role', DEFAULT_USER_ROLE),
+    'ENABLE_OAUTH': ('oauth.enable', ENABLE_OAUTH),
     'ENABLE_OAUTH_SIGNUP': ('oauth.enable_signup', ENABLE_OAUTH_SIGNUP),
     'OAUTH_REFRESH_TOKEN_INCLUDE_SCOPE': (
         'oauth.refresh_token.include_scope',
@@ -1670,6 +1672,8 @@ class OAuthManager:
 
     async def handle_login(self, request, provider):
         auth_config = await get_oauth_runtime_config()
+        if not auth_config.ENABLE_OAUTH:
+            raise HTTPException(404)
         if provider not in OAUTH_PROVIDERS:
             raise HTTPException(404)
         # If the provider has a custom redirect URL, use that, otherwise automatically generate one
@@ -1690,6 +1694,8 @@ class OAuthManager:
 
     async def handle_callback(self, request, provider, response, db=None):
         auth_config = await get_oauth_runtime_config()
+        if not auth_config.ENABLE_OAUTH:
+            raise HTTPException(404)
         if provider not in OAUTH_PROVIDERS:
             raise HTTPException(404)
 

--- a/src/lib/components/admin/Settings/Authentication.svelte
+++ b/src/lib/components/admin/Settings/Authentication.svelte
@@ -523,283 +523,305 @@
 
 		{#if oauthConfig}
 			<AdminSettingSection title={$i18n.t('OAuth / OIDC')}>
-				<div class="grid grid-cols-1 gap-x-3 gap-y-2.5 sm:grid-cols-2">
-					<AdminSettingField
-						label={$i18n.t('Provider Name')}
-						description={$i18n.t('Display name shown for the OAuth provider.')}
-					>
-						<input
-							class={inputClass}
-							placeholder="SSO"
-							bind:value={oauthConfig.OAUTH_PROVIDER_NAME}
-						/>
-					</AdminSettingField>
-
-					<AdminSettingField
-						label={$i18n.t('Provider URL')}
-						description={$i18n.t('OpenID discovery URL for this provider.')}
-					>
-						<input
-							class={inputClass}
-							placeholder="https://accounts.google.com/.well-known/openid-configuration"
-							bind:value={oauthConfig.OPENID_PROVIDER_URL}
-						/>
-					</AdminSettingField>
-				</div>
-
-				<div class="grid grid-cols-1 gap-x-3 gap-y-2.5 sm:grid-cols-2">
-					<AdminSettingField
-						label={$i18n.t('Client ID')}
-						description={$i18n.t('OAuth client identifier from the provider.')}
-					>
-						<input
-							class={inputClass}
-							placeholder={$i18n.t('Enter Client ID')}
-							bind:value={oauthConfig.OAUTH_CLIENT_ID}
-						/>
-					</AdminSettingField>
-
-					<AdminSettingField
-						label={$i18n.t('Client Secret')}
-						description={$i18n.t('OAuth client secret from the provider.')}
-					>
-						<SensitiveInput
-							variant="settings"
-							placeholder={$i18n.t('Enter Client Secret')}
-							required={false}
-							bind:value={oauthConfig.OAUTH_CLIENT_SECRET}
-						/>
-					</AdminSettingField>
-				</div>
-
-				<div class="grid grid-cols-1 gap-x-3 gap-y-2.5 sm:grid-cols-2">
-					<AdminSettingField
-						label={$i18n.t('Redirect URI')}
-						description={$i18n.t('Callback URI registered with the provider.')}
-					>
-						<input
-							class={inputClass}
-							placeholder={$i18n.t('Enter Redirect URI')}
-							bind:value={oauthConfig.OPENID_REDIRECT_URI}
-						/>
-					</AdminSettingField>
-
-					<AdminSettingField
-						label={$i18n.t('Scopes')}
-						description={$i18n.t('OAuth scopes requested during sign-in.')}
-					>
-						<input
-							class={inputClass}
-							placeholder="openid email profile"
-							bind:value={oauthConfig.OAUTH_SCOPES}
-						/>
-					</AdminSettingField>
-				</div>
-
-				<div class="grid grid-cols-1 gap-x-3 gap-y-2.5 sm:grid-cols-2">
-					<AdminSettingField
-						label={$i18n.t('Email Claim')}
-						description={$i18n.t('Claim used as the user email address.')}
-					>
-						<input
-							class={inputClass}
-							placeholder="email"
-							bind:value={oauthConfig.OAUTH_EMAIL_CLAIM}
-						/>
-					</AdminSettingField>
-
-					<AdminSettingField
-						label={$i18n.t('Username Claim')}
-						description={$i18n.t('Claim used as the display name.')}
-					>
-						<input
-							class={inputClass}
-							placeholder="name"
-							bind:value={oauthConfig.OAUTH_USERNAME_CLAIM}
-						/>
-					</AdminSettingField>
-				</div>
-
-				<div class="grid grid-cols-1 gap-x-3 gap-y-2.5 sm:grid-cols-2">
-					<AdminSettingField
-						label={$i18n.t('Picture Claim')}
-						description={$i18n.t('Claim used as the profile picture URL.')}
-					>
-						<input
-							class={inputClass}
-							placeholder="picture"
-							bind:value={oauthConfig.OAUTH_PICTURE_CLAIM}
-						/>
-					</AdminSettingField>
-
-					<AdminSettingField
-						label={$i18n.t('Sub Claim')}
-						description={$i18n.t('Claim used as the stable user identifier.')}
-					>
-						<input class={inputClass} placeholder="sub" bind:value={oauthConfig.OAUTH_SUB_CLAIM} />
-					</AdminSettingField>
-				</div>
-
 				<AdminSettingRow
-					label={$i18n.t('OAuth Signup')}
-					description={$i18n.t('Allow users to create accounts through OAuth.')}
+					label={$i18n.t('OAuth / OIDC')}
+					description={$i18n.t('Allow users to authenticate with an OAuth / OIDC provider.')}
 					let:labelId
 				>
-					<Switch bind:state={oauthConfig.ENABLE_OAUTH_SIGNUP} ariaLabelledbyId={labelId} />
+					<Switch bind:state={oauthConfig.ENABLE_OAUTH} ariaLabelledbyId={labelId} />
 				</AdminSettingRow>
 
-				<AdminSettingRow
-					label={$i18n.t('Merge Accounts by Email')}
-					description={$i18n.t('Link OAuth sign-ins to existing accounts with the same email.')}
-					let:labelId
-				>
-					<Switch
-						bind:state={oauthConfig.OAUTH_MERGE_ACCOUNTS_BY_EMAIL}
-						ariaLabelledbyId={labelId}
-					/>
-				</AdminSettingRow>
-
-				<AdminSettingRow
-					label={$i18n.t('Auto Redirect')}
-					description={$i18n.t('Send users directly to the OAuth provider from the sign-in page.')}
-					let:labelId
-				>
-					<Switch bind:state={oauthConfig.OAUTH_AUTO_REDIRECT} ariaLabelledbyId={labelId} />
-				</AdminSettingRow>
-
-				<AdminSettingField
-					label={$i18n.t('Allowed Domains')}
-					description={$i18n.t('Email domains allowed to sign in with OAuth.')}
-				>
-					<input
-						class={inputClass}
-						placeholder="* (all domains)"
-						bind:value={oauthConfig.OAUTH_ALLOWED_DOMAINS}
-					/>
-				</AdminSettingField>
-
-				<AdminSettingRow
-					label={$i18n.t('Role Mapping')}
-					description={$i18n.t('Map OAuth claims to Open WebUI roles.')}
-					let:labelId
-				>
-					<Switch
-						bind:state={oauthConfig.ENABLE_OAUTH_ROLE_MANAGEMENT}
-						ariaLabelledbyId={labelId}
-					/>
-				</AdminSettingRow>
-
-				{#if oauthConfig.ENABLE_OAUTH_ROLE_MANAGEMENT}
+				{#if oauthConfig.ENABLE_OAUTH}
 					<div class="grid grid-cols-1 gap-x-3 gap-y-2.5 sm:grid-cols-2">
 						<AdminSettingField
-							label={$i18n.t('Roles Claim')}
-							description={$i18n.t('Claim containing provider roles.')}
+							label={$i18n.t('Provider Name')}
+							description={$i18n.t('Display name shown for the OAuth provider.')}
 						>
 							<input
 								class={inputClass}
-								placeholder="roles"
-								bind:value={oauthConfig.OAUTH_ROLES_CLAIM}
+								placeholder="SSO"
+								bind:value={oauthConfig.OAUTH_PROVIDER_NAME}
 							/>
 						</AdminSettingField>
 
 						<AdminSettingField
-							label={$i18n.t('Admin Roles')}
-							description={$i18n.t('Provider roles that grant admin access.')}
+							label={$i18n.t('Provider URL')}
+							description={$i18n.t('OpenID discovery URL for this provider.')}
 						>
 							<input
 								class={inputClass}
-								placeholder="admin"
-								bind:value={oauthConfig.OAUTH_ADMIN_ROLES}
+								placeholder="https://accounts.google.com/.well-known/openid-configuration"
+								bind:value={oauthConfig.OPENID_PROVIDER_URL}
 							/>
 						</AdminSettingField>
 					</div>
 
-					<AdminSettingField
-						label={$i18n.t('Allowed Roles')}
-						description={$i18n.t('Provider roles allowed to sign in.')}
-					>
-						<input
-							class={inputClass}
-							placeholder="*"
-							bind:value={oauthConfig.OAUTH_ALLOWED_ROLES}
-						/>
-					</AdminSettingField>
-				{/if}
+					<div class="grid grid-cols-1 gap-x-3 gap-y-2.5 sm:grid-cols-2">
+						<AdminSettingField
+							label={$i18n.t('Client ID')}
+							description={$i18n.t('OAuth client identifier from the provider.')}
+						>
+							<input
+								class={inputClass}
+								placeholder={$i18n.t('Enter Client ID')}
+								bind:value={oauthConfig.OAUTH_CLIENT_ID}
+							/>
+						</AdminSettingField>
 
-				<AdminSettingRow
-					label={$i18n.t('Group Mapping')}
-					description={$i18n.t('Map OAuth claims to Open WebUI groups.')}
-					let:labelId
-				>
-					<Switch
-						bind:state={oauthConfig.ENABLE_OAUTH_GROUP_MANAGEMENT}
-						ariaLabelledbyId={labelId}
-					/>
-				</AdminSettingRow>
+						<AdminSettingField
+							label={$i18n.t('Client Secret')}
+							description={$i18n.t('OAuth client secret from the provider.')}
+						>
+							<SensitiveInput
+								variant="settings"
+								placeholder={$i18n.t('Enter Client Secret')}
+								required={false}
+								bind:value={oauthConfig.OAUTH_CLIENT_SECRET}
+							/>
+						</AdminSettingField>
+					</div>
 
-				{#if oauthConfig.ENABLE_OAUTH_GROUP_MANAGEMENT}
+					<div class="grid grid-cols-1 gap-x-3 gap-y-2.5 sm:grid-cols-2">
+						<AdminSettingField
+							label={$i18n.t('Redirect URI')}
+							description={$i18n.t('Callback URI registered with the provider.')}
+						>
+							<input
+								class={inputClass}
+								placeholder={$i18n.t('Enter Redirect URI')}
+								bind:value={oauthConfig.OPENID_REDIRECT_URI}
+							/>
+						</AdminSettingField>
+
+						<AdminSettingField
+							label={$i18n.t('Scopes')}
+							description={$i18n.t('OAuth scopes requested during sign-in.')}
+						>
+							<input
+								class={inputClass}
+								placeholder="openid email profile"
+								bind:value={oauthConfig.OAUTH_SCOPES}
+							/>
+						</AdminSettingField>
+					</div>
+
+					<div class="grid grid-cols-1 gap-x-3 gap-y-2.5 sm:grid-cols-2">
+						<AdminSettingField
+							label={$i18n.t('Email Claim')}
+							description={$i18n.t('Claim used as the user email address.')}
+						>
+							<input
+								class={inputClass}
+								placeholder="email"
+								bind:value={oauthConfig.OAUTH_EMAIL_CLAIM}
+							/>
+						</AdminSettingField>
+
+						<AdminSettingField
+							label={$i18n.t('Username Claim')}
+							description={$i18n.t('Claim used as the display name.')}
+						>
+							<input
+								class={inputClass}
+								placeholder="name"
+								bind:value={oauthConfig.OAUTH_USERNAME_CLAIM}
+							/>
+						</AdminSettingField>
+					</div>
+
+					<div class="grid grid-cols-1 gap-x-3 gap-y-2.5 sm:grid-cols-2">
+						<AdminSettingField
+							label={$i18n.t('Picture Claim')}
+							description={$i18n.t('Claim used as the profile picture URL.')}
+						>
+							<input
+								class={inputClass}
+								placeholder="picture"
+								bind:value={oauthConfig.OAUTH_PICTURE_CLAIM}
+							/>
+						</AdminSettingField>
+
+						<AdminSettingField
+							label={$i18n.t('Sub Claim')}
+							description={$i18n.t('Claim used as the stable user identifier.')}
+						>
+							<input
+								class={inputClass}
+								placeholder="sub"
+								bind:value={oauthConfig.OAUTH_SUB_CLAIM}
+							/>
+						</AdminSettingField>
+					</div>
+
 					<AdminSettingRow
-						label={$i18n.t('Auto-Create Groups')}
-						description={$i18n.t('Create missing groups from OAuth claims.')}
+						label={$i18n.t('OAuth Signup')}
+						description={$i18n.t('Allow users to create accounts through OAuth.')}
+						let:labelId
+					>
+						<Switch bind:state={oauthConfig.ENABLE_OAUTH_SIGNUP} ariaLabelledbyId={labelId} />
+					</AdminSettingRow>
+
+					<AdminSettingRow
+						label={$i18n.t('Merge Accounts by Email')}
+						description={$i18n.t('Link OAuth sign-ins to existing accounts with the same email.')}
 						let:labelId
 					>
 						<Switch
-							bind:state={oauthConfig.ENABLE_OAUTH_GROUP_CREATION}
+							bind:state={oauthConfig.OAUTH_MERGE_ACCOUNTS_BY_EMAIL}
 							ariaLabelledbyId={labelId}
 						/>
 					</AdminSettingRow>
 
-					<div class="grid grid-cols-1 gap-x-3 gap-y-2.5 sm:grid-cols-2">
-						<AdminSettingField
-							label={$i18n.t('Group Claim')}
-							description={$i18n.t('Claim containing provider groups.')}
-						>
-							<input
-								class={inputClass}
-								placeholder="groups"
-								bind:value={oauthConfig.OAUTH_GROUP_CLAIM}
-							/>
-						</AdminSettingField>
+					<AdminSettingRow
+						label={$i18n.t('Auto Redirect')}
+						description={$i18n.t(
+							'Send users directly to the OAuth provider from the sign-in page.'
+						)}
+						let:labelId
+					>
+						<Switch bind:state={oauthConfig.OAUTH_AUTO_REDIRECT} ariaLabelledbyId={labelId} />
+					</AdminSettingRow>
+
+					<AdminSettingField
+						label={$i18n.t('Allowed Domains')}
+						description={$i18n.t('Email domains allowed to sign in with OAuth.')}
+					>
+						<input
+							class={inputClass}
+							placeholder="* (all domains)"
+							bind:value={oauthConfig.OAUTH_ALLOWED_DOMAINS}
+						/>
+					</AdminSettingField>
+
+					<AdminSettingRow
+						label={$i18n.t('Role Mapping')}
+						description={$i18n.t('Map OAuth claims to Open WebUI roles.')}
+						let:labelId
+					>
+						<Switch
+							bind:state={oauthConfig.ENABLE_OAUTH_ROLE_MANAGEMENT}
+							ariaLabelledbyId={labelId}
+						/>
+					</AdminSettingRow>
+
+					{#if oauthConfig.ENABLE_OAUTH_ROLE_MANAGEMENT}
+						<div class="grid grid-cols-1 gap-x-3 gap-y-2.5 sm:grid-cols-2">
+							<AdminSettingField
+								label={$i18n.t('Roles Claim')}
+								description={$i18n.t('Claim containing provider roles.')}
+							>
+								<input
+									class={inputClass}
+									placeholder="roles"
+									bind:value={oauthConfig.OAUTH_ROLES_CLAIM}
+								/>
+							</AdminSettingField>
+
+							<AdminSettingField
+								label={$i18n.t('Admin Roles')}
+								description={$i18n.t('Provider roles that grant admin access.')}
+							>
+								<input
+									class={inputClass}
+									placeholder="admin"
+									bind:value={oauthConfig.OAUTH_ADMIN_ROLES}
+								/>
+							</AdminSettingField>
+						</div>
 
 						<AdminSettingField
-							label={$i18n.t('Blocked Groups')}
-							description={$i18n.t('Provider groups blocked from signing in.')}
+							label={$i18n.t('Allowed Roles')}
+							description={$i18n.t('Provider roles allowed to sign in.')}
 						>
 							<input
 								class={inputClass}
-								placeholder={$i18n.t('Comma-separated group names')}
-								bind:value={oauthConfig.OAUTH_BLOCKED_GROUPS}
+								placeholder="*"
+								bind:value={oauthConfig.OAUTH_ALLOWED_ROLES}
 							/>
 						</AdminSettingField>
-					</div>
+					{/if}
+
+					<AdminSettingRow
+						label={$i18n.t('Group Mapping')}
+						description={$i18n.t('Map OAuth claims to Open WebUI groups.')}
+						let:labelId
+					>
+						<Switch
+							bind:state={oauthConfig.ENABLE_OAUTH_GROUP_MANAGEMENT}
+							ariaLabelledbyId={labelId}
+						/>
+					</AdminSettingRow>
+
+					{#if oauthConfig.ENABLE_OAUTH_GROUP_MANAGEMENT}
+						<AdminSettingRow
+							label={$i18n.t('Auto-Create Groups')}
+							description={$i18n.t('Create missing groups from OAuth claims.')}
+							let:labelId
+						>
+							<Switch
+								bind:state={oauthConfig.ENABLE_OAUTH_GROUP_CREATION}
+								ariaLabelledbyId={labelId}
+							/>
+						</AdminSettingRow>
+
+						<div class="grid grid-cols-1 gap-x-3 gap-y-2.5 sm:grid-cols-2">
+							<AdminSettingField
+								label={$i18n.t('Group Claim')}
+								description={$i18n.t('Claim containing provider groups.')}
+							>
+								<input
+									class={inputClass}
+									placeholder="groups"
+									bind:value={oauthConfig.OAUTH_GROUP_CLAIM}
+								/>
+							</AdminSettingField>
+
+							<AdminSettingField
+								label={$i18n.t('Blocked Groups')}
+								description={$i18n.t('Provider groups blocked from signing in.')}
+							>
+								<input
+									class={inputClass}
+									placeholder={$i18n.t('Comma-separated group names')}
+									bind:value={oauthConfig.OAUTH_BLOCKED_GROUPS}
+								/>
+							</AdminSettingField>
+						</div>
+					{/if}
+
+					<AdminSettingRow
+						label={$i18n.t('Update Email')}
+						description={$i18n.t('Refresh the account email from OAuth on sign-in.')}
+						let:labelId
+					>
+						<Switch
+							bind:state={oauthConfig.OAUTH_UPDATE_EMAIL_ON_LOGIN}
+							ariaLabelledbyId={labelId}
+						/>
+					</AdminSettingRow>
+
+					<AdminSettingRow
+						label={$i18n.t('Update Name')}
+						description={$i18n.t('Refresh the account name from OAuth on sign-in.')}
+						let:labelId
+					>
+						<Switch
+							bind:state={oauthConfig.OAUTH_UPDATE_NAME_ON_LOGIN}
+							ariaLabelledbyId={labelId}
+						/>
+					</AdminSettingRow>
+
+					<AdminSettingRow
+						label={$i18n.t('Update Picture')}
+						description={$i18n.t('Refresh the profile picture from OAuth on sign-in.')}
+						let:labelId
+					>
+						<Switch
+							bind:state={oauthConfig.OAUTH_UPDATE_PICTURE_ON_LOGIN}
+							ariaLabelledbyId={labelId}
+						/>
+					</AdminSettingRow>
 				{/if}
-
-				<AdminSettingRow
-					label={$i18n.t('Update Email')}
-					description={$i18n.t('Refresh the account email from OAuth on sign-in.')}
-					let:labelId
-				>
-					<Switch bind:state={oauthConfig.OAUTH_UPDATE_EMAIL_ON_LOGIN} ariaLabelledbyId={labelId} />
-				</AdminSettingRow>
-
-				<AdminSettingRow
-					label={$i18n.t('Update Name')}
-					description={$i18n.t('Refresh the account name from OAuth on sign-in.')}
-					let:labelId
-				>
-					<Switch bind:state={oauthConfig.OAUTH_UPDATE_NAME_ON_LOGIN} ariaLabelledbyId={labelId} />
-				</AdminSettingRow>
-
-				<AdminSettingRow
-					label={$i18n.t('Update Picture')}
-					description={$i18n.t('Refresh the profile picture from OAuth on sign-in.')}
-					let:labelId
-				>
-					<Switch
-						bind:state={oauthConfig.OAUTH_UPDATE_PICTURE_ON_LOGIN}
-						ariaLabelledbyId={labelId}
-					/>
-				</AdminSettingRow>
 			</AdminSettingSection>
 		{/if}
 	</div>


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

**Before submitting, make sure you've checked the following:**

- [ ] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions/27176) — `Closes #___` / `Relates to #___`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** No new dependencies.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **feat**: New features or enhancements

> _This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author._

# Changelog Entry

### Description

- **What:** Adds a master **OAuth / OIDC** enable/disable toggle to **Admin Settings → Authentication**, matching the **LDAP** toggle directly above it. Previously the OAuth / OIDC section had no on/off switch — it was always expanded and OAuth was implicitly "on" whenever a provider was configured, with no way to turn it off from the UI short of clearing the provider settings.
- **How it behaves:** The toggle both **collapses the section** and **functionally gates OAuth sign-in** (mirroring the LDAP toggle). It persists via the existing **Save** button. When disabled:
  - the login page no longer shows OAuth buttons (and can't auto-redirect to OAuth), and
  - the OAuth login/callback endpoints reject requests,
  - **without** clearing the configured provider — re-enabling restores everything.
- **Backward compatible:** `ENABLE_OAUTH` defaults to **True** (and honors an `ENABLE_OAUTH` env var), so existing deployments that already have a provider configured keep working unchanged after upgrade.

**Backend** (`config.py`, `utils/oauth.py`, `main.py`, `routers/auths.py`):

```python
# config.py — new persistent config, default on
ENABLE_OAUTH = os.getenv('ENABLE_OAUTH', 'True').lower() == 'true'
# registered in DEFAULT_CONFIG:
'oauth.enable': ENABLE_OAUTH,
```

```python
# utils/oauth.py — exposed via the OAuth runtime config and used to gate the handlers
'ENABLE_OAUTH': ('oauth.enable', ENABLE_OAUTH),
# in handle_login() and handle_callback():
if not auth_config.ENABLE_OAUTH:
    raise HTTPException(404)
```

```python
# main.py — /api/config hides providers (buttons + auto-redirect) when disabled
'providers': (
    {name: provider.get('name', name) for name, provider in OAUTH_PROVIDERS.items()}
    if config.get('oauth.enable', True) else {}
),
```

```python
# routers/auths.py — surfaced through the admin OAuth get/update endpoints
class OAuthConfigForm(BaseModel):
    ENABLE_OAUTH: bool | None = None
    ...
OAUTH_CONFIG_KEYS = {'ENABLE_OAUTH': 'oauth.enable', ...}
```

**Frontend** (`Authentication.svelte`): the OAuth / OIDC header Switch binds to the persisted `oauthConfig.ENABLE_OAUTH`, and the section body is wrapped in `{#if oauthConfig.ENABLE_OAUTH}`. The header uses the same classes as the LDAP header (`text-sm`, `font-medium`, `pr-1.5`) so the label size and toggle alignment match.

> **Reviewer note:** most of the line count in the `Authentication.svelte` diff is re-indentation from wrapping the existing section body in the `{#if}` block. Review with `git diff -w` (ignore whitespace) — the logical change is small. The backend changes total ~23 lines across four files.

### Added

- `ENABLE_OAUTH` master toggle for OAuth / OIDC sign-in in Admin Settings → Authentication (persisted; also settable via the `ENABLE_OAUTH` env var), defaulting to enabled.

---

### Additional Information

- Gating points (defense in depth): `/api/config` provider exposure (hides login buttons + auto-redirect), and the `handle_login` / `handle_callback` OAuth routes (reject when disabled). The unrelated `/oauth/clients/...` MCP client-OAuth routes are intentionally left untouched.
- Disabling does not delete provider credentials; it only stops OAuth sign-in until re-enabled.

### Screenshots or Videos

- Before: OAuth / OIDC always expanded, no enable switch, misaligned/oversized heading.

<img width="2555" height="1268" alt="image" src="https://github.com/user-attachments/assets/be3f3df8-71f7-44cc-9d9a-2ba7fe91fb60" />

- After: OAuth / OIDC has an enable toggle aligned with the LDAP one; toggling off collapses the section and disables OAuth sign-in; the choice persists across refresh after Save.

<img width="2555" height="1268" alt="image" src="https://github.com/user-attachments/assets/d629ce5d-577e-4f49-ae73-765a78d5dfa2" />

<img width="2555" height="1268" alt="image" src="https://github.com/user-attachments/assets/99a79bd1-fa13-4199-9040-48e36695d571" />

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
