### PR TITLE
fix: restrict folder deletion to the owner or an admin

### DIFF
--- a/backend/open_webui/routers/folders.py
+++ b/backend/open_webui/routers/folders.py
@@ -534,25 +534,20 @@ async def delete_folder_by_id(
     folder = await Folders.get_folder_by_id_and_user_id(id, user.id, db=db)
 
     if not folder:
-        # Check if it's a shared subfolder with write access
+        # Caller is not the owner. Deletion cascades into the owner's chats and
+        # whole subfolder subtree, so a write-collaborator (whose grant is even
+        # inherited by subfolders) must not trigger it. Only the owner or an
+        # admin may delete, for root and subfolders alike.
         folder = await Folders.get_folder_by_id(id, db=db)
-        if folder and folder.parent_id:
-            if user.role != 'admin' and not await _has_folder_access(user.id, folder, 'write', db):
-                raise HTTPException(
-                    status_code=status.HTTP_403_FORBIDDEN,
-                    detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
-                )
-        elif folder and not folder.parent_id:
-            # Root shared folders can only be deleted by owner/admin
-            if user.role != 'admin':
-                raise HTTPException(
-                    status_code=status.HTTP_403_FORBIDDEN,
-                    detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
-                )
-        else:
+        if not folder:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=ERROR_MESSAGES.NOT_FOUND,
+            )
+        if user.role != 'admin':
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
             )
 
     folder_owner_id = folder.user_id

--- a/backend/open_webui/routers/folders.py
+++ b/backend/open_webui/routers/folders.py
@@ -534,10 +534,7 @@ async def delete_folder_by_id(
     folder = await Folders.get_folder_by_id_and_user_id(id, user.id, db=db)
 
     if not folder:
-        # Caller is not the owner. Deletion cascades into the owner's chats and
-        # whole subfolder subtree, so a write-collaborator (whose grant is even
-        # inherited by subfolders) must not trigger it. Only the owner or an
-        # admin may delete, for root and subfolders alike.
+        # Deletion cascades into the owner's data, so only the owner or an admin may delete
         folder = await Folders.get_folder_by_id(id, db=db)
         if not folder:
             raise HTTPException(


### PR DESCRIPTION
Deleting a folder cascades into the folder owner's chats, messages and the entire subfolder subtree; the cascade is bound to the folder's owner, not the caller. The delete handler only enforced owner/admin for root folders. Subfolder deletion required merely write access, and a write grant on a shared root folder is inherited by every descendant subfolder. A write-collaborator could therefore permanently delete the owner's chats by deleting a subfolder of a shared folder, data they do not own. With delete_contents=false the same path force-moved the owner's chats out of the folder instead.

This also contradicted the documented sharing model: only the owner or an admin may delete a shared folder, and write access covers adding and editing chats and subfolders, not removing the folder.

Because any folder deletion cascades into the owner's data, restrict it to the owner or an admin for root and subfolders alike, replacing the root/subfolder split with a single check. Owners and admins are unaffected, and a write-collaborator can still create, rename and add to shared folders and delete subfolders they own.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
