### PR TITLE
fix: persist raw streaming errors in chat history

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -4022,7 +4022,7 @@ async def streaming_chat_response_handler(response, ctx):
                                 raw_error = raw_obj.get('error') if isinstance(raw_obj, dict) else None
                                 if raw_error:
                                     try:
-                                        Chats.upsert_message_to_chat_by_id_and_message_id(
+                                        await Chats.upsert_message_to_chat_by_id_and_message_id(
                                             metadata['chat_id'],
                                             metadata['message_id'],
                                             {


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Fixes #27074.
- [x] **Target branch:** This pull request targets `dev`.
- [x] **Description:** The raw-JSON streaming-error fallback now awaits the chat update, so the normalized provider error is retained in chat history as well as emitted to the client.
- [x] **Changelog:** Included below.
- [x] **Documentation:** Not applicable; no public API or configuration changes.
- [x] **Dependencies:** No dependency changes.
- [x] **Testing:** Verified the raw-error persistence call is awaited with a focused AST assertion; ran `python -m compileall`, `ruff check` with the repository CI rule selection, and `git diff --check`.
- [x] **No Unchecked AI Code:** The change was reviewed against the streaming and SSE error paths and manually validated for the affected execution path.
- [x] **Self-Review:** Confirmed the diff contains only the missing `await`.
- [x] **Architecture:** Reuses the existing async persistence path and preserves all existing error handling.
- [x] **Git Hygiene:** Atomic one-line fix, based on `dev`, with no unrelated changes.
- [x] **Title Prefix:** `fix`

## Description

Some OpenAI-compatible providers return a raw JSON error line instead of an SSE `data:` event. Open WebUI already normalizes that line and emits a completion error, but the async chat upsert was invoked without `await`, so no error was stored on the message. Awaiting the existing call makes this fallback consistent with the normal SSE error path.

## Checks

- Focused AST assertion for the raw JSON error persistence call
- `python -m compileall -q backend/open_webui/utils/middleware.py`
- `uvx ruff check --select=F --ignore=F401,F403,F405,F541,F811,F841 backend/open_webui/utils/middleware.py`
- `git diff --check upstream/dev...HEAD`

# Changelog Entry

### Fixed

- Raw JSON provider errors in streaming chats are now retained in the chat history.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
