### PR TITLE
fix: context compaction reads last-call input, not additive usage total

### DIFF
--- a/backend/open_webui/utils/context_compaction.py
+++ b/backend/open_webui/utils/context_compaction.py
@@ -232,8 +232,11 @@ def _exceeds_token_threshold(messages: list[dict], system_prompt: str, summary: 
 
     for idx in range(len(messages) - 1, -1, -1):
         usage = messages[idx].get('usage') or (messages[idx].get('info') or {}).get('usage')
-        if isinstance(usage, dict) and usage.get('input_tokens'):
-            total = int(usage.get('input_tokens') or 0) + int(usage.get('output_tokens') or 0)
+        if isinstance(usage, dict) and (usage.get('last_input_tokens') or usage.get('input_tokens')):
+            # Last call's real context, not merge_usage's additive tool-loop total.
+            context_input = int(usage.get('last_input_tokens') or usage.get('input_tokens') or 0)
+            context_output = int(usage.get('last_output_tokens') or usage.get('output_tokens') or 0)
+            total = context_input + context_output
             return total + _estimate_messages_tokens(messages[idx + 1 :]) > threshold
 
     estimated = _estimate_tokens(system_prompt) + _estimate_tokens(summary or '') + _estimate_messages_tokens(messages)

--- a/backend/open_webui/utils/response.py
+++ b/backend/open_webui/utils/response.py
@@ -47,6 +47,9 @@ def normalize_usage(usage: dict) -> dict:
     result['input_tokens'] = int(input_tokens)
     result['output_tokens'] = int(output_tokens)
     result['total_tokens'] = int(total_tokens)
+    # Last call's real counts (not summed): merge_usage keeps these last-write-wins.
+    result['last_input_tokens'] = int(usage.get('last_input_tokens') or input_tokens)
+    result['last_output_tokens'] = int(usage.get('last_output_tokens') or output_tokens)
 
     return result
 


### PR DESCRIPTION
merge_usage() sums token fields across the calls of a tool-loop turn, so a turn that makes N model calls stores input_tokens as the sum of every call's prompt. Because each call re-sends the growing conversation, the shared history is counted once per call: a 3-call turn at ~40k/80k/120k stores ~240k input_tokens though the real end-of-turn context is ~120k.

context_compaction._exceeds_token_threshold() reads that stored value as the current context size and compacts far below the real threshold (default 80000), summarizing away history that never needed to be dropped.

Keep the additive totals (used for analytics) and instead track the last call's real input/output under last_input_tokens / last_output_tokens. normalize_usage() stamps each usage with its own counts and preserves them when re-normalizing an already-merged object; these keys are not in USAGE_TOKEN_KEYS, so merge_usage keeps them last-write-wins and after a tool loop they hold the final call's usage = the true context size. Compaction now reads those, falling back to input_tokens for usage objects predating them.

https://github.com/open-webui/open-webui/issues/27031

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
