### PR TITLE
fix: make admin Models list rows mobile-friendly

### DIFF
--- a/src/lib/components/admin/Settings/Models.svelte
+++ b/src/lib/components/admin/Settings/Models.svelte
@@ -604,13 +604,13 @@
 							id="model-item-{model.id}"
 						>
 							<button
-								class=" flex flex-1 text-left space-x-3.5 cursor-pointer w-full"
+								class=" flex flex-1 text-left space-x-3.5 cursor-pointer w-full min-w-0"
 								type="button"
 								on:click={() => {
 									selectedModelId = model.id;
 								}}
 							>
-								<div class=" self-center w-9">
+								<div class=" self-center w-9 shrink-0">
 									<div
 										class=" rounded-full object-cover {(model?.is_active ?? true)
 											? ''
@@ -628,7 +628,9 @@
 								</div>
 
 								<div
-									class=" flex-1 self-center {(model?.is_active ?? true) ? '' : 'text-gray-500'}"
+									class=" flex-1 self-center min-w-0 {(model?.is_active ?? true)
+										? ''
+										: 'text-gray-500'}"
 								>
 									<Tooltip
 										content={marked.parse(
@@ -638,13 +640,23 @@
 													? `${model?.ollama?.digest} **(${model?.ollama?.modified_at})**`
 													: model.id
 										)}
-										className=" w-fit"
+										className=" w-full min-w-0"
 										placement="top-start"
 									>
-										<div class="font-medium line-clamp-1 flex items-center gap-2">
-											{model.name}
-
-											<Badge
+										<div class="font-medium truncate min-w-0">{model.name}</div>
+									</Tooltip>
+									<div
+										class=" text-xs overflow-hidden text-ellipsis line-clamp-1 flex items-center gap-1 text-gray-500 min-w-0"
+									>
+										<span class=" truncate min-w-0">
+											{!!model?.meta?.description
+												? model?.meta?.description
+												: model?.ollama?.digest
+													? `${model.id} (${model?.ollama?.digest})`
+													: model.id}
+										</span>
+										<span class="shrink-0"
+											><Badge
 												type={(model?.access_grants ?? []).some(
 													(g) =>
 														g.principal_type === 'user' &&
@@ -661,23 +673,12 @@
 												)
 													? $i18n.t('Public')
 													: $i18n.t('Private')}
-											/>
-										</div>
-									</Tooltip>
-									<div
-										class=" text-xs overflow-hidden text-ellipsis line-clamp-1 flex items-center gap-1 text-gray-500"
-									>
-										<span class=" line-clamp-1">
-											{!!model?.meta?.description
-												? model?.meta?.description
-												: model?.ollama?.digest
-													? `${model.id} (${model?.ollama?.digest})`
-													: model.id}
-										</span>
+											/></span
+										>
 									</div>
 								</div>
 							</button>
-							<div class="flex flex-row gap-0.5 items-center self-center">
+							<div class="flex flex-row gap-0.5 items-center self-center shrink-0">
 								{#if shiftKey}
 									<Tooltip content={model?.meta?.hidden ? $i18n.t('Show') : $i18n.t('Hide')}>
 										<button
@@ -696,7 +697,7 @@
 									</Tooltip>
 								{:else}
 									<button
-										class="self-center w-fit text-sm px-2 py-2 dark:text-gray-300 dark:hover:text-white hover:bg-black/5 dark:hover:bg-white/5 rounded-xl"
+										class="hidden sm:flex self-center w-fit text-sm px-2 py-2 dark:text-gray-300 dark:hover:text-white hover:bg-black/5 dark:hover:bg-white/5 rounded-xl"
 										type="button"
 										on:click={() => {
 											selectedModelId = model.id;


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

**Before submitting, make sure you've checked the following:**

- [ ] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Closes #___` / `Relates to #___`. <!-- TODO: add the Issue/Discussion number here before opening. -->
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

# Changelog Entry

### Description

The admin **Settings → Models** list was effectively unusable on mobile / narrow viewports. Each row lays out a model avatar, name, id, a `PUBLIC`/`PRIVATE` badge, an edit button, a `⋯` menu, and an enable toggle on a single horizontal line. As the viewport narrowed, the avatar, name and id collapsed into vertical stacks of individual characters (e.g. `allam-2-7b` rendered one letter per line), while the badge and controls stayed intact — so the least important elements survived and the model's actual identity disappeared.

**Root cause:**
- The model name and id used `line-clamp-1`, but the same elements were also `display:flex` (to sit next to the badge/icons). `display:flex` overrides the `display:-webkit-box` that `line-clamp` requires, so the clamp never took effect.
- The flex chain from the row down to the text had no `min-w-0`, so the flexible name/id columns were allowed to shrink below their content width and wrap character-by-character instead of truncating.
- The badge and action controls had no shrink guard relative to the text, so flexbox took space from the name/id first.

**Fix (UI-only, single file):**
- Restore a proper flexbox truncation chain: `min-w-0` on the row button, the name/id column, and the tooltip wrapper, with real `truncate` spans on the model name and id (replacing the ineffective `line-clamp-1`). Long names/ids now show an ellipsis.
- Anchor the avatar (`shrink-0`) so it stays as a visual anchor, and pin the action group (`shrink-0`) so the `⋯` menu and toggle remain reachable.
- Move the `PUBLIC`/`PRIVATE` badge onto the id line so it no longer competes with the model name for first-line space — the name keeps priority, the badge rides along with the id.
- Hide the redundant edit pencil on mobile (`hidden sm:flex`). Tapping the row already opens the model editor (identical handler), so nothing is lost; the pencil remains on `sm`+ screens.

Result: on mobile the row reads `[avatar] Model Name … ⋯ ◉` on the first line and `model/id  PRIVATE` on the second, with graceful truncation — matching the desktop hierarchy. Desktop layout is unchanged apart from the badge now sitting on the id line.

### Fixed

- Fixed the admin Settings → Models list rows collapsing model avatars, names and ids into one-character-per-line stacks on mobile / narrow viewports, which made the page nearly unusable. Names and ids now truncate with an ellipsis, the avatar and controls stay anchored, and the Public/Private badge no longer outranks the model name.

---

### Additional Information

This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author on mobile viewports (down to very narrow widths) and re-verified on desktop to confirm no regressions. Changes are limited to Tailwind utility classes and small markup restructuring in a single component — no component logic, data, or i18n strings were altered.

### Screenshots or Videos

| Viewport | Before | After |
|---|---|---|
| Mobile / narrow (model list rows) | ![Models list before](https://github.com/user-attachments/assets/a835bc9d-c235-4361-85dc-fb49d55ccf3d) | ![Models list after](https://github.com/user-attachments/assets/18d28287-fb0a-4d84-83bd-002f608e3521) |
| Desktop (regression check) | ![Models desktop before](https://github.com/user-attachments/assets/bd053ad2-2467-4615-9fda-6ef407401426) | ![Models desktop after](https://github.com/user-attachments/assets/dbb2e1b3-2b0a-4177-8a81-723a208a44a7) |

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.