### PR TITLE
fix: preserve chronological chunk order in transcribe when using asyncio.as_completed

### DIFF
--- a/backend/open_webui/routers/audio.py
+++ b/backend/open_webui/routers/audio.py
@@ -1078,7 +1078,15 @@ async def transcribe(request: Request, file_path: str, metadata: Optional[dict] 
 
     results = []
     try:
-        tasks = [transcription_handler(request, chunk_path, metadata, user) for chunk_path in chunk_paths]
+        # Wrap transcription handler to tag each result with its chunk path,
+        # so we can reorder results back to chronological order regardless of
+        # which chunk finishes first.
+        async def transcribe_with_path(chunk_path):
+            result = await transcription_handler(request, chunk_path, metadata, user)
+            result['chunk_path'] = chunk_path
+            return result
+
+        tasks = [transcribe_with_path(chunk_path) for chunk_path in chunk_paths]
         for coro in asyncio.as_completed(tasks):
             try:
                 results.append(await coro)
@@ -1097,6 +1105,12 @@ async def transcribe(request: Request, file_path: str, metadata: Optional[dict] 
                     os.remove(chunk_path)
                 except Exception:
                     pass
+
+    # Sort results by chunk index to preserve chronological order.
+    # asyncio.as_completed() yields in completion order, which is non-deterministic
+    # when per-chunk transcription times vary. Reassemble in chunk_paths order.
+    chunk_index = {path: idx for idx, path in enumerate(chunk_paths)}
+    results.sort(key=lambda r: chunk_index.get(r.get('chunk_path', ''), 0))
 
     return {
         'text': ' '.join([result['text'] for result in results]),

--- a/backend/tests/test_audio_chunk_order.py
+++ b/backend/tests/test_audio_chunk_order.py
@@ -1,0 +1,148 @@
+"""
+Tests for asyncio.as_completed chunk ordering fix in audio.py.
+
+Verifies that the sort-by-chunk-index logic correctly reorders results
+when asyncio.as_completed() yields them out of order.
+"""
+import asyncio
+import pytest
+
+
+class TestChunkOrdering:
+    """Unit tests for the chunk ordering fix."""
+
+    def test_results_sorted_when_as_completed_out_of_order(self):
+        """Results are sorted back to chunk_paths order when asyncio
+        yields them in non-sequential completion order."""
+        chunk_paths = [
+            '/tmp/chunk_0.wav',
+            '/tmp/chunk_1.wav',
+            '/tmp/chunk_2.wav',
+        ]
+        # Simulate results coming back in non-sequential order
+        # (chunk_2 completes first, then chunk_0, then chunk_1)
+        results = [
+            {'text': 'second half transcript', 'chunk_path': '/tmp/chunk_2.wav'},
+            {'text': 'opening transcript', 'chunk_path': '/tmp/chunk_0.wav'},
+            {'text': 'middle transcript', 'chunk_path': '/tmp/chunk_1.wav'},
+        ]
+
+        # Apply the sort logic from the fix
+        chunk_index = {path: idx for idx, path in enumerate(chunk_paths)}
+        results.sort(key=lambda r: chunk_index.get(r.get('chunk_path', ''), 0))
+
+        assert results[0]['text'] == 'opening transcript'
+        assert results[1]['text'] == 'middle transcript'
+        assert results[2]['text'] == 'second half transcript'
+
+    def test_results_preserved_when_already_in_order(self):
+        """Already-sorted results remain in order."""
+        chunk_paths = ['/tmp/chunk_0.wav', '/tmp/chunk_1.wav']
+        results = [
+            {'text': 'first', 'chunk_path': '/tmp/chunk_0.wav'},
+            {'text': 'second', 'chunk_path': '/tmp/chunk_1.wav'},
+        ]
+
+        chunk_index = {path: idx for idx, path in enumerate(chunk_paths)}
+        results.sort(key=lambda r: chunk_index.get(r.get('chunk_path', ''), 0))
+
+        assert results[0]['text'] == 'first'
+        assert results[1]['text'] == 'second'
+
+    def test_single_chunk_unchanged(self):
+        """Single chunk is unaffected by the sort."""
+        chunk_paths = ['/tmp/chunk_0.wav']
+        results = [
+            {'text': 'solo transcript', 'chunk_path': '/tmp/chunk_0.wav'},
+        ]
+
+        chunk_index = {path: idx for idx, path in enumerate(chunk_paths)}
+        results.sort(key=lambda r: chunk_index.get(r.get('chunk_path', ''), 0))
+
+        assert len(results) == 1
+        assert results[0]['text'] == 'solo transcript'
+
+    def test_empty_results_handled_gracefully(self):
+        """Empty results list doesn't error on sort."""
+        chunk_paths = ['/tmp/chunk_0.wav']
+        results = []
+
+        chunk_index = {path: idx for idx, path in enumerate(chunk_paths)}
+        results.sort(key=lambda r: chunk_index.get(r.get('chunk_path', ''), 0))
+
+        assert results == []
+
+    def test_missing_chunk_path_falls_back_to_zero(self):
+        """Results without chunk_path are treated as index 0 (safe default)."""
+        chunk_paths = ['/tmp/chunk_0.wav', '/tmp/chunk_1.wav']
+        results = [
+            {'text': 'mystery result'},  # no chunk_path
+            {'text': 'first chunk', 'chunk_path': '/tmp/chunk_0.wav'},
+        ]
+
+        chunk_index = {path: idx for idx, path in enumerate(chunk_paths)}
+        results.sort(key=lambda r: chunk_index.get(r.get('chunk_path', ''), 0))
+
+        # Both map to index 0 since missing key → 0 and chunk_0 → 0
+        assert len(results) == 2
+
+    def test_joined_text_preserves_order(self):
+        """The final ' '.join produces correct chronological text."""
+        chunk_paths = [
+            '/tmp/chunk_0.wav',
+            '/tmp/chunk_1.wav',
+        ]
+        results = [
+            {'text': 'WORLD', 'chunk_path': '/tmp/chunk_1.wav'},
+            {'text': 'HELLO', 'chunk_path': '/tmp/chunk_0.wav'},
+        ]
+
+        chunk_index = {path: idx for idx, path in enumerate(chunk_paths)}
+        results.sort(key=lambda r: chunk_index.get(r.get('chunk_path', ''), 0))
+        joined = ' '.join([result['text'] for result in results])
+
+        assert joined == 'HELLO WORLD'
+
+    @pytest.mark.asyncio
+    async def test_as_completed_interleaving_does_not_corrupt_order(self):
+        """Integration-style test: async tasks finishing in reverse order
+        still produce correctly sorted output."""
+        chunk_paths = ['/a/chunk_0.wav', '/a/chunk_1.wav', '/a/chunk_2.wav']
+
+        async def fake_handler(chunk_path):
+            # Simulate per-chunk timing differences:
+            # later chunks finish faster
+            delays = {
+                '/a/chunk_0.wav': 0.05,
+                '/a/chunk_1.wav': 0.02,
+                '/a/chunk_2.wav': 0.005,
+            }
+            await asyncio.sleep(delays.get(chunk_path, 0.01))
+            return {
+                'text': f'text_from_{chunk_path.split("/")[-1].split(".")[0]}',
+                'chunk_path': chunk_path,
+            }
+
+        tasks = [fake_handler(p) for p in chunk_paths]
+        results = []
+        for coro in asyncio.as_completed(tasks):
+            results.append(await coro)
+
+        # Results are now in completion order, NOT chunk_paths order
+        # (chunk_2 first because it's fastest)
+        assert results[0]['chunk_path'] == '/a/chunk_2.wav', (
+            f'Expected chunk_2 first (fastest), got {results[0]["chunk_path"]}'
+        )
+
+        # Apply the fix sort
+        chunk_index = {path: idx for idx, path in enumerate(chunk_paths)}
+        results.sort(key=lambda r: chunk_index.get(r.get('chunk_path', ''), 0))
+
+        # Now they should be in chronological order
+        assert [r['chunk_path'] for r in results] == [
+            '/a/chunk_0.wav',
+            '/a/chunk_1.wav',
+            '/a/chunk_2.wav',
+        ]
+        joined = ' '.join([r['text'] for r in results])
+        assert joined == 'text_from_chunk_0 text_from_chunk_1 text_from_chunk_2'


### PR DESCRIPTION
## Pull Request Checklist

- [x] **Linked Issue/Discussion:** This PR fixes #27143
- [x] **Target branch:** `dev` ✅
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry is included at the bottom.
- [x] **Documentation:** No documentation changes needed (bugfix).
- [x] **Dependencies:** No new dependencies.
- [x] **Testing:** Manual tests performed + 7 new unit tests added and passing.
- [x] **No Unchecked AI Code:** This PR has undergone thorough human review AND manual testing.
- [x] **Self-Review:** A self-review of the code has been performed.
- [x] **Architecture:** Smart defaults preserved. Minimal scoped change.
- [x] **Git Hygiene:** Single atomic commit, rebased on `dev`.
- [x] **Title Prefix:** `fix:`

## Description

`asyncio.as_completed()` yields coroutine results in **completion order**, not submission order. When an audio/video file is split into multiple chunks for transcription, whichever chunk finishes first gets placed first in the assembled text. For long recordings this non-deterministically scrambles the timeline — the second half of a conversation can end up before the opening.

### Root Cause

In `transcribe()` (`audio.py:1082`), tasks are dispatched in chunk order via `chunk_paths` but results are collected via `asyncio.as_completed(tasks)`, which yields by finish time. The per-chunk transcription handler returns only `{"text": ...}` with no chunk index, so completion order is irretrievably lost — and `" ".join(results)` concatenates segments in the wrong order.

### Fix

Wrap each `transcription_handler` call in a thin async function that tags the result dict with its `chunk_path`. After all chunks complete, sort `results` by chunk index (position in `chunk_paths`) before joining text. This ensures the assembled transcript always reads start-to-finish.

The fix:
- Preserves the concurrency benefit of `asyncio.as_completed` (no wasted wall-clock time)
- Adds a deterministic sort by chunk index after collection
- Is minimal and scoped to the affected code path only

### Test Plan

7 unit tests covering: out-of-order completion, already-ordered, single chunk, empty results, missing chunk_path fallback, final joined text, and an async integration test simulating real timing variance — all pass.

## Changelog Entry

### Fixed

- Fixed non-deterministic transcript ordering for long audio/video files where `asyncio.as_completed()` caused chunks to be assembled in completion order rather than chronological order. Results are now tagged with their chunk path and sorted by chunk index before the final join.

---

### Additional Information

- Report: #27143
- No visual/screenshot changes needed (bugfix)

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)