### PR TITLE
fix: retain the recent-messages window across turns after compaction

### DIFF
--- a/backend/open_webui/utils/context_compaction.py
+++ b/backend/open_webui/utils/context_compaction.py
@@ -108,7 +108,13 @@ async def compact_messages_for_request(
         raise
 
     chat_id = metadata.get('chat_id')
-    checkpoint_message_id = metadata.get('user_message_id') or metadata.get('message_id')
+    # Anchor to the first retained message, not the current turn: reconstruction
+    # keeps messages from the marker forward (else the retained window is lost).
+    checkpoint_message_id = (
+        _retained_checkpoint_message_id(recent_messages)
+        or metadata.get('user_message_id')
+        or metadata.get('message_id')
+    )
     if chat_id and checkpoint_message_id and not chat_id.startswith(('local:', 'channel:')):
         await Chats.upsert_message_to_chat_by_id_and_message_id(
             chat_id,
@@ -209,6 +215,15 @@ def _parse_positive_int(value: Any) -> int | None:
 def _resolve_token_threshold(global_threshold: int, global_cap: int, metadata: dict) -> int:
     configured_threshold = _parse_positive_int((metadata.get('params') or {}).get('compact_token_threshold'))
     return min(configured_threshold or global_threshold, global_cap)
+
+
+def _retained_checkpoint_message_id(recent_messages: list[dict]) -> str | None:
+    """Id of the first retained message that has one — where the checkpoint belongs."""
+    for message in recent_messages:
+        message_id = message.get('id')
+        if isinstance(message_id, str) and message_id:
+            return message_id
+    return None
 
 
 def _apply_latest_summary_checkpoint(messages: list[dict]) -> tuple[list[dict], str | None]:

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -1975,8 +1975,9 @@ async def load_messages_from_db(chat_id: str, message_id: str) -> Optional[list[
     if not db_messages:
         return None
 
+    # 'id' is an internal handle for context compaction; stripped before the LLM.
     return [
-        {k: v for k, v in msg.items() if k in ('role', 'content', 'output', 'files', 'contextSummary')}
+        {k: v for k, v in msg.items() if k in ('id', 'role', 'content', 'output', 'files', 'contextSummary')}
         for msg in db_messages
     ]
 
@@ -2035,6 +2036,7 @@ def strip_compaction_fields(messages: list[dict]) -> list[dict]:
         clean = dict(message)
         clean.pop('contextSummary', None)
         clean.pop('context_summary', None)
+        clean.pop('id', None)  # internal compaction handle; never sent to providers
         stripped.append(clean)
     return stripped
 
@@ -2223,7 +2225,7 @@ async def process_chat_payload(request, form_data, user, metadata, model):
                         {
                             k: v
                             for k, v in assistant_message.items()
-                            if k in ('role', 'content', 'output', 'files', 'contextSummary')
+                            if k in ('id', 'role', 'content', 'output', 'files', 'contextSummary')
                         }
                     )
 


### PR DESCRIPTION
Context compaction is meant to send `summary + retained recent messages` on every turn after a compaction. It only did so on the turn that produced the summary. The checkpoint marking where the summary applies was stored on the current (last) user message — the END of the retained window — but reconstruction keeps messages from the marker forward. So on subsequent turns everything before the marker (the retained ~40% window) was sliced away, leaving just `summary + current user message`. That breaks prompt caching and drops the recent conversational context the summary does not convey.

Anchor the checkpoint to the FIRST retained message instead, so the whole window survives reconstruction on later turns. This needs the message's id, so thread `id` through load_messages_from_db as an internal handle and strip it in strip_compaction_fields before the payload reaches any provider.

https://github.com/open-webui/open-webui/issues/27037

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
