### PR TITLE
feat: add MCP elicitation support for server-enforced user confirmation

### DIFF
--- a/backend/open_webui/utils/mcp/client.py
+++ b/backend/open_webui/utils/mcp/client.py
@@ -11,6 +11,7 @@ from mcp import ClientSession
 from mcp.client.auth import OAuthClientProvider, TokenStorage
 from mcp.client.streamable_http import streamablehttp_client
 from mcp.shared.auth import OAuthClientInformationFull, OAuthClientMetadata, OAuthToken
+from mcp.types import ElicitRequestURLParams, ElicitResult
 from open_webui.env import (
     AIOHTTP_CLIENT_SESSION_TOOL_SERVER_SSL,
     AIOHTTP_CLIENT_TIMEOUT_TOOL_SERVER,
@@ -60,6 +61,60 @@ class MCPClient:
     def __init__(self):
         self.session: Optional[ClientSession] = None
         self.exit_stack = None
+        self.instructions: Optional[str] = None
+        self._event_caller = None
+
+    async def _elicitation_callback(self, context, params):
+        """Handle MCP elicitation requests from server tools.
+
+        Uses OWUI's event_caller to show a confirmation dialog to the user
+        and waits for their response.
+        """
+        message = getattr(params, 'message', 'Action confirmation requested')
+        log.debug('MCP elicitation callback: %s', message[:200])
+
+        try:
+            response = await self._event_caller(
+                {
+                    'type': 'confirmation',
+                    'data': {
+                        'title': '⚠️ Action Confirmation',
+                        'message': message,
+                    },
+                }
+            )
+            if isinstance(response, dict) and response.get('error'):
+                log.warning('MCP elicitation event_caller error: %s', response['error'])
+                return ElicitResult(action='cancel', content=None)
+            if response:
+                log.debug('MCP elicitation approved by user')
+                # URL-mode elicitation: content must be omitted
+                if isinstance(params, ElicitRequestURLParams):
+                    return ElicitResult(action='accept', content=None)
+                # Form-mode: build content matching the requestedSchema
+                schema = getattr(params, 'requestedSchema', None)
+                if schema and isinstance(schema, dict):
+                    props = schema.get('properties', {})
+                    content = {}
+                    for key, prop in props.items():
+                        prop_type = prop.get('type', 'boolean')
+                        if prop_type == 'boolean':
+                            content[key] = True
+                        elif prop_type == 'string':
+                            content[key] = 'confirmed'
+                        elif prop_type in ('number', 'integer'):
+                            content[key] = 1
+                        else:
+                            content[key] = True
+                else:
+                    content = {'value': True}
+                return ElicitResult(action='accept', content=content)
+            else:
+                log.debug('MCP elicitation rejected by user')
+                return ElicitResult(action='decline', content=None)
+        except Exception as e:
+            log.warning('MCP elicitation event_caller failed: %s', e)
+            return ElicitResult(action='decline', content=None)
 
     async def connect(self, url: str, headers: Optional[dict] = None):
         async with AsyncExitStack() as exit_stack:
@@ -75,11 +130,16 @@ class MCPClient:
                 transport = await exit_stack.enter_async_context(self._streams_context)
                 read_stream, write_stream, _ = transport
 
-                self._session_context = ClientSession(read_stream, write_stream)  # pylint: disable=W0201
+                self._session_context = ClientSession(
+                    read_stream,
+                    write_stream,
+                    elicitation_callback=self._elicitation_callback if self._event_caller else None,
+                )
 
                 self.session = await exit_stack.enter_async_context(self._session_context)
                 with anyio.fail_after(MCP_INITIALIZE_TIMEOUT):
-                    await self.session.initialize()
+                    init_result = await self.session.initialize()
+                self.instructions = getattr(init_result, 'instructions', None)
                 self.exit_stack = exit_stack.pop_all()
             except Exception as e:
                 await self.disconnect()

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2195,6 +2195,7 @@ async def connect_mcp_server(
     )
 
     client = MCPClient()
+    client._event_caller = extra_params.get('__event_call__')
     await client.connect(
         url=mcp_server_connection.get('url', ''),
         headers=headers if headers else None,
@@ -2706,6 +2707,21 @@ async def process_chat_payload(request, form_data, user, metadata, model):
 
                         client, tool_specs = result
                         mcp_clients[server_id] = client
+
+                        if client.instructions:
+                            # Sanitize to prevent label-breakout injection
+                            safe_server_id = server_id.replace(']', '').replace('\n', '')
+                            safe_instructions = client.instructions.replace(
+                                '[/MCP_SERVER_INSTRUCTIONS', '[/MCP\\_SERVER\\_INSTRUCTIONS'
+                            ).replace('[MCP_SERVER_INSTRUCTIONS', '[MCP\\_SERVER\\_INSTRUCTIONS')
+                            labeled_instructions = (
+                                f'[MCP_SERVER_INSTRUCTIONS: {safe_server_id}]\n'
+                                f'{safe_instructions}\n'
+                                f'[/MCP_SERVER_INSTRUCTIONS: {safe_server_id}]'
+                            )
+                            form_data['messages'] = add_or_update_system_message(
+                                labeled_instructions, form_data['messages'], append=True
+                            )
 
                         for tool_spec in tool_specs:
 


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Relates to https://github.com/open-webui/open-webui/discussions/27156
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** No new dependencies. Uses existing `mcp.types.ElicitResult` and `mcp.types.ElicitRequestURLParams` already available via `mcp` SDK.
- [x] **Testing:** Manual tests performed — approve and reject paths verified with mcp-atlassian server (38 write tools). Screenshots included below.
- [x] **No Unchecked AI Code:** Code has been manually reviewed, tested, and iterated through multiple review passes.
- [x] **Self-Review:** Self-review performed.
- [x] **Architecture:** No new settings. Reuses existing `event_caller` + `ConfirmDialog` infrastructure. Capability only advertised when interactive session is available.
- [x] **Git Hygiene:** Single atomic commit, one logical change.
- [x] **Title Prefix:** `feat:`

# Changelog Entry

### Description

Adds MCP elicitation support to Open WebUI, enabling MCP servers to request user confirmation mid-tool-execution. When a server calls `ctx.elicit()`, the user sees a native ConfirmDialog and must approve or reject before the tool proceeds. This is server-enforced — the LLM cannot bypass it.

Also captures MCP server `instructions` from the init handshake and injects them into the system prompt with labeled, sanitized blocks per server.

Motivation: MCP servers with write operations (Jira, Confluence, databases) need a way to gate destructive actions. The MCP spec defines elicitation for this purpose, but Open WebUI's MCP client doesn't implement it yet.

### Added

- `_elicitation_callback` method on `MCPClient` — handles `elicitation/create` requests from MCP servers using OWUI's existing `event_caller` mechanism (Socket.IO `sio.call()` → frontend `ConfirmDialog`)
- `elicitation_callback` passed to `ClientSession` when `_event_caller` is available (capability gated to interactive WebSocket sessions only)
- `client.instructions` captured from `InitializeResult` after `session.initialize()`
- Server instructions injected into system message with sanitized `[MCP_SERVER_INSTRUCTIONS: server_id]` labels

### Changed

- `MCPClient.__init__` — added `instructions` and `_event_caller` attributes
- `connect_mcp_server()` in middleware — sets `_event_caller` from `extra_params['__event_call__']` before connecting

### Deprecated

- N/A

### Removed

- N/A

### Fixed

- N/A

### Security

- Safe default: declines on errors, timeouts, and disconnected sessions (never auto-approves)
- Elicitation capability only advertised for interactive sessions (not REST API / config validation paths)
- Server instructions sanitized to prevent label-breakout injection
- `server_id` sanitized in label boundaries (strips `]` and `\n`)
- Log messages truncated to prevent server-controlled PII/log flooding

### Breaking Changes

- None. Clients without elicitation support are unaffected — servers that call `ctx.elicit()` will get an error and should handle it gracefully (existing MCP SDK behavior).

---

### Additional Information

- MCP Elicitation Spec: https://modelcontextprotocol.io/specification/2025-06-18/client/elicitation
- Related discussion: https://github.com/open-webui/open-webui/discussions/27156
- Related community discussion (HITL): https://github.com/open-webui/open-webui/discussions/16701
- Discussion #19940 covers MCP Sampling (different feature — server asks for LLM completions, not user input)

**Known limitations (documented in discussion):**
- Works as a confirmation gate (accept/decline) — not full form data collection yet. A dynamic form renderer for `requestedSchema` would be a future enhancement.
- URL-mode elicitation returns spec-compliant response but doesn't redirect the user to the URL. Frontend would need a dedicated link/redirect event type.

### Screenshots or Videos

<img width="1164" height="693" alt="Screenshot 2026-07-17 at 16 01 18" src="https://github.com/user-attachments/assets/c3870d3b-c8d0-4dba-a014-6d4b5dbd5f4c" />
*Native ConfirmDialog triggered by MCP server elicitation during a write operation. User must click Confirm or Cancel before the tool executes.*

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.

