### PR TITLE
fix: clear stale response error after successful continuation

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -3534,6 +3534,7 @@ async def non_streaming_chat_response_handler(response, ctx):
                             'type': 'chat:completion',
                             'data': {
                                 'done': True,
+                                'error': None,
                                 'output': response_output,
                                 'title': title,
                             },
@@ -3549,6 +3550,7 @@ async def non_streaming_chat_response_handler(response, ctx):
                             metadata['message_id'],
                             {
                                 'done': True,
+                                'error': None,
                                 'role': 'assistant',
                                 'output': response_output,
                                 **({'usage': usage} if usage else {}),
@@ -5230,6 +5232,7 @@ async def streaming_chat_response_handler(response, ctx):
                 )
                 data = {
                     'done': True,
+                    'error': None,
                     'output': output,
                     'title': title,
                     **({'usage': usage} if usage else {}),
@@ -5243,6 +5246,7 @@ async def streaming_chat_response_handler(response, ctx):
                             metadata['message_id'],
                             {
                                 'done': True,
+                                'error': None,
                                 'output': output,
                                 **({'usage': usage} if usage else {}),
                             },
@@ -5251,13 +5255,13 @@ async def streaming_chat_response_handler(response, ctx):
                         await Chats.upsert_message_to_chat_by_id_and_message_id(
                             metadata['chat_id'],
                             metadata['message_id'],
-                            {'done': True, 'usage': usage},
+                            {'done': True, 'error': None, 'usage': usage},
                         )
                     else:
                         await Chats.upsert_message_to_chat_by_id_and_message_id(
                             metadata['chat_id'],
                             metadata['message_id'],
-                            {'done': True},
+                            {'done': True, 'error': None},
                         )
 
                 # Send a webhook notification if the user is not active

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -1974,6 +1974,8 @@
 
 		if (error) {
 			await handleOpenAIError(error, message);
+		} else if (error === null) {
+			delete message.error;
 		}
 
 		if (sources && !message?.sources) {


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Closes #26892.
- [x] **Target branch:** This pull request targets `dev`.
- [x] **Description:** The root cause and changes are described below.
- [x] **Changelog:** A Keep a Changelog entry is included below.
- [x] **Documentation:** No documentation change is needed for this bug fix.
- [x] **Dependencies:** No dependencies were added or updated.
- [ ] **Testing:** Manual end-to-end testing is pending; focused automated checks are listed below.
- [ ] **No Unchecked AI Code:** Final human review and manual testing are pending while this PR is a draft.
- [ ] **Self-Review:** Final human self-review is pending while this PR is a draft.
- [x] **Architecture:** This reuses the existing completion event and message persistence paths without adding settings.
- [x] **Git Hygiene:** The change is atomic, based on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The title uses the `fix` prefix.

## Description

When an assistant response fails, the error is stored both in the frontend message state and in the persisted chat history. Continuing that same response reuses its message ID. A successful continuation updates the output and marks the message done, but neither the streaming nor non-streaming success path clears the old error. The frontend also only handles truthy errors, so the stale value remains visible and blocks the next prompt.

Successful completions now persist `error: null` and include that explicit value in the final completion event. The frontend distinguishes that success signal from an event where the error field is absent and removes the stale local error. Failed continuations still use the existing error event and retain their current behavior.

Closes #26892.

## Validation

- `npx prettier --check src/lib/components/chat/Chat.svelte`
- `uvx ruff@0.15.5 format --check backend/open_webui/utils/middleware.py`
- `uvx ruff@0.15.5 check --select=F --ignore=F401,F403,F405,F541,F811,F841 backend/open_webui/utils/middleware.py`
- `npm run test:frontend` (passes; the current tree contains no frontend test files)
- `git diff --check`

The repository-wide `npm run check` currently reports 9,531 pre-existing diagnostics across 377 files; the changed frontend line has no diagnostic. The production build reaches 1,614 transformed modules, then fails in unchanged code because `AddTerminalServerModal.svelte` imports `getOrchestratorPolicy`, which `src/lib/apis/configs/index.ts` does not export.

OpenAI Codex assisted with investigation and implementation. The author will complete the final review and manual verification before marking this draft ready.

# Changelog Entry

### Fixed

- Clear a failed assistant response's stale API error after a successful continuation, including across chat reloads.

### Breaking Changes

- None.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.

