### PR TITLE
feat: add system_oauth auth type for RAG OpenAI embedding connection

### DIFF
--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -579,6 +579,13 @@ AIOHTTP_CLIENT_SESSION_SSL = _parse_ssl_env(os.getenv('AIOHTTP_CLIENT_SESSION_SS
 # has no active OAuth session.
 RAG_OPENAI_API_AUTH_TYPE = os.getenv('RAG_OPENAI_API_AUTH_TYPE', 'bearer').strip().lower()
 
+# Auth type for the external RAG reranker connection.
+# "bearer" (default): send RAG_EXTERNAL_RERANKER_API_KEY as a static Bearer token.
+# "system_oauth": send the acting user's SSO OAuth access token instead, same
+# semantics as the embedding connection above. Falls back to the static key
+# when the user has no active OAuth session.
+RAG_EXTERNAL_RERANKER_API_AUTH_TYPE = os.getenv('RAG_EXTERNAL_RERANKER_API_AUTH_TYPE', 'bearer').strip().lower()
+
 # When False (default), outbound HTTP requests do not follow 3xx redirects.
 AIOHTTP_CLIENT_ALLOW_REDIRECTS = os.getenv('AIOHTTP_CLIENT_ALLOW_REDIRECTS', 'False').lower() == 'true'
 

--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -571,6 +571,14 @@ except (ValueError, TypeError):
 # When "True", falls back to AIOHTTP_CLIENT_SSL_CERT_FILE if set.
 AIOHTTP_CLIENT_SESSION_SSL = _parse_ssl_env(os.getenv('AIOHTTP_CLIENT_SESSION_SSL', 'True'))
 
+# Auth type for the RAG OpenAI-compatible embedding connection.
+# "bearer" (default): send RAG_OPENAI_API_KEY as a static Bearer token.
+# "system_oauth": send the acting user's SSO OAuth access token instead,
+# mirroring the `system_oauth` auth type of chat connections — for gateways
+# that only accept OAuth tokens. Falls back to the static key when the user
+# has no active OAuth session.
+RAG_OPENAI_API_AUTH_TYPE = os.getenv('RAG_OPENAI_API_AUTH_TYPE', 'bearer').strip().lower()
+
 # When False (default), outbound HTTP requests do not follow 3xx redirects.
 AIOHTTP_CLIENT_ALLOW_REDIRECTS = os.getenv('AIOHTTP_CLIENT_ALLOW_REDIRECTS', 'False').lower() == 'true'
 

--- a/backend/open_webui/retrieval/models/external.py
+++ b/backend/open_webui/retrieval/models/external.py
@@ -1,9 +1,14 @@
+import asyncio
 import logging
 from typing import List, Optional, Tuple
 from urllib.parse import quote
 
 import requests
-from open_webui.env import ENABLE_FORWARD_USER_INFO_HEADERS, REQUESTS_VERIFY
+from open_webui.env import (
+    ENABLE_FORWARD_USER_INFO_HEADERS,
+    RAG_EXTERNAL_RERANKER_API_AUTH_TYPE,
+    REQUESTS_VERIFY,
+)
 from open_webui.retrieval.models.base_reranker import BaseReranker
 from open_webui.utils.headers import include_user_info_headers
 
@@ -38,9 +43,32 @@ class ExternalReranker(BaseReranker):
             log.info(f'ExternalReranker:predict:model {self.model}')
             log.info(f'ExternalReranker:predict:query {query}')
 
+            api_key = self.api_key
+            if RAG_EXTERNAL_RERANKER_API_AUTH_TYPE == 'system_oauth' and user is not None:
+                # Mirrors the embedding connection's system_oauth auth type.
+                # predict() runs in a worker thread (asyncio.to_thread), so a
+                # private event loop is safe for the async token lookup.
+                # Lazy import: retrieval.utils would be a circular import here.
+                from open_webui.retrieval.utils import get_system_oauth_access_token
+
+                access_token = None
+                try:
+                    access_token = asyncio.run(get_system_oauth_access_token(user))
+                except Exception as e:
+                    log.error(f'Error resolving system OAuth token for reranking: {e}')
+
+                if access_token:
+                    api_key = access_token
+                else:
+                    log.warning(
+                        'RAG_EXTERNAL_RERANKER_API_AUTH_TYPE=system_oauth but no OAuth '
+                        f'token available for user {user.id}; falling back to the '
+                        'static RAG_EXTERNAL_RERANKER_API_KEY'
+                    )
+
             headers = {
                 'Content-Type': 'application/json',
-                'Authorization': f'Bearer {self.api_key}',
+                'Authorization': f'Bearer {api_key}',
             }
 
             if ENABLE_FORWARD_USER_INFO_HEADERS and user:

--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -666,6 +666,7 @@ async def query_collection(
     queries: list[str],
     embedding_function,
     k: int,
+    user=None,
 ) -> dict:
     config = await Config.get_many(
         'rag.enable_hybrid_search',
@@ -678,7 +679,9 @@ async def query_collection(
     if request and config.get('rag.enable_hybrid_search'):
         try:
             reranking_function = (
-                (lambda query, documents: request.app.state.RERANKING_FUNCTION(query, documents))
+                # Bind the acting user so an external reranker with
+                # system_oauth auth can resolve their SSO OAuth token.
+                (lambda query, documents: request.app.state.RERANKING_FUNCTION(query, documents, user=user))
                 if request.app.state.RERANKING_FUNCTION
                 else None
             )
@@ -1652,6 +1655,7 @@ async def get_sources_from_items(
                         queries=queries,
                         embedding_function=embedding_function,
                         k=k,
+                        user=user,
                     )
             except Exception as e:
                 log.exception(e)

--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -33,6 +33,7 @@ from open_webui.env import (
     ENABLE_FORWARD_USER_INFO_HEADERS,
     ENABLE_RETRIEVAL_UNSCOPED_COLLECTIONS,
     OFFLINE_MODE,
+    RAG_OPENAI_API_AUTH_TYPE,
 )
 from open_webui.models.access_grants import AccessGrants
 from open_webui.models.chats import Chats
@@ -1163,6 +1164,34 @@ def get_embedding_function(
         raise ValueError(f'Unknown embedding engine: {embedding_engine}')
 
 
+async def get_system_oauth_access_token(user: UserModel) -> Union[str, None]:
+    """Resolve the user's SSO OAuth access token for embedding requests.
+
+    Mirrors the `system_oauth` auth type of chat connections, but without a
+    request context: the most recently updated non-MCP OAuth session for the
+    user is looked up in the DB and refreshed by the OAuthManager if expired.
+    """
+    try:
+        # Lazy imports: main imports the retrieval router which imports this
+        # module, so a top-level import would be circular.
+        from open_webui.main import oauth_manager
+        from open_webui.models.oauth_sessions import OAuthSessions
+
+        sessions = await OAuthSessions.get_sessions_by_user_id(user.id)
+        sessions = sorted(
+            [s for s in sessions if not (s.provider or '').startswith('mcp:')],
+            key=lambda s: s.updated_at or 0,
+            reverse=True,
+        )
+        for session in sessions:
+            token = await oauth_manager.get_oauth_token(user.id, session.id)
+            if token and token.get('access_token'):
+                return token['access_token']
+    except Exception as e:
+        log.error(f'Error resolving system OAuth token for embeddings (user {user.id}): {e}')
+    return None
+
+
 async def generate_embeddings(
     engine: str,
     model: str,
@@ -1173,6 +1202,16 @@ async def generate_embeddings(
     url = kwargs.get('url', '')
     key = kwargs.get('key', '')
     user = kwargs.get('user')
+
+    if engine == 'openai' and RAG_OPENAI_API_AUTH_TYPE == 'system_oauth' and user is not None:
+        access_token = await get_system_oauth_access_token(user)
+        if access_token:
+            key = access_token
+        else:
+            log.warning(
+                f'RAG_OPENAI_API_AUTH_TYPE=system_oauth but no OAuth token available '
+                f'for user {user.id}; falling back to the static RAG_OPENAI_API_KEY'
+            )
 
     if prefix is not None and RAG_EMBEDDING_PREFIX_FIELD_NAME is None:
         if isinstance(text, list):

--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -1167,6 +1167,27 @@ def get_embedding_function(
         raise ValueError(f'Unknown embedding engine: {embedding_engine}')
 
 
+# Token resolution is cached briefly and serialized per user. A document
+# upload embeds many batches concurrently; letting each batch call
+# oauth_manager.get_oauth_token() in parallel fires simultaneous refreshes
+# with the SAME refresh token (OAuthManager._refresh_token has no concurrency
+# protection). IdPs that rotate refresh tokens treat the reuse as theft and
+# revoke the grant; OWUI then deletes the session — which also breaks chat's
+# system_oauth for that user. One resolution per user per TTL window keeps
+# the session healthy. Any token get_oauth_token returns is valid for at
+# least ~5 minutes (its refresh window), so a 60s cache is always safe.
+_SYSTEM_OAUTH_TOKEN_CACHE_TTL = 60  # seconds
+_system_oauth_token_cache: dict[str, tuple[str, float]] = {}
+_system_oauth_token_locks: dict[str, tuple[object, asyncio.Lock]] = {}
+
+
+def _get_cached_system_oauth_token(user_id: str) -> Union[str, None]:
+    cached = _system_oauth_token_cache.get(user_id)
+    if cached and cached[1] > time.monotonic():
+        return cached[0]
+    return None
+
+
 async def get_system_oauth_access_token(user: UserModel) -> Union[str, None]:
     """Resolve the user's SSO OAuth access token for embedding requests.
 
@@ -1174,25 +1195,48 @@ async def get_system_oauth_access_token(user: UserModel) -> Union[str, None]:
     request context: the most recently updated non-MCP OAuth session for the
     user is looked up in the DB and refreshed by the OAuthManager if expired.
     """
-    try:
-        # Lazy imports: main imports the retrieval router which imports this
-        # module, so a top-level import would be circular.
-        from open_webui.main import oauth_manager
-        from open_webui.models.oauth_sessions import OAuthSessions
+    access_token = _get_cached_system_oauth_token(user.id)
+    if access_token:
+        return access_token
 
-        sessions = await OAuthSessions.get_sessions_by_user_id(user.id)
-        sessions = sorted(
-            [s for s in sessions if not (s.provider or '').startswith('mcp:')],
-            key=lambda s: s.updated_at or 0,
-            reverse=True,
-        )
-        for session in sessions:
-            token = await oauth_manager.get_oauth_token(user.id, session.id)
-            if token and token.get('access_token'):
-                return token['access_token']
-    except Exception as e:
-        log.error(f'Error resolving system OAuth token for embeddings (user {user.id}): {e}')
-    return None
+    # Per-user, per-loop lock: embedding calls all run on the main loop; the
+    # external reranker resolves inside its own asyncio.run() loop, and an
+    # asyncio.Lock cannot be shared across loops — there the cache alone
+    # dedups. Stale foreign-loop entries are replaced rather than awaited.
+    loop = asyncio.get_running_loop()
+    entry = _system_oauth_token_locks.get(user.id)
+    if entry is None or entry[0] is not loop:
+        entry = (loop, asyncio.Lock())
+        _system_oauth_token_locks[user.id] = entry
+
+    async with entry[1]:
+        access_token = _get_cached_system_oauth_token(user.id)
+        if access_token:
+            return access_token
+        try:
+            # Lazy imports: main imports the retrieval router which imports this
+            # module, so a top-level import would be circular.
+            from open_webui.main import oauth_manager
+            from open_webui.models.oauth_sessions import OAuthSessions
+
+            sessions = await OAuthSessions.get_sessions_by_user_id(user.id)
+            sessions = sorted(
+                [s for s in sessions if not (s.provider or '').startswith('mcp:')],
+                key=lambda s: s.updated_at or 0,
+                reverse=True,
+            )
+            for session in sessions:
+                token = await oauth_manager.get_oauth_token(user.id, session.id)
+                if token and token.get('access_token'):
+                    access_token = token['access_token']
+                    _system_oauth_token_cache[user.id] = (
+                        access_token,
+                        time.monotonic() + _SYSTEM_OAUTH_TOKEN_CACHE_TTL,
+                    )
+                    return access_token
+        except Exception as e:
+            log.error(f'Error resolving system OAuth token for embeddings (user {user.id}): {e}')
+        return None
 
 
 async def generate_embeddings(

--- a/backend/open_webui/tools/builtin.py
+++ b/backend/open_webui/tools/builtin.py
@@ -2580,6 +2580,7 @@ async def query_knowledge_files(
         from open_webui.models.files import Files
         from open_webui.models.knowledge import Knowledges
         from open_webui.models.notes import Notes
+        from open_webui.models.users import Users
         from open_webui.retrieval.external import retrieve_external_knowledge
         from open_webui.retrieval.utils import query_collection
 
@@ -2587,9 +2588,18 @@ async def query_knowledge_files(
         user_role = __user__.get('role', 'user')
         user_group_ids = [group.id for group in await Groups.get_groups_by_member_id(user_id)]
 
-        embedding_function = __request__.app.state.EMBEDDING_FUNCTION
-        if not embedding_function:
+        base_embedding_function = __request__.app.state.EMBEDDING_FUNCTION
+        if not base_embedding_function:
             return json.dumps({'error': 'Embedding function not configured'})
+
+        # Bind the acting user so query_collection's embedding call can resolve
+        # their SSO OAuth token (RAG_OPENAI_API_AUTH_TYPE=system_oauth).
+        # query_collection has no user parameter; without this the static
+        # RAG_OPENAI_API_KEY is sent and an OAuth-only gateway returns 401.
+        acting_user = await Users.get_user_by_id(user_id)
+
+        async def embedding_function(query, prefix=None, user=None):
+            return await base_embedding_function(query, prefix=prefix, user=user or acting_user)
 
         collection_names = []
         external_knowledges = []
@@ -2775,12 +2785,17 @@ async def query_knowledge_bases(
         import heapq
 
         from open_webui.models.knowledge import Knowledges
+        from open_webui.models.users import Users
         from open_webui.retrieval.vector.async_client import ASYNC_VECTOR_DB_CLIENT
         from open_webui.routers.knowledge import KNOWLEDGE_BASES_COLLECTION
 
         user_id = __user__.get('id')
         user_group_ids = [group.id for group in await Groups.get_groups_by_member_id(user_id)]
-        query_embedding = await __request__.app.state.EMBEDDING_FUNCTION(query)
+        # Pass the acting user so system_oauth embedding auth can resolve their
+        # OAuth token; otherwise the static key is sent and OAuth-only gateways 401.
+        query_embedding = await __request__.app.state.EMBEDDING_FUNCTION(
+            query, user=await Users.get_user_by_id(user_id)
+        )
 
         # Min-heap of (distance, knowledge_base_id) - only holds top `count` results
         top_results_heap = []

--- a/backend/open_webui/tools/builtin.py
+++ b/backend/open_webui/tools/builtin.py
@@ -2709,6 +2709,7 @@ async def query_knowledge_files(
                 queries=[query],
                 embedding_function=embedding_function,
                 k=count,
+                user=acting_user,
             )
 
             if query_results and 'documents' in query_results:


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Relates to #26976 (OAuth2 auth for external LLM/embedding/reranking connections — this PR covers the embedding engine with the existing `system_oauth` mechanism)
- [x] **Target branch:** targets `dev`
- [x] **Description:** provided below
- [x] **Changelog:** included below
- [ ] **Documentation:** happy to follow up with a docs PR for the new env var if this is accepted
- [x] **Dependencies:** no new dependencies
- [x] **Testing:** verified end-to-end (details below)
- [x] **No Unchecked AI Code:** developed with Claude Code, verified by an automated e2e suite and live end-to-end against an OAuth-only gateway; human review pass completed
- [x] **Self-Review:** done
- [x] **Architecture:** the new env var defaults to `bearer`, which is byte-for-byte stock behavior; no UI changes, no new persisted settings
- [x] **Git Hygiene:** atomic commits based on `dev` — the embedding connection, plus three follow-up commits: closing the same gap in the builtin knowledge tools and the external reranker, and a concurrency fix for the token resolution (see below)
- [x] **Title Prefix:** `feat`

## Description

Chat connections already support `auth_type: "system_oauth"` — forwarding the signed-in
user's SSO OAuth access token as the `Authorization: Bearer` header — so deployments behind
OAuth-authenticated LLM gateways work for chat/models.

The RAG **embedding** path, however, only ever sends the static `RAG_OPENAI_API_KEY`
(`retrieval/utils.py`, `agenerate_openai_batch_embeddings`); there is no auth option at all
(`routers/retrieval.py` `OpenAIConfigForm` is just `url` + `key`). Against an OAuth-only
gateway every embedding request gets **401**, so document uploads and RAG queries fail even
though chat works.

This PR adds a `RAG_OPENAI_API_AUTH_TYPE` environment variable:

| Value | Behavior |
|---|---|
| `bearer` (default) | Unchanged stock behavior — static key as Bearer token |
| `system_oauth` | Send the **acting user's** SSO OAuth access token as the Bearer token |

Implementation notes:

- Token resolution mirrors the chat-side `system_oauth`, but works **without a request
  context** (embeddings also run during background document processing): the user's most
  recently updated non-MCP OAuth session is read via `OAuthSessions`, and
  `OAuthManager.get_oauth_token()` transparently refreshes it when near expiry — the same
  refresh path the chat proxy uses.
- Every embedding call site already passes `user=` (file upload via `save_docs_to_vector_db`,
  query endpoints, chat-time retrieval in `utils/middleware.py`), so upload-time and
  query-time embeddings both authenticate as the acting user.
- Graceful fallback: if the user has no OAuth session (e.g. local password account), the
  static key is used and a warning is logged.
- Purely additive: +47 lines across `env.py` and `retrieval/utils.py`; no schema, API, or
  frontend changes.

## Follow-up commits

Exercising this feature against an OAuth-only gateway (Keycloak + Envoy `jwt_authn`,
which 401s static keys) surfaced two more code paths with the same bug — they send the
static key even with `system_oauth` configured — and a concurrency bug in the token
resolution itself:

- **`fix: builtin knowledge tools drop user context on embedding calls`** — the agentic
  knowledge tools (`query_knowledge_base`, `query_knowledge_bases`) call the app-level
  `EMBEDDING_FUNCTION` without the acting user, so token resolution never runs. Passes the
  user at both call sites.
- **`feat: system_oauth auth type for the external reranker connection`** — the external
  reranker always sends the static `RAG_EXTERNAL_RERANKER_API_KEY`. Adds
  `RAG_EXTERNAL_RERANKER_API_AUTH_TYPE` (`bearer` default | `system_oauth`) with the same
  token resolution and fallback semantics, and binds the user through `query_collection`'s
  rerank wrapper (the middleware and retrieval-router wrappers already pass it).
- **`fix: serialize and cache system_oauth token resolution per user`** — a document upload
  embeds many batches concurrently, so token resolution raced: N parallel
  `oauth_manager.get_oauth_token()` calls could each trigger a refresh with the **same**
  refresh token (`OAuthManager._refresh_token` has no concurrency protection). An IdP that
  rotates refresh tokens treats the reuse as replay and revokes the grant — Open WebUI then
  deletes the OAuth session, breaking chat's `system_oauth` for that user too. Fixed by
  serializing resolution behind a per-user `asyncio.Lock` and caching the token for 60s
  (always within its refresh window, so a cached token is never expired).

All three fixed and verified live against that gateway: knowledge-tool queries and
hybrid-search reranking authenticate with the acting user's token end-to-end, concurrent
uploads resolve the token once per user, and with `bearer` (default) behavior is
byte-for-byte stock.

## Testing

Automated end-to-end suite (run against this branch): a mock OpenAI-compatible gateway that
**only** accepts a specific OAuth token (static keys get 401, mimicking a corporate gateway),
a real server boot, a real signup, and a real Fernet-encrypted OAuth session seeded through
`OAuthSessions.create_session()`.

All 7 checks pass:

- `system_oauth`: `POST /api/v1/retrieval/process/text` → 200; `POST /api/v1/retrieval/query/doc` → 200; the gateway received `Bearer <oauth token>`; the static key was never sent.
- `bearer` (stock): same request fails; the gateway received the static key and returned 401 (reproduces the bug this fixes); the OAuth token was never sent — the flag fully gates the feature.

# Changelog Entry

### Description

- Allow the RAG OpenAI-compatible embedding connection to authenticate with the acting user's SSO OAuth access token, matching the `system_oauth` auth type already available on chat connections.

### Added

- `RAG_OPENAI_API_AUTH_TYPE` environment variable (`bearer` | `system_oauth`, default `bearer`) for the RAG OpenAI embedding engine.

### Changed

- None (default behavior is unchanged).

### Deprecated

- None

### Removed

- None

### Fixed

- 401 errors on document upload and RAG queries when the embedding endpoint sits behind an OAuth-authenticated gateway while chat connections use `system_oauth`.
- Concurrent embedding batches racing the OAuth token refresh (the same refresh token used in parallel), which on IdPs with refresh-token rotation revokes the grant and invalidates the user's OAuth session.

### Security

- OAuth tokens are read through the existing encrypted `OAuthSessions` storage and are never logged.

### Breaking Changes

- None

---

### Additional Information

- Resubmission of #27097, which was closed for an unchecked CLA box.
- Relates to #26976. That issue asks for OAuth2 **client-credentials** (machine-to-machine) auth for LLM/embedding/reranking connections; this PR covers the complementary user-token case for embeddings by reusing the `system_oauth` mechanism that chat connections already have. The two approaches compose: client credentials would still be the right answer for accounts without an SSO session.

### Screenshots or Videos

- N/A (backend only; e2e transcript summarized above)

<!--
Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.


