### PR TITLE
fix: remove frozen=True from EventDefinition to allow default setting (closes #26843)

### DIFF
--- a/backend/open_webui/events.py
+++ b/backend/open_webui/events.py
@@ -23,7 +23,7 @@ DEFAULT_WEBHOOK_ID = 'default'
 
 
 class EventDefinition(BaseModel):
-    model_config = ConfigDict(frozen=True)
+    # frozen=True removed to allow setting defaults in model_validator
 
     name: str
     description: str | None = None
@@ -33,9 +33,9 @@ class EventDefinition(BaseModel):
     def defaults(self) -> 'EventDefinition':
         title = self.name.replace('.', ' ').replace('_', ' ').title()
         if self.description is None:
-            object.__setattr__(self, 'description', f'{title}.')
+            self.description = f'{title}.'
         if self.message is None:
-            object.__setattr__(self, 'message', title)
+            self.message = title
         return self
 
 


### PR DESCRIPTION
## What
The EventDefinition model had `frozen=True` in its ConfigDict, which caused a runtime error when the `defaults` model_validator tried to set default values using `object.__setattr__`. This led to a startup crash if any EventDefinition was instantiated with null (None) description or message.

## Fix
- Removed `frozen=True` from the model config, allowing normal attribute assignment.
- Replaced `object.__setattr__` with direct attribute assignment in the validator.

Closes #26843