### PR TITLE
fix: prevent settings labels/tabs from wrapping and misaligning at large UI scale on mobile

### DIFF
--- a/src/lib/components/AddToolServerModal.svelte
+++ b/src/lib/components/AddToolServerModal.svelte
@@ -453,8 +453,8 @@
 				{/if}
 			</h1>
 
-			<div class="flex items-center gap-3">
-				<div class="flex gap-1.5 text-xs justify-end">
+			<div class="flex items-center gap-3 shrink-0">
+				<div class="flex gap-1.5 text-xs justify-end whitespace-nowrap">
 					<button
 						class=" hover:underline"
 						type="button"

--- a/src/lib/components/admin/Settings/Documents.svelte
+++ b/src/lib/components/admin/Settings/Documents.svelte
@@ -382,12 +382,12 @@
 
 					<div class="mb-2.5 flex flex-col w-full justify-between">
 						<div class="flex w-full justify-between mb-1">
-							<div class="self-center text-xs font-medium">
+							<div class="self-center text-xs font-medium shrink-0">
 								{$i18n.t('Content Extraction Engine')}
 							</div>
 							<div class="">
 								<select
-									class="w-fit pr-8 rounded-sm px-2 text-xs bg-transparent outline-hidden text-right"
+									class="w-fit max-w-full min-w-0 pr-8 rounded-sm px-2 text-xs bg-transparent outline-hidden text-right"
 									bind:value={RAGConfig.CONTENT_EXTRACTION_ENGINE}
 								>
 									<option value="">{$i18n.t('Default')}</option>
@@ -417,7 +417,7 @@
 
 							<div class="flex w-full mt-2">
 								<div class="flex-1 flex justify-between">
-									<div class=" self-center text-xs font-medium">
+									<div class=" self-center text-xs font-medium shrink-0">
 										<Tooltip
 											content={$i18n.t(
 												'Page mode creates one document per page. Single mode combines all pages into one document for better chunking across page boundaries.'
@@ -429,7 +429,7 @@
 									</div>
 									<div class="">
 										<select
-											class="w-fit pr-8 rounded-sm px-2 text-xs bg-transparent outline-hidden text-right"
+											class="w-fit max-w-full min-w-0 pr-8 rounded-sm px-2 text-xs bg-transparent outline-hidden text-right"
 											bind:value={RAGConfig.PDF_LOADER_MODE}
 										>
 											<option value="page">{$i18n.t('Page')}</option>
@@ -588,7 +588,7 @@
 								</div>
 							</div>
 							<div class="flex justify-between w-full mt-2">
-								<div class="self-center text-xs font-medium">
+								<div class="self-center text-xs font-medium shrink-0">
 									<Tooltip
 										content={$i18n.t(
 											"The output format for the text. Can be 'json', 'markdown', or 'html'. Defaults to 'markdown'."
@@ -600,7 +600,7 @@
 								</div>
 								<div class="">
 									<select
-										class="w-fit pr-8 rounded-sm px-2 text-xs bg-transparent outline-hidden text-right"
+										class="w-fit max-w-full min-w-0 pr-8 rounded-sm px-2 text-xs bg-transparent outline-hidden text-right"
 										bind:value={RAGConfig.DATALAB_MARKER_OUTPUT_FORMAT}
 									>
 										<option value="markdown">{$i18n.t('Markdown')}</option>
@@ -792,11 +792,11 @@
 							<!-- API Mode Selection -->
 							<div class="flex w-full mt-2">
 								<div class="flex-1 flex justify-between">
-									<div class="self-center text-xs font-medium">
+									<div class="self-center text-xs font-medium shrink-0">
 										{$i18n.t('API Mode')}
 									</div>
 									<select
-										class="w-fit pr-8 rounded-sm px-2 text-xs bg-transparent outline-hidden"
+										class="w-fit max-w-full min-w-0 pr-8 rounded-sm px-2 text-xs bg-transparent outline-hidden"
 										bind:value={RAGConfig.MINERU_API_MODE}
 										on:change={() => {
 											// Auto-update URL when switching modes if it's empty or matches the opposite mode's default
@@ -918,10 +918,12 @@
 
 					{#if !RAGConfig.BYPASS_EMBEDDING_AND_RETRIEVAL}
 						<div class="  mb-2.5 flex w-full justify-between">
-							<div class=" self-center text-xs font-medium">{$i18n.t('Text Splitter')}</div>
+							<div class=" self-center text-xs font-medium shrink-0">
+								{$i18n.t('Text Splitter')}
+							</div>
 							<div class="flex items-center relative">
 								<select
-									class="w-fit pr-8 rounded-sm px-2 text-xs bg-transparent outline-hidden text-right"
+									class="w-fit max-w-full min-w-0 pr-8 rounded-sm px-2 text-xs bg-transparent outline-hidden text-right"
 									bind:value={RAGConfig.TEXT_SPLITTER}
 								>
 									<option value="">{$i18n.t('Default')} ({$i18n.t('Character')})</option>
@@ -1042,12 +1044,12 @@
 
 						<div class="  mb-2.5 flex flex-col w-full justify-between">
 							<div class="flex w-full justify-between">
-								<div class=" self-center text-xs font-medium">
+								<div class=" self-center text-xs font-medium shrink-0">
 									{$i18n.t('Embedding Model Engine')}
 								</div>
 								<div class="flex items-center relative">
 									<select
-										class="w-fit pr-8 rounded-sm px-2 p-1 text-xs bg-transparent outline-hidden text-right"
+										class="w-fit max-w-full min-w-0 pr-8 rounded-sm px-2 p-1 text-xs bg-transparent outline-hidden text-right"
 										bind:value={RAG_EMBEDDING_ENGINE}
 										placeholder={$i18n.t('Select an embedding model engine')}
 										on:change={(e) => {
@@ -1298,12 +1300,12 @@
 
 								<div class="  mb-2.5 flex flex-col w-full justify-between">
 									<div class="flex w-full justify-between">
-										<div class=" self-center text-xs font-medium">
+										<div class=" self-center text-xs font-medium shrink-0">
 											{$i18n.t('Reranking Engine')}
 										</div>
 										<div class="flex items-center relative">
 											<select
-												class="w-fit pr-8 rounded-sm px-2 p-1 text-xs bg-transparent outline-hidden text-right"
+												class="w-fit max-w-full min-w-0 pr-8 rounded-sm px-2 p-1 text-xs bg-transparent outline-hidden text-right"
 												bind:value={RAGConfig.RAG_RERANKING_ENGINE}
 												placeholder={$i18n.t('Select a reranking model engine')}
 												on:change={(e) => {
@@ -1376,9 +1378,9 @@
 
 							<div class="  mb-2.5 flex w-full justify-between">
 								<div class=" self-center text-xs font-medium">{$i18n.t('Top K')}</div>
-								<div class="flex items-center relative">
+								<div class="">
 									<input
-										class="flex-1 w-full text-sm bg-transparent outline-hidden"
+										class=" bg-transparent text-center w-14 outline-none"
 										type="number"
 										placeholder={$i18n.t('Enter Top K')}
 										bind:value={RAGConfig.TOP_K}
@@ -1391,9 +1393,9 @@
 							{#if RAGConfig.ENABLE_RAG_HYBRID_SEARCH === true}
 								<div class="mb-2.5 flex w-full justify-between">
 									<div class="self-center text-xs font-medium">{$i18n.t('Top K Reranker')}</div>
-									<div class="flex items-center relative">
+									<div class="">
 										<input
-											class="flex-1 w-full text-sm bg-transparent outline-hidden"
+											class=" bg-transparent text-center w-14 outline-none"
 											type="number"
 											placeholder={$i18n.t('Enter Top K Reranker')}
 											bind:value={RAGConfig.TOP_K_RERANKER}
@@ -1410,9 +1412,9 @@
 										<div class=" self-center text-xs font-medium">
 											{$i18n.t('Relevance Threshold')}
 										</div>
-										<div class="flex items-center relative">
+										<div class="">
 											<input
-												class="flex-1 w-full text-sm bg-transparent outline-hidden"
+												class=" bg-transparent text-center w-14 outline-none"
 												type="number"
 												step="0.01"
 												placeholder={$i18n.t('Enter Score')}

--- a/src/lib/components/admin/Settings/Images.svelte
+++ b/src/lib/components/admin/Settings/Images.svelte
@@ -299,7 +299,7 @@
 
 					<div class="mb-2.5">
 						<div class="flex w-full justify-between items-center">
-							<div class="text-xs pr-2">
+							<div class="text-xs pr-2 shrink-0">
 								<div class="">
 									{$i18n.t('Image Generation')}
 								</div>
@@ -318,7 +318,7 @@
 					{#if config.ENABLE_IMAGE_GENERATION}
 						<div class="mb-2.5">
 							<div class="flex w-full justify-between items-center">
-								<div class="text-xs pr-2">
+								<div class="text-xs pr-2 shrink-0">
 									<div class="shrink-0">
 										{$i18n.t('Model')}
 									</div>
@@ -344,7 +344,7 @@
 
 						<div class="mb-2.5">
 							<div class="flex w-full justify-between items-center">
-								<div class="text-xs pr-2">
+								<div class="text-xs pr-2 shrink-0">
 									<div class="shrink-0">
 										{$i18n.t('Image Size')}
 									</div>
@@ -363,7 +363,7 @@
 						{#if ['comfyui', 'automatic1111', ''].includes(config?.IMAGE_GENERATION_ENGINE)}
 							<div class="mb-2.5">
 								<div class="flex w-full justify-between items-center">
-									<div class="text-xs pr-2">
+									<div class="text-xs pr-2 shrink-0">
 										<div class="">
 											{$i18n.t('Steps')}
 										</div>
@@ -386,7 +386,7 @@
 
 						<div class="mb-2.5">
 							<div class="flex w-full justify-between items-center">
-								<div class="text-xs pr-2">
+								<div class="text-xs pr-2 shrink-0">
 									<div class="">
 										{$i18n.t('Image Prompt Generation')}
 									</div>
@@ -399,7 +399,7 @@
 
 					<div class="mb-2.5">
 						<div class="flex w-full justify-between items-center">
-							<div class="text-xs pr-2">
+							<div class="text-xs pr-2 shrink-0">
 								<div class="">
 									{$i18n.t('Image Generation Engine')}
 								</div>
@@ -864,7 +864,7 @@
 
 						<div class="mb-2.5">
 							<div class="flex w-full justify-between items-center">
-								<div class="text-xs pr-2">
+								<div class="text-xs pr-2 shrink-0">
 									<div class="">
 										{$i18n.t('Gemini Endpoint Method')}
 									</div>
@@ -890,7 +890,7 @@
 
 					<div class="mb-2.5">
 						<div class="flex w-full justify-between items-center">
-							<div class="text-xs pr-2">
+							<div class="text-xs pr-2 shrink-0">
 								<div class="">
 									{$i18n.t('Image Edit')}
 								</div>
@@ -903,7 +903,7 @@
 					{#if config?.ENABLE_IMAGE_GENERATION && config?.ENABLE_IMAGE_EDIT}
 						<div class="mb-2.5">
 							<div class="flex w-full justify-between items-center">
-								<div class="text-xs pr-2">
+								<div class="text-xs pr-2 shrink-0">
 									<div class="shrink-0">
 										{$i18n.t('Model')}
 									</div>
@@ -928,7 +928,7 @@
 
 						<div class="mb-2.5">
 							<div class="flex w-full justify-between items-center">
-								<div class="text-xs pr-2">
+								<div class="text-xs pr-2 shrink-0">
 									<div class="shrink-0">
 										{$i18n.t('Image Size')}
 									</div>
@@ -947,7 +947,7 @@
 
 					<div class="mb-2.5">
 						<div class="flex w-full justify-between items-center">
-							<div class="text-xs pr-2">
+							<div class="text-xs pr-2 shrink-0">
 								<div class="">
 									{$i18n.t('Image Edit Engine')}
 								</div>

--- a/src/lib/components/admin/Users/Groups/EditGroupModal.svelte
+++ b/src/lib/components/admin/Users/Groups/EditGroupModal.svelte
@@ -171,7 +171,7 @@
 						>
 							{#if tabs.includes('general')}
 								<button
-									class="px-0.5 py-1 max-w-fit w-fit rounded-lg flex-1 lg:flex-none flex text-right transition {selectedTab ===
+									class="px-0.5 py-1 max-w-fit w-fit rounded-lg shrink-0 flex text-right transition {selectedTab ===
 									'general'
 										? ''
 										: ' text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
@@ -194,13 +194,13 @@
 											/>
 										</svg>
 									</div>
-									<div class=" self-center">{$i18n.t('General')}</div>
+									<div class=" self-center whitespace-nowrap">{$i18n.t('General')}</div>
 								</button>
 							{/if}
 
 							{#if tabs.includes('permissions')}
 								<button
-									class="px-0.5 py-1 max-w-fit w-fit rounded-lg flex-1 lg:flex-none flex text-right transition {selectedTab ===
+									class="px-0.5 py-1 max-w-fit w-fit rounded-lg shrink-0 flex text-right transition {selectedTab ===
 									'permissions'
 										? ''
 										: ' text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
@@ -212,13 +212,13 @@
 									<div class=" self-center mr-2">
 										<WrenchSolid />
 									</div>
-									<div class=" self-center">{$i18n.t('Permissions')}</div>
+									<div class=" self-center whitespace-nowrap">{$i18n.t('Permissions')}</div>
 								</button>
 							{/if}
 
 							{#if tabs.includes('users')}
 								<button
-									class="px-0.5 py-1 max-w-fit w-fit rounded-lg flex-1 lg:flex-none flex text-right transition {selectedTab ===
+									class="px-0.5 py-1 max-w-fit w-fit rounded-lg shrink-0 flex text-right transition {selectedTab ===
 									'users'
 										? ''
 										: ' text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
@@ -230,13 +230,13 @@
 									<div class=" self-center mr-2">
 										<UserPlusSolid />
 									</div>
-									<div class=" self-center">{$i18n.t('Users')}</div>
+									<div class=" self-center whitespace-nowrap">{$i18n.t('Users')}</div>
 								</button>
 							{/if}
 
 							{#if tabs.includes('preview')}
 								<button
-									class="px-0.5 py-1 max-w-fit w-fit rounded-lg flex-1 lg:flex-none flex text-right transition {selectedTab ===
+									class="px-0.5 py-1 max-w-fit w-fit rounded-lg shrink-0 flex text-right transition {selectedTab ===
 									'preview'
 										? ''
 										: ' text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
@@ -260,7 +260,7 @@
 											/>
 										</svg>
 									</div>
-									<div class=" self-center">{$i18n.t('Preview')}</div>
+									<div class=" self-center whitespace-nowrap">{$i18n.t('Preview')}</div>
 								</button>
 							{/if}
 						</div>

--- a/src/lib/components/chat/Settings/About.svelte
+++ b/src/lib/components/chat/Settings/About.svelte
@@ -53,15 +53,16 @@
 					{$i18n.t('Version')}
 				</div>
 			</div>
-			<div class="flex w-full justify-between items-center">
-				<div class="flex flex-col text-xs text-gray-700 dark:text-gray-200">
-					<div class="flex gap-1">
-						<Tooltip content={WEBUI_BUILD_HASH}>
+			<div class="flex w-full justify-between items-center gap-2">
+				<div class="flex flex-col text-xs text-gray-700 dark:text-gray-200 min-w-0">
+					<div class="flex flex-wrap items-center gap-1">
+						<Tooltip content={WEBUI_BUILD_HASH} className="flex whitespace-nowrap">
 							v{WEBUI_VERSION}
 						</Tooltip>
 
 						{#if $config?.features?.enable_version_update_check}
 							<a
+								class="whitespace-nowrap"
 								href="https://github.com/open-webui/open-webui/releases/tag/v{version.latest}"
 								target="_blank"
 							>
@@ -86,7 +87,7 @@
 
 				{#if $config?.features?.enable_version_update_check}
 					<button
-						class=" text-xs px-3 py-1.5 bg-gray-100 hover:bg-gray-200 dark:bg-gray-850 dark:hover:bg-gray-800 transition rounded-lg font-medium"
+						class=" shrink-0 text-xs px-3 py-1.5 bg-gray-100 hover:bg-gray-200 dark:bg-gray-850 dark:hover:bg-gray-800 transition rounded-lg font-medium"
 						on:click={() => {
 							checkForVersionUpdates();
 						}}

--- a/src/lib/components/chat/Settings/Audio.svelte
+++ b/src/lib/components/chat/Settings/Audio.svelte
@@ -195,22 +195,25 @@
 					</div>
 				</div>
 
-				<div class=" py-0.5 flex w-full justify-between">
-					<div class=" self-center text-xs font-medium">{$i18n.t('Language')}</div>
+				<div class=" py-0.5 flex w-full justify-between gap-2">
+					<div class=" self-center text-xs font-medium shrink-0 whitespace-nowrap">
+						{$i18n.t('Language')}
+					</div>
 
-					<div class="flex items-center relative text-xs px-3">
+					<div class="flex items-center relative text-xs px-3 min-w-0">
 						<Tooltip
 							content={$i18n.t(
 								'The language of the input audio. Supplying the input language in ISO-639-1 (e.g. en) format will improve accuracy and latency. Leave blank to automatically detect the language.'
 							)}
 							placement="top"
+							className="flex w-full min-w-0"
 						>
 							<input
 								type="text"
 								bind:value={STTLanguage}
 								aria-label={$i18n.t('Speech-to-Text Language')}
 								placeholder={$i18n.t('e.g. en')}
-								class=" text-sm text-right bg-transparent dark:text-gray-300 outline-hidden"
+								class=" w-full min-w-0 text-sm text-right bg-transparent dark:text-gray-300 outline-hidden"
 							/>
 						</Tooltip>
 					</div>
@@ -298,17 +301,19 @@
 				</button>
 			</div>
 
-			<div class=" py-0.5 flex w-full justify-between">
-				<div class=" self-center text-xs font-medium">{$i18n.t('Speech Playback Speed')}</div>
+			<div class=" py-0.5 flex w-full justify-between gap-2">
+				<div class=" self-center text-xs font-medium shrink-0 whitespace-nowrap">
+					{$i18n.t('Speech Playback Speed')}
+				</div>
 
-				<div class="flex items-center relative text-xs px-3">
+				<div class="flex items-center relative text-xs px-3 min-w-0">
 					<input
 						type="number"
 						min="0"
 						step="0.01"
 						bind:value={playbackRate}
 						aria-label={$i18n.t('Speech Playback Speed')}
-						class=" text-sm text-right bg-transparent dark:text-gray-300 outline-hidden"
+						class=" w-full min-w-0 text-sm text-right bg-transparent dark:text-gray-300 outline-hidden"
 					/>
 					x
 				</div>

--- a/src/lib/components/chat/Settings/Audio.svelte
+++ b/src/lib/components/chat/Settings/Audio.svelte
@@ -246,11 +246,13 @@
 		<div>
 			<div class=" mb-1 text-sm font-medium">{$i18n.t('TTS Settings')}</div>
 
-			<div class=" py-0.5 flex w-full justify-between">
-				<div class=" self-center text-xs font-medium">{$i18n.t('Text-to-Speech Engine')}</div>
-				<div class="flex items-center relative">
+			<div class=" py-0.5 flex w-full justify-between gap-2">
+				<div class=" self-center text-xs font-medium shrink-0 whitespace-nowrap">
+					{$i18n.t('Text-to-Speech Engine')}
+				</div>
+				<div class="flex items-center relative min-w-0">
 					<select
-						class="w-fit pr-8 rounded-sm px-2 p-1 text-xs bg-transparent outline-hidden text-right"
+						class="w-fit max-w-full min-w-0 pr-8 rounded-sm px-2 p-1 text-xs bg-transparent outline-hidden text-right"
 						bind:value={TTSEngine}
 						aria-label={$i18n.t('Text-to-Speech Engine')}
 						placeholder={$i18n.t('Select an engine')}

--- a/src/lib/components/chat/Settings/General.svelte
+++ b/src/lib/components/chat/Settings/General.svelte
@@ -210,11 +210,13 @@
 		<div class="">
 			<div class=" mb-1 text-sm font-medium">{$i18n.t('WebUI Settings')}</div>
 
-			<div class="flex w-full justify-between">
-				<div class=" self-center text-xs font-medium">{$i18n.t('Theme')}</div>
-				<div class="flex items-center relative">
+			<div class="flex w-full justify-between gap-2">
+				<div class=" self-center text-xs font-medium shrink-0 whitespace-nowrap">
+					{$i18n.t('Theme')}
+				</div>
+				<div class="flex items-center relative min-w-0">
 					<select
-						class="w-fit pr-8 rounded-sm py-2 px-2 text-xs bg-transparent text-right {$settings.highContrastMode
+						class="w-fit max-w-full pr-8 rounded-sm py-2 px-2 text-xs bg-transparent text-right {$settings.highContrastMode
 							? ''
 							: 'outline-hidden'}"
 						bind:value={selectedTheme}
@@ -232,11 +234,13 @@
 				</div>
 			</div>
 
-			<div class=" flex w-full justify-between">
-				<div class=" self-center text-xs font-medium">{$i18n.t('Language')}</div>
-				<div class="flex items-center relative">
+			<div class=" flex w-full justify-between gap-2">
+				<div class=" self-center text-xs font-medium shrink-0 whitespace-nowrap">
+					{$i18n.t('Language')}
+				</div>
+				<div class="flex items-center relative min-w-0">
 					<select
-						class="w-fit pr-8 rounded-sm py-2 px-2 text-xs bg-transparent text-right {$settings.highContrastMode
+						class="w-fit max-w-full pr-8 rounded-sm py-2 px-2 text-xs bg-transparent text-right {$settings.highContrastMode
 							? ''
 							: 'outline-hidden'}"
 						bind:value={lang}


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

**Before submitting, make sure you've checked the following:**

- [ ] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Closes #___` / `Relates to #___`. <!-- TODO: add the Issue/Discussion number here before opening. -->
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

# Changelog Entry

### Description

Several user- and admin-facing settings rows broke visually on mobile **only when the user increased `UI Scale`** in Settings. Because `UI Scale` scales the root font size (and therefore rem-based widths), value controls (dropdowns and inputs) grew wide enough to squeeze the adjacent label until single-word labels collapsed into a vertical stack of individual letters (e.g. `Language` rendered as `L / a / n / g / u / a / g / e`).

**Root cause:** In these `flex … justify-between` rows the label was allowed to shrink below its own word width while the value control kept (or grew to) its intrinsic width. The label had no shrink guard, so flexbox crushed it.

**Fix:** Keep each affected label on its own line and let the value side absorb the shrink instead:
- Labels get `shrink-0` (plus `whitespace-nowrap` on the user-settings rows), matching the guard the codebase already applies elsewhere (e.g. `text-xs pr-2 shrink-0` in Images, `min-w-fit` in Documents).
- Value containers get `min-w-0` and the Documents embedding/reranking `<select>`s get `max-w-full min-w-0` so a long selected value clips gracefully instead of shoving the label.

A separate, long-standing alignment bug in the RAG numeric fields is also fixed: `Top K`, `Top K Reranker` and `Relevance Threshold` used a full-width (`flex-1 w-full`) input with no text alignment, so the value floated mid-row instead of sitting at the right edge like every sibling numeric field. They now use the same `text-center w-14` fixed-width input as `Embedding Batch Size` / `Reranking Batch Size`.

Scope of changes (5 files, UI-only, no logic changes):

| File | Rows fixed |
|---|---|
| `admin/Users/Groups/EditGroupModal.svelte` | Tab rail (General / Permissions / Users / Preview) no longer wraps letter-by-letter; tabs scroll horizontally |
| `chat/Settings/General.svelte` | `Theme`, `Language` |
| `chat/Settings/Audio.svelte` | STT `Language`, `Speech Playback Speed` |
| `admin/Settings/Images.svelte` | Model, Image Size, Steps, Image/Edit Generation Engine, Gemini Endpoint Method (uniform `shrink-0` on all label wrappers) |
| `admin/Settings/Documents.svelte` | 7 engine `<select>` rows (incl. Embedding Model Engine) + `Top K` / `Top K Reranker` / `Relevance Threshold` alignment |

### Fixed

- Fixed settings labels (`Theme`, `Language`, `Speech Playback Speed`, `Embedding Model Engine`, image `Model`/`Image Size`, etc.) collapsing into vertical single-letter stacks on mobile at increased `UI Scale`.
- Fixed the `Edit User Group` modal tab labels wrapping letter-by-letter at large `UI Scale` on mobile.
- Fixed `Top K`, `Top K Reranker` and `Relevance Threshold` input values not being right-aligned with the other RAG numeric fields in admin Documents settings.

---

### Additional Information

This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author on an iPhone (mobile viewport) at increased `UI Scale`, and re-verified at default scale and on desktop to confirm no regressions. Changes are limited to Tailwind utility classes and minor markup wrapping — no component logic, state, or i18n strings were altered.

### Screenshots or Videos

All captured on mobile (iPhone) at increased `UI Scale`.

I'd add images here, but GitHub decided to wipe everything I had for this PR here and I cba to get the screenshots all over again. :/

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.