### PR TITLE
fix: respect ENABLE_OLLAMA_API for RAG embeddings

### DIFF
--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -25,6 +25,7 @@ from open_webui.config import (
     RAG_EMBEDDING_QUERY_PREFIX,
     VECTOR_DB,
 )
+from open_webui.constants import ERROR_MESSAGES
 from open_webui.env import (
     AIOHTTP_CLIENT_ALLOW_REDIRECTS,
     AIOHTTP_CLIENT_SESSION_SSL,
@@ -1181,6 +1182,9 @@ async def generate_embeddings(
             text = f'{prefix}{text}'
 
     if engine == 'ollama':
+        if not await Config.get('ollama.enable'):
+            raise ValueError(ERROR_MESSAGES.OLLAMA_API_DISABLED)
+
         embeddings = await agenerate_ollama_batch_embeddings(
             **{
                 'model': model,

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -518,6 +518,12 @@ async def update_embedding_config(request: Request, form_data: EmbeddingModelUpd
     log.info(f'Updating embedding model: {config.RAG_EMBEDDING_MODEL} to {form_data.RAG_EMBEDDING_MODEL}')
     await unload_embedding_model(request)
     try:
+        if form_data.RAG_EMBEDDING_ENGINE == 'ollama' and not await Config.get('ollama.enable'):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=ERROR_MESSAGES.OLLAMA_API_DISABLED,
+            )
+
         config.RAG_EMBEDDING_ENGINE = form_data.RAG_EMBEDDING_ENGINE
         config.RAG_EMBEDDING_MODEL = form_data.RAG_EMBEDDING_MODEL.strip()
         config.RAG_EMBEDDING_BATCH_SIZE = form_data.RAG_EMBEDDING_BATCH_SIZE


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Closes #27111
- [x] **Target branch:** `dev`
- [x] **Description:** below
- [x] **Changelog:** below
- [x] **Testing:** checked against upload embedding path (`generate_embeddings` with engine=ollama)
- [x] **Self-Review:** yes
- [x] **Title Prefix:** fix

# Changelog Entry

### Description

- File upload / RAG embedding still used the Ollama embed endpoint when `ENABLE_OLLAMA_API` was false, which leads to connection errors against the default Docker Ollama URL.

### Fixed

- Respect `ollama.enable` when `RAG_EMBEDDING_ENGINE=ollama` (same flag as the Ollama chat routes).

### Additional Information

- Also blocks selecting Ollama as the embedding engine in admin settings while Ollama is disabled.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.

