### PR TITLE
fix: serialize sidebar chat pagination

### DIFF
--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -98,6 +98,7 @@
 	// Pagination variables
 	let chatListLoading = false;
 	let allChatsLoaded = false;
+	let chatListGeneration = 0;
 
 	let showCreateFolderModal = false;
 
@@ -321,10 +322,13 @@
 	};
 
 	const initChatList = async () => {
+		const generation = ++chatListGeneration;
+
 		// Reset pagination variables
 		console.log('initChatList');
 		currentChatPage.set(1);
 		allChatsLoaded = false;
+		chatListLoading = false;
 		scrollPaginationEnabled.set(false);
 
 		initFolders();
@@ -352,31 +356,46 @@
 			})(),
 			(async () => {
 				console.log('Init chat list');
-				const _chats = await getChatList(localStorage.token, $currentChatPage);
-				await chats.set(_chats);
+				const _chats = await getChatList(localStorage.token, 1);
+				if (generation === chatListGeneration) {
+					await chats.set(_chats);
+				}
 			})()
 		]);
 
 		// Enable pagination
-		scrollPaginationEnabled.set(true);
+		if (generation === chatListGeneration) {
+			scrollPaginationEnabled.set(true);
+		}
 	};
 
 	const loadMoreChats = async () => {
+		if (chatListLoading || allChatsLoaded || !$scrollPaginationEnabled) {
+			return;
+		}
+
+		const generation = chatListGeneration;
+		const nextPage = $currentChatPage + 1;
 		chatListLoading = true;
 
-		currentChatPage.set($currentChatPage + 1);
+		try {
+			const newChatList = await getChatList(localStorage.token, nextPage);
 
-		let newChatList = [];
+			if (generation !== chatListGeneration) {
+				return;
+			}
 
-		newChatList = await getChatList(localStorage.token, $currentChatPage);
-
-		// once the bottom of the list has been reached (no results) there is no need to continue querying
-		allChatsLoaded = newChatList.length === 0;
-		const existingIds = new Set(($chats ?? []).map((c) => c.id));
-		const uniqueNewChats = newChatList.filter((c) => !existingIds.has(c.id));
-		await chats.set([...($chats ? $chats : []), ...uniqueNewChats]);
-
-		chatListLoading = false;
+			// Once the bottom of the list has been reached (no results), stop querying.
+			allChatsLoaded = newChatList.length === 0;
+			const existingIds = new Set(($chats ?? []).map((c) => c.id));
+			const uniqueNewChats = newChatList.filter((c) => !existingIds.has(c.id));
+			await chats.set([...($chats ? $chats : []), ...uniqueNewChats]);
+			currentChatPage.set(nextPage);
+		} finally {
+			if (generation === chatListGeneration) {
+				chatListLoading = false;
+			}
+		}
 	};
 
 	const importChatHandler = async (items, pinned = false, folderId = null) => {


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Closes #27014.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** The pagination race and fix are described below.
- [x] **Changelog:** A changelog entry is included below.
- [x] **Documentation:** No user-facing documentation change is required.
- [x] **Dependencies:** No dependencies are added or updated.
- [x] **Testing:** The reproduction was verified on Chrome for Android against a Docker deployment; the v0.10.2 frontend build completed successfully.
- [x] **No Unchecked AI Code:** The state transitions and final diff were reviewed after production reproduction.
- [x] **Self-Review:** The diff is limited to chat-list initialization and pagination state.
- [x] **Architecture:** A request generation guards ephemeral UI state without adding settings or backend behavior.
- [x] **Git Hygiene:** The PR is a single atomic commit based on `dev`.
- [x] **Title Prefix:** The title uses `fix`.

## Description

Mobile sidebar initialization and infinite-scroll pagination share `currentChatPage`, `chatListLoading`, and the global `chats` store. A pagination request already in flight can complete after a newer sidebar initialization and mutate the newly initialized list.

This change:

- gives each sidebar chat-list initialization a generation;
- always initializes from page 1;
- ignores stale initialization and load-more responses;
- advances `currentChatPage` only after the requested page is accepted;
- prevents duplicate pagination while loading, after exhaustion, or while pagination is disabled.

The generation is intentionally scoped to chat-list state. Tags, folders, pinned chats, and component lifecycle behavior are unchanged.

# Changelog Entry

### Description

- Serialize sidebar chat-list initialization and infinite-scroll pagination so stale responses cannot replace newer state.

### Added

- No user-facing features added.

### Changed

- Page state now advances only after a load-more response is accepted.

### Deprecated

- None.

### Removed

- None.

### Fixed

- Fixed mobile sidebar chat history disappearing when a stale pagination response races with sidebar initialization.

### Security

- No security changes.

### Breaking Changes

- None.

---

### Additional Information

- Closes #27014.
- `git diff --check` passes.
- Full v0.10.2 frontend build completed successfully for the deployed reproduction fix.
- No backend, database, API, or dependency changes.

### Screenshots or Videos

The linked issue contains reproduction details and the observed backend request sequence. The affected Android deployment no longer loses visible chat history after applying the initialization fix.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
