### PR TITLE
feat: show context-window usage in the message input

### DIFF
--- a/src/lib/apis/ollama/index.ts
+++ b/src/lib/apis/ollama/index.ts
@@ -524,3 +524,31 @@ export const uploadModel = async (token: string, file: File, urlIdx: string | nu
 // 		})
 // 	});
 // };
+
+export const getOllamaModelInfo = async (token: string = '', name: string) => {
+	let error = null;
+
+	const res = await fetch(`${OLLAMA_API_BASE_URL}/api/show`, {
+		method: 'POST',
+		headers: {
+			Accept: 'application/json',
+			'Content-Type': 'application/json',
+			Authorization: `Bearer ${token}`
+		},
+		body: JSON.stringify({ name })
+	})
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			error = err;
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
+
+	return res;
+};

--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -91,6 +91,7 @@
 	import Terminal from '../icons/Terminal.svelte';
 	import IntegrationsMenu from './MessageInput/IntegrationsMenu.svelte';
 	import TerminalMenu from './MessageInput/TerminalMenu.svelte';
+	import ContextUsage from './MessageInput/ContextUsage.svelte';
 	import Component from '../icons/Component.svelte';
 	import PlusAlt from '../icons/PlusAlt.svelte';
 	import Dropdown from '../common/Dropdown.svelte';
@@ -2002,6 +2003,7 @@
 								</div>
 
 								<div class="self-end flex space-x-1 mr-1 shrink-0 gap-[0.5px]">
+									<ContextUsage {history} {selectedModels} />
 									{#if isActive && prompt === '' && files.length === 0}
 										<div class=" flex items-center">
 											<Tooltip content={$i18n.t('Stop')}>

--- a/src/lib/components/chat/MessageInput/ContextUsage.svelte
+++ b/src/lib/components/chat/MessageInput/ContextUsage.svelte
@@ -1,0 +1,124 @@
+<script lang="ts">
+	import { getContext } from 'svelte';
+	import { models } from '$lib/stores';
+	import { getOllamaModelInfo } from '$lib/apis/ollama';
+
+	const i18n = getContext('i18n');
+
+	export let history;
+	export let selectedModels: string[] = [];
+
+	// Numerator: tokens the most recent response consumed. Only assistant
+	// responses carry usage/info token counts, so their presence is enough.
+	let used: number | null = null;
+	$: {
+		const msg = history?.currentId ? history?.messages?.[history.currentId] : null;
+		const usage = msg?.usage ?? {};
+		const info = msg?.info ?? {};
+		if (typeof usage.total_tokens === 'number') {
+			used = usage.total_tokens;
+		} else if (
+			typeof usage.prompt_tokens === 'number' ||
+			typeof usage.completion_tokens === 'number'
+		) {
+			used = (usage.prompt_tokens ?? 0) + (usage.completion_tokens ?? 0);
+		} else if (typeof info.total_tokens === 'number') {
+			used = info.total_tokens;
+		} else if (typeof info.prompt_eval_count === 'number' || typeof info.eval_count === 'number') {
+			used = (info.prompt_eval_count ?? 0) + (info.eval_count ?? 0);
+		} else {
+			used = null;
+		}
+	}
+
+	// Denominator: the model's context window.
+	//  - Ollama models expose the real window; fetch it once from /api/show and cache.
+	//  - Other models use a configured num_ctx when present.
+	let windowCache: Record<string, number> = {};
+
+	const resolveOllamaWindow = async (id: string) => {
+		if (!id || windowCache[id] !== undefined) {
+			return;
+		}
+		try {
+			const res = await getOllamaModelInfo(localStorage.token, id);
+			const modelInfo = res?.model_info ?? {};
+			const key = Object.keys(modelInfo).find((k) => k.endsWith('.context_length'));
+			const n = key ? modelInfo[key] : undefined;
+			if (typeof n === 'number' && n > 0) {
+				windowCache = { ...windowCache, [id]: n };
+			}
+		} catch {
+			// No window available; the gauge falls back to a raw token count.
+		}
+	};
+
+	$: model = ($models ?? []).find((m) => m.id === selectedModels?.[0]);
+	$: if (model?.owned_by === 'ollama' && model?.id) {
+		resolveOllamaWindow(model.id);
+	}
+
+	let limit: number | null = null;
+	$: {
+		const cached = model?.id ? windowCache[model.id] : undefined;
+		const configured = ((model?.info?.params ?? {}) as Record<string, unknown>).num_ctx;
+		const n = typeof cached === 'number' ? cached : configured;
+		limit = typeof n === 'number' && n > 0 ? n : null;
+	}
+
+	// Once the window is known, show the gauge from the start (0% before the first
+	// response); otherwise fall back to the raw count once tokens are reported.
+	$: shownUsed = used ?? 0;
+	$: percent = limit != null ? Math.min(100, Math.round((shownUsed / limit) * 100)) : 0;
+
+	const RADIUS = 7;
+	const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
+	$: dashOffset = CIRCUMFERENCE * (1 - percent / 100);
+
+	$: color =
+		percent >= 90
+			? 'text-red-500'
+			: percent >= 75
+				? 'text-yellow-500'
+				: 'text-gray-400 dark:text-gray-500';
+
+	const fmt = (n: number) => n.toLocaleString();
+</script>
+
+{#if limit != null}
+	<div
+		class="flex items-center gap-1 self-center px-1 text-xs {color}"
+		title={`${fmt(shownUsed)} / ${fmt(limit)} ${$i18n.t('tokens')} (${percent}%)`}
+	>
+		<svg width="16" height="16" viewBox="0 0 18 18" class="-rotate-90 shrink-0">
+			<circle
+				cx="9"
+				cy="9"
+				r={RADIUS}
+				fill="none"
+				stroke="currentColor"
+				stroke-width="2"
+				class="text-gray-200 dark:text-gray-700"
+			/>
+			<circle
+				cx="9"
+				cy="9"
+				r={RADIUS}
+				fill="none"
+				stroke="currentColor"
+				stroke-width="2"
+				stroke-linecap="round"
+				stroke-dasharray={CIRCUMFERENCE}
+				stroke-dashoffset={dashOffset}
+			/>
+		</svg>
+		<span>{percent}%</span>
+	</div>
+{:else if used != null}
+	<div
+		class="flex items-center self-center px-1 text-xs text-gray-400 dark:text-gray-500"
+		title={`${fmt(used)} ${$i18n.t('tokens')}`}
+	>
+		{fmt(used)}
+	</div>
+{/if}


### PR DESCRIPTION
### Description

Adds a compact context-usage indicator to the chat composer footer, showing how much of the selected model's context window the current conversation is using.

- Numerator: the most recent response's reported token counts (usage.total_tokens, or prompt_tokens + completion_tokens; for local models prompt_eval_count + eval_count). No extra tokenizer pass.
- Denominator (context window): for local models the real window is fetched once from the model info and cached; for other models a configured num_ctx is used when set. No hardcoded or guessed windows.
- UI: a small circular gauge, visible from 0% once the window is known and filling as the conversation grows (used/total in the tooltip; gray -> yellow at >=75% -> red at >=90%). Falls back to a raw token count when no window is known.

Relates to #27058

**Checklist**
- [x] Linked Issue/Discussion - Relates to #27058
- [x] Targets `dev`
- [x] Description provided
- [x] Changelog entry included
- [ ] Documentation - N/A (no user-facing docs change)
- [x] Dependencies - none added
- [x] Testing - manually verified with a local model: the gauge shows from 0% and fills to the correct used/total after replies
- [x] No Unchecked AI Code - human-reviewed and manually tested
- [x] Self-Review done
- [x] Architecture - smart default (uses reported usage + real/configured window; no new setting)
- [x] Git Hygiene - atomic, rebased on `dev`
- [x] Title Prefix - `feat:`

# Changelog Entry

### Added
- Context-window usage indicator in the message input footer: shows tokens used vs the selected model's context window as a small circular gauge with a percentage, or a raw token count when the window is unknown.

### Additional Information
Three files: a new src/lib/components/chat/MessageInput/ContextUsage.svelte component, a getOllamaModelInfo helper in the Ollama API module, and a 2-line integration in MessageInput.svelte. The context window for local models is read from the model info and cached per model; the numerator uses each response's reported usage (no live tokenizer), so it reflects context after each reply.

### Screenshots or Videos
Omitted for privacy. Manual test: with a local 256K-context model, the footer shows a circular gauge starting at 0% before the first reply, then used/total after each reply (e.g. ~2% early on), turning yellow at >=75% and red at >=90%.

### Contributor License Agreement
- [x] By submitting this pull request, I confirm that I have read and fully agree to the Contributor License Agreement (CLA), and I am providing my contributions under its terms.
