### PR TITLE
fix: code-interpreter import restriction bypass via importlib + empty default blocklist

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -450,7 +450,23 @@ CODE_INTERPRETER_JUPYTER_TIMEOUT = int(
 )
 
 CODE_INTERPRETER_BLOCKED_MODULES = [
-    library.strip() for library in os.getenv('CODE_INTERPRETER_BLOCKED_MODULES', '').split(',') if library.strip()
+    library.strip()
+    for library in os.getenv(
+        'CODE_INTERPRETER_BLOCKED_MODULES',
+        # NOTE: this list is defense-in-depth only, NOT a security boundary.
+        # Python's import machinery (and many already-imported modules) keep
+        # references that a determined attacker can reach even with every name
+        # below blocked. Real isolation requires executing untrusted code in a
+        # separate process/container (or the pyodide frontend sandbox). The
+        # blocklist only raises the bar for the trivial primitives.
+        # `importlib` (and the frozen bootstrap / `_imp`) MUST be included:
+        # without them, `import importlib; importlib.import_module('os')`
+        # bypasses the builtins.__import__ override entirely, because
+        # importlib.import_module uses the bootstrap loader directly.
+        'os,sys,subprocess,socket,ctypes,shutil,pty,platform,multiprocessing,'
+        'importlib,_frozen_importlib,_frozen_importlib_external,_imp',
+    ).split(',')
+    if library.strip()
 ]
 
 DEFAULT_CODE_INTERPRETER_PROMPT = """

--- a/backend/open_webui/tools/builtin.py
+++ b/backend/open_webui/tools/builtin.py
@@ -458,7 +458,16 @@ async def execute_code(
         # Import blocked modules from config (same as middleware)
         from open_webui.config import CODE_INTERPRETER_BLOCKED_MODULES
 
-        # Add import blocking code if there are blocked modules
+        # Add import blocking code if there are blocked modules.
+        # NOTE: this is defense-in-depth, NOT a security boundary -- see the
+        # comment on CODE_INTERPRETER_BLOCKED_MODULES in config.py. The list
+        # MUST include `importlib` (and the frozen bootstrap helpers): without
+        # it, `import importlib; importlib.import_module('os')` bypasses the
+        # builtins.__import__ override, because importlib.import_module reaches
+        # the bootstrap loader directly and never calls builtins.__import__.
+        # The blocklist check must NOT be gated on `importer_name == '__main__'`,
+        # as that allows bypass from any non-__main__ context (importlib,
+        # helper modules, exec with custom globals).
         if CODE_INTERPRETER_BLOCKED_MODULES:
             import textwrap
 
@@ -471,11 +480,9 @@ async def execute_code(
                 _real_import = builtins.__import__
                 def restricted_import(name, globals=None, locals=None, fromlist=(), level=0):
                     if name.split('.')[0] in BLOCKED_MODULES:
-                        importer_name = globals.get('__name__') if globals else None
-                        if importer_name == '__main__':
-                            raise ImportError(
-                                f"Direct import of module {{name}} is restricted."
-                            )
+                        raise ImportError(
+                            f"Import of module {{name}} is restricted."
+                        )
                     return _real_import(name, globals, locals, fromlist, level)
 
                 builtins.__import__ = restricted_import

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -5074,22 +5074,26 @@ async def streaming_chat_response_handler(response, ctx):
                                 # Sanitize code (strips ANSI codes and markdown fences)
                                 code = sanitize_code(code)
 
+                                # NOTE: defense-in-depth only, NOT a security
+                                # boundary -- see CODE_INTERPRETER_BLOCKED_MODULES
+                                # in config.py. `importlib` must stay in the list
+                                # or `importlib.import_module('os')` bypasses the
+                                # builtins.__import__ override below, and the
+                                # blocklist check must not be gated on __main__.
                                 if CODE_INTERPRETER_BLOCKED_MODULES:
                                     blocking_code = textwrap.dedent(f"""
                                         import builtins
-    
+
                                         BLOCKED_MODULES = {CODE_INTERPRETER_BLOCKED_MODULES}
-    
+
                                         _real_import = builtins.__import__
                                         async def restricted_import(name, globals=None, locals=None, fromlist=(), level=0):
                                             if name.split('.')[0] in BLOCKED_MODULES:
-                                                importer_name = globals.get('__name__') if globals else None
-                                                if importer_name == '__main__':
-                                                    raise ImportError(
-                                                        f"Direct import of module {{name}} is restricted."
-                                                    )
+                                                raise ImportError(
+                                                    f"Import of module {{name}} is restricted."
+                                                )
                                             return _real_import(name, globals, locals, fromlist, level)
-    
+
                                         builtins.__import__ = restricted_import
                                     """)
                                     code = blocking_code + '\n' + code


### PR DESCRIPTION
[security] Fix code-interpreter import restriction bypass (importlib + `__main__` gate + empty default)

## Summary

The code interpreter's `restricted_import` defense (applied to both the pyodide
path in `tools/builtin.py` and the streaming path in `utils/middleware.py`) is
bypassable in two ways on the current `dev` branch, and is effectively inactive
by default. This PR fixes all three issues in a self-contained change.

### 1. `importlib.import_module` bypasses the blocklist entirely (RCE)

The sandbox overrides `builtins.__import__` to block `os`, `sys`, `subprocess`,
etc. But `importlib.import_module` uses the importlib bootstrap loader directly
and **never calls `builtins.__import__`**, so the blocklist is not consulted:

```python
import importlib
importlib.import_module('os').system('id')   # arbitrary command execution
```

`os` is also already cached in `sys.modules` from interpreter startup, so
`import_module` returns it instantly. `os.system` works because it does not
internally `import subprocess` (the one path the blocklist would catch), giving
a clean RCE primitive as the server / Jupyter-kernel user.

### 2. The `__main__` gate makes the blocklist a no-op from any other context

`restricted_import` only raises when `importer_name == '__main__'`. Importing
from any non-`__main__` context (a helper module, `exec` with custom globals,
or the `importlib` path above) skips the check entirely.

### 3. `CODE_INTERPRETER_BLOCKED_MODULES` defaults to empty

On current `dev`, the env var default is `''`, so the entire `if
CODE_INTERPRETER_BLOCKED_MODULES:` block is skipped unless an operator
explicitly sets the env var. The sandbox ships inactive.

## Fix

- **config.py**: default the blocklist to
  `os,sys,subprocess,socket,ctypes,shutil,pty,platform,multiprocessing,importlib,_frozen_importlib,_frozen_importlib_external,_imp`.
  Adding `importlib` and the frozen bootstrap helpers closes the trivial
  `importlib.import_module('os')` bypass — without them a one-liner defeats
  the entire mechanism.
- **builtin.py / middleware.py**: remove the `importer_name == '__main__'`
  gate so the blocklist fires unconditionally, and document in both sites that
  this is defense-in-depth.
- All three files now carry a comment stating plainly that the blocklist is
  **defense-in-depth, not a security boundary**: `os`/`sys` remain reachable
  via attribute chains and frame-walking because they are pre-loaded in
  `sys.modules`. Real isolation requires executing untrusted code in the
  pyodide frontend sandbox or a separate container.

## Verification

- Reproduced the bypass against the current `dev` blocklist: the PoC installs
  the exact `restricted_import` override, then
  `importlib.import_module('os').system(...)` returns exit 0.
- After the fix: `import importlib` and `import os` both raise `ImportError`;
  allowed modules (e.g. `math`) still import — no regression.
- `ruff format` and `ruff check`: 0 new errors vs `dev` baseline across all
  three files.

## Scope note (important)

This change closes the **trivial** bypass a model would actually emit
(`import importlib; importlib.import_module('os')`). It does **not** turn the
blocklist into a real sandbox — `os`/`sys` are reachable via more sophisticated
escapes because they are already loaded. The comments added here state this so
that maintainers and operators do not over-trust the Jupyter backend. A
follow-up discussion (out of scope for this PR) is whether the Jupyter engine
should be containerized by default and whether pyodide should remain the
recommended engine for untrusted users.

# Changelog Entry

### Description

- Fix code-interpreter import restriction bypass: `importlib.import_module`
  reached blocked modules without consulting the `builtins.__import__` override,
  giving arbitrary command execution. Also remove the `__main__`-only gate and
  default the blocklist to a sensible non-empty value.

### Security

- **[security] Code interpreter / import sandbox bypass via `importlib.import_module`.**
  The `restricted_import` override on `builtins.__import__` did not intercept
  `importlib.import_module`, which uses the bootstrap loader directly, so
  `importlib.import_module('os').system(...)` executed arbitrary commands as
  the server user. `os`/`sys` are also pre-loaded in `sys.modules`. Fixed by
  adding `importlib` (and frozen bootstrap helpers) to the default blocklist,
  removing the `__main__`-only gate so the check fires unconditionally, and
  defaulting `CODE_INTERPRETER_BLOCKED_MODULES` to a non-empty value. The
  blocklist remains defense-in-depth (not a real boundary); real isolation
  requires the pyodide frontend or a containerized Jupyter backend.

---

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
