### PR TITLE
fix: align Knowledge workspace source dropdown and New button with other pages

### DIFF
--- a/src/lib/components/workspace/Knowledge.svelte
+++ b/src/lib/components/workspace/Knowledge.svelte
@@ -29,6 +29,7 @@
 	import Tooltip from '../common/Tooltip.svelte';
 	import XMark from '../icons/XMark.svelte';
 	import ViewSelector from './common/ViewSelector.svelte';
+	import SourceSelector from './common/SourceSelector.svelte';
 	import Loader from '../common/Loader.svelte';
 
 	type KnowledgeListItem = {
@@ -201,7 +202,7 @@
 
 			<div class="flex w-full justify-end gap-1.5">
 				<a
-					class=" px-2 py-1.5 rounded-xl bg-black text-white dark:bg-white dark:text-black transition font-medium text-sm flex items-center"
+					class=" px-2 py-1.5 h-7 rounded-xl bg-black text-white dark:bg-white dark:text-black transition font-medium text-sm flex items-center"
 					href="/workspace/knowledge/create"
 				>
 					<Plus className="size-3" strokeWidth="2.5" />
@@ -266,18 +267,13 @@
 					}}
 				/>
 
-				<select
-					class="relative w-full flex items-center gap-0.5 px-2.5 py-1.5 bg-gray-50 dark:bg-gray-850 rounded-xl outline-hidden"
+				<SourceSelector
 					bind:value={sourceOption}
-					on:change={async () => {
+					onChange={async () => {
 						localStorage.workspaceKnowledgeSourceOption = sourceOption;
 						await tick();
 					}}
-				>
-					<option value="">{$i18n.t('All Sources')}</option>
-					<option value="local">{$i18n.t('Local')}</option>
-					<option value="external">{$i18n.t('Connected')}</option>
-				</select>
+				/>
 			</div>
 		</div>
 

--- a/src/lib/components/workspace/common/SourceSelector.svelte
+++ b/src/lib/components/workspace/common/SourceSelector.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+	import { getContext } from 'svelte';
+
+	import ChevronDown from '$lib/components/icons/ChevronDown.svelte';
+	import Check from '$lib/components/icons/Check.svelte';
+	import Select from '$lib/components/common/Select.svelte';
+
+	const i18n = getContext('i18n');
+
+	export let value = '';
+	export let placeholder = $i18n.t('All Sources');
+	export let onChange: (value: string) => void = () => {};
+
+	const items = [
+		{ value: '', label: $i18n.t('All Sources') },
+		{ value: 'local', label: $i18n.t('Local') },
+		{ value: 'external', label: $i18n.t('Connected') }
+	];
+</script>
+
+<Select
+	bind:value
+	{items}
+	{placeholder}
+	triggerClass="relative w-full flex items-center gap-0.5 px-2.5 py-1.5 rounded-xl "
+	labelClass="inline-flex h-input px-0.5 w-full outline-hidden bg-transparent truncate  placeholder-gray-400  focus:outline-hidden"
+	onChange={() => onChange(value)}
+>
+	<svelte:fragment slot="trigger" let:selectedLabel>
+		<span
+			class="inline-flex h-input px-0.5 w-full outline-hidden bg-transparent truncate placeholder-gray-400 focus:outline-hidden"
+		>
+			{selectedLabel}
+		</span>
+		<ChevronDown className=" size-3.5" strokeWidth="2.5" />
+	</svelte:fragment>
+
+	<svelte:fragment slot="item" let:item let:selected>
+		{item.label}
+		<div class="ml-auto {selected ? '' : 'invisible'}">
+			<Check />
+		</div>
+	</svelte:fragment>
+</Select>


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

**Before submitting, make sure you've checked the following:**

- [ ] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Closes #___` / `Relates to #___`. <!-- TODO: add the Issue/Discussion number here before opening. -->
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

# Changelog Entry

### Description

Two small visual-consistency fixes on the **Workspace → Knowledge** page, bringing it in line with the other workspace list pages (Models, Prompts, Skills, Tools).

**1. Source filter used a native `<select>`.** The `All Sources` / `Local` / `Connected` filter was a raw HTML `<select>`, so it opened the OS-native dropdown menu — visually inconsistent with the app's own `View` (`All`) and `Tag` dropdowns, which are built on the shared `Select` component. Added a small `SourceSelector` component (mirroring the existing `ViewSelector` / `TagSelector`) so the filter now renders the in-app dropdown. Behavior is unchanged — it still binds `sourceOption` (which drives the reactive filter) and persists the choice to `localStorage`.

**2. The `New Knowledge` button rendered slightly shorter than the other pages' New buttons.** The header action row (`flex w-full justify-end gap-1.5`) has no `items-center`, so it defaults to `align-items: stretch`. On Models/Prompts/Skills the `Import`/`Export` buttons sit in that row and stretch the New button to full height (~28px). Knowledge has no sibling buttons, so nothing stretched its New button and it stayed ~4px shorter — most visible in the collapsed, icon-only state on narrow viewports. Pinning the button to `h-7` (28px, the same height the others reach via stretch) makes it match. It's a no-op at widths where the label is shown (the button is already 28px there).

```diff
  <!-- Source filter -->
- <select class="… bg-gray-50 dark:bg-gray-850 rounded-xl outline-hidden" bind:value={sourceOption} on:change={…}>
-   <option value="">All Sources</option>
-   <option value="local">Local</option>
-   <option value="external">Connected</option>
- </select>
+ <SourceSelector bind:value={sourceOption} onChange={…} />

  <!-- New Knowledge button -->
- <a class=" px-2 py-1.5 rounded-xl bg-black text-white … flex items-center" href="/workspace/knowledge/create">
+ <a class=" px-2 py-1.5 h-7 rounded-xl bg-black text-white … flex items-center" href="/workspace/knowledge/create">
```

Files:
- `src/lib/components/workspace/common/SourceSelector.svelte` (new — thin wrapper around the shared `Select`, following the `ViewSelector`/`TagSelector` pattern)
- `src/lib/components/workspace/Knowledge.svelte` (use `SourceSelector`; add `h-7` to the New button)

### Fixed

- Fixed the Workspace → Knowledge source filter (`All Sources` / `Local` / `Connected`) rendering the OS-native `<select>` menu instead of the app's own dropdown used elsewhere in the workspace.
- Fixed the `New Knowledge` button rendering slightly shorter than the New buttons on the other workspace pages (it lacked the `Import`/`Export` siblings that stretch the others to full height).

---

### Additional Information

This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author. Changes are limited to a small new presentational component and Tailwind utility classes — no data flow, filtering logic, or i18n strings were altered (the three source labels reuse existing translation keys).

### Screenshots or Videos

| Area | Before | After |
|---|---|---|
| Source filter dropdown | ![Source dropdown before](https://github.com/user-attachments/assets/7e0f37ca-96d8-42e3-9dbb-0ea3cfd67536) | ![Source dropdown after](https://github.com/user-attachments/assets/2b97a017-eaa4-4cb3-ae14-cc59a6a649fe) |
| New Knowledge button (collapsed, vs other pages) | ![New button before](https://github.com/user-attachments/assets/3efc82fd-654d-4b8f-97fc-754260d8e9f5) | ![New button after](https://github.com/user-attachments/assets/be2edbc0-31d7-4a20-8777-f00f0b3cecb0) |

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.