### PR TITLE
Fix #27001: prevent Setext heading rule from swallowing a <details> block

### DIFF
--- a/src/lib/utils/__tests__/processResponseContent.test.ts
+++ b/src/lib/utils/__tests__/processResponseContent.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import { processResponseContent } from '$lib/utils';
+import { marked, type Token } from 'marked';
+import markedExtension from '$lib/utils/marked/extension';
+
+// Wire up the same block/inline extensions the chat Markdown renderer uses so we
+// exercise the real pipeline (processResponseContent -> marked lexer).
+marked.use(markedExtension({}));
+
+const tokenTypes = (src: string): string[] =>
+	marked
+		.lexer(processResponseContent(src))
+		.map((t: Token) => t.type + (t.type === 'heading' ? `(depth ${(t as any).depth})` : ''));
+
+const hasDetailsWidget = (src: string): boolean => {
+	const tokens = marked.lexer(processResponseContent(src));
+	// A correctly-rendered <details> block produces either a custom `details`
+	// token (this extension) or an `html` token whose raw starts with `<details`
+	// (no heading swallowing the tag source).
+	return tokens.some(
+		(t) => (t.type === 'details' || t.type === 'html') && (t.raw ?? '').startsWith('<details')
+	);
+};
+
+describe('processResponseContent - #27001 details/setext heading regression', () => {
+	it('precedes a <details> block with a blank line so it is not swallowed into a heading', () => {
+		const input = [
+			'Here is some introductory text before the widget.',
+			'<details>',
+			'<summary>Click to expand</summary>',
+			'line one',
+			'---',
+			'line two',
+			'</details>'
+		].join('\n');
+
+		const output = processResponseContent(input);
+
+		// The paragraph and the <details> tag must be separated by a blank line.
+		expect(output).toContain(
+			'Here is some introductory text before the widget.\n\n<details>'
+		);
+	});
+
+	it('renders a real collapsed details widget (not a heading) when bare --- is present', () => {
+		const input = [
+			'Here is some introductory text before the widget.',
+			'<details>',
+			'<summary>Click to expand</summary>',
+			'line one',
+			'---',
+			'line two',
+			'</details>'
+		].join('\n');
+
+		expect(tokenTypes(input)).not.toContain('heading(depth 2)');
+		expect(hasDetailsWidget(input)).toBe(true);
+	});
+
+	it('renders a real collapsed details widget (not a heading) when bare === is present', () => {
+		const input = [
+			'Here is some introductory text before the widget.',
+			'<details>',
+			'<summary>Click to expand</summary>',
+			'line one',
+			'===',
+			'line two',
+			'</details>'
+		].join('\n');
+
+		expect(tokenTypes(input)).not.toContain('heading(depth 1)');
+		expect(hasDetailsWidget(input)).toBe(true);
+	});
+
+	it('does not add a blank line when one already exists (no double spacing)', () => {
+		const input = [
+			'Here is some introductory text before the widget.',
+			'',
+			'<details>',
+			'<summary>Click to expand</summary>',
+			'line one',
+			'---',
+			'line two',
+			'</details>'
+		].join('\n');
+
+		const output = processResponseContent(input);
+		expect(output).not.toContain('\n\n\n<details>');
+		expect(hasDetailsWidget(input)).toBe(true);
+	});
+
+	it('handles <details> with attributes directly after prose', () => {
+		const input = [
+			'Some prose.',
+			'<details type="tool_calls" name="search">',
+			'<summary>Tool call</summary>',
+			'result',
+			'---',
+			'</details>'
+		].join('\n');
+
+		const output = processResponseContent(input);
+		expect(output).toContain('Some prose.\n\n<details type="tool_calls" name="search">');
+		expect(tokenTypes(input)).not.toContain('heading(depth 2)');
+	});
+
+	it('leaves standalone paragraphs without a trailing <details> untouched', () => {
+		const input = 'Just a normal paragraph.\nAnother line without details.\n---';
+		const output = processResponseContent(input);
+		// No <details> present, so the normalization should not change anything
+		// beyond the existing trim.
+		expect(output).toBe(input.trim());
+	});
+});

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -96,8 +96,25 @@ export const sanitizeResponseContent = (content: string) => {
 
 export const processResponseContent = (content: string) => {
 	content = processChineseContent(content);
+	content = normalizeDetailsBlock(content);
 	return content.trim();
 };
+
+// Ensure a `<details>` block (optionally with attributes) is always preceded by a
+// blank line so the markdown parser treats it as a standalone HTML block.
+//
+// Without this, when a paragraph is *directly* followed by a `<details>` block and
+// that block's content contains a bare `---` or `===` line, marked's Setext-heading
+// rule fires first and swallows both the preceding paragraph text and the literal
+// `<details>`/`<summary>` source into one (escaped) heading, destroying the
+// collapsible widget. See open-webui/open-webui#27001.
+//
+// A blank line makes the parser commit to raw-HTML-block mode for `<details>` before
+// the Setext rule can misinterpret the content, matching the behavior users already
+// get when they separate the prose from the block with an empty line.
+function normalizeDetailsBlock(content: string): string {
+	return content.replace(/^([^\n]+)\n(<details(?:\s[^>]*)?>)/gim, '$1\n\n$2');
+}
 
 function isChineseChar(char: string): boolean {
 	return /\p{Script=Han}/u.test(char);


### PR DESCRIPTION
## Summary
Fixes [open-webui/open-webui#27001](https://github.com/open-webui/open-webui/issues/27001).

When an assistant message contains prose text **immediately** followed by a `<details>` block (no blank line between them) **and** that `<details>` block's content contains a line that is only `---` or `===`, the markdown pipeline misinterpreted the whole thing: the preceding paragraph text and the literal `<details>`/`<summary>` source were wrapped into one escaped `<h1>`/`<h2>` heading, and the collapsible widget was destroyed.

### Root cause
The renderer runs `marked` over `processResponseContent(content)`. In `marked@9`, the Setext-heading (`lheading`) rule is applied to the full source *before* the paragraph tokenizer is clipped by an extension `start` hook. So when prose directly precedes `<details>` and a bare `---`/`===` line is present, the Setext rule fires first and swallows both the prose and the literal tag source into a heading. The same input with a blank line before `<details>` always rendered correctly.

### Fix
Normalize any `<details>` (optionally with attributes) that immediately follows a non-blank line by inserting a blank line in `processResponseContent` (`src/lib/utils/index.ts`). This makes the parser commit to raw-HTML block mode for `<details>` before the Setext rule can misinterpret the content — matching the behavior users already get when they separate prose from the block with an empty line. The change is scoped to `processResponseContent`, which is only used by the chat `Markdown.svelte` renderer.

### Testing
Added `src/lib/utils/__tests__/processResponseContent.test.ts` (vitest), which exercises the real pipeline (`processResponseContent` + `marked` with the project's `details` extension). It covers:
- bare `---` inside a `<details>` block after prose (previously broken -> now a `details`/`html` token, no heading)
- bare `===` inside a `<details>` block after prose (previously broken -> now a widget)
- `<details>` with attributes (`type="tool_calls"`) directly after prose
- existing blank line before `<details>` (no double spacing introduced)
- a paragraph containing `---` with **no** `<details>` block (untouched)

Run with: `npx vitest run src/lib/utils/__tests__/processResponseContent.test.ts` -> all 6 tests pass.

## OpenJobs
- Job listing ID: `2716f487-bead-4c33-a15b-7b1597f0f0dc`
- Listing URL: https://platform.openjobs.com/jobs/2716f487-bead-4c33-a15b-7b1597f0f0dc
- Submitted by **openjobs.bot**
- References issue: https://github.com/open-webui/open-webui/issues/27001

Generated with Claude Code.
