### PR TITLE
fix: normalize multimodal tool results when replaying chat history

### DIFF
--- a/backend/open_webui/test/test_multimodal_tool_messages.py
+++ b/backend/open_webui/test/test_multimodal_tool_messages.py
@@ -1,0 +1,134 @@
+import os
+from copy import deepcopy
+
+os.environ.setdefault('WEBUI_SECRET_KEY', 'test-secret')
+
+from open_webui.utils.misc import convert_output_to_messages, flatten_multimodal_tool_messages
+
+
+def test_text_only_tool_messages_are_unchanged():
+    messages = [
+        {'role': 'assistant', 'content': '', 'tool_calls': []},
+        {'role': 'tool', 'tool_call_id': 'call_1', 'content': 'plain text'},
+    ]
+    original = deepcopy(messages)
+
+    assert flatten_multimodal_tool_messages(messages) == original
+
+
+def test_multimodal_output_becomes_text_tool_result_followed_by_user_image():
+    output = [
+        {
+            'type': 'function_call',
+            'call_id': 'call_1',
+            'name': 'view',
+            'arguments': '{}',
+        },
+        {
+            'type': 'function_call_output',
+            'call_id': 'call_1',
+            'output': [
+                {'type': 'input_text', 'text': 'Image loaded.'},
+                {'type': 'input_image', 'image_url': 'data:image/png;base64,AAAA'},
+            ],
+        },
+        {
+            'type': 'message',
+            'role': 'assistant',
+            'content': [{'type': 'output_text', 'text': 'Done.'}],
+        },
+    ]
+
+    messages = flatten_multimodal_tool_messages(convert_output_to_messages(output, raw=True), mark_image_messages=True)
+
+    assert messages[1] == {
+        'role': 'tool',
+        'tool_call_id': 'call_1',
+        'content': 'Image loaded.',
+    }
+    assert messages[2]['role'] == 'user'
+    assert messages[2]['_tool_result_image'] is True
+    assert messages[2]['content'][1] == {
+        'type': 'image_url',
+        'image_url': {'url': 'data:image/png;base64,AAAA'},
+    }
+    assert messages[3] == {'role': 'assistant', 'content': 'Done.'}
+
+
+def test_parallel_tool_results_precede_one_user_image_message():
+    output = [
+        {'type': 'function_call', 'call_id': 'call_1', 'name': 'view', 'arguments': '{}'},
+        {'type': 'function_call', 'call_id': 'call_2', 'name': 'view', 'arguments': '{}'},
+        {
+            'type': 'function_call_output',
+            'call_id': 'call_1',
+            'output': [
+                {'type': 'input_text', 'text': 'First.'},
+                {'type': 'input_image', 'image_url': 'data:image/png;base64,AAAA'},
+            ],
+        },
+        {
+            'type': 'function_call_output',
+            'call_id': 'call_2',
+            'output': [
+                {'type': 'input_text', 'text': 'Second.'},
+                {'type': 'input_image', 'image_url': 'data:image/png;base64,BBBB'},
+            ],
+        },
+        {
+            'type': 'message',
+            'role': 'assistant',
+            'content': [{'type': 'output_text', 'text': 'Done.'}],
+        },
+    ]
+
+    messages = flatten_multimodal_tool_messages(convert_output_to_messages(output, raw=True))
+
+    assert [message['role'] for message in messages] == ['assistant', 'tool', 'tool', 'user', 'assistant']
+    assert [message['tool_call_id'] for message in messages[1:3]] == ['call_1', 'call_2']
+    assert [part['image_url']['url'] for part in messages[3]['content'][1:]] == [
+        'data:image/png;base64,AAAA',
+        'data:image/png;base64,BBBB',
+    ]
+
+
+def test_empty_image_urls_are_omitted():
+    messages = [
+        {
+            'role': 'tool',
+            'tool_call_id': 'call_1',
+            'content': [
+                {'type': 'input_text', 'text': 'Images loaded.'},
+                {'type': 'input_image', 'image_url': ''},
+                {'type': 'input_image', 'image_url': 'data:image/png;base64,AAAA'},
+                {'type': 'input_image', 'image_url': 'data:image/png;base64,BBBB'},
+            ],
+        }
+    ]
+
+    result = flatten_multimodal_tool_messages(messages)
+
+    assert result[0]['content'] == 'Images loaded.'
+    assert [part['image_url']['url'] for part in result[1]['content'][1:]] == [
+        'data:image/png;base64,AAAA',
+        'data:image/png;base64,BBBB',
+    ]
+
+
+def test_source_messages_are_not_mutated():
+    messages = [
+        {
+            'role': 'tool',
+            'tool_call_id': 'call_1',
+            'content': [
+                {'type': 'input_text', 'text': 'Image loaded.'},
+                {'type': 'input_image', 'image_url': 'data:image/png;base64,AAAA'},
+            ],
+        }
+    ]
+    original = deepcopy(messages)
+
+    result = flatten_multimodal_tool_messages(messages)
+
+    assert messages == original
+    assert '_tool_result_image' not in result[1]

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -101,6 +101,7 @@ from open_webui.utils.misc import (
     convert_output_to_messages,
     deep_update,
     extract_urls,
+    flatten_multimodal_tool_messages,
     get_content_from_message,
     get_last_assistant_message,
     get_last_user_message,
@@ -1578,7 +1579,7 @@ async def add_file_context(messages: list, chat_id: str, user) -> list:
     # the payload message list longer than the stored message list. A naive
     # positional zip() would pair user messages with wrong stored messages,
     # causing later images to lose their file context (see #21878).
-    user_messages = [m for m in messages if m.get('role') == 'user']
+    user_messages = [m for m in messages if m.get('role') == 'user' and not m.get('_tool_result_image')]
     stored_user_messages = [m for m in stored_messages if m.get('role') == 'user']
 
     for message, stored_message in zip(user_messages, stored_user_messages):
@@ -2064,7 +2065,7 @@ def process_messages_with_output(
                 reasoning_format=reasoning_format,
             )
             if output_messages:
-                processed.extend(output_messages)
+                processed.extend(flatten_multimodal_tool_messages(output_messages, mark_image_messages=True))
                 continue
 
         # Strip 'output' field before adding (LLM shouldn't see it)
@@ -2908,6 +2909,8 @@ async def process_chat_payload(request, form_data, user, metadata, model):
     # Strip empty text content blocks from multimodal messages
     # to prevent errors from providers like Gemini and Claude
     form_data['messages'] = strip_empty_content_blocks(form_data.get('messages', []))
+    for message in form_data['messages']:
+        message.pop('_tool_result_image', None)
 
     # Merge any duplicate system messages into a single message at position 0
     # to prevent template parsing errors with strict chat templates (e.g. Qwen)
@@ -5053,38 +5056,12 @@ async def streaming_chat_response_handler(response, ctx):
                             tool_messages = convert_output_to_messages(
                                 output, raw=True, reasoning_format=get_reasoning_format(model)
                             )
-
-                            # Chat Completions providers don't support multimodal
-                            # tool messages.  Extract images into a user message.
-                            image_urls = []
-                            for message in tool_messages:
-                                if message.get('role') == 'tool' and isinstance(message.get('content'), list):
-                                    text_parts = []
-                                    for part in message['content']:
-                                        if part.get('type') == 'input_text':
-                                            text_parts.append(part.get('text', ''))
-                                        elif part.get('type') == 'input_image':
-                                            image_urls.append(part.get('image_url', ''))
-                                    message['content'] = ''.join(text_parts)
+                            tool_messages = flatten_multimodal_tool_messages(tool_messages)
 
                             new_form_data['messages'] = [
                                 *form_data['messages'],
                                 *tool_messages,
                             ]
-
-                            if image_urls:
-                                new_form_data['messages'].append(
-                                    {
-                                        'role': 'user',
-                                        'content': [
-                                            {
-                                                'type': 'text',
-                                                'text': 'Here are the images from the tool results above. Please analyze them.',
-                                            },
-                                            *[{'type': 'image_url', 'image_url': {'url': url}} for url in image_urls],
-                                        ],
-                                    }
-                                )
 
                         res = await generate_chat_completion(
                             request,

--- a/backend/open_webui/utils/misc.py
+++ b/backend/open_webui/utils/misc.py
@@ -220,6 +220,52 @@ def reconcile_tool_pairs(messages: list[dict]) -> list[dict]:
     return reconciled_messages
 
 
+def flatten_multimodal_tool_messages(messages: list[dict], mark_image_messages: bool = False) -> list[dict]:
+    """Move tool-result images into a provider-compatible user message."""
+    flattened_messages = []
+    image_urls = []
+
+    def append_image_message():
+        nonlocal image_urls
+        if not image_urls:
+            return
+        flattened_messages.append(
+            {
+                'role': 'user',
+                **({'_tool_result_image': True} if mark_image_messages else {}),
+                'content': [
+                    {
+                        'type': 'text',
+                        'text': 'Here are the images from the tool results above. Please analyze them.',
+                    },
+                    *[{'type': 'image_url', 'image_url': {'url': url}} for url in image_urls],
+                ],
+            }
+        )
+        image_urls = []
+
+    for message in messages:
+        if message.get('role') != 'tool':
+            append_image_message()
+            flattened_messages.append(message)
+            continue
+
+        if isinstance(message.get('content'), list):
+            text_parts = []
+            for part in message['content']:
+                if part.get('type') == 'input_text':
+                    text_parts.append(part.get('text', ''))
+                elif part.get('type') == 'input_image' and part.get('image_url'):
+                    image_urls.append(part['image_url'])
+
+            message = {**message, 'content': ''.join(text_parts)}
+
+        flattened_messages.append(message)
+
+    append_image_message()
+    return flattened_messages
+
+
 def convert_output_to_messages(
     output: list,
     raw: bool = False,


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Relates to https://github.com/open-webui/open-webui/discussions/22591.
- [x] **Target branch:** This PR targets `dev`.
- [x] **Description:** A concise description is provided below.
- [x] **Changelog:** A Keep a Changelog entry is included below.
- [x] **Documentation:** No documentation update is required for this replay compatibility fix.
- [x] **Dependencies:** No dependencies were added or updated.
- [x] **Testing:** Focused automated tests and manual end-to-end comparison were performed.
- [x] **No Unchecked AI Code:** The agent-assisted implementation underwent self-review, independent agent review, manual end-to-end testing, and final human review and approval.
- [x] **Self-Review:** The final three-file diff was reviewed for protocol ordering, mutation, provider compatibility, and attachment pairing.
- [x] **Architecture:** This reuses the existing live-continuation normalization rather than adding settings or a new return type.
- [x] **Git Hygiene:** This is one atomic commit based on the latest `dev`.
- [x] **Title Prefix:** The title uses the `fix` prefix.

## Description

Python toolkit image data URIs already work during the immediate native tool continuation: Open WebUI converts the image-bearing `function_call_output` into a text-valued `role: tool` message followed by a normal user `image_url` message.

Persisted-history reconstruction did not apply that normalization. On a fresh turn, `process_messages_with_output()` reconstructed a list-valued tool message containing Responses-style `input_text` and `input_image` parts. Chat Completions providers cannot represent images in tool-message content, so the image was stripped or rejected before reaching the model.

This PR extracts the existing live transformation into `flatten_multimodal_tool_messages()` and applies it to persisted output replay as well as live stateless continuation. The helper:

- keeps tool result content string-valued;
- inserts one user image message after each contiguous tool-result batch;
- keeps parallel tool results adjacent;
- preserves all non-empty image URLs;
- avoids mutating source messages;
- marks synthetic replay messages internally so they do not shift later user/file attachment pairing, then removes that marker before provider dispatch.

Stateful Responses continuation remains unchanged because Responses natively supports multimodal `function_call_output` items.

## Testing

Focused regression tests:

```text
WEBUI_SECRET_KEY=test-secret .venv/bin/pytest backend/open_webui/test/test_multimodal_tool_messages.py
5 passed
```

Touched-file formatting and logic checks:

```text
.venv/bin/ruff format --check backend/open_webui/utils/misc.py backend/open_webui/utils/middleware.py backend/open_webui/test/test_multimodal_tool_messages.py
.venv/bin/ruff check --select=F --ignore=F401,F403,F405,F541,F811,F841 backend/open_webui/utils/misc.py backend/open_webui/utils/middleware.py backend/open_webui/test/test_multimodal_tool_messages.py
```

Both passed.

Manual end-to-end regression test used the same public toolkit canary, OpenRouter connection, `google/gemini-2.5-flash` model, and two-turn prompts against two isolated local servers:

| Server | Turn 1 | Persisted `input_image` | Fresh Turn 2 |
|---|---|---:|---|
| Untouched `origin/dev` | `READY.` | 1 | Hallucinated the impossible alphanumeric code `GC2Y8C`; verifier returned `CANARY FAIL` |
| This branch | `READY.` | 1 | Recovered digits-only code `929964`; verifier returned `CANARY PASS` |

The Turn 2 requests supplied `messages: []`, forcing Open WebUI to reconstruct the conversation from persisted parent-linked history.

Reproduction toolkit: https://gist.github.com/rndmcnlly/b8aaafc7f65c435a7433ab818d9e03cd

# Changelog Entry

### Description

- Normalize persisted multimodal tool results using the same provider-compatible representation as immediate tool continuation.

### Added

- Focused tests for text-only results, image replay chronology, parallel tool calls, multiple and empty image URLs, and source-message immutability.

### Changed

- Shared the multimodal tool-message normalization between live stateless continuation and stored-history replay.

### Deprecated

- None.

### Removed

- Duplicate inline normalization logic from the live continuation path.

### Fixed

- Model-visible Python toolkit images are retained when persisted chat history is reconstructed on a later turn.
- Synthetic replay image messages no longer shift file attachment context for later user messages.

### Security

- None.

### Breaking Changes

- None.

---

### Additional Information

- Relates to https://github.com/open-webui/open-webui/discussions/22591.
- No new toolkit response type is introduced. Existing `data:image/...;base64,...` handling is used.
- This PR was developed with agent assistance. The final diff and test evidence were reviewed and approved by the human author before submission.

### Screenshots or Videos

- Not applicable. This is a backend message-reconstruction fix; the before/after verifier output is recorded above.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
