### PR TITLE
fix: make skill prompt order deterministic

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2525,7 +2525,7 @@ async def process_chat_payload(request, form_data, user, metadata, model):
         from open_webui.models.skills import Skills as SkillsModel
 
         accessible_skill_ids = {s.id for s in await SkillsModel.get_skills_by_user_id(user.id, 'read')}
-        for sid in skill_ids:
+        for sid in sorted(skill_ids):
             if sid in accessible_skill_ids:
                 s = await SkillsModel.get_skill_by_id(sid)
                 if s and s.is_active:


### PR DESCRIPTION
## Summary

Make skill traversal deterministic when constructing skill injections and the `<available_skills>` manifest.

`skill_ids` is a set union assembled from request, model, and mentioned skills. Iterating that set directly can yield different orders across Python workers because string hashes are randomized per process. Sorting the IDs at the existing traversal chokepoint makes identical skill sets produce byte-stable prompt content, improving provider prompt-cache reuse.

Fixes https://github.com/open-webui/open-webui/issues/26986

## Change

- Iterate over `sorted(skill_ids)` instead of the set directly.
- Preserve existing deduplication, accessibility checks, active-skill filtering, and skill-loading behavior.

## Testing

- Ran a deterministic AST change-detector against both revisions:
  - parent revision: **RED**, detected direct unordered `skill_ids` traversal;
  - candidate revision: **GREEN**, confirmed traversal through `sorted(skill_ids)`.
- `python3 -m py_compile backend/open_webui/utils/middleware.py`: **PASS**
- `git diff --check HEAD^`: **PASS**

The AST check confirms the intended edit but is not claimed as end-to-end behavioral coverage. This prompt-construction path is embedded in a large asynchronous middleware function without an existing focused unit-test seam.

## OpenJobs

This contribution was prepared for [openjobs.bot](https://openjobs.bot/) listing [`9a57018c-a4cf-4e07-bbbf-6e9fcd6a4451`](https://openjobs.bot/jobs/9a57018c-a4cf-4e07-bbbf-6e9fcd6a4451).
