### PR TITLE
fix(headers): expand lowercase custom header template placeholders

### DIFF
--- a/backend/open_webui/utils/headers.py
+++ b/backend/open_webui/utils/headers.py
@@ -95,6 +95,7 @@ def get_custom_headers(custom_headers: dict, user=None, metadata: dict = None, r
         '{{USER_ROLE}}': (user.role if user else '') or '',
         '{{USER_AGENT}}': user_agent,
     }
+    template_vars.update({token.lower(): value for token, value in template_vars.items()})
 
     parsed_headers = {}
     for key, value in custom_headers.items():

--- a/backend/tests/test_utils_headers.py
+++ b/backend/tests/test_utils_headers.py
@@ -1,0 +1,39 @@
+from open_webui.utils.headers import get_custom_headers
+
+
+def test_get_custom_headers_expands_lowercase_and_uppercase_chat_id():
+    headers = {
+        'X-Lowercase': '{{chat_id}}',
+        'X-Uppercase': '{{CHAT_ID}}',
+    }
+
+    assert get_custom_headers(headers, metadata={'chat_id': 'chat-123'}) == {
+        'X-Lowercase': 'chat-123',
+        'X-Uppercase': 'chat-123',
+    }
+
+
+def test_get_custom_headers_preserves_static_values_and_coerces_non_strings():
+    headers = {
+        'X-Mixed': 'chat={{chat_id}}; static=value',
+        'X-Static': 'unchanged',
+        'X-Number': 42,
+    }
+
+    assert get_custom_headers(headers, metadata={'chat_id': 'chat-123'}) == {
+        'X-Mixed': 'chat=chat-123; static=value',
+        'X-Static': 'unchanged',
+        'X-Number': '42',
+    }
+
+
+def test_get_custom_headers_uses_empty_string_for_missing_known_values():
+    assert get_custom_headers({'X-Chat': 'before-{{chat_id}}-after'}) == {
+        'X-Chat': 'before--after'
+    }
+
+
+def test_get_custom_headers_preserves_unknown_tokens():
+    assert get_custom_headers({'X-Unknown': '{{unknown}}'}) == {
+        'X-Unknown': '{{unknown}}'
+    }


### PR DESCRIPTION
<!--
CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE)
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** `Closes #26989`
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following Keep a Changelog format is included at the bottom.
- [x] **Documentation:** No docs repo change required for this small backend compatibility fix.
- [x] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Unit coverage for lowercase and uppercase placeholders; import-style local verification of `get_custom_headers`.
- [x] **No Unchecked AI Code:** Changes reviewed for scope and correctness.
- [x] **Self-Review:** Self-review performed.
- [x] **Architecture:** No new settings; only expands existing header template tokens to accept lowercase forms used by users.
- [x] **Git Hygiene:** Single logical change on `dev`.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

Custom connection headers only expanded uppercase template tokens such as `{{CHAT_ID}}`. Users commonly configure lowercase forms such as `{{chat_id}}` (as in the original header-template design), so those values were sent upstream literally. This change accepts both casings for every existing template key.

### Added

- Unit tests for lowercase and uppercase custom header template expansion

### Changed

- None

### Deprecated

- None

### Removed

- None

### Fixed

- Expand lowercase placeholders (`{{chat_id}}`, `{{user_id}}`, etc.) in custom connection headers while keeping uppercase forms working

### Security

- None

### Breaking Changes

- None

### Additional Information

- Relates to issue #26989
- Keeps the existing variable set; only adds case-compatible aliases via lowercasing known tokens

### Screenshots or Videos

- N/A

### Contributor License Agreement

<!--
DO NOT DELETE THE TEXT BELOW
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

