### PR TITLE
fix: enforce AUTOMATION_MAX_COUNT in create_automation builtin tool

### DIFF
--- a/backend/open_webui/routers/automations.py
+++ b/backend/open_webui/routers/automations.py
@@ -19,10 +19,11 @@ from open_webui.models.config import Config
 from open_webui.utils.access_control import has_permission
 from open_webui.utils.auth import get_admin_user, get_verified_user
 from open_webui.utils.automations import (
+    AutomationLimitError,
+    enforce_automation_limits,
     execute_automation,
     next_n_runs_ns,
     next_run_ns,
-    rrule_interval_seconds,
     validate_rrule,
 )
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -70,31 +71,19 @@ def check_automation_access(automation, user):
 
 async def check_automation_limits(request, user, rrule_str: str, db, is_create: bool = False):
     """Enforce global automation limits. Admins bypass all checks."""
-    if user.role == 'admin':
-        return
-
-    # Max count (create only)
-    if is_create:
-        max_count = await Config.get('automations.max_count')
-        if max_count:
-            max_count = int(max_count)
-            if max_count > 0 and await Automations.count_by_user(user.id, db=db) >= max_count:
-                raise HTTPException(
-                    status_code=status.HTTP_403_FORBIDDEN,
-                    detail=ERROR_MESSAGES.AUTOMATION_LIMIT_EXCEEDED(max_count),
-                )
-
-    # Min interval (create + update)
-    min_interval = await Config.get('automations.min_interval')
-    if min_interval:
-        min_interval = int(min_interval)
-        if min_interval > 0:
-            interval = rrule_interval_seconds(rrule_str)
-            if interval is not None and interval < min_interval:
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail=ERROR_MESSAGES.AUTOMATION_TOO_FREQUENT(min_interval),
-                )
+    try:
+        await enforce_automation_limits(
+            user_role=user.role,
+            user_id=user.id,
+            rrule_str=rrule_str,
+            is_create=is_create,
+            db=db,
+        )
+    except AutomationLimitError as e:
+        raise HTTPException(
+            status_code=e.status_code,
+            detail=e.message,
+        )
 
 
 async def enrich_automation(automation: AutomationModel, db: AsyncSession, tz: str = None) -> AutomationResponse:

--- a/backend/open_webui/tools/builtin.py
+++ b/backend/open_webui/tools/builtin.py
@@ -3313,6 +3313,19 @@ async def create_automation(
         except ValueError as e:
             return json.dumps({'error': f'Invalid schedule: {e}'})
 
+        # Enforce AUTOMATION_MAX_COUNT / AUTOMATION_MIN_INTERVAL (same as API)
+        from open_webui.utils.automations import AutomationLimitError, enforce_automation_limits
+
+        try:
+            await enforce_automation_limits(
+                user_role=user.role,
+                user_id=user_id,
+                rrule_str=rrule,
+                is_create=True,
+            )
+        except AutomationLimitError as e:
+            return json.dumps({'error': e.message})
+
         tz = user.timezone
         form = AutomationForm(
             name=name,
@@ -3393,6 +3406,19 @@ async def update_automation(
                 validate_rrule(new_rrule, tz=user.timezone if user else None)
             except ValueError as e:
                 return json.dumps({'error': f'Invalid schedule: {e}'})
+
+        # Enforce AUTOMATION_MIN_INTERVAL (same as API)
+        from open_webui.utils.automations import AutomationLimitError, enforce_automation_limits
+
+        try:
+            await enforce_automation_limits(
+                user_role=user.role if user else __user__.get('role', 'user'),
+                user_id=user_id,
+                rrule_str=new_rrule,
+                is_create=False,
+            )
+        except AutomationLimitError as e:
+            return json.dumps({'error': e.message})
 
         tz = user.timezone if user else None
         form = AutomationForm(

--- a/backend/open_webui/utils/automations.py
+++ b/backend/open_webui/utils/automations.py
@@ -171,6 +171,56 @@ def rrule_interval_seconds(s: str) -> Optional[int]:
     return int((second - first).total_seconds())
 
 
+class AutomationLimitError(Exception):
+    """Raised when automation count or schedule frequency limits are exceeded."""
+
+    def __init__(self, message: str, status_code: int = 403):
+        self.message = message
+        self.status_code = status_code
+        super().__init__(message)
+
+
+async def enforce_automation_limits(
+    user_role: str,
+    user_id: str,
+    rrule_str: str,
+    is_create: bool = False,
+    db=None,
+) -> None:
+    """Enforce global automation limits for non-admin users.
+
+    Admins bypass all checks. Raises AutomationLimitError on violation.
+    Used by both the automations API and the create_automation/update_automation
+    builtin tools so AUTOMATION_MAX_COUNT / AUTOMATION_MIN_INTERVAL cannot be
+    bypassed via the chat tool path.
+    """
+    if user_role == 'admin':
+        return
+
+    # Max count (create only)
+    if is_create:
+        max_count = await Config.get('automations.max_count')
+        if max_count:
+            max_count = int(max_count)
+            if max_count > 0 and await Automations.count_by_user(user_id, db=db) >= max_count:
+                raise AutomationLimitError(
+                    ERROR_MESSAGES.AUTOMATION_LIMIT_EXCEEDED(max_count),
+                    status_code=403,
+                )
+
+    # Min interval (create + update)
+    min_interval = await Config.get('automations.min_interval')
+    if min_interval:
+        min_interval = int(min_interval)
+        if min_interval > 0:
+            interval = rrule_interval_seconds(rrule_str)
+            if interval is not None and interval < min_interval:
+                raise AutomationLimitError(
+                    ERROR_MESSAGES.AUTOMATION_TOO_FREQUENT(min_interval),
+                    status_code=400,
+                )
+
+
 ############################
 # Worker Loop
 ############################

--- a/backend/open_webui/utils/tools.py
+++ b/backend/open_webui/utils/tools.py
@@ -670,9 +670,15 @@ async def get_builtin_tools(
     if is_builtin_tool_enabled('tasks'):
         builtin_functions.extend([create_tasks, update_task])
 
-    # Automation tools - create and manage scheduled automations from chat
+    # Automation tools - create and manage scheduled automations from chat.
+    # Skip during automation runs so a scheduled prompt cannot spawn more
+    # automations (which would grow exponentially when the model has this tool).
+    metadata = extra_params.get('__metadata__') or {}
+    session_id = metadata.get('session_id') or ''
+    is_automation_run = isinstance(session_id, str) and session_id.startswith('automation:')
     if (
-        is_builtin_tool_enabled('automations')
+        not is_automation_run
+        and is_builtin_tool_enabled('automations')
         and config.get('automations.enable')
         and await has_user_permission('automations')
     ):


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27121
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following Keep a Changelog format is included at the bottom.
- [x] **Documentation:** N/A — behavior aligns with existing AUTOMATION_MAX_COUNT / AUTOMATION_MIN_INTERVAL docs.
- [x] **Dependencies:** No new dependencies.
- [x] **Testing:** Code review of API vs tool path; shared helper ensures identical limit checks.
- [x] **No Unchecked AI Code:** Changes reviewed for correctness against the API path in `routers/automations.py`.
- [x] **Self-Review:** Performed.
- [x] **Architecture:** Reuses existing limits; no new settings.
- [x] **Git Hygiene:** Atomic fix rebased on `dev`.
- [x] **Title Prefix:** fix

# Changelog Entry

### Description

- Enforce `AUTOMATION_MAX_COUNT` and `AUTOMATION_MIN_INTERVAL` in the `create_automation` / `update_automation` builtin tools (same checks as the automations API).
- Prevent recursive automation creation by omitting automation tools when a chat is running as an automation (`session_id` starts with `automation:`).

### Added

- Shared `enforce_automation_limits()` helper and `AutomationLimitError` in `utils/automations.py`.

### Changed

- Automations API router now calls the shared limit helper.
- Builtin automation tools are not injected during automation runs.

### Fixed

- Non-admin users could bypass `AUTOMATION_MAX_COUNT` by creating automations via the chat builtin tool instead of the API UI path (#27121).
- Automations whose prompt asked the model to "create an automation..." could spawn more automations on each run when the Automations tool was enabled on the model.

### Additional Information

- Reproduces steps in #27121: with `AUTOMATION_MAX_COUNT=1`, second `create_automation` tool call returns an error such as `Automation limit reached (1)`.
- Admins continue to bypass limits (unchanged).

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.

