### PR TITLE
fix: salvage list-typed structuredContent from non-conformant MCP servers

### DIFF
--- a/backend/open_webui/utils/mcp/client.py
+++ b/backend/open_webui/utils/mcp/client.py
@@ -1,7 +1,10 @@
 import asyncio
+import json
 import logging
 from contextlib import AsyncExitStack
 from typing import Optional
+
+from pydantic import ValidationError
 
 log = logging.getLogger(__name__)
 
@@ -110,7 +113,29 @@ class MCPClient:
         if not self.session:
             raise RuntimeError('MCP client is not connected.')
 
-        result = await self.session.call_tool(function_name, function_args)
+        try:
+            result = await self.session.call_tool(function_name, function_args)
+        except ValidationError as e:
+            # Some MCP servers (e.g. memos) return structuredContent as a
+            # bare JSON array instead of an object, which the SDK's
+            # CallToolResult Pydantic model rejects with a dict_type error.
+            # Extract the list from the error and return it as MCP text
+            # content so the existing process_tool_result pipeline can handle it.
+            sc_error = next(
+                (err for err in e.errors()
+                 if err.get('loc') == ('structuredContent',) and err.get('type') == 'dict_type'),
+                None
+            )
+            if sc_error is not None:
+                content_list = sc_error.get('input', [])
+                if isinstance(content_list, list):
+                    log.debug(
+                        'MCP server returned structuredContent as list for tool "%s"; salvaging as text content',
+                        function_name,
+                    )
+                    return [{'type': 'text', 'text': json.dumps(content_list, ensure_ascii=False)}]
+            raise
+
         if not result:
             raise Exception('No result returned from MCP tool call.')
 


### PR DESCRIPTION
Closes #27021
## Description
Some MCP servers (e.g. memos) return `structuredContent` as a bare JSON array
instead of an object, which the MCP SDK's `CallToolResult` Pydantic model
rejects with a `ValidationError` (dict_type). This causes tool calls to
silently fail with no results returned to the user.
Catch `pydantic.ValidationError` in `MCPClient.call_tool()`. When the error
is specifically about `structuredContent` being a list instead of a dict,
extract the array and return it as MCP text content that the existing
`process_tool_result()` pipeline already handles.
## Linked Issue
Closes #27021
## Changes
- **`backend/open_webui/utils/mcp/client.py`**: Added try/except around
  `session.call_tool()` to catch `pydantic.ValidationError`. When
  `structuredContent` fails with a dict_type error (server returned a list),
  the list is extracted from the error, serialized as JSON, and returned as
  an MCP text content item for the existing pipeline.
## Testing
- Verified against real Pydantic 2.13.4 (project version) in Docker — error
  structure matches exactly, fix salvages data end-to-end through
  `process_tool_result()`
- Six edge cases tested: non-matching errors re-raise, empty lists handled,
  wrong loc skipped, non-list input skipped
- Syntax check passed (`python3 -m py_compile`)
- No new dependencies; `json` is stdlib, `pydantic` is already a project
  dependency
## Changelog
### Fixed
- **MCP**: Non-conformant MCP servers that return `structuredContent` as a
  JSON array (e.g. memos) no longer cause silent tool call failures. The
  array is salvaged and returned as text content through the existing result
  pipeline.
---
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->
# Pull Request Checklist
**Before submitting, make sure you've checked the following:**
- [x] **Linked Issue/Discussion:** Closes #27021
- [x] **Target branch:** `dev`
- [x] **Description:** Provided above
- [x] **Changelog:** Included below
- [ ] **Documentation:** No documentation changes required
- [x] **Dependencies:** No new dependencies
- [ ] **Testing:** Manual testing with actual memos MCP server required (PR author)
- [x] **No Unchecked AI Code:** Thoroughly reviewed and verified
- [x] **Self-Review:** Performed — matches existing code style, conventions, and architecture
- [x] **Architecture:** Uses existing pipeline; no new settings or configuration
- [x] **Git Hygiene:** Atomic commit, branched from `dev`, single concern
- [x] **Title Prefix:** `fix:`
# Changelog Entry
### Description
- Fix silent MCP tool call failures when a server returns `structuredContent`
  as a JSON array instead of an object. The fix extracts the array from the
  validation error and passes it through the existing `process_tool_result()`
  pipeline as text content.
### Fixed
- MCP tool calls to servers (e.g. memos) that return `structuredContent` as
  a bare array now succeed instead of failing with a `ValidationError`
  (dict_type)
---
### Contributor License Agreement
- [x] By submitting this pull request, I confirm that I have read and fully
  agree to the
  [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT),
  and I am providing my contributions under its terms.