### PR TITLE
feat: add time to file manager for easier file classification

### DIFF
--- a/src/lib/components/layout/FilesModal.svelte
+++ b/src/lib/components/layout/FilesModal.svelte
@@ -350,7 +350,7 @@
 
 									<div class="basis-2/5 flex items-center justify-end">
 										<div class="hidden sm:flex text-gray-500 dark:text-gray-400 text-xs">
-                    {dayjs(file.created_at * 1000).format('MMM D, YYYY h:mm A')}
+										{dayjs(file.created_at * 1000).format('MMM D, YYYY h:mm A')}
 										</div>
 
 										<div class="flex justify-end pl-2.5 text-gray-600 dark:text-gray-300">

--- a/src/lib/components/layout/FilesModal.svelte
+++ b/src/lib/components/layout/FilesModal.svelte
@@ -350,7 +350,7 @@
 
 									<div class="basis-2/5 flex items-center justify-end">
 										<div class="hidden sm:flex text-gray-500 dark:text-gray-400 text-xs">
-											{dayjs(file.created_at * 1000).format('MMM D, YYYY')}
+                    {dayjs(file.created_at * 1000).format('MMM D, YYYY h:mm A')}
 										</div>
 
 										<div class="flex justify-end pl-2.5 text-gray-600 dark:text-gray-300">


### PR DESCRIPTION
# Changelog Entry

- add time to file management dialog

### Description

This adds a time to the file manager dialog instead of just listing date.  This turns out to be very useful when you have many images to process since you can look at when the image was created instead of just looking at the date.


This is linked to #27086 

### Added

Add time to the file dialog


### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [ X] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
