### PR TITLE
fix(oauth): refresh when id_token JWT is near expiry

### DIFF
--- a/backend/open_webui/test/test_oauth_token.py
+++ b/backend/open_webui/test/test_oauth_token.py
@@ -1,0 +1,62 @@
+import base64
+import datetime as dt
+import importlib.util
+import json
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+module_path = Path(__file__).parents[1] / 'utils' / 'oauth_token.py'
+spec = importlib.util.spec_from_file_location('oauth_token', module_path)
+oauth_token = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(oauth_token)
+
+_get_id_token_expiry = oauth_token._get_id_token_expiry
+_is_oauth_token_refresh_needed = oauth_token._is_oauth_token_refresh_needed
+
+
+def _make_jwt(payload: dict) -> str:
+    def encode(value: dict) -> str:
+        data = json.dumps(value, separators=(',', ':')).encode()
+        return base64.urlsafe_b64encode(data).rstrip(b'=').decode()
+
+    return f'{encode({"alg": "none"})}.{encode(payload)}.'
+
+
+class TestOAuthTokenRefresh(unittest.TestCase):
+    def test_id_token_near_expiry_requires_refresh(self):
+        session = SimpleNamespace(
+            expires_at=(dt.datetime.now() + dt.timedelta(hours=1)).timestamp(),
+            token={'id_token': _make_jwt({'exp': int((dt.datetime.now() + dt.timedelta(minutes=1)).timestamp())})},
+        )
+
+        self.assertTrue(_is_oauth_token_refresh_needed(session))
+
+    def test_valid_id_token_does_not_require_refresh(self):
+        expiry = int((dt.datetime.now() + dt.timedelta(hours=1)).timestamp())
+        session = SimpleNamespace(
+            expires_at=(dt.datetime.now() + dt.timedelta(hours=1)).timestamp(),
+            token={'id_token': _make_jwt({'exp': expiry})},
+        )
+
+        self.assertEqual(_get_id_token_expiry(session.token), expiry)
+        self.assertFalse(_is_oauth_token_refresh_needed(session))
+
+    def test_missing_or_malformed_id_token_keeps_access_token_behavior(self):
+        access_expiry = (dt.datetime.now() + dt.timedelta(hours=1)).timestamp()
+
+        for token in ({}, {'id_token': 'not-a-jwt'}, {'id_token': _make_jwt({})}):
+            with self.subTest(token=token):
+                session = SimpleNamespace(expires_at=access_expiry, token=token)
+                self.assertIsNone(_get_id_token_expiry(token))
+                self.assertFalse(_is_oauth_token_refresh_needed(session))
+
+        session = SimpleNamespace(
+            expires_at=(dt.datetime.now() + dt.timedelta(minutes=1)).timestamp(),
+            token={'id_token': 'not-a-jwt'},
+        )
+        self.assertTrue(_is_oauth_token_refresh_needed(session))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -10,7 +10,7 @@ import time
 import urllib
 import uuid
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta
+from datetime import datetime
 from types import SimpleNamespace
 from typing import Literal, Optional
 
@@ -86,6 +86,7 @@ from open_webui.retrieval.web.utils import validate_url
 from open_webui.utils.auth import create_token, get_password_hash
 from open_webui.utils.groups import apply_default_group_assignment
 from open_webui.utils.misc import parse_duration
+from open_webui.utils.oauth_token import _is_oauth_token_refresh_needed
 from open_webui.utils.validate import validate_profile_image_url
 from starlette.responses import RedirectResponse
 
@@ -990,11 +991,7 @@ class OAuthClientManager:
                 log.warning(f'No OAuth session found for user {user_id}, client_id {client_id}')
                 return None
 
-            if (
-                force_refresh
-                or session.expires_at is None
-                or datetime.now() + timedelta(minutes=5) >= datetime.fromtimestamp(session.expires_at)
-            ):
+            if _is_oauth_token_refresh_needed(session, force_refresh):
                 log.debug(f'Token refresh needed for user {user_id}, client_id {session.provider}')
                 refreshed_token = await self._refresh_token(session)
                 if refreshed_token:
@@ -1268,11 +1265,7 @@ class OAuthManager:
                 )
                 return None
 
-            if (
-                force_refresh
-                or session.expires_at is None
-                or datetime.now() + timedelta(minutes=5) >= datetime.fromtimestamp(session.expires_at)
-            ):
+            if _is_oauth_token_refresh_needed(session, force_refresh):
                 log.debug(f'Token refresh needed for user {user_id}, provider {session.provider}')
                 refreshed_token = await self._refresh_token(session)
                 if refreshed_token:

--- a/backend/open_webui/utils/oauth_token.py
+++ b/backend/open_webui/utils/oauth_token.py
@@ -1,0 +1,31 @@
+import datetime as dt
+import logging
+
+import jwt as pyjwt
+
+log = logging.getLogger(__name__)
+
+
+def _get_id_token_expiry(token: dict | None) -> int | float | None:
+    if not isinstance(token, dict) or not token.get('id_token'):
+        return None
+
+    try:
+        claims = pyjwt.decode(token['id_token'], options={'verify_signature': False})
+        expiry = claims.get('exp')
+        if isinstance(expiry, bool) or not isinstance(expiry, (int, float)):
+            return None
+        return expiry
+    except Exception as e:
+        log.debug(f'Unable to decode OAuth id_token expiry: {e}')
+        return None
+
+
+def _is_oauth_token_refresh_needed(session, force_refresh: bool = False) -> bool:
+    refresh_cutoff = dt.datetime.now() + dt.timedelta(minutes=5)
+
+    if force_refresh or session.expires_at is None or refresh_cutoff >= dt.datetime.fromtimestamp(session.expires_at):
+        return True
+
+    id_token_expiry = _get_id_token_expiry(session.token)
+    return id_token_expiry is not None and refresh_cutoff.timestamp() >= id_token_expiry


### PR DESCRIPTION
## Summary

OAuth token refresh only checked `session.expires_at` (access token lifetime). Providers like Microsoft Entra ID often issue an `id_token` that expires earlier. Pipes and tools that read `__oauth_token__["id_token"]` could receive an expired JWT while the access token was still considered valid.

## Changes

- Add a small helper that reads numeric `exp` from the session `id_token` via unverified JWT decode (same approach already used for back-channel logout).
- Share one refresh gate used by both `OAuthClientManager.get_oauth_token` and `OAuthManager.get_oauth_token`.
- Trigger refresh when the access token is near expiry **or** the `id_token` is within the existing 5-minute window.
- Leave access-token-only behavior unchanged when `id_token` is missing or unparseable.
- Add unit coverage for near-expiry, still-valid, and malformed/missing `id_token` cases.

Fixes #27066

## Verification

```bash
uv run --no-project --with 'PyJWT==2.13.0' \
  python backend/open_webui/test/test_oauth_token.py -v
```

All 3 tests passed locally.

## Backwards compatibility

No public API changes. Sessions without an `id_token` (or without a numeric `exp` claim) keep the previous access-token refresh behavior.
