### PR TITLE
fix(rag): allow special token literals

### DIFF
--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -1689,6 +1689,7 @@ def save_docs_to_vector_db(
                 chunk_size=config.CHUNK_SIZE,
                 chunk_overlap=config.CHUNK_OVERLAP,
                 add_start_index=True,
+                disallowed_special=(),
             )
             docs = text_splitter.split_documents(docs)
         elif config.TEXT_SPLITTER == 'token_transformers':


### PR DESCRIPTION
## Summary

- configure the RAG token text splitter to encode special-token literals as ordinary text
- keep token splitting consistent with the existing token length function

Closes #27094

## Validation

- instantiated `TokenTextSplitter` with the repository-pinned `tiktoken==0.13.0` and `langchain-text-splitters==1.1.2`, then split `"<|endoftext|> documentation"`
- `python -m py_compile backend/open_webui/routers/retrieval.py`
- `git diff --check`

# Changelog Entry

### Fixed

- Prevent token-based RAG splitting from failing when source content contains a literal tiktoken special token.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
