### PR TITLE
fix: make skill prompt order deterministic

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2527,7 +2527,7 @@ async def process_chat_payload(request, form_data, user, metadata, model):
         from open_webui.models.skills import Skills as SkillsModel
 
         accessible_skill_ids = {s.id for s in await SkillsModel.get_skills_by_user_id(user.id, 'read')}
-        for sid in skill_ids:
+        for sid in sorted(skill_ids):
             if sid in accessible_skill_ids:
                 s = await SkillsModel.get_skill_by_id(sid)
                 if s and s.is_active:


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Fixes https://github.com/open-webui/open-webui/issues/26986.
- [x] **Target branch:** This pull request targets the `dev` branch.
- [x] **Description:** A concise description is provided below.
- [x] **Changelog:** A Keep a Changelog-style entry is included below.
- [x] **Documentation:** No documentation change is needed for this internal determinism fix.
- [x] **Dependencies:** No dependencies are added or changed.
- [x] **Testing:** The focused source invariant, Python compilation, and diff validation were run against the rebased `dev` commit.
- [x] **No Unchecked AI Code:** The change underwent independent Claude review and deterministic local verification; findings and limitations were reviewed before submission.
- [x] **Self-Review:** The one-line diff and affected prompt-construction path were reviewed.
- [x] **Architecture:** This uses the existing skill-resolution chokepoint and adds no setting or architectural surface.
- [x] **Git Hygiene:** The PR is atomic, rebased on current `dev`, and contains one relevant commit.
- [x] **Title Prefix:** The title uses the `fix` prefix.

## Description

`skill_ids` is a set union assembled from request, model, and mentioned skills. Iterating that set directly can yield different orders across Python workers because string hashes are randomized per process. Sorting IDs at the existing traversal chokepoint makes identical skill sets produce byte-stable skill injections and `<available_skills>` manifests, improving provider prompt-cache reuse.

The change preserves existing deduplication, accessibility checks, active-skill filtering, and skill-loading behavior.

Fixes https://github.com/open-webui/open-webui/issues/26986

# Changelog Entry

### Fixed

- Made skill prompt and manifest ordering deterministic across Python workers to preserve prompt-cache stability.

---

### Additional Information

Testing on the commit rebased onto `dev`:

- deterministic AST change-detector on parent: **RED**, direct unordered `skill_ids` traversal detected;
- same detector on candidate: **GREEN**, `sorted(skill_ids)` traversal confirmed;
- `python3 -m py_compile backend/open_webui/utils/middleware.py`: **PASS**;
- `git diff --check HEAD^`: **PASS**.

The AST check confirms the intended code shape and is not claimed as end-to-end behavioral coverage. The affected asynchronous middleware function does not have an existing focused unit-test seam.

Prepared for [openjobs.bot](https://openjobs.bot/) listing [`9a57018c-a4cf-4e07-bbbf-6e9fcd6a4451`](https://openjobs.bot/jobs/9a57018c-a4cf-4e07-bbbf-6e9fcd6a4451).

### Screenshots or Videos

Not applicable; this is a backend prompt-ordering fix with no UI change.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
