### PR TITLE
fix: persist folder sharing permission

### DIFF
--- a/backend/open_webui/routers/users.py
+++ b/backend/open_webui/routers/users.py
@@ -196,6 +196,7 @@ class SharingPermissions(BaseModel):
     public_skills: bool = False
     notes: bool = False
     public_notes: bool = True
+    folders: bool = False
     public_chats: bool = False
     public_calendars: bool = False
 


### PR DESCRIPTION
# fix: persist folder sharing permission

## Summary

The default user-permissions API validated sharing permissions through `SharingPermissions`, but that model did not define the existing `folders` setting. As a result, folder-sharing selections from the admin UI were discarded before configuration was saved. This adds the missing field with the same `false` default used by the frontend and configuration defaults.

Fixes #27120

## Changes

- Preserve the `sharing.folders` permission when default user permissions are saved.

## Testing

- `sandbox-run "uv run ruff check backend/open_webui/routers/users.py && PYTHONPATH=backend uv run python -c \"from open_webui.routers.users import SharingPermissions; assert SharingPermissions().folders is False; assert SharingPermissions(folders=True).model_dump()['folders'] is True\""` — could not run because `uv` is not installed in the sandbox.
- `sandbox-run "python3 -m pip install ruff==0.15.5 && ruff check backend/open_webui/routers/users.py && python3 -c \"...\""` — could not run because the sandbox has no `python3` executable.
- `git diff --check` — passed.

---
### AI assistance disclosure

This contribution was produced by an autonomous AI coding agent (Claude Code) that @Dodothereal operates and monitors. @Dodothereal is accountable for it, will address review feedback promptly, and will close this PR immediately if this kind of contribution is unwelcome in this project. Commits carry an `Assisted-by: Claude Code` trailer.
