### PR TITLE
fix: re-validate redirect targets in the Playwright web loader

### DIFF
--- a/backend/open_webui/retrieval/web/utils.py
+++ b/backend/open_webui/retrieval/web/utils.py
@@ -542,6 +542,20 @@ class SafeMicrosoftWebIQLoader(BaseLoader, RateLimitMixin, URLProcessingMixin):
                 raise e
 
 
+# Playwright follows redirects inside route.fetch() without re-entering
+# validate_url(), so when redirects are enabled we follow them manually and
+# re-validate every hop against the SSRF filter. Cap the chain length.
+MAX_WEB_LOADER_REDIRECTS = 20
+
+
+def _redirect_location(resp) -> str | None:
+    """Absolute redirect target of a 3xx Playwright APIResponse, or None if absent."""
+    location = resp.headers.get('location')
+    if not location:
+        return None
+    return urllib.parse.urljoin(resp.url, location)
+
+
 class SafePlaywrightURLLoader(PlaywrightURLLoader, RateLimitMixin, URLProcessingMixin):
     """Load HTML pages safely with Playwright, supporting SSL verification, rate limiting, and remote browser connection.
 
@@ -610,18 +624,27 @@ class SafePlaywrightURLLoader(PlaywrightURLLoader, RateLimitMixin, URLProcessing
             route.abort()
             return
 
-        if AIOHTTP_CLIENT_ALLOW_REDIRECTS:
-            resp = route.fetch()
-        else:
-            try:
-                resp = route.fetch(max_redirects=0)
-            except TypeError:
-                route.abort()
-                return
+        try:
+            resp = route.fetch(max_redirects=0)
+        except TypeError:
+            route.abort()
+            return
 
-            if 300 <= resp.status < 400:
+        redirects = 0
+        while 300 <= resp.status < 400:
+            if not AIOHTTP_CLIENT_ALLOW_REDIRECTS or redirects >= MAX_WEB_LOADER_REDIRECTS:
                 route.abort()
                 return
+            next_url = _redirect_location(resp)
+            if not next_url:
+                break
+            try:
+                validate_url(next_url)
+                resp = route.fetch(url=next_url, max_redirects=0)
+            except Exception:
+                route.abort()
+                return
+            redirects += 1
 
         route.fulfill(response=resp)
 
@@ -638,18 +661,27 @@ class SafePlaywrightURLLoader(PlaywrightURLLoader, RateLimitMixin, URLProcessing
             await route.abort()
             return
 
-        if AIOHTTP_CLIENT_ALLOW_REDIRECTS:
-            resp = await route.fetch()
-        else:
-            try:
-                resp = await route.fetch(max_redirects=0)
-            except TypeError:
-                await route.abort()
-                return
+        try:
+            resp = await route.fetch(max_redirects=0)
+        except TypeError:
+            await route.abort()
+            return
 
-            if 300 <= resp.status < 400:
+        redirects = 0
+        while 300 <= resp.status < 400:
+            if not AIOHTTP_CLIENT_ALLOW_REDIRECTS or redirects >= MAX_WEB_LOADER_REDIRECTS:
                 await route.abort()
                 return
+            next_url = _redirect_location(resp)
+            if not next_url:
+                break
+            try:
+                await run_in_threadpool(validate_url, next_url)
+                resp = await route.fetch(url=next_url, max_redirects=0)
+            except Exception:
+                await route.abort()
+                return
+            redirects += 1
 
         await route.fulfill(response=resp)
 


### PR DESCRIPTION
The Playwright web loader validated only the first-hop URL, then, when AIOHTTP_CLIENT_ALLOW_REDIRECTS was enabled, delegated the whole redirect chain to route.fetch(), which follows 3xx redirects without re-entering validate_url(). A public first hop could therefore redirect into a private address and the loader would fetch and return it (SSRF), even with ENABLE_LOCAL_WEB_FETCH off, while the sibling requests and aiohttp transports re-validate at the connection layer.

Follow redirects manually in both the sync and async navigation interceptors: fetch with max_redirects=0, and for each 3xx resolve the Location, run it through validate_url() before fetching the next hop, aborting on any disallowed target or past a fixed redirect cap. Redirect following is unchanged for public targets; only private, loopback and link-local destinations are now blocked.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
