### PR TITLE
fix: prevent Setext heading rule from swallowing a <details> block (#27001)

### DIFF
--- a/src/lib/utils/__tests__/processResponseContent.test.ts
+++ b/src/lib/utils/__tests__/processResponseContent.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import { processResponseContent } from '$lib/utils';
+import { marked, type Token } from 'marked';
+import markedExtension from '$lib/utils/marked/extension';
+
+// Wire up the same block/inline extensions the chat Markdown renderer uses so we
+// exercise the real pipeline (processResponseContent -> marked lexer).
+marked.use(markedExtension({}));
+
+const tokenTypes = (src: string): string[] =>
+	marked
+		.lexer(processResponseContent(src))
+		.map((t: Token) => t.type + (t.type === 'heading' ? `(depth ${(t as any).depth})` : ''));
+
+const hasDetailsWidget = (src: string): boolean => {
+	const tokens = marked.lexer(processResponseContent(src));
+	// A correctly-rendered <details> block produces either a custom `details`
+	// token (this extension) or an `html` token whose raw starts with `<details`
+	// (no heading swallowing the tag source).
+	return tokens.some(
+		(t) => (t.type === 'details' || t.type === 'html') && (t.raw ?? '').startsWith('<details')
+	);
+};
+
+describe('processResponseContent - #27001 details/setext heading regression', () => {
+	it('precedes a <details> block with a blank line so it is not swallowed into a heading', () => {
+		const input = [
+			'Here is some introductory text before the widget.',
+			'<details>',
+			'<summary>Click to expand</summary>',
+			'line one',
+			'---',
+			'line two',
+			'</details>'
+		].join('\n');
+
+		const output = processResponseContent(input);
+
+		// The paragraph and the <details> tag must be separated by a blank line.
+		expect(output).toContain(
+			'Here is some introductory text before the widget.\n\n<details>'
+		);
+	});
+
+	it('renders a real collapsed details widget (not a heading) when bare --- is present', () => {
+		const input = [
+			'Here is some introductory text before the widget.',
+			'<details>',
+			'<summary>Click to expand</summary>',
+			'line one',
+			'---',
+			'line two',
+			'</details>'
+		].join('\n');
+
+		expect(tokenTypes(input)).not.toContain('heading(depth 2)');
+		expect(hasDetailsWidget(input)).toBe(true);
+	});
+
+	it('renders a real collapsed details widget (not a heading) when bare === is present', () => {
+		const input = [
+			'Here is some introductory text before the widget.',
+			'<details>',
+			'<summary>Click to expand</summary>',
+			'line one',
+			'===',
+			'line two',
+			'</details>'
+		].join('\n');
+
+		expect(tokenTypes(input)).not.toContain('heading(depth 1)');
+		expect(hasDetailsWidget(input)).toBe(true);
+	});
+
+	it('does not add a blank line when one already exists (no double spacing)', () => {
+		const input = [
+			'Here is some introductory text before the widget.',
+			'',
+			'<details>',
+			'<summary>Click to expand</summary>',
+			'line one',
+			'---',
+			'line two',
+			'</details>'
+		].join('\n');
+
+		const output = processResponseContent(input);
+		expect(output).not.toContain('\n\n\n<details>');
+		expect(hasDetailsWidget(input)).toBe(true);
+	});
+
+	it('handles <details> with attributes directly after prose', () => {
+		const input = [
+			'Some prose.',
+			'<details type="tool_calls" name="search">',
+			'<summary>Tool call</summary>',
+			'result',
+			'---',
+			'</details>'
+		].join('\n');
+
+		const output = processResponseContent(input);
+		expect(output).toContain('Some prose.\n\n<details type="tool_calls" name="search">');
+		expect(tokenTypes(input)).not.toContain('heading(depth 2)');
+	});
+
+	it('leaves standalone paragraphs without a trailing <details> untouched', () => {
+		const input = 'Just a normal paragraph.\nAnother line without details.\n---';
+		const output = processResponseContent(input);
+		// No <details> present, so the normalization should not change anything
+		// beyond the existing trim.
+		expect(output).toBe(input.trim());
+	});
+});

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -96,8 +96,25 @@ export const sanitizeResponseContent = (content: string) => {
 
 export const processResponseContent = (content: string) => {
 	content = processChineseContent(content);
+	content = normalizeDetailsBlock(content);
 	return content.trim();
 };
+
+// Ensure a `<details>` block (optionally with attributes) is always preceded by a
+// blank line so the markdown parser treats it as a standalone HTML block.
+//
+// Without this, when a paragraph is *directly* followed by a `<details>` block and
+// that block's content contains a bare `---` or `===` line, marked's Setext-heading
+// rule fires first and swallows both the preceding paragraph text and the literal
+// `<details>`/`<summary>` source into one (escaped) heading, destroying the
+// collapsible widget. See open-webui/open-webui#27001.
+//
+// A blank line makes the parser commit to raw-HTML-block mode for `<details>` before
+// the Setext rule can misinterpret the content, matching the behavior users already
+// get when they separate the prose from the block with an empty line.
+function normalizeDetailsBlock(content: string): string {
+	return content.replace(/^([^\n]+)\n(<details(?:\s[^>]*)?>)/gim, '$1\n\n$2');
+}
 
 function isChineseChar(char: string): boolean {
 	return /\p{Script=Han}/u.test(char);


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing Issue — `Closes #27001`.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following Keep a Changelog format is included at the bottom.
- [x] **Testing:** Manual tests have been performed to verify the fix works correctly and does not introduce regressions.

# Summary

Fixes [open-webui/open-webui#27001](https://github.com/open-webui/open-webui/issues/27001).

When an assistant message contains prose immediately followed by a `<details>` block (no blank line between them), and that block's content contains a bare `---` or `===` line, the markdown renderer misinterprets the whole thing: instead of rendering a collapsed `<details>`/`<summary>` widget, it wraps the preceding paragraph text **and** the literal, HTML-escaped `<details>` tag source into one big `<h1>`/`<h2>` heading. The collapsible widget is destroyed and raw tag markup leaks into the visible output.

### Root cause
`<details>` blocks normally render fine even without a preceding blank line. But when a bare `---`/`===` line appears inside the block before the parser has "committed" to raw-HTML-block mode, marked's Setext-heading rule fires first and reinterprets the accumulated text (prose + literal tag source) as a heading.

### Fix
`processResponseContent` now calls a `normalizeDetailsBlock` step that inserts a blank line between any non-blank line and a following `<details>` (with or without attributes) opening tag. This makes the parser commit to raw-HTML-block mode for `<details>` before the Setext rule can misfire — matching the behavior users already get when they separate the prose from the block with an empty line. It is a no-op when a blank line already exists and when no `<details>` is present.

## Changelog Entry

### Fixed
- Fixed a markdown rendering bug where prose immediately followed by a `<details>` block (no blank line) would be swallowed into an escaped `<h1>`/`<h2>` heading when the block contained a bare `---` or `===` line. A real collapsed `<details>` widget is now preserved instead of leaking literal tag markup. (Closes #27001)

## Testing notes
- Added `src/lib/utils/__tests__/processResponseContent.test.ts` (Vitest) exercising `processResponseContent` through the real marked + `details` extension pipeline.
- Cases covered: bare `---`, bare `===`, `<details>` with attributes, an already-present blank line (no double spacing), and a standalone paragraph with no trailing `<details>` (left untouched).
- Negative control: with the fix reverted, the reproduction input (`prose\n<details>\n...\n---\n...`) lexes to `heading(d2)` + `paragraph` + `html` (swallowed, no widget). With the fix applied it lexes to a real `details`/`html(<details...)` token and produces no heading.
- `npx vitest run src/lib/utils/__tests__/processResponseContent.test.ts` -> **6 passed**.

## OpenJobs metadata
- openjobs.bot
- OpenJobs listing: https://openjobs.bot/jobs/2716f487-bead-4c33-a15b-7b1597f0f0dc (id `2716f487-bead-4c33-a15b-7b1597f0f0dc`)
- Linked issue: https://github.com/open-webui/open-webui/issues/27001

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
