### PR TITLE
fix(tool-servers): correct selection key + honor function-name filter for direct tool servers

### DIFF
--- a/src/lib/apis/index.ts
+++ b/src/lib/apis/index.ts
@@ -474,10 +474,43 @@ export const getToolServersData = async (servers: object[]) => {
 							};
 						}
 
-						const { openapi, info, specs } = {
+						let specs = convertOpenApiToToolPayload(res);
+
+						// Apply the per-connection function-name filter (the
+						// "Filterliste für Funktionsnamen" field). The backend only
+						// honours this on the admin `server:openapi:` path, so for
+						// direct/personal tool servers it was silently ignored and
+						// the full tool set (often thousands of tokens) was always
+						// sent to the model. Filter here so the field actually works
+						// on every path. Same allow/block semantics as the backend
+						// `is_string_allowed`: bare entries are an allow-list matched
+						// by suffix; entries prefixed with "!" are blocked.
+						const rawFilter = server?.config?.function_name_filter_list ?? '';
+						const filterList = (typeof rawFilter === 'string' ? rawFilter.split(',') : rawFilter)
+							.map((s: string) => (s ?? '').trim())
+							.filter((s: string) => s.length > 0);
+						if (filterList.length > 0) {
+							const allowList = filterList
+								.filter((s: string) => !s.startsWith('!'))
+								.map((s: string) => s);
+							const blockList = filterList
+								.filter((s: string) => s.startsWith('!'))
+								.map((s: string) => s.slice(1));
+							specs = specs.filter((spec: { name: string }) => {
+								const name = spec?.name ?? '';
+								if (allowList.length > 0 && !allowList.some((a: string) => name.endsWith(a))) {
+									return false;
+								}
+								if (blockList.some((b: string) => name.endsWith(b))) {
+									return false;
+								}
+								return true;
+							});
+						}
+
+						const { openapi, info } = {
 							openapi: res,
-							info: res.info,
-							specs: convertOpenApiToToolPayload(res)
+							info: res.info
 						};
 
 						const result: Record<string, any> = {

--- a/src/lib/components/chat/MessageInput/IntegrationsMenu.svelte
+++ b/src/lib/components/chat/MessageInput/IntegrationsMenu.svelte
@@ -96,10 +96,17 @@
 			for (const serverIdx in $toolServers) {
 				const server = $toolServers[serverIdx];
 				if (server.info) {
-					tools[`direct_server:${serverIdx}`] = {
+					// Use the server's stable backend-assigned id (falls back to its
+					// index only when the backend itself had no better id to give),
+					// rather than this component's own local array position, so the
+					// selection key stays correct even if $toolServers is ever
+					// re-fetched or re-ordered between opening this menu and the
+					// message actually being sent.
+					const stableId = server?.id ?? serverIdx;
+					tools[`direct_server:${stableId}`] = {
 						name: server?.info?.title ?? server.url,
 						description: server.info.description ?? '',
-						enabled: selectedToolIds.includes(`direct_server:${serverIdx}`)
+						enabled: selectedToolIds.includes(`direct_server:${stableId}`)
 					};
 				}
 			}


### PR DESCRIPTION
Relates to #21805

# Changelog Entry

### Description

Two independent bugs in how **direct / personal OpenAPI tool servers** (embedded in the chat request as `tool_servers[]`, as opposed to admin `server:openapi:` connections) are turned into the tool set sent to the model:

1. **Wrong / empty tool set with multiple servers.** `IntegrationsMenu.svelte` keyed each direct server by its **array position** (`direct_server:${serverIdx}`), while `Chat.svelte` matches those keys back by index or `server.id`. Because `$toolServers` can be re-fetched/reordered between opening the picker and sending, the positional key can point at the wrong slot — sending a *different* server's tools, or (with 2+ servers) an empty `tool_servers` array (the symptom in #21805).
   **Fix:** use the backend-assigned stable `server.id` (fall back to index only when the backend supplied no id).

2. **`function_name_filter_list` silently ignored for direct servers.** The connection's "Function name filter list" field is only honored on the admin `server:openapi:` and MCP paths in the backend. Direct/personal tool-server specs are built client-side in `getToolServersData` (`apis/index.ts`) and embedded in the request; that function never read the filter, so the full tool set was always sent, bloating every request with unused tool definitions.
   **Fix:** apply the same allow/block semantics as the backend `is_string_allowed` (bare entries = suffix allow-list, `!`-prefixed = block) to the generated specs, so the existing UI field works on every path.

**Measured impact** (68-tool Proxmox MCP-proxy, qwen3:4b via Ollama, `num_ctx=16384`, base Apple M3): filtering to 19 tools cut prompt tokens ~69%, prompt-eval 19.2s → 5.6s (3.4× faster), and restored correct tool selection (with all 68 tools the model emitted no tool call; with 19 it called the right one).

### Fixed

- Direct/personal tool servers now keyed by stable `server.id` instead of array position, preventing the wrong server's tools (or an empty `tool_servers`) from being sent when multiple servers are configured.
- The per-connection "Function name filter list" is now applied to direct/personal OpenAPI tool servers in `getToolServersData`, matching the backend's existing filter behavior and drastically reducing prompt size for large tool servers.

---

### Additional Information

- Frontend-only; no API or DB schema change.
- Verified end-to-end: with a 19-of-68 filter, `tool_servers[0].specs.length` in the outgoing `/api/chat/completions` body drops from 68 to 19, and the model correctly calls the requested tool with live data. Bug 1 verified by capturing the request body while toggling one of two configured servers.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
