### PR TITLE
feat/PERF: add WEBSOCKET_PER_MESSAGE_DEFLATE env var

### DIFF
--- a/backend/open_webui/__init__.py
+++ b/backend/open_webui/__init__.py
@@ -72,6 +72,7 @@ def serve(
 
     import open_webui.main  # noqa: F401
     from open_webui.env import UVICORN_WORKERS  # Import the workers setting
+    from open_webui.env import WEBSOCKET_PER_MESSAGE_DEFLATE
 
     # On Windows, uvicorn's default loop factory hardcodes ProactorEventLoop,
     # which is incompatible with psycopg v3 async.  Setting loop='none' lets
@@ -85,6 +86,7 @@ def serve(
         forwarded_allow_ips='*',
         workers=UVICORN_WORKERS,
         loop=loop,
+        ws_per_message_deflate=WEBSOCKET_PER_MESSAGE_DEFLATE,
     )
 
 
@@ -94,12 +96,15 @@ def dev(
     port: int = 8080,
     reload: bool = True,
 ):
+    from open_webui.env import WEBSOCKET_PER_MESSAGE_DEFLATE
+
     uvicorn.run(
         'open_webui.main:app',
         host=host,
         port=port,
         reload=reload,
         forwarded_allow_ips='*',
+        ws_per_message_deflate=WEBSOCKET_PER_MESSAGE_DEFLATE,
     )
 
 

--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -487,6 +487,11 @@ try:
 except ValueError:
     WEBSOCKET_SERVER_PING_INTERVAL = 25
 
+# Controls uvicorn's WebSocket per-message-deflate (RFC 7692). Compressing
+# every outgoing frame is a per-event CPU cost on the event loop; deployments
+# that stream heavily behind a reverse proxy may want to disable it.
+WEBSOCKET_PER_MESSAGE_DEFLATE = os.getenv('WEBSOCKET_PER_MESSAGE_DEFLATE', 'True').lower() == 'true'
+
 WEBSOCKET_EVENT_CALLER_TIMEOUT = os.getenv('WEBSOCKET_EVENT_CALLER_TIMEOUT', '')
 
 if WEBSOCKET_EVENT_CALLER_TIMEOUT == '':

--- a/backend/start.sh
+++ b/backend/start.sh
@@ -99,6 +99,12 @@ fi
 PYTHON_CMD=$(command -v python3 || command -v python)
 UVICORN_WORKERS="${UVICORN_WORKERS:-1}"
 
+# WebSocket per-message-deflate (RFC 7692): zlib-compresses every outgoing
+# frame, which is a per-event CPU cost on the event loop. Deployments that
+# stream heavily behind a reverse proxy can set
+# WEBSOCKET_PER_MESSAGE_DEFLATE=false to disable it.
+WEBSOCKET_PER_MESSAGE_DEFLATE="${WEBSOCKET_PER_MESSAGE_DEFLATE:-true}"
+
 if [[ "$#" -gt 0 ]]; then
   ARGS=("$@")
 else
@@ -110,4 +116,5 @@ exec env WEBUI_SECRET_KEY="${WEBUI_SECRET_KEY:-}" \
     --host "$HOST" \
     --port "$PORT" \
     --forwarded-allow-ips "${FORWARDED_ALLOW_IPS:-*}" \
+    --ws-per-message-deflate "$WEBSOCKET_PER_MESSAGE_DEFLATE" \
     "${ARGS[@]}"

--- a/backend/start_windows.bat
+++ b/backend/start_windows.bat
@@ -50,5 +50,6 @@ IF "%WEBUI_SECRET_KEY% %WEBUI_JWT_SECRET_KEY%" == " " (
 :: Execute uvicorn
 SET "WEBUI_SECRET_KEY=%WEBUI_SECRET_KEY%"
 IF "%UVICORN_WORKERS%"=="" SET UVICORN_WORKERS=1
-uvicorn open_webui.main:app --host "%HOST%" --port "%PORT%" --forwarded-allow-ips %FORWARDED_ALLOW_IPS% --workers %UVICORN_WORKERS% --ws auto
+IF "%WEBSOCKET_PER_MESSAGE_DEFLATE%"=="" SET WEBSOCKET_PER_MESSAGE_DEFLATE=true
+uvicorn open_webui.main:app --host "%HOST%" --port "%PORT%" --forwarded-allow-ips %FORWARDED_ALLOW_IPS% --workers %UVICORN_WORKERS% --ws auto --ws-per-message-deflate %WEBSOCKET_PER_MESSAGE_DEFLATE%
 :: For ssl user uvicorn open_webui.main:app --host "%HOST%" --port "%PORT%" --forwarded-allow-ips '*' --ssl-keyfile "key.pem" --ssl-certfile "cert.pem" --ws auto


### PR DESCRIPTION
Profiling 24 production workers showed ~14% of burst CPU spent in permessage_deflate.encode compressing outgoing socket.io frames. Streaming chat deltas re-send growing payloads every flush, so per-frame zlib is a per-token CPU cost with little bandwidth benefit behind a reverse proxy.

start.sh now passes --ws-per-message-deflate (default true) to uvicorn. Placed before passthrough args so an explicit flag in the container command still wins.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
