### PR TITLE
style: apply ruff format to two files failing the format gate on dev

### DIFF
--- a/backend/open_webui/retrieval/vector/dbs/milvus_multitenancy.py
+++ b/backend/open_webui/retrieval/vector/dbs/milvus_multitenancy.py
@@ -156,9 +156,7 @@ class MilvusClient(VectorDBBase):
             except MilvusException as e:
                 # The index only accelerates resource_id filters; never fail
                 # collection creation over it.
-                log.warning(
-                    f'Could not create {RESOURCE_ID_FIELD} index on {mt_collection_name}: {e}'
-                )
+                log.warning(f'Could not create {RESOURCE_ID_FIELD} index on {mt_collection_name}: {e}')
         log.info(f'Created shared collection: {mt_collection_name}')
         return collection
 

--- a/backend/open_webui/routers/files.py
+++ b/backend/open_webui/routers/files.py
@@ -203,9 +203,7 @@ async def process_uploaded_file(
                     else:
                         # Keep the generic file status stream open until the
                         # KB-specific vector write and durable link both finish.
-                        await Files.update_file_data_by_id(
-                            file_item.id, {'status': 'processing'}, db=db_session
-                        )
+                        await Files.update_file_data_by_id(file_item.id, {'status': 'processing'}, db=db_session)
                         await process_file(
                             request,
                             ProcessFileForm(file_id=file_item.id, collection_name=knowledge_id),


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Closes #27029
- [x] **Target branch:** targets `dev`, rebased on `dev` @ `09d4cccb`.
- [x] **Description:** below.
- [x] **Changelog:** below.
- [ ] **Documentation:** not applicable — no user-facing change.
- [ ] **Dependencies:** none added or changed.
- [x] **Testing:** I ran the two gates from `backend.yaml` in a clean container — see below. For a formatting-only change that is the whole test; I did not boot the app, because this diff cannot alter its behaviour.
- [x] **No Unchecked AI Code:** there is no authored code here. The diff is the literal output of `ruff format` — your formatter, your settings — on two files. I read every line before opening this. I used an AI assistant to find the failing gate and prepare the PR, and credited it in the commit trailer rather than hiding it.
- [x] **Self-Review:** done.
- [x] **Architecture:** not applicable.
- [x] **Git Hygiene:** single atomic commit, rebased on `dev`, nothing unrelated. *(Apologies for the branch name — it's a leftover from a broader change I abandoned in favour of this minimal one.)*
- [x] **Title Prefix:** `style`.

### Description

`Python CI / Ruff Format` has been failing on `dev` since **2026-07-09**. The last green run I can find is `d3ea8eb7`, and the workflow has failed on the **7 runs since**, including current `dev` HEAD `09d4cccb`.

Two files no longer match `ruff format` under the repo's own settings (`line-length = 120`, `quote-style = "single"`):

```
$ ruff format --check . --exclude .venv --exclude venv
Would reformat: backend/open_webui/retrieval/vector/dbs/milvus_multitenancy.py
Would reformat: backend/open_webui/routers/files.py
2 files would be reformatted, 236 files already formatted   # exit 1
```

Both are the same small thing: a call that comfortably fits inside the 120-column limit had been split across three lines. This PR runs `ruff format` on exactly those two files and nothing else.

**2 files changed, +2 −6. No logic touched.** It's short enough to read in full in the Files tab, and I'd encourage that rather than taking my word for it.

To be explicit about scope: this is **only** the formatter check — the gate you already have switched on. It is **not** the ruff *lint-rules* question from #23902, which you closed as not planned; I've deliberately kept that entirely out of this PR.

### How this was verified

Ruff 0.15.21 (what `pip install "ruff>=0.15.5"` resolves to today), in a clean container, running the gates exactly as `backend.yaml` runs them:

```
ruff format --check . --exclude .venv --exclude venv
  → 238 files already formatted            exit 0   ✅  (was: 2 would be reformatted, exit 1)

ruff check --select=F --ignore=F401,F403,F405,F541,F811,F841 --output-format=github .
  → no findings                            exit 0   ✅  (unchanged)
```

If you'd rather fix this differently, or fold it into something already in flight, please just close it — no hard feelings, and thanks for the project.

# Changelog Entry

### Fixed

- Restored the `Ruff Format` CI check on `dev` by formatting two files that no longer matched `ruff format`.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
