### PR TITLE
fix: apply model-attached tools in multi-model chats

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -2528,7 +2528,12 @@
 		const toolIds = [];
 		const toolServerIds = [];
 
-		for (const toolId of selectedToolIds) {
+		// Include this model's own attached tools so they apply in multi-model chats,
+		// independent of the composer's selectedToolIds lifecycle.
+		const modelDefaultToolIds = (model?.info?.meta?.toolIds ?? []).filter((id) =>
+			$tools.find((t) => t.id === id)
+		);
+		for (const toolId of [...new Set([...selectedToolIds, ...modelDefaultToolIds])]) {
 			if (toolId.startsWith('direct_server:')) {
 				let serverId = toolId.replace('direct_server:', '');
 				// Check if serverId is a number


### PR DESCRIPTION
### Description
Tools attached to a model (Workspace -> Models -> model -> Tools) were not applied to that model's requests in multi-model (compare) chats. Each model's tool_ids was derived only from the composer's selectedToolIds, which is not reliably populated per model in compare mode (resetInput considers only the first selected model, and auto-populated tools do not persist to submit). So a model that relies on its own attached tools could not call them in compare mode, even though the same model works in single-model chat.

This unions each model's own installed info.meta.toolIds into its request payload at the per-model build step in submitPrompt, so model-attached tools apply regardless of selectedToolIds state.

Relates to #27043

**Checklist**
- [x] Linked Issue/Discussion - Relates to #27043
- [x] Targets `dev`
- [x] Description provided
- [x] Changelog entry included
- [ ] Documentation - N/A (no user-facing docs change)
- [x] Dependencies - none added
- [x] Testing - manually verified on dev in compare mode with two tool-attached models; both invoked their attached tools (details below)
- [x] No Unchecked AI Code - human-reviewed and manually tested
- [x] Self-Review done
- [x] Architecture - smart default, no new setting
- [x] Git Hygiene - atomic, rebased on `dev`
- [x] Title Prefix - `fix:`

# Changelog Entry

### Fixed
- Tools attached to a model are now applied per model in multi-model (compare) chats, matching single-model behavior.

### Additional Information
Minimal change (6+/1-) in src/lib/components/chat/Chat.svelte at the per-model request builder in submitPrompt. Note: dev's resetInput includes OAuth authed/unauthed tool handling; this change sends attached tool IDs directly, so interactive-OAuth tools in compare mode may warrant a follow-up - happy to align with maintainer preference.

### Screenshots or Videos
Omitted for privacy. Manual test on dev: opened a fresh compare chat with two models that each have a tool attached, asked a question requiring the tool, and both model columns invoked their attached tool and returned results - verified from a default compare state with no manual tool selection and no model re-add workaround.

### Contributor License Agreement
- [x] By submitting this pull request, I confirm that I have read and fully agree to the Contributor License Agreement (CLA), and I am providing my contributions under its terms.
