### PR TITLE
fix(retrieval): respect admin UI web loader engine and credential settings

### DIFF
--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -108,6 +108,20 @@ LOADER_CONFIG_KEYS = {
     'MINERU_API_TIMEOUT': 'rag.mineru_api_timeout',
     'MINERU_PARAMS': 'rag.mineru_params',
     'MINERU_FILE_EXTENSIONS': 'rag.mineru_file_extensions',
+    'web_loader_engine': 'web.loader.engine',
+    'web_loader_timeout': 'web.loader.timeout',
+    'playwright_timeout': 'web.loader.playwright_timeout',
+    'playwright_ws_url': 'web.loader.playwright_ws_url',
+    'firecrawl_api_key': 'web.loader.firecrawl_api_key',
+    'firecrawl_api_url': 'web.loader.firecrawl_api_url',
+    'firecrawl_timeout': 'web.loader.firecrawl_timeout',
+    'tavily_api_key': 'web.search.tavily_api_key',
+    'tavily_extract_depth': 'web.search.tavily_extract_depth',
+    'microsoft_web_iq_api_base_url': 'web.search.microsoft_web_iq_api_base_url',
+    'microsoft_web_iq_api_key': 'web.search.microsoft_web_iq_api_key',
+    'microsoft_web_iq_language': 'web.search.microsoft_web_iq_language',
+    'external_web_loader_url': 'web.loader.external_web_loader_url',
+    'external_web_loader_api_key': 'web.loader.external_web_loader_api_key',
 }
 
 
@@ -128,6 +142,20 @@ def get_loader(request, url: str, config: dict):
         verify_ssl=config.get('web_loader_ssl_verification'),
         requests_per_second=config.get('web_loader_concurrent_requests'),
         trust_env=config.get('web_search_trust_env'),
+        engine=config.get('web_loader_engine'),
+        timeout=config.get('web_loader_timeout'),
+        playwright_timeout=config.get('playwright_timeout'),
+        playwright_ws_url=config.get('playwright_ws_url'),
+        firecrawl_api_key=config.get('firecrawl_api_key'),
+        firecrawl_api_url=config.get('firecrawl_api_url'),
+        firecrawl_timeout=config.get('firecrawl_timeout'),
+        tavily_api_key=config.get('tavily_api_key'),
+        tavily_extract_depth=config.get('tavily_extract_depth'),
+        microsoft_web_iq_api_base_url=config.get('microsoft_web_iq_api_base_url'),
+        microsoft_web_iq_api_key=config.get('microsoft_web_iq_api_key'),
+        microsoft_web_iq_language=config.get('microsoft_web_iq_language'),
+        external_url=config.get('external_web_loader_url'),
+        external_api_key=config.get('external_web_loader_api_key'),
     )
 
 
@@ -1340,9 +1368,7 @@ async def get_sources_from_items(
         folder = await Folders.get_folder_by_id(folder_id)
         if folder and (user.role == 'admin' or await has_folder_access(user.id, folder, 'read', db=None)):
             files = (folder.data or {}).get('files', [])
-            folder_items.update(
-                (entry.get('type'), entry.get('id')) for entry in files if isinstance(entry, dict)
-            )
+            folder_items.update((entry.get('type'), entry.get('id')) for entry in files if isinstance(entry, dict))
             items.extend(files)
 
     for item in items:

--- a/backend/open_webui/retrieval/web/firecrawl.py
+++ b/backend/open_webui/retrieval/web/firecrawl.py
@@ -28,10 +28,12 @@ def build_firecrawl_url(base_url: str | None, path: str) -> str:
 
 
 def build_firecrawl_headers(api_key: str | None) -> dict[str, str]:
-    return {
+    headers = {
         'Content-Type': 'application/json',
-        'Authorization': f'Bearer {api_key or ""}',
     }
+    if api_key:
+        headers['Authorization'] = f'Bearer {api_key}'
+    return headers
 
 
 def get_firecrawl_timeout_seconds(timeout: Any) -> float | None:

--- a/backend/open_webui/retrieval/web/test_web_loader.py
+++ b/backend/open_webui/retrieval/web/test_web_loader.py
@@ -1,0 +1,172 @@
+import unittest
+from unittest.mock import patch
+
+from open_webui.retrieval.utils import get_loader
+from open_webui.retrieval.web.firecrawl import build_firecrawl_headers
+from open_webui.retrieval.web.utils import (
+    SafeWebBaseLoader,
+    get_web_loader,
+)
+
+
+class TestWebLoaderConfig(unittest.TestCase):
+    def test_build_firecrawl_headers(self):
+        # Test headers with api_key
+        headers_with_key = build_firecrawl_headers('test-key')
+        self.assertEqual(headers_with_key.get('Authorization'), 'Bearer test-key')
+        self.assertEqual(headers_with_key.get('Content-Type'), 'application/json')
+
+        # Test headers with empty api_key (should not contain Authorization)
+        headers_empty_key = build_firecrawl_headers('')
+        self.assertNotIn('Authorization', headers_empty_key)
+        self.assertEqual(headers_empty_key.get('Content-Type'), 'application/json')
+
+        # Test headers with None api_key (should not contain Authorization)
+        headers_none_key = build_firecrawl_headers(None)
+        self.assertNotIn('Authorization', headers_none_key)
+        self.assertEqual(headers_none_key.get('Content-Type'), 'application/json')
+
+    @patch('open_webui.retrieval.web.utils.SafePlaywrightURLLoader')
+    @patch('open_webui.retrieval.web.utils.SafeFireCrawlLoader')
+    @patch('open_webui.retrieval.web.utils.SafeTavilyLoader')
+    @patch('open_webui.retrieval.web.utils.SafeMicrosoftWebIQLoader')
+    @patch('open_webui.retrieval.web.utils.ExternalWebLoader')
+    @patch('open_webui.retrieval.web.utils.safe_validate_urls')
+    def test_get_web_loader_fallback_and_custom(self, mock_validate, mock_ext, mock_ms, mock_tv, mock_fc, mock_pw):
+        mock_validate.return_value = ['https://example.com']
+
+        # Test fallback to constants (safe_web by default)
+        loader = get_web_loader('https://example.com')
+        self.assertIsInstance(loader, SafeWebBaseLoader)
+
+        # Test custom engine playwright
+        get_web_loader(
+            'https://example.com',
+            engine='playwright',
+            playwright_timeout=5000,
+            playwright_ws_url='ws://localhost',
+        )
+        mock_pw.assert_called_once_with(
+            web_paths=['https://example.com'],
+            verify_ssl=True,
+            requests_per_second=2,
+            continue_on_failure=True,
+            trust_env=False,
+            playwright_timeout=5000,
+            playwright_ws_url='ws://localhost',
+        )
+
+        # Test custom engine firecrawl
+        get_web_loader(
+            'https://example.com',
+            engine='firecrawl',
+            firecrawl_api_key='fc-key',
+            firecrawl_api_url='http://fc-api',
+            firecrawl_timeout=20,
+        )
+        mock_fc.assert_called_once_with(
+            web_paths=['https://example.com'],
+            verify_ssl=True,
+            requests_per_second=2,
+            continue_on_failure=True,
+            trust_env=False,
+            api_key='fc-key',
+            api_url='http://fc-api',
+            timeout=20,
+        )
+
+        # Test custom engine tavily
+        get_web_loader('https://example.com', engine='tavily', tavily_api_key='tv-key')
+        mock_tv.assert_called_once_with(
+            web_paths=['https://example.com'],
+            verify_ssl=True,
+            requests_per_second=2,
+            continue_on_failure=True,
+            trust_env=False,
+            api_key='tv-key',
+            extract_depth='basic',
+        )
+
+        # Test custom engine microsoft_web_iq
+        get_web_loader(
+            'https://example.com',
+            engine='microsoft_web_iq',
+            microsoft_web_iq_api_base_url='http://ms-api',
+            microsoft_web_iq_api_key='ms-key',
+            microsoft_web_iq_language='fr',
+            timeout='15',
+        )
+        mock_ms.assert_called_once_with(
+            web_paths=['https://example.com'],
+            verify_ssl=True,
+            requests_per_second=2,
+            continue_on_failure=True,
+            trust_env=False,
+            api_base_url='http://ms-api',
+            api_key='ms-key',
+            language='fr',
+            timeout=15,
+        )
+
+        # Test custom engine external
+        get_web_loader(
+            'https://example.com',
+            engine='external',
+            external_url='http://ext-api',
+            external_api_key='ext-key',
+        )
+        mock_ext.assert_called_once_with(
+            web_paths=['https://example.com'],
+            verify_ssl=True,
+            requests_per_second=2,
+            continue_on_failure=True,
+            trust_env=False,
+            external_url='http://ext-api',
+            external_api_key='ext-key',
+        )
+
+    @patch('open_webui.retrieval.utils.get_web_loader')
+    def test_get_loader_config_propagation(self, mock_get_web_loader):
+        # Mock config dict
+        mock_config = {
+            'web_loader_ssl_verification': True,
+            'web_loader_concurrent_requests': 5,
+            'web_search_trust_env': True,
+            'web_loader_engine': 'firecrawl',
+            'web_loader_timeout': '30',
+            'playwright_timeout': 10000,
+            'playwright_ws_url': 'ws://custom',
+            'firecrawl_api_key': 'test-fc-key',
+            'firecrawl_api_url': 'http://test-fc-base',
+            'firecrawl_timeout': 20,
+            'tavily_api_key': 'test-tv-key',
+            'tavily_extract_depth': 'advanced',
+            'microsoft_web_iq_api_base_url': 'http://test-ms-base',
+            'microsoft_web_iq_api_key': 'test-ms-key',
+            'microsoft_web_iq_language': 'fr',
+            'external_web_loader_url': 'http://test-ext-url',
+            'external_web_loader_api_key': 'test-ext-key',
+        }
+
+        get_loader(None, 'https://example.com', mock_config)
+
+        mock_get_web_loader.assert_called_once_with(
+            'https://example.com',
+            verify_ssl=True,
+            requests_per_second=5,
+            trust_env=True,
+            engine='firecrawl',
+            timeout='30',
+            playwright_timeout=10000,
+            playwright_ws_url='ws://custom',
+            firecrawl_api_key='test-fc-key',
+            firecrawl_api_url='http://test-fc-base',
+            firecrawl_timeout=20,
+            tavily_api_key='test-tv-key',
+            tavily_extract_depth='advanced',
+            microsoft_web_iq_api_base_url='http://test-ms-base',
+            microsoft_web_iq_api_key='test-ms-key',
+            microsoft_web_iq_language='fr',
+            external_url='http://test-ext-url',
+            external_api_key='test-ext-key',
+        )

--- a/backend/open_webui/retrieval/web/utils.py
+++ b/backend/open_webui/retrieval/web/utils.py
@@ -838,6 +838,20 @@ def get_web_loader(
     verify_ssl: bool = True,
     requests_per_second: int = 2,
     trust_env: bool = False,
+    engine: str = None,
+    timeout: str = None,
+    playwright_timeout: int = None,
+    playwright_ws_url: str = None,
+    firecrawl_api_key: str = None,
+    firecrawl_api_url: str = None,
+    firecrawl_timeout: int = None,
+    tavily_api_key: str = None,
+    tavily_extract_depth: str = None,
+    microsoft_web_iq_api_base_url: str = None,
+    microsoft_web_iq_api_key: str = None,
+    microsoft_web_iq_language: str = None,
+    external_url: str = None,
+    external_api_key: str = None,
 ):
     # Check if the URLs are valid
     safe_urls = safe_validate_urls([urls] if isinstance(urls, str) else urls)
@@ -854,13 +868,37 @@ def get_web_loader(
         'trust_env': trust_env,
     }
 
-    if WEB_LOADER_ENGINE == '' or WEB_LOADER_ENGINE == 'safe_web':
+    # Resolve effective values: caller overrides take precedence over env defaults
+    web_loader_engine = engine if engine is not None else WEB_LOADER_ENGINE
+    web_loader_timeout = timeout if timeout is not None else WEB_LOADER_TIMEOUT
+    playwright_timeout_val = playwright_timeout if playwright_timeout is not None else PLAYWRIGHT_TIMEOUT
+    playwright_ws_url_val = playwright_ws_url if playwright_ws_url is not None else PLAYWRIGHT_WS_URL
+    firecrawl_api_key_val = firecrawl_api_key if firecrawl_api_key is not None else FIRECRAWL_API_KEY
+    firecrawl_api_url_val = firecrawl_api_url if firecrawl_api_url is not None else FIRECRAWL_API_BASE_URL
+    firecrawl_timeout_val = firecrawl_timeout if firecrawl_timeout is not None else FIRECRAWL_TIMEOUT
+    tavily_api_key_val = tavily_api_key if tavily_api_key is not None else TAVILY_API_KEY
+    tavily_extract_depth_val = tavily_extract_depth if tavily_extract_depth is not None else TAVILY_EXTRACT_DEPTH
+    microsoft_web_iq_api_base_url_val = (
+        microsoft_web_iq_api_base_url if microsoft_web_iq_api_base_url is not None else MICROSOFT_WEB_IQ_API_BASE_URL
+    )
+    microsoft_web_iq_api_key_val = (
+        microsoft_web_iq_api_key if microsoft_web_iq_api_key is not None else MICROSOFT_WEB_IQ_API_KEY
+    )
+    microsoft_web_iq_language_val = (
+        microsoft_web_iq_language if microsoft_web_iq_language is not None else MICROSOFT_WEB_IQ_LANGUAGE
+    )
+    external_url_val = external_url if external_url is not None else EXTERNAL_WEB_LOADER_URL
+    external_api_key_val = external_api_key if external_api_key is not None else EXTERNAL_WEB_LOADER_API_KEY
+
+    WebLoaderClass = None
+
+    if web_loader_engine == '' or web_loader_engine == 'safe_web':
         WebLoaderClass = SafeWebBaseLoader
 
         request_kwargs = {}
-        if WEB_LOADER_TIMEOUT:
+        if web_loader_timeout:
             try:
-                timeout_value = float(WEB_LOADER_TIMEOUT)
+                timeout_value = float(web_loader_timeout)
             except ValueError:
                 timeout_value = None
 
@@ -870,42 +908,42 @@ def get_web_loader(
         if request_kwargs:
             web_loader_args['requests_kwargs'] = request_kwargs
 
-    if WEB_LOADER_ENGINE == 'playwright':
+    if web_loader_engine == 'playwright':
         WebLoaderClass = SafePlaywrightURLLoader
-        web_loader_args['playwright_timeout'] = PLAYWRIGHT_TIMEOUT
-        if PLAYWRIGHT_WS_URL:
-            web_loader_args['playwright_ws_url'] = PLAYWRIGHT_WS_URL
+        web_loader_args['playwright_timeout'] = playwright_timeout_val
+        if playwright_ws_url_val:
+            web_loader_args['playwright_ws_url'] = playwright_ws_url_val
 
-    if WEB_LOADER_ENGINE == 'firecrawl':
+    if web_loader_engine == 'firecrawl':
         WebLoaderClass = SafeFireCrawlLoader
-        web_loader_args['api_key'] = FIRECRAWL_API_KEY
-        web_loader_args['api_url'] = FIRECRAWL_API_BASE_URL
-        if FIRECRAWL_TIMEOUT:
+        web_loader_args['api_key'] = firecrawl_api_key_val
+        web_loader_args['api_url'] = firecrawl_api_url_val
+        if firecrawl_timeout_val:
             try:
-                web_loader_args['timeout'] = int(FIRECRAWL_TIMEOUT)
+                web_loader_args['timeout'] = int(firecrawl_timeout_val)
             except ValueError:
                 pass
 
-    if WEB_LOADER_ENGINE == 'tavily':
+    if web_loader_engine == 'tavily':
         WebLoaderClass = SafeTavilyLoader
-        web_loader_args['api_key'] = TAVILY_API_KEY
-        web_loader_args['extract_depth'] = TAVILY_EXTRACT_DEPTH
+        web_loader_args['api_key'] = tavily_api_key_val
+        web_loader_args['extract_depth'] = tavily_extract_depth_val
 
-    if WEB_LOADER_ENGINE == 'microsoft_web_iq':
+    if web_loader_engine == 'microsoft_web_iq':
         WebLoaderClass = SafeMicrosoftWebIQLoader
-        web_loader_args['api_base_url'] = MICROSOFT_WEB_IQ_API_BASE_URL
-        web_loader_args['api_key'] = MICROSOFT_WEB_IQ_API_KEY
-        web_loader_args['language'] = MICROSOFT_WEB_IQ_LANGUAGE
-        if WEB_LOADER_TIMEOUT:
+        web_loader_args['api_base_url'] = microsoft_web_iq_api_base_url_val
+        web_loader_args['api_key'] = microsoft_web_iq_api_key_val
+        web_loader_args['language'] = microsoft_web_iq_language_val
+        if web_loader_timeout:
             try:
-                web_loader_args['timeout'] = int(WEB_LOADER_TIMEOUT)
+                web_loader_args['timeout'] = int(web_loader_timeout)
             except ValueError:
                 pass
 
-    if WEB_LOADER_ENGINE == 'external':
+    if web_loader_engine == 'external':
         WebLoaderClass = ExternalWebLoader
-        web_loader_args['external_url'] = EXTERNAL_WEB_LOADER_URL
-        web_loader_args['external_api_key'] = EXTERNAL_WEB_LOADER_API_KEY
+        web_loader_args['external_url'] = external_url_val
+        web_loader_args['external_api_key'] = external_api_key_val
 
     if WebLoaderClass:
         web_loader = WebLoaderClass(**web_loader_args)
@@ -919,6 +957,6 @@ def get_web_loader(
         return web_loader
     else:
         raise ValueError(
-            f'Invalid WEB_LOADER_ENGINE: {WEB_LOADER_ENGINE}. '
+            f'Invalid WEB_LOADER_ENGINE: {web_loader_engine}. '
             "Please set it to 'safe_web', 'playwright', 'firecrawl', 'tavily', 'external', or 'microsoft_web_iq'."
         )

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -2609,6 +2609,20 @@ async def process_web_search(request: Request, form_data: SearchForm, user=Depen
                 verify_ssl=config.ENABLE_WEB_LOADER_SSL_VERIFICATION,
                 requests_per_second=config.WEB_LOADER_CONCURRENT_REQUESTS,
                 trust_env=config.WEB_SEARCH_TRUST_ENV,
+                engine=getattr(config, 'WEB_LOADER_ENGINE', None),
+                timeout=getattr(config, 'WEB_LOADER_TIMEOUT', None),
+                playwright_timeout=getattr(config, 'PLAYWRIGHT_TIMEOUT', None),
+                playwright_ws_url=getattr(config, 'PLAYWRIGHT_WS_URL', None),
+                firecrawl_api_key=getattr(config, 'FIRECRAWL_API_KEY', None),
+                firecrawl_api_url=getattr(config, 'FIRECRAWL_API_BASE_URL', None),
+                firecrawl_timeout=getattr(config, 'FIRECRAWL_TIMEOUT', None),
+                tavily_api_key=getattr(config, 'TAVILY_API_KEY', None),
+                tavily_extract_depth=getattr(config, 'TAVILY_EXTRACT_DEPTH', None),
+                microsoft_web_iq_api_base_url=getattr(config, 'MICROSOFT_WEB_IQ_API_BASE_URL', None),
+                microsoft_web_iq_api_key=getattr(config, 'MICROSOFT_WEB_IQ_API_KEY', None),
+                microsoft_web_iq_language=getattr(config, 'MICROSOFT_WEB_IQ_LANGUAGE', None),
+                external_url=getattr(config, 'EXTERNAL_WEB_LOADER_URL', None),
+                external_api_key=getattr(config, 'EXTERNAL_WEB_LOADER_API_KEY', None),
             )
             docs = await loader.aload()
 


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

Before submitting, make sure you've checked the following:

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — Closes #27061
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [x] **Documentation:** Relevant documentation has been added or updated.
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses the following prefix: `fix`

# Changelog Entry

### Description

This pull request resolves issue #27061, where the web loader configuration settings saved in the admin UI (stored in the database/app config) were ignored at runtime.

### Added

- A comprehensive unit test suite in `backend/open_webui/retrieval/web/test_web_loader.py` covering fallback engine parameters, custom engines, and header configurations.

### Changed

- Updated `get_web_loader` in `backend/open_webui/retrieval/web/utils.py` to accept dynamic parameter overrides.
- Updated `get_loader` in `backend/open_webui/retrieval/utils.py` to load all web loader settings into `LOADER_CONFIG_KEYS` and propagate them dynamically.
- Updated `process_web_search` in `backend/open_webui/routers/retrieval.py` to forward retrieved settings from the dynamic database `RetrievalConfig` to the web loader dispatcher.
- Modified `build_firecrawl_headers` in `backend/open_webui/retrieval/web/firecrawl.py` to skip setting the `Authorization` header when `api_key` is empty/None to prevent self-hosted instances from failing with protocol errors.

### Fixed

- Resolved the web loader configuration settings regression.
- Fixed `LocalProtocolError` when using Firecrawl without an API key.

---

### Additional Information

Closes #27061

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
