### PR TITLE
fix: keep details blocks separate from setext headings

### DIFF
--- a/src/lib/utils/marked/extension.test.ts
+++ b/src/lib/utils/marked/extension.test.ts
@@ -1,0 +1,169 @@
+import { Marked } from 'marked';
+import { describe, expect, test } from 'vitest';
+
+import markedExtension from './extension';
+
+const createMarked = () => new Marked(markedExtension());
+
+const findDetailsToken = (tokens: { type: string }[]) =>
+	tokens.find((token) => token.type === 'details');
+
+describe('marked details extension', () => {
+	test.each([
+		['bare --- without a blank line', 'line one\n---\nline two'],
+		['bare === without a blank line', 'line one\n===\nline two'],
+		['content without setext marker and without a blank line', 'line one\nline two']
+	])('keeps paragraph and details separate for %s', (_, body) => {
+		const marked = createMarked();
+		const tokens = marked.lexer(`Here is some introductory text before the widget.
+<details>
+<summary>Click to expand</summary>
+${body}
+</details>`);
+
+		expect(tokens[0]).toMatchObject({
+			type: 'paragraph',
+			text: 'Here is some introductory text before the widget.'
+		});
+		expect(tokens[1]).toMatchObject({
+			type: 'details',
+			summary: 'Click to expand',
+			text: body
+		});
+		expect(tokens).toHaveLength(2);
+	});
+
+	test('keeps details with a preceding blank line separate', () => {
+		const marked = createMarked();
+		const tokens = marked.lexer(`Here is some introductory text before the widget.
+
+<details>
+<summary>Click to expand</summary>
+line one
+---
+line two
+</details>`);
+
+		expect(tokens[0]).toMatchObject({ type: 'paragraph' });
+		const details = findDetailsToken(tokens);
+		expect(details).toMatchObject({
+			type: 'details',
+			summary: 'Click to expand',
+			text: 'line one\n---\nline two'
+		});
+	});
+
+	test('preserves ordinary setext headings and horizontal rules outside details blocks', () => {
+		const marked = createMarked();
+		const setextTokens = marked.lexer('Heading\n---');
+		const hrTokens = marked.lexer('---');
+
+		expect(setextTokens[0]).toMatchObject({ type: 'heading', depth: 2, text: 'Heading' });
+		expect(hrTokens[0]).toMatchObject({ type: 'hr' });
+	});
+
+	test('does not tokenize details markup inside fenced code or inline code', () => {
+		const marked = createMarked();
+		const fencedTokens = marked.lexer(`\`\`\`
+Here is some introductory text before the widget.
+<details>
+<summary>Click to expand</summary>
+line one
+---
+line two
+</details>
+\`\`\``);
+		const inlineTokens = marked.lexer('`<details>`');
+
+		expect(fencedTokens[0]).toMatchObject({ type: 'code' });
+		expect(findDetailsToken(fencedTokens)).toBeUndefined();
+		expect(inlineTokens[0]).toMatchObject({ type: 'paragraph', text: '`<details>`' });
+		expect(findDetailsToken(inlineTokens)).toBeUndefined();
+	});
+
+	test('preserves supported details attributes and nested details blocks', () => {
+		const marked = createMarked();
+		const tokens = marked.lexer(`<details open="true" class="abc">
+<summary>Outer</summary>
+outer
+<details>
+<summary>Inner</summary>
+inner
+</details>
+</details>`);
+
+		expect(tokens[0]).toMatchObject({
+			type: 'details',
+			summary: 'Outer',
+			attributes: { open: 'true', class: 'abc' }
+		});
+		expect(tokens[0]).toMatchObject({ text: expect.stringContaining('<details>') });
+		expect(tokens).toHaveLength(1);
+	});
+
+	test('does not consume malformed unclosed details markup', () => {
+		const marked = createMarked();
+		const tokens = marked.lexer(`<details>
+<summary>Click to expand</summary>
+line one`);
+
+		expect(findDetailsToken(tokens)).toBeUndefined();
+	});
+
+	test('handles CRLF input consistently with LF input', () => {
+		const marked = createMarked();
+		const tokens = marked.lexer(
+			'Here is some introductory text before the widget.\r\n<details>\r\n<summary>Click to expand</summary>\r\nline one\r\n---\r\nline two\r\n</details>'
+		);
+
+		expect(tokens[0]).toMatchObject({ type: 'paragraph' });
+		const details = findDetailsToken(tokens);
+		expect(details).toMatchObject({
+			type: 'details',
+			summary: 'Click to expand',
+			text: 'line one\n---\nline two'
+		});
+	});
+
+	test.each([
+		['with a setext marker', 'line one\n---\nline two'],
+		['without a setext marker', 'line one\nline two']
+	])('keeps a multi-line paragraph intact %s', (_, body) => {
+		const marked = createMarked();
+		const tokens = marked.lexer(`First line of the introduction.
+Second line of the introduction.
+<details>
+<summary>Click to expand</summary>
+${body}
+</details>`);
+
+		expect(tokens[0]).toMatchObject({
+			type: 'paragraph',
+			text: 'First line of the introduction.\nSecond line of the introduction.'
+		});
+		expect(tokens[1]).toMatchObject({ type: 'details', text: body });
+		expect(tokens).toHaveLength(2);
+	});
+
+	test('does not coerce native block tokens into paragraphs before details', () => {
+		const marked = createMarked();
+		const listTokens = marked.lexer(`- list item
+<details>
+<summary>Click to expand</summary>
+line one
+---
+line two
+</details>`);
+		const blockquoteTokens = marked.lexer(`> quoted text
+<details>
+<summary>Click to expand</summary>
+line one
+---
+line two
+</details>`);
+
+		expect(listTokens[0]).toMatchObject({ type: 'list' });
+		expect(blockquoteTokens[0]).toMatchObject({ type: 'blockquote' });
+		expect(blockquoteTokens[1]).toMatchObject({ type: 'details' });
+	});
+});

--- a/src/lib/utils/marked/extension.ts
+++ b/src/lib/utils/marked/extension.ts
@@ -1,3 +1,11 @@
+import type {
+	MarkedExtension,
+	TokenizerAndRendererExtension,
+	TokenizerExtension,
+	TokenizerThis,
+	Tokens
+} from 'marked';
+
 // Helper function to find matching closing tag
 function findMatchingClosingTag(src: string, openTag: string, closeTag: string): number {
 	let depth = 1;
@@ -26,10 +34,39 @@ function parseAttributes(tag: string): { [key: string]: string } {
 	return attributes;
 }
 
+type DetailsToken = Tokens.Generic & {
+	attributes?: Record<string, string>;
+	summary?: string;
+	text: string;
+};
+
+function paragraphBeforeDetailsTokenizer(
+	this: TokenizerThis,
+	src: string
+): Tokens.Generic | undefined {
+	const boundary = /\r?\n(?=<details(?:\s+[^>]*)?>\r?\n)/.exec(src);
+	if (!boundary) return;
+
+	const raw = src.slice(0, boundary.index + boundary[0].length);
+	const tokens = this.lexer.blockTokens(raw, []);
+
+	if (tokens.length !== 1 || tokens[0].type !== 'paragraph') return;
+
+	return tokens[0] as Tokens.Generic;
+}
+
+function paragraphBeforeDetailsExtension(): TokenizerExtension {
+	return {
+		name: 'paragraphBeforeDetails',
+		level: 'block',
+		tokenizer: paragraphBeforeDetailsTokenizer
+	};
+}
+
 function detailsTokenizer(src: string) {
 	// Updated regex to capture attributes inside <details>
-	const detailsRegex = /^<details(\s+[^>]*)?>\n/;
-	const summaryRegex = /^<summary>(.*?)<\/summary>\n/;
+	const detailsRegex = /^<details(\s+[^>]*)?>\r?\n/;
+	const summaryRegex = /^<summary>(.*?)<\/summary>\r?\n/;
 
 	const detailsMatch = detailsRegex.exec(src);
 	if (detailsMatch) {
@@ -59,11 +96,8 @@ function detailsTokenizer(src: string) {
 	}
 }
 
-function detailsStart(src: string) {
-	return src.match(/^<details[\s>]/) ? 0 : -1;
-}
-
-function detailsRenderer(token: any) {
+function detailsRenderer(genericToken: Tokens.Generic) {
+	const token = genericToken as DetailsToken;
 	const attributesString = token.attributes
 		? Object.entries(token.attributes)
 				.map(([key, value]) => `${key}="${value}"`)
@@ -77,18 +111,17 @@ function detailsRenderer(token: any) {
 }
 
 // Extension wrapper function
-function detailsExtension() {
+function detailsExtension(): TokenizerAndRendererExtension {
 	return {
 		name: 'details',
 		level: 'block',
-		start: detailsStart,
 		tokenizer: detailsTokenizer,
 		renderer: detailsRenderer
 	};
 }
 
-export default function (options = {}) {
+export default function (): MarkedExtension {
 	return {
-		extensions: [detailsExtension(options)]
+		extensions: [paragraphBeforeDetailsExtension(), detailsExtension()]
 	};
 }


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Closes #27001`.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [x] **Documentation:** No documentation changes are needed for this parser bug fix.
- [x] **Dependencies:** This change adds or updates no dependencies.
- [x] **Testing:** Parser regression tests and production build verification were performed locally. Screenshots are not applicable to this tokenizer-stage fix.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses the `fix` prefix.

# Changelog Entry

### Description

- Keep a `<details>` block separate from immediately preceding prose when its body contains a bare `---` or `===` line.

### Added

- Regression coverage for paragraph boundaries, setext markers, code, native block tokens, nested and malformed details, attributes, and CRLF input.

### Changed

- Add a narrow block-token boundary before details tokenization so Marked cannot consume the surrounding content as a setext heading.

### Deprecated

- None.

### Removed

- None.

### Fixed

- Closes #27001.

### Security

- None. HTML sanitization behavior is unchanged.

### Breaking Changes

- None.

---

### Additional Information

- `npm run build` passed.
- The complete configured Vitest suite passed: 12/12 tests.
- Targeted ESLint and Prettier checks passed.
- The repository-wide `svelte-check` has thousands of pre-existing diagnostics; neither changed file reports a diagnostic.

### Screenshots or Videos

- Not applicable; this is a Markdown tokenizer regression covered by automated tests.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
