### PR TITLE
fix(tool-servers): correct selection key + honor function-name filter for direct tool servers

### DIFF
--- a/src/lib/apis/index.ts
+++ b/src/lib/apis/index.ts
@@ -474,10 +474,43 @@ export const getToolServersData = async (servers: object[]) => {
 							};
 						}
 
-						const { openapi, info, specs } = {
+						let specs = convertOpenApiToToolPayload(res);
+
+						// Apply the per-connection function-name filter (the
+						// "Filterliste für Funktionsnamen" field). The backend only
+						// honours this on the admin `server:openapi:` path, so for
+						// direct/personal tool servers it was silently ignored and
+						// the full tool set (often thousands of tokens) was always
+						// sent to the model. Filter here so the field actually works
+						// on every path. Same allow/block semantics as the backend
+						// `is_string_allowed`: bare entries are an allow-list matched
+						// by suffix; entries prefixed with "!" are blocked.
+						const rawFilter = server?.config?.function_name_filter_list ?? '';
+						const filterList = (typeof rawFilter === 'string' ? rawFilter.split(',') : rawFilter)
+							.map((s: string) => (s ?? '').trim())
+							.filter((s: string) => s.length > 0);
+						if (filterList.length > 0) {
+							const allowList = filterList
+								.filter((s: string) => !s.startsWith('!'))
+								.map((s: string) => s);
+							const blockList = filterList
+								.filter((s: string) => s.startsWith('!'))
+								.map((s: string) => s.slice(1));
+							specs = specs.filter((spec: { name: string }) => {
+								const name = spec?.name ?? '';
+								if (allowList.length > 0 && !allowList.some((a: string) => name.endsWith(a))) {
+									return false;
+								}
+								if (blockList.some((b: string) => name.endsWith(b))) {
+									return false;
+								}
+								return true;
+							});
+						}
+
+						const { openapi, info } = {
 							openapi: res,
-							info: res.info,
-							specs: convertOpenApiToToolPayload(res)
+							info: res.info
 						};
 
 						const result: Record<string, any> = {

--- a/src/lib/components/chat/MessageInput/IntegrationsMenu.svelte
+++ b/src/lib/components/chat/MessageInput/IntegrationsMenu.svelte
@@ -95,10 +95,17 @@
 			for (const serverIdx in $toolServers) {
 				const server = $toolServers[serverIdx];
 				if (server.info) {
-					tools[`direct_server:${serverIdx}`] = {
+					// Use the server's stable backend-assigned id (falls back to its
+					// index only when the backend itself had no better id to give),
+					// rather than this component's own local array position, so the
+					// selection key stays correct even if $toolServers is ever
+					// re-fetched or re-ordered between opening this menu and the
+					// message actually being sent.
+					const stableId = server?.id ?? serverIdx;
+					tools[`direct_server:${stableId}`] = {
 						name: server?.info?.title ?? server.url,
 						description: server.info.description ?? '',
-						enabled: selectedToolIds.includes(`direct_server:${serverIdx}`)
+						enabled: selectedToolIds.includes(`direct_server:${stableId}`)
 					};
 				}
 			}


### PR DESCRIPTION
### Summary

Two independent bugs in how **direct / personal OpenAPI tool servers** (embedded in the chat request as `tool_servers[]`, as opposed to admin `server:openapi:` connections) are turned into the tool set sent to the model:

1. The tool picker keyed each direct server by its **array position**, so toggling one of several servers could send the *wrong* server's tools — or, with 2+ servers, an empty `tool_servers` array.
2. The connection's **"Function name filter list"** field was silently ignored for direct tool servers (only the admin `server:openapi:` and MCP paths honor it in the backend), so the full tool set was always sent — bloating every request with thousands of tokens of unused tool definitions.

### Bug 1 — positional selection key

`IntegrationsMenu.svelte` built each direct server's selection key as `direct_server:${serverIdx}` (position in `$toolServers`). `Chat.svelte` matches those keys back by index or `server.id`. Since `$toolServers` can be re-fetched/reordered between opening the menu and sending, the positional key can point at the wrong slot.

**Fix:** use the backend-assigned stable `server.id` (fall back to index only when the backend supplied no id).

### Bug 2 — function-name filter ignored for direct servers

Direct tool-server specs are built client-side in `getToolServersData` (`apis/index.ts`) and embedded in the request; that function never read `config.function_name_filter_list`, so the UI field had no effect.

**Fix:** apply the same allow/block semantics as the backend `is_string_allowed` (bare entries = suffix allow-list, `!`-prefixed = block) to the generated specs, so the existing field works on every path.

### Performance impact (measured)

68-tool Proxmox MCP-proxy server, qwen3:4b via Ollama, `num_ctx=16384`, base Apple M3:

| | 68 tools (unfiltered) | 19 tools (filtered) |
|---|---|---|
| prompt tokens | 2820 | 882 (−69%) |
| prompt-eval time | 19.2 s | 5.6 s (3.4× faster) |
| total response time | 28.1 s | 12.8 s |
| tool call emitted | none | correct |

Note the correctness effect: flooded with 68 tools the model emitted no tool call; with the filtered 19 it called the right one. Real specs with full parameter schemas are larger (the unfiltered request measured ~8850 prompt tokens), so the practical saving is bigger.

### Testing

- Verified end-to-end in a real chat: with the filter set to 19 of 68 tools, `tool_servers[0].specs.length` in the outgoing `/api/chat/completions` body drops from 68 to 19, and the model correctly calls the requested tool with live data.
- Verified Bug 1 by capturing the request body while toggling one of two configured tool servers.

### Notes

- Frontend-only; no API or DB schema change.
- The filter matches the backend's existing `is_string_allowed` semantics for consistency with the admin `server:openapi:` path.
