### PR TITLE
fix: preserve complete turns during context compaction

### DIFF
--- a/backend/open_webui/utils/context_compaction.py
+++ b/backend/open_webui/utils/context_compaction.py
@@ -244,15 +244,18 @@ def _find_compaction_boundary(messages: list[dict]) -> int:
     keep_count = max(2, len(messages) * 2 // 5)
     split = max(1, len(messages) - keep_count)
 
-    while split < len(messages) - 1:
-        previous = messages[split - 1] if split > 0 else {}
-        current = messages[split]
-        if current.get('role') == 'tool' or previous.get('tool_calls') or previous.get('output'):
-            split += 1
-            continue
-        break
+    turn_starts = [
+        idx
+        for idx, message in enumerate(messages)
+        if message.get('role') == 'user' and idx <= len(messages) - 2
+    ]
+    for turn_start in turn_starts:
+        if turn_start >= split:
+            return turn_start
 
-    return min(split, len(messages) - 2)
+    if turn_starts:
+        return turn_starts[-1]
+    return 0
 
 
 async def _generate_summary(


### PR DESCRIPTION
## Summary

- choose context-compaction boundaries only at complete user-turn starts
- keep the existing approximately 40% recent-context target when a later complete turn is available
- fall back to the most recent complete turn, or no compaction boundary when no complete turn exists

Closes #27035

## Why

The existing count-based boundary can land inside one assistant/tool turn. That sends only part of the turn to the summary model and leaves the remainder in recent context. Selecting a user-message boundary keeps tool calls and results from the same completed turn together.

## Validation

- deterministic 506-case boundary evaluation: `486` baseline errors to `0`
- gates for source scope, compatibility, input mutation, determinism, invalid boundaries, and exceptions
- `python -m py_compile backend/open_webui/utils/context_compaction.py`
- manual diff review against current `dev`

This boundary algorithm was refined through autoresearch with Weco and then reduced to the minimal targeted patch. [Public Weco run](https://dashboard.weco.ai/share/SGvjOOBSFJFr1ZVLqqrfHDn9i-G4W6NS)

## Pull Request Checklist

- [x] **Linked Issue/Discussion:** Closes #27035.
- [x] **Target branch:** This pull request targets `dev`.
- [x] **Description:** The behavior, motivation, and impact are described above.
- [x] **Changelog:** Included below.
- [x] **Documentation:** No documentation change is required for this bug fix.
- [x] **Dependencies:** No dependencies were added or changed.
- [x] **Testing:** The strict deterministic evaluation and syntax check pass.
- [x] **No Unchecked AI Code:** The final patch was manually reduced, reviewed, and validated.
- [x] **Self-Review:** The diff and edge cases were reviewed.
- [x] **Architecture:** The change preserves the existing compaction policy and settings.
- [x] **Git Hygiene:** The pull request contains one atomic source change on current `dev`.
- [x] **Title Prefix:** The title uses the `fix` prefix.

# Changelog Entry

### Fixed

- Context compaction no longer splits a completed assistant/tool turn across summarized and recent context.

### Additional Information

- No UI changes or screenshots.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
