### PR TITLE
feat: add system_oauth auth type for RAG OpenAI embedding connection

### DIFF
--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -571,6 +571,14 @@ except (ValueError, TypeError):
 # When "True", falls back to AIOHTTP_CLIENT_SSL_CERT_FILE if set.
 AIOHTTP_CLIENT_SESSION_SSL = _parse_ssl_env(os.getenv('AIOHTTP_CLIENT_SESSION_SSL', 'True'))
 
+# Auth type for the RAG OpenAI-compatible embedding connection.
+# "bearer" (default): send RAG_OPENAI_API_KEY as a static Bearer token.
+# "system_oauth": send the acting user's SSO OAuth access token instead,
+# mirroring the `system_oauth` auth type of chat connections — for gateways
+# that only accept OAuth tokens. Falls back to the static key when the user
+# has no active OAuth session.
+RAG_OPENAI_API_AUTH_TYPE = os.getenv('RAG_OPENAI_API_AUTH_TYPE', 'bearer').strip().lower()
+
 # When False (default), outbound HTTP requests do not follow 3xx redirects.
 AIOHTTP_CLIENT_ALLOW_REDIRECTS = os.getenv('AIOHTTP_CLIENT_ALLOW_REDIRECTS', 'False').lower() == 'true'
 

--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -33,6 +33,7 @@ from open_webui.env import (
     ENABLE_FORWARD_USER_INFO_HEADERS,
     ENABLE_RETRIEVAL_UNSCOPED_COLLECTIONS,
     OFFLINE_MODE,
+    RAG_OPENAI_API_AUTH_TYPE,
 )
 from open_webui.models.access_grants import AccessGrants
 from open_webui.models.chats import Chats
@@ -1163,6 +1164,34 @@ def get_embedding_function(
         raise ValueError(f'Unknown embedding engine: {embedding_engine}')
 
 
+async def get_system_oauth_access_token(user: UserModel) -> Union[str, None]:
+    """Resolve the user's SSO OAuth access token for embedding requests.
+
+    Mirrors the `system_oauth` auth type of chat connections, but without a
+    request context: the most recently updated non-MCP OAuth session for the
+    user is looked up in the DB and refreshed by the OAuthManager if expired.
+    """
+    try:
+        # Lazy imports: main imports the retrieval router which imports this
+        # module, so a top-level import would be circular.
+        from open_webui.main import oauth_manager
+        from open_webui.models.oauth_sessions import OAuthSessions
+
+        sessions = await OAuthSessions.get_sessions_by_user_id(user.id)
+        sessions = sorted(
+            [s for s in sessions if not (s.provider or '').startswith('mcp:')],
+            key=lambda s: s.updated_at or 0,
+            reverse=True,
+        )
+        for session in sessions:
+            token = await oauth_manager.get_oauth_token(user.id, session.id)
+            if token and token.get('access_token'):
+                return token['access_token']
+    except Exception as e:
+        log.error(f'Error resolving system OAuth token for embeddings (user {user.id}): {e}')
+    return None
+
+
 async def generate_embeddings(
     engine: str,
     model: str,
@@ -1173,6 +1202,16 @@ async def generate_embeddings(
     url = kwargs.get('url', '')
     key = kwargs.get('key', '')
     user = kwargs.get('user')
+
+    if engine == 'openai' and RAG_OPENAI_API_AUTH_TYPE == 'system_oauth' and user is not None:
+        access_token = await get_system_oauth_access_token(user)
+        if access_token:
+            key = access_token
+        else:
+            log.warning(
+                f'RAG_OPENAI_API_AUTH_TYPE=system_oauth but no OAuth token available '
+                f'for user {user.id}; falling back to the static RAG_OPENAI_API_KEY'
+            )
 
     if prefix is not None and RAG_EMBEDDING_PREFIX_FIELD_NAME is None:
         if isinstance(text, list):


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Relates to #26976 (OAuth2 auth for external LLM/embedding/reranking connections — this PR covers the embedding engine with the existing `system_oauth` mechanism)
- [x] **Target branch:** targets `dev`
- [x] **Description:** provided below
- [x] **Changelog:** included below
- [ ] **Documentation:** happy to follow up with a docs PR for the new env var if this is accepted
- [x] **Dependencies:** no new dependencies
- [x] **Testing:** verified end-to-end (details below)
- [ ] **No Unchecked AI Code:** developed with Claude Code and verified by an automated e2e suite; final human review pass pending — will check once done
- [ ] **Self-Review:** pending final pass
- [x] **Architecture:** the new env var defaults to `bearer`, which is byte-for-byte stock behavior; no UI changes, no new persisted settings
- [x] **Git Hygiene:** single atomic commit, based on `dev`
- [x] **Title Prefix:** `feat`

## Description

Chat connections already support `auth_type: "system_oauth"` — forwarding the signed-in
user's SSO OAuth access token as the `Authorization: Bearer` header — so deployments behind
OAuth-authenticated LLM gateways work for chat/models.

The RAG **embedding** path, however, only ever sends the static `RAG_OPENAI_API_KEY`
(`retrieval/utils.py`, `agenerate_openai_batch_embeddings`); there is no auth option at all
(`routers/retrieval.py` `OpenAIConfigForm` is just `url` + `key`). Against an OAuth-only
gateway every embedding request gets **401**, so document uploads and RAG queries fail even
though chat works.

This PR adds a `RAG_OPENAI_API_AUTH_TYPE` environment variable:

| Value | Behavior |
|---|---|
| `bearer` (default) | Unchanged stock behavior — static key as Bearer token |
| `system_oauth` | Send the **acting user's** SSO OAuth access token as the Bearer token |

Implementation notes:

- Token resolution mirrors the chat-side `system_oauth`, but works **without a request
  context** (embeddings also run during background document processing): the user's most
  recently updated non-MCP OAuth session is read via `OAuthSessions`, and
  `OAuthManager.get_oauth_token()` transparently refreshes it when near expiry — the same
  refresh path the chat proxy uses.
- Every embedding call site already passes `user=` (file upload via `save_docs_to_vector_db`,
  query endpoints, chat-time retrieval in `utils/middleware.py`), so upload-time and
  query-time embeddings both authenticate as the acting user.
- Graceful fallback: if the user has no OAuth session (e.g. local password account), the
  static key is used and a warning is logged.
- Purely additive: +47 lines across `env.py` and `retrieval/utils.py`; no schema, API, or
  frontend changes.

## Testing

Automated end-to-end suite (run against this branch): a mock OpenAI-compatible gateway that
**only** accepts a specific OAuth token (static keys get 401, mimicking a corporate gateway),
a real server boot, a real signup, and a real Fernet-encrypted OAuth session seeded through
`OAuthSessions.create_session()`.

All 7 checks pass:

- `system_oauth`: `POST /api/v1/retrieval/process/text` → 200; `POST /api/v1/retrieval/query/doc` → 200; the gateway received `Bearer <oauth token>`; the static key was never sent.
- `bearer` (stock): same request fails; the gateway received the static key and returned 401 (reproduces the bug this fixes); the OAuth token was never sent — the flag fully gates the feature.

# Changelog Entry

### Description

- Allow the RAG OpenAI-compatible embedding connection to authenticate with the acting user's SSO OAuth access token, matching the `system_oauth` auth type already available on chat connections.

### Added

- `RAG_OPENAI_API_AUTH_TYPE` environment variable (`bearer` | `system_oauth`, default `bearer`) for the RAG OpenAI embedding engine.

### Changed

- None (default behavior is unchanged).

### Deprecated

- None

### Removed

- None

### Fixed

- 401 errors on document upload and RAG queries when the embedding endpoint sits behind an OAuth-authenticated gateway while chat connections use `system_oauth`.

### Security

- OAuth tokens are read through the existing encrypted `OAuthSessions` storage and are never logged.

### Breaking Changes

- None

---

### Additional Information

- Relates to #26976. That issue asks for OAuth2 **client-credentials** (machine-to-machine) auth for LLM/embedding/reranking connections; this PR covers the complementary user-token case for embeddings by reusing the `system_oauth` mechanism that chat connections already have. The two approaches compose: client credentials would still be the right answer for accounts without an SSO session.

### Screenshots or Videos

- N/A (backend only; e2e transcript summarized above)

<!--
Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [ ] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
