### PR TITLE
fix: keep sidebar New Chat/Search label and shortcut hint on one line

### DIFF
--- a/src/lib/components/common/HotkeyHint.svelte
+++ b/src/lib/components/common/HotkeyHint.svelte
@@ -37,7 +37,7 @@
 
 {#if mounted && isVisible}
 	<div
-		class="hidden md:flex items-center self-center text-xs text-gray-400 dark:text-gray-600 {className}"
+		class="hidden md:flex items-center self-center whitespace-nowrap text-xs text-gray-400 dark:text-gray-600 {className}"
 	>
 		<span>{displayKeys()}</span>
 	</div>

--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -1067,7 +1067,7 @@
 			</div>
 
 			<div
-				class="relative flex flex-col flex-1 overflow-y-auto scrollbar-hidden pt-2.5 pb-2.5"
+				class="relative flex flex-col flex-1 overflow-x-hidden overflow-y-auto scrollbar-hidden pt-2.5 pb-2.5"
 				on:scroll={(e) => {
 					if (e.target.scrollTop === 0) {
 						scrollTop = 0;
@@ -1077,7 +1077,7 @@
 				}}
 			>
 				<div class="pb-1">
-					<div class="px-1 flex justify-center text-gray-800 dark:text-gray-200">
+					<div class="px-1 flex justify-start text-gray-800 dark:text-gray-200">
 						<a
 							id="sidebar-new-chat-button"
 							class="group grow flex items-center space-x-2 rounded-xl px-2 py-1.5 hover:bg-gray-100 dark:hover:bg-gray-900 transition outline-none"
@@ -1091,14 +1091,16 @@
 							</div>
 
 							<div class="flex flex-1 self-center translate-y-[0.5px]">
-								<div class=" self-center text-sm">{$i18n.t('New Chat')}</div>
+								<div class=" self-center text-sm whitespace-nowrap">
+									{$i18n.t('New Chat')}
+								</div>
 							</div>
 
 							<HotkeyHint name="newChat" className=" group-hover:visible invisible" />
 						</a>
 					</div>
 
-					<div class="px-1 flex justify-center text-gray-800 dark:text-gray-200">
+					<div class="px-1 flex justify-start text-gray-800 dark:text-gray-200">
 						<button
 							id="sidebar-search-button"
 							class="group grow flex items-center space-x-2 rounded-xl px-2 py-1.5 hover:bg-gray-100 dark:hover:bg-gray-900 transition outline-none"
@@ -1113,7 +1115,9 @@
 							</div>
 
 							<div class="flex flex-1 self-center translate-y-[0.5px]">
-								<div class=" self-center text-sm">{$i18n.t('Search')}</div>
+								<div class=" self-center text-sm whitespace-nowrap">
+									{$i18n.t('Search')}
+								</div>
 							</div>
 							<HotkeyHint name="search" className=" group-hover:visible invisible" />
 						</button>


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

**Before submitting, make sure you've checked the following:**

- [ ] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Closes #___` / `Relates to #___`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** No new dependencies.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

> _This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author._

# Changelog Entry

### Description

- **Problem:** With a high **UI Scale** (Settings → Interface), the sidebar **New Chat** and **Search** buttons broke apart visually: the label wrapped character-by-character (e.g. "N / e / w …"), the hover keyboard-shortcut hint (e.g. "Ctrl+Shift+O") stacked vertically, and because the row was centered, the icon and label were pushed off the left edge.
- **Root cause:** The label and the `HotkeyHint` had no `whitespace-nowrap`, so when the reserved hint width (the hint uses `invisible`, which still reserves layout space) squeezed the row, the label and hint collapsed onto multiple lines. The row wrapper also used `justify-center`, so once the content became wider than the sidebar, the overflow was centered and the icon/label spilled off the left.
- **Fix:**
  - Add `whitespace-nowrap` to the New Chat / Search labels so they stay on one line.
  - Add `whitespace-nowrap` to `HotkeyHint` so shortcut hints render on one line everywhere they appear.
  - Anchor the New Chat / Search rows with `justify-start` instead of `justify-center` so the icon and label stay locked at the left when the row overflows (the hint overflows to the right instead of the whole row centering off the left edge).
  - Add `overflow-x-hidden` to the sidebar nav scroll container so the now-rigid hint can't introduce a horizontal scrollbar. That container uses `overflow-y-auto`, which promotes `overflow-x` to `auto`; the outer sidebar containers already clip the x axis, so this aligns the scroll area with the existing intent (the sidebar shouldn't scroll horizontally).

```diff
# src/lib/components/common/HotkeyHint.svelte
-    class="hidden md:flex items-center self-center text-xs text-gray-400 dark:text-gray-600 {className}"
+    class="hidden md:flex items-center self-center whitespace-nowrap text-xs text-gray-400 dark:text-gray-600 {className}"
```

```diff
# src/lib/components/layout/Sidebar.svelte (New Chat and Search rows)
-  <div class="px-[0.4375rem] flex justify-center text-gray-800 dark:text-gray-200">
+  <div class="px-[0.4375rem] flex justify-start text-gray-800 dark:text-gray-200">
   ...
-      <div class=" self-center text-sm font-primary">{$i18n.t('New Chat')}</div>
+      <div class=" self-center text-sm font-primary whitespace-nowrap">{$i18n.t('New Chat')}</div>
```

### Fixed

- Fixed the sidebar **New Chat** and **Search** buttons wrapping/mis-aligning at high UI Scale: the labels and their keyboard-shortcut hints now stay on a single line, and the icon and label stay anchored to the left instead of being pushed off the edge. The sidebar no longer shows a stray horizontal scrollbar from the shortcut hint.

---

### Additional Information

- `whitespace-nowrap` on `HotkeyHint` is a general improvement — keyboard-shortcut hints should never wrap regardless of where they are rendered.
- Only the New Chat and Search rows are re-anchored (`justify-start`); the pinned menu items wrapper is intentionally left unchanged.
- At normal UI Scale there is no visual change (the button already fills the row via `grow`, so `justify-start` vs `justify-center` only differs once the content overflows).
- Just adding a URL here to say it's related to something, although, it isn't. https://github.com/open-webui/open-webui/discussions/25460

### Screenshots or Videos

#### Before (high UI Scale): "New Chat"/"Search" labels wrap character-by-character.

<img width="2555" height="1268" alt="image" src="https://github.com/user-attachments/assets/dad4f4c0-c5ec-4126-9af0-b614c449ea70" />

<img width="2555" height="1268" alt="image" src="https://github.com/user-attachments/assets/0315660b-47c6-4905-98f3-72e7db71429a" />

#### After: labels and shortcut hints stay on one line; icon and label remain anchored at the left.

<img width="2555" height="1272" alt="image" src="https://github.com/user-attachments/assets/b8391cb8-3aa0-4b20-a39f-b8983f969507" />

<img width="2555" height="1272" alt="image" src="https://github.com/user-attachments/assets/8819a6bf-6976-4a13-9ae0-fc8829263dd7" />

### Manual Verification Performed

1. Settings → Interface → increase **UI Scale** toward the maximum.
2. Confirm the sidebar **New Chat** and **Search** labels stay on one line (no character-by-character wrapping).
3. Hover each button and confirm the keyboard-shortcut hint ("Ctrl+Shift+O", "Ctrl+K") renders horizontally on one line.
4. Confirm the icon and label stay anchored at the left edge (not pushed off-screen) as the scale increases.
5. Confirm no horizontal scrollbar appears in the sidebar (previously the shortcut hint introduced one above the username).
6. At default UI Scale, confirm the buttons look unchanged.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.