### PR TITLE
fix: handle null user_id in event definitions gracefully (closes #26843)

### DIFF
--- a/backend/open_webui/events.py
+++ b/backend/open_webui/events.py
@@ -38,6 +38,9 @@ class EventDefinition(BaseModel):
             object.__setattr__(self, 'message', title)
         return self
 
+    # Add a field for user_id with default 'unknown' to prevent null crashes
+    user_id: str = 'unknown'
+
 
 class EventDefinitions(BaseModel):
     model_config = ConfigDict(frozen=True)


### PR DESCRIPTION
## What
If a function has a null user_id, the startup crashes because event handling code assumes user_id is always present.

## Fix
Added a default user_id field to EventDefinition to provide a fallback value 'unknown' instead of None, preventing crashes when user_id is missing or null.

Closes #26843