### PR TITLE
fix: Set default Redis socket timeout to None

### DIFF
--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -389,6 +389,12 @@ try:
 except ValueError:
     REDIS_SOCKET_CONNECT_TIMEOUT = None
 
+REDIS_SOCKET_TIMEOUT = os.getenv('REDIS_SOCKET_TIMEOUT', '')
+try:
+    REDIS_SOCKET_TIMEOUT = float(REDIS_SOCKET_TIMEOUT)
+except ValueError:
+    REDIS_SOCKET_TIMEOUT = None
+
 # Whether to enable TCP SO_KEEPALIVE on Redis client sockets. Opt-in:
 # defaults to off so behavior is unchanged for existing deployments. When
 # enabled, the kernel sends TCP keepalive probes on idle connections so

--- a/backend/open_webui/utils/redis.py
+++ b/backend/open_webui/utils/redis.py
@@ -24,6 +24,7 @@ from open_webui.env import (
     REDIS_SENTINEL_PORT,
     REDIS_SOCKET_CONNECT_TIMEOUT,
     REDIS_SOCKET_KEEPALIVE,
+    REDIS_SOCKET_TIMEOUT,
     REDIS_URL,
 )
 
@@ -248,6 +249,8 @@ def _socket_options() -> dict[str, Any]:
     opts: dict[str, Any] = {}
     if REDIS_SOCKET_CONNECT_TIMEOUT is not None:
         opts['socket_connect_timeout'] = REDIS_SOCKET_CONNECT_TIMEOUT
+    if REDIS_SOCKET_TIMEOUT:
+        opts['socket_timeout'] = REDIS_SOCKET_TIMEOUT
     if REDIS_SOCKET_KEEPALIVE:
         opts['socket_keepalive'] = True
     if REDIS_HEALTH_CHECK_INTERVAL:


### PR DESCRIPTION
# Changelog Entry

### Description

- This PR introduces the `REDIS_SOCKET_TIMEOUT` environment variable, which allows setting Redis's `socket_timeout` to either `None` or a user-specified value. Before this PR is applied, Redis pubsub listen will time out after 5 seconds, causing the `redis_task_command_listener`, which uses Redis to manage tasks across replicas, to encounter an error and terminate 5 seconds after no new messages are pushed. No errors will be shown in the console. As a result, for users using Redis, the task stopping functionality will fail regardless of whether multiple replicas are actually deployed. A typical manifestation is that after a user clicks the stop button to stop a chat, the backend continues to push new streaming tokens even after the chat has completed.

### Added

- Added `REDIS_SOCKET_TIMEOUT` environment variable

### Fixed

- Fixed the issue where stream transmission could not be stopped when using Redis.

---

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
