### PR TITLE
fix: keep sidebar chat initialization on first page

### DIFF
--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -352,7 +352,10 @@
 			})(),
 			(async () => {
 				console.log('Init chat list');
-				const _chats = await getChatList(localStorage.token, $currentChatPage);
+				// The mobile sidebar's visible loader may advance currentChatPage while
+				// initialization is awaiting the other requests. Always initialize from
+				// page 1 so an empty later page cannot replace the visible chat list.
+				const _chats = await getChatList(localStorage.token, 1);
 				await chats.set(_chats);
 			})()
 		]);


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Closes #27014.
- [x] **Target branch:** This pull request targets `dev`.
- [x] **Description:** The change and race condition are described below.
- [x] **Changelog:** A Keep a Changelog entry is included below.
- [x] **Documentation:** No user-facing documentation change is required for this bug fix.
- [x] **Dependencies:** No dependencies are added or updated.
- [x] **Testing:** The fix was built from v0.10.2 and manually verified on Chrome for Android against a Docker deployment.
- [x] **No Unchecked AI Code:** The one-line behavior change and surrounding control flow were reviewed and manually tested.
- [x] **Self-Review:** The diff is limited to sidebar initialization.
- [x] **Architecture:** Existing pagination state remains unchanged; initialization uses its invariant first page.
- [x] **Git Hygiene:** The PR is atomic and based on `dev`.
- [x] **Title Prefix:** The title uses `fix`.

## Description

On a mobile-width viewport, opening the sidebar enables the visible bottom loader. The loader can advance `currentChatPage` while `initChatList()` is awaiting the other requests in its `Promise.all`. Because the initialization callback previously read `$currentChatPage` at execution time, it could request page 2 and replace the valid first-page chat store with an empty page.

Always request page 1 when initializing the sidebar. `loadMoreChats()` continues to own all later-page requests.

Observed failing sequence before the change:

```text
GET /api/v1/chats/?page=1 200
GET /api/v1/chats/?page=2 200
GET /api/v1/chats/?page=2 200  # sidebar re-initialization
```

After the change, sidebar re-initialization consistently requests page 1 and the Android chat history remains visible.

# Changelog Entry

### Fixed

- Fixed mobile sidebar chat history disappearing when pagination advances during sidebar initialization.

### Additional Information

- Closes #27014.
- `npx prettier --check src/lib/components/layout/Sidebar.svelte` passes.
- Full v0.10.2 frontend build completed successfully.
- No backend, database, or API behavior changes.

### Screenshots or Videos

The issue report includes the reproduction details and request sequence. The affected production-like Docker deployment was verified after applying the patch.

### Contributor License Agreement

<!-- The account owner should check this box after reviewing the CLA. -->
- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.