### PR TITLE
fix: stack automation modal footer on mobile

### DIFF
--- a/src/lib/components/AutomationModal.svelte
+++ b/src/lib/components/AutomationModal.svelte
@@ -138,14 +138,16 @@
 		</div>
 
 		<!-- Bottom toolbar -->
-		<div class="flex items-center justify-between px-4 pb-3.5 pt-1 gap-2">
-			<div class="flex items-center gap-0.5 flex-wrap flex-1 min-w-0">
+		<div
+			class="flex flex-col sm:flex-row sm:items-center sm:justify-between px-4 pb-3.5 pt-1 gap-2"
+		>
+			<div class="flex items-center gap-0.5 flex-wrap min-w-0 sm:flex-1">
 				<ScheduleDropdown bind:this={scheduleDropdown} side="top" align="start" />
 
 				<ModelDropdown bind:model_id side="top" align="start" />
 			</div>
 
-			<div class="flex items-center gap-2 shrink-0">
+			<div class="flex items-center justify-end gap-2 shrink-0">
 				<button
 					class="px-3 py-1 text-xs text-gray-500 hover:text-gray-700 dark:hover:text-gray-200 transition"
 					type="button"


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

**Before submitting, make sure you've checked the following:**

- [ ] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Closes #___` / `Relates to #___`. <!-- TODO: add the Issue/Discussion number here before opening. -->
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

# Changelog Entry

### Description

The automation create/edit modal (`AutomationModal.svelte`) footer placed the schedule dropdown (`Daily`), the model dropdown (`Select model`), and the `Cancel` / `Create` actions in a single horizontal `flex ... justify-between` row. On a narrow modal (mobile) the fixed-width action buttons (`shrink-0`) claimed their space first, leaving too little room for the dropdowns — which then wrapped to two stacked lines, pushing `Cancel` into an awkward mid-row position.

**Fix:** Make the footer responsive — stack it vertically on mobile and keep the original horizontal row at `sm` and up:
- Footer container: `flex items-center justify-between` → `flex flex-col sm:flex-row sm:items-center sm:justify-between`.
- Dropdowns group: `flex-1` → `sm:flex-1` (the row-fill behavior only applies to the horizontal layout).
- Actions group: added `justify-end` so `Cancel` / `Create` right-align on their own row on mobile.

On mobile the dropdowns now share their own full-width row (side by side, no wrap) and the actions sit right-aligned on the row below. Desktop / `sm`+ layout is unchanged.

```diff
- <div class="flex items-center justify-between px-4 pb-3.5 pt-1 gap-2">
-   <div class="flex items-center gap-0.5 flex-wrap flex-1 min-w-0">
+ <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between px-4 pb-3.5 pt-1 gap-2">
+   <div class="flex items-center gap-0.5 flex-wrap min-w-0 sm:flex-1">
      <ScheduleDropdown … />
      <ModelDropdown … />
    </div>
-   <div class="flex items-center gap-2 shrink-0">
+   <div class="flex items-center justify-end gap-2 shrink-0">
      … Cancel / Create …
    </div>
  </div>
```

Files:
- `src/lib/components/AutomationModal.svelte`

### Fixed

- Fixed the automation create/edit modal footer wrapping awkwardly on mobile — the schedule/model dropdowns stacked and `Cancel` was squeezed into the middle of the row. The footer now stacks cleanly into a dropdowns row and a right-aligned actions row on narrow viewports.

---

### Additional Information

This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author on a mobile viewport, and re-verified at desktop width to confirm no regressions. The change is limited to Tailwind responsive utility classes on the modal footer — no component logic or i18n strings were altered.

### Screenshots or Videos

| Viewport | Before | After |
|---|---|---|
| Mobile (automation modal footer) | ![Automation footer before](https://github.com/user-attachments/assets/f82e5782-75e0-4fd4-8b21-2e2198b4d72b) | ![Automation footer after](https://github.com/user-attachments/assets/8e0ede52-ffd7-4733-aa9b-f8508e1fdb76) |

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.