### PR TITLE
fix: strip model params for read-only callers in the model list endpoint

### DIFF
--- a/backend/open_webui/routers/models.py
+++ b/backend/open_webui/routers/models.py
@@ -176,16 +176,16 @@ async def get_models(
         data = model.model_dump()
         if data.get('meta'):
             data['meta'].pop('profile_image_url', None)
-        items.append(
-            ModelAccessResponse(
-                **data,
-                write_access=(
-                    (user.role == 'admin' and BYPASS_ADMIN_ACCESS_CONTROL)
-                    or user.id == model.user_id
-                    or model.id in writable_model_ids
-                ),
-            )
+        write_access = (
+            (user.role == 'admin' and BYPASS_ADMIN_ACCESS_CONTROL)
+            or user.id == model.user_id
+            or model.id in writable_model_ids
         )
+        # Strip params (system prompt and other curated config) for read-only
+        # callers, mirroring the per-id endpoint.
+        if not write_access:
+            data['params'] = {}
+        items.append(ModelAccessResponse(**data, write_access=write_access))
 
     return ModelAccessListResponse(
         items=items,


### PR DESCRIPTION
The per-id model endpoint (GET /api/v1/models/model) strips params, the system prompt and other curated model config, for callers who only have read access. The list endpoint (GET /api/v1/models/list) did not: it returned each read-accessible model's full params, so a read-shared model exposed its params.system to non-owner read-grant holders.

Mirror the per-id behaviour: compute write_access per item and drop params before serialising when the caller lacks write access (not the owner, not an admin under BYPASS_ADMIN_ACCESS_CONTROL and holding no write grant). The model-card list UI does not render params, so this does not change functionality.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
