### PR TITLE
fix: do not expose tool source code to read-only users

### DIFF
--- a/backend/open_webui/routers/tools.py
+++ b/backend/open_webui/routers/tools.py
@@ -56,32 +56,6 @@ async def get_tool_module(request, tool_id, load_from_db=True):
     return tool_module
 
 
-def _tool_has_write_access(user, tool, user_group_ids: set) -> bool:
-    return (
-        (user.role == 'admin' and BYPASS_ADMIN_ACCESS_CONTROL)
-        or user.id == tool.user_id
-        or any(
-            g.permission == 'write'
-            and (
-                (g.principal_type == 'user' and g.principal_id in (user.id, '*'))
-                or (g.principal_type == 'group' and g.principal_id in user_group_ids)
-            )
-            for g in tool.access_grants
-        )
-    )
-
-
-def _tool_response_data(tool, has_write: bool) -> dict:
-    # `content` (Python source) and `specs` are writer-only. The read schema omits
-    # them, but ConfigDict(extra='allow') re-admits them when the response is built
-    # from model_dump(), so strip them here for non-writers.
-    data = tool.model_dump()
-    if not has_write:
-        data.pop('content', None)
-        data.pop('specs', None)
-    return data
-
-
 ############################
 # GetTools
 # The danger is not in having tools, but in reaching
@@ -100,7 +74,6 @@ async def get_tools(
     # Local Tools
     if ENABLE_PLUGINS:
         tools_cache = get_tools_cache(request)
-        user_group_ids = {group.id for group in await Groups.get_groups_by_member_id(user.id, db=db)}
         for tool in await Tools.get_tools(defer_content=True, db=db):
             tool_module = tools_cache.get(tool.id)
             has_user_valves = (
@@ -108,11 +81,10 @@ async def get_tools(
                 if tool_module
                 else (tool.meta.has_user_valves if tool.meta else False)
             )
-            data = _tool_response_data(tool, _tool_has_write_access(user, tool, user_group_ids))
             tools.append(
                 ToolUserResponse(
                     **{
-                        **data,
+                        **tool.model_dump(),
                         'has_user_valves': has_user_valves,
                     }
                 )
@@ -242,10 +214,21 @@ async def get_tool_list(user=Depends(get_verified_user), db: AsyncSession = Depe
 
     result = []
     for tool in tools:
-        has_write = _tool_has_write_access(user, tool, user_group_ids)
+        has_write = (
+            (user.role == 'admin' and BYPASS_ADMIN_ACCESS_CONTROL)
+            or user.id == tool.user_id
+            or any(
+                g.permission == 'write'
+                and (
+                    (g.principal_type == 'user' and (g.principal_id == user.id or g.principal_id == '*'))
+                    or (g.principal_type == 'group' and g.principal_id in user_group_ids)
+                )
+                for g in tool.access_grants
+            )
+        )
         result.append(
             ToolAccessResponse(
-                **_tool_response_data(tool, has_write),
+                **tool.model_dump(),
                 write_access=has_write,
             )
         )
@@ -474,10 +457,11 @@ async def get_tools_by_id(id: str, user=Depends(get_verified_user), db: AsyncSes
                     db=db,
                 )
             )
-            return ToolAccessResponse(
-                **_tool_response_data(tools, write_access),
-                write_access=write_access,
-            )
+            data = tools.model_dump()
+            if not write_access:
+                # extra='allow' re-admits content from model_dump; source is writer-only
+                data.pop('content', None)
+            return ToolAccessResponse(**data, write_access=write_access)
         else:
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,

--- a/backend/open_webui/routers/tools.py
+++ b/backend/open_webui/routers/tools.py
@@ -56,6 +56,32 @@ async def get_tool_module(request, tool_id, load_from_db=True):
     return tool_module
 
 
+def _tool_has_write_access(user, tool, user_group_ids: set) -> bool:
+    return (
+        (user.role == 'admin' and BYPASS_ADMIN_ACCESS_CONTROL)
+        or user.id == tool.user_id
+        or any(
+            g.permission == 'write'
+            and (
+                (g.principal_type == 'user' and g.principal_id in (user.id, '*'))
+                or (g.principal_type == 'group' and g.principal_id in user_group_ids)
+            )
+            for g in tool.access_grants
+        )
+    )
+
+
+def _tool_response_data(tool, has_write: bool) -> dict:
+    # `content` (Python source) and `specs` are writer-only. The read schema omits
+    # them, but ConfigDict(extra='allow') re-admits them when the response is built
+    # from model_dump(), so strip them here for non-writers.
+    data = tool.model_dump()
+    if not has_write:
+        data.pop('content', None)
+        data.pop('specs', None)
+    return data
+
+
 ############################
 # GetTools
 # The danger is not in having tools, but in reaching
@@ -74,6 +100,7 @@ async def get_tools(
     # Local Tools
     if ENABLE_PLUGINS:
         tools_cache = get_tools_cache(request)
+        user_group_ids = {group.id for group in await Groups.get_groups_by_member_id(user.id, db=db)}
         for tool in await Tools.get_tools(defer_content=True, db=db):
             tool_module = tools_cache.get(tool.id)
             has_user_valves = (
@@ -81,10 +108,11 @@ async def get_tools(
                 if tool_module
                 else (tool.meta.has_user_valves if tool.meta else False)
             )
+            data = _tool_response_data(tool, _tool_has_write_access(user, tool, user_group_ids))
             tools.append(
                 ToolUserResponse(
                     **{
-                        **tool.model_dump(),
+                        **data,
                         'has_user_valves': has_user_valves,
                     }
                 )
@@ -214,21 +242,10 @@ async def get_tool_list(user=Depends(get_verified_user), db: AsyncSession = Depe
 
     result = []
     for tool in tools:
-        has_write = (
-            (user.role == 'admin' and BYPASS_ADMIN_ACCESS_CONTROL)
-            or user.id == tool.user_id
-            or any(
-                g.permission == 'write'
-                and (
-                    (g.principal_type == 'user' and (g.principal_id == user.id or g.principal_id == '*'))
-                    or (g.principal_type == 'group' and g.principal_id in user_group_ids)
-                )
-                for g in tool.access_grants
-            )
-        )
+        has_write = _tool_has_write_access(user, tool, user_group_ids)
         result.append(
             ToolAccessResponse(
-                **tool.model_dump(),
+                **_tool_response_data(tool, has_write),
                 write_access=has_write,
             )
         )
@@ -446,19 +463,20 @@ async def get_tools_by_id(id: str, user=Depends(get_verified_user), db: AsyncSes
                 db=db,
             )
         ):
+            write_access = (
+                (user.role == 'admin' and BYPASS_ADMIN_ACCESS_CONTROL)
+                or user.id == tools.user_id
+                or await AccessGrants.has_access(
+                    user_id=user.id,
+                    resource_type='tool',
+                    resource_id=tools.id,
+                    permission='write',
+                    db=db,
+                )
+            )
             return ToolAccessResponse(
-                **tools.model_dump(),
-                write_access=(
-                    (user.role == 'admin' and BYPASS_ADMIN_ACCESS_CONTROL)
-                    or user.id == tools.user_id
-                    or await AccessGrants.has_access(
-                        user_id=user.id,
-                        resource_type='tool',
-                        resource_id=tools.id,
-                        permission='write',
-                        db=db,
-                    )
-                ),
+                **_tool_response_data(tools, write_access),
+                write_access=write_access,
             )
         else:
             raise HTTPException(


### PR DESCRIPTION
`GET /tools/id/{id}` returned the full tool record to anyone with read access, including `content`, which is the tool's source code. Read access is meant to allow using a tool, not reading its implementation, and the response model uses `extra='allow'`, so `content` is re-admitted from the model dump even though it is not a declared field.

The endpoint now computes write access once and removes `content` for callers that do not have it. `specs` is deliberately left in place, because the chat Available Tools modal renders it for every read-shared tool a user can call. The list endpoints are not touched: upstream's `defer_content` change already keeps source out of those responses.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
