### PR TITLE
fix: forward chat_id as user field in OpenAI-compatible chat completions

### DIFF
--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -1225,6 +1225,9 @@ async def generate_chat_completion(
     payload = {**form_data}
     metadata = payload.pop('metadata', None)
 
+    if metadata and metadata.get('chat_id'):
+        payload['user'] = metadata.get('chat_id')
+
     model_id = form_data.get('model')
     model_info = await Models.get_model_by_id(model_id)
 


### PR DESCRIPTION
### Description

When Open WebUI proxies to an OpenAI-compatible backend that uses the standard `user` field for session identification, every chat request creates a new backend session because the `chat_id` from metadata is never forwarded as the `user` field.

The `metadata` object (which contains `chat_id`) is already popped from the payload before forwarding, but the `user` field is never set from it. This is a one-line fix.

### Fixed

- Forward `chat_id` from metadata as the standard OpenAI `user` field in `/v1/chat/completions` requests, enabling upstream backends (like OpenClaw Gateway) to maintain conversation continuity.

### Additional Information

- Closes #27174
- Minimal change: 3 lines added, 0 removed
- Targets `dev` branch
- No new dependencies, no config changes, no breaking changes
- The `user` field is a standard, optional field in the OpenAI Chat Completions API spec

### Screenshots or Videos

N/A — behavioral change tested via manual inspection of upstream request payloads.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
