### PR TITLE
fix: keep chats shared with an admin readable when ENABLE_ADMIN_CHAT_ACCESS is off

### DIFF
--- a/backend/open_webui/routers/chats.py
+++ b/backend/open_webui/routers/chats.py
@@ -1178,30 +1178,31 @@ async def compact_chat_by_id(
 async def get_chat_by_id(id: str, user=Depends(get_verified_user), db: AsyncSession = Depends(get_async_session)):
     chat = await Chats.get_chat_by_id_and_user_id(id, user.id, db=db)
 
-    if not chat:
-        # Check if user has access via access grants (shared_chat grants)
-        if user.role == 'admin':
-            candidate = await Chats.get_chat_by_id(id, db=db)
-            if ENABLE_ADMIN_CHAT_ACCESS or (candidate and is_internal_chat(candidate.meta)):
-                chat = candidate
-        else:
-            has_grant = await AccessGrants.has_access(
-                user_id=user.id,
-                resource_type='shared_chat',
-                resource_id=id,
-                permission='read',
-                db=db,
-            )
-            if has_grant:
-                chat = await Chats.get_chat_by_id(id, db=db)
+    if not chat and user.role == 'admin':
+        candidate = await Chats.get_chat_by_id(id, db=db)
+        if ENABLE_ADMIN_CHAT_ACCESS or (candidate and is_internal_chat(candidate.meta)):
+            chat = candidate
 
-            # Check folder-based access (shared folders)
-            if not chat:
-                candidate = await Chats.get_chat_by_id(id, db=db)
-                if candidate and candidate.folder_id:
-                    folder = await Folders.get_folder_by_id(candidate.folder_id, db=db)
-                    if folder and await has_folder_access(user.id, folder, 'read', db):
-                        chat = candidate
+    # Access explicitly granted to this user applies to admins too, so an admin
+    # does not lose a chat shared with them when ENABLE_ADMIN_CHAT_ACCESS is off.
+    if not chat:
+        has_grant = await AccessGrants.has_access(
+            user_id=user.id,
+            resource_type='shared_chat',
+            resource_id=id,
+            permission='read',
+            db=db,
+        )
+        if has_grant:
+            chat = await Chats.get_chat_by_id(id, db=db)
+
+        # Check folder-based access (shared folders)
+        if not chat:
+            candidate = await Chats.get_chat_by_id(id, db=db)
+            if candidate and candidate.folder_id:
+                folder = await Folders.get_folder_by_id(candidate.folder_id, db=db)
+                if folder and await has_folder_access(user.id, folder, 'read', db):
+                    chat = candidate
 
     if chat:
         data = ChatResponse(**chat.model_dump()).model_dump()


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions).
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [x] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Manual tests have been performed to verify the fix works correctly and does not introduce regressions.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing.
- [x] **Self-Review:** A self-review of the code has been performed.
- [x] **Architecture:** No new settings introduced; restores prior behaviour of an existing one.
- [x] **Git Hygiene:** The PR is atomic (one logical change), based on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

- `get_chat_by_id` sent admins down a branch that returned the chat only when `ENABLE_ADMIN_CHAT_ACCESS` was on, or the chat was internal, and never fell through to the access-grant and shared-folder checks.
- With the setting off, an admin was denied a chat that had been **deliberately shared with them**, directly or via a shared folder, while any non-admin holding the same grant could open it. The admin role removed access the user had been given, rather than only closing the admin-only path.
- On `main` this worked: admins fell through to the `else` branch and were treated like any other user for grant/folder access.
- The fix tries the admin path first, then lets everyone fall through to the grant and folder checks. `ENABLE_ADMIN_CHAT_ACCESS=false` still closes the admin-only route to other users' chats, and internal chats stay reachable.

### Fixed

- Fixed admins being denied chats explicitly shared with them (via access grant or shared folder) when `ENABLE_ADMIN_CHAT_ACCESS` is disabled.

---

### Additional Information

Verified against the real `get_chat_by_id` with the data layer faked, exercising each branch.

Reproduced on unpatched `dev` — admin, flag off, chat shared with them:

```
401
```

After the fix:

```
PASS  admin, flag ON,  no grant -> backdoor works    got=ALLOWED  want=ALLOWED
PASS  admin, flag OFF, no grant -> backdoor CLOSED   got=401      want=401
PASS  admin, flag OFF, SHARED   -> THE BUG           got=ALLOWED  want=ALLOWED
PASS  user,  flag OFF, SHARED   -> unchanged         got=ALLOWED  want=ALLOWED
PASS  user,  flag OFF, no grant -> unchanged         got=401      want=401
```

The privacy guarantee is unchanged: with the setting off an admin still cannot reach a chat nobody shared with them.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
