### PR TITLE
fix: implement missing orchestrator policy and lifecycle GET proxy endpoints

### DIFF
--- a/backend/open_webui/routers/configs.py
+++ b/backend/open_webui/routers/configs.py
@@ -412,6 +412,13 @@ class TerminalServerRefreshForm(BaseModel):
     reset: bool = False
 
 
+class TerminalServerPolicyGetForm(BaseModel):
+    url: str
+    key: str | None = ''
+    auth_type: str | None = 'bearer'
+    policy_id: str
+
+
 @router.post('/terminal_servers/policy')
 async def put_terminal_server_policy(
     request: Request, form_data: TerminalServerPolicyForm, user=Depends(get_admin_user)
@@ -483,6 +490,72 @@ async def put_terminal_server_lifecycle(
     except Exception as e:
         log.debug(f'Failed to save lifecycle to terminal server: {e}')
         raise HTTPException(status_code=400, detail='Failed to save lifecycle to terminal server')
+
+
+@router.post('/terminal_servers/policy/get')
+async def get_terminal_server_policy(
+    request: Request, form_data: TerminalServerPolicyGetForm, user=Depends(get_admin_user)
+):
+    """
+    Proxy a policy GET from an orchestrator terminal server.
+    """
+    base_url = (form_data.url or '').rstrip('/')
+    if not base_url:
+        raise HTTPException(status_code=400, detail='Terminal server URL is required')
+
+    headers = {}
+    if form_data.auth_type == 'bearer' and form_data.key:
+        headers.update(bearer_auth_header(form_data.key))
+
+    try:
+        async with aiohttp.ClientSession(
+            trust_env=True,
+            timeout=aiohttp.ClientTimeout(total=AIOHTTP_CLIENT_TIMEOUT),
+        ) as session:
+            policy_url = f'{base_url}/api/v1/policies/{form_data.policy_id}'
+            async with session.get(policy_url, headers=headers, ssl=AIOHTTP_CLIENT_SESSION_SSL) as resp:
+                if resp.ok:
+                    return await resp.json()
+                detail = await resp.text()
+                raise HTTPException(status_code=resp.status, detail=detail)
+    except HTTPException:
+        raise
+    except Exception as e:
+        log.debug(f'Failed to get policy from terminal server: {e}')
+        raise HTTPException(status_code=400, detail='Failed to get policy from terminal server')
+
+
+@router.post('/terminal_servers/lifecycle/get')
+async def get_terminal_server_lifecycle(
+    request: Request, form_data: TerminalServerPolicyGetForm, user=Depends(get_admin_user)
+):
+    """
+    Proxy a policy lifecycle GET from an orchestrator terminal server.
+    """
+    base_url = (form_data.url or '').rstrip('/')
+    if not base_url:
+        raise HTTPException(status_code=400, detail='Terminal server URL is required')
+
+    headers = {}
+    if form_data.auth_type == 'bearer' and form_data.key:
+        headers.update(bearer_auth_header(form_data.key))
+
+    try:
+        async with aiohttp.ClientSession(
+            trust_env=True,
+            timeout=aiohttp.ClientTimeout(total=AIOHTTP_CLIENT_TIMEOUT),
+        ) as session:
+            lifecycle_url = f'{base_url}/api/v1/policies/{form_data.policy_id}/lifecycle'
+            async with session.get(lifecycle_url, headers=headers, ssl=AIOHTTP_CLIENT_SESSION_SSL) as resp:
+                if resp.ok:
+                    return await resp.json()
+                detail = await resp.text()
+                raise HTTPException(status_code=resp.status, detail=detail)
+    except HTTPException:
+        raise
+    except Exception as e:
+        log.debug(f'Failed to get lifecycle from terminal server: {e}')
+        raise HTTPException(status_code=400, detail='Failed to get lifecycle from terminal server')
 
 
 @router.post('/terminal_servers/refresh')

--- a/src/lib/apis/configs/index.ts
+++ b/src/lib/apis/configs/index.ts
@@ -396,6 +396,84 @@ export const refreshOrchestratorTerminals = async (
 	return res;
 };
 
+export const getOrchestratorPolicy = async (
+	token: string,
+	url: string,
+	key: string,
+	policyId: string,
+	authType: string = 'bearer'
+): Promise<object | null> => {
+	let error = null;
+
+	const res = await fetch(`${WEBUI_API_BASE_URL}/configs/terminal_servers/policy/get`, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			Authorization: `Bearer ${token}`
+		},
+		body: JSON.stringify({
+			url: url.replace(/\/$/, ''),
+			key,
+			auth_type: authType,
+			policy_id: policyId
+		})
+	})
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			console.error(err);
+			error = err.detail;
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
+
+	return res;
+};
+
+export const getOrchestratorLifecycle = async (
+	token: string,
+	url: string,
+	key: string,
+	policyId: string,
+	authType: string = 'bearer'
+): Promise<object | null> => {
+	let error = null;
+
+	const res = await fetch(`${WEBUI_API_BASE_URL}/configs/terminal_servers/lifecycle/get`, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			Authorization: `Bearer ${token}`
+		},
+		body: JSON.stringify({
+			url: url.replace(/\/$/, ''),
+			key,
+			auth_type: authType,
+			policy_id: policyId
+		})
+	})
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			console.error(err);
+			error = err.detail;
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
+
+	return res;
+};
+
 /**
  * Verify a terminal server connection via the backend proxy.
  * Used for system/admin connections to avoid CORS issues and API key exposure.


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Relates to commit 49d202a18`.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [x] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

# Changelog Entry

### Description

This PR implements the missing client functions and backend endpoints required to load terminal server policies and lifecycles dynamically from an orchestrator. 

In a recent commit, the connection setup in the UI modal was modified to retrieve this policy configuration dynamically using `getOrchestratorPolicy` and `getOrchestratorLifecycle` from the `$lib/apis/configs` module. However, these functions were not exported by the API module, and the matching FastAPI proxy endpoints were not implemented on the backend. This broke the frontend production build.

This change:
1. Implements `getOrchestratorPolicy` and `getOrchestratorLifecycle` in `src/lib/apis/configs/index.ts`.
2. Adds `/terminal_servers/policy/get` and `/terminal_servers/lifecycle/get` endpoints on the FastAPI backend, utilizing `TerminalServerPolicyGetForm` to securely forward authorization headers and policy IDs to the orchestrator.

### Added

- `backend/open_webui/routers/configs.py`: Added `TerminalServerPolicyGetForm` schema.
- `backend/open_webui/routers/configs.py`: Added `/terminal_servers/policy/get` and `/terminal_servers/lifecycle/get` endpoints to proxy GET requests to the terminal server orchestrator.
- `src/lib/apis/configs/index.ts`: Added and exported `getOrchestratorPolicy` and `getOrchestratorLifecycle` to query the backend endpoints.

### Fixed

- Resolved Vite/Rollup build compilation error: `"getOrchestratorPolicy" is not exported by "src/lib/apis/configs/index.ts"`.

---

### Additional Information

- Relates to the recent refactoring of the Open WebUI terminal server settings.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.