### PR TITLE
fix: hide redundant edit pencil on mobile in admin Models list

### DIFF
--- a/src/lib/components/admin/Settings/Models.svelte
+++ b/src/lib/components/admin/Settings/Models.svelte
@@ -1008,7 +1008,7 @@
 									{/if}
 
 									<button
-										class="self-center w-fit text-sm p-1.5 dark:text-gray-300 dark:hover:text-white hover:bg-black/5 dark:hover:bg-white/5 rounded-xl"
+										class="hidden sm:flex self-center w-fit text-sm p-1.5 dark:text-gray-300 dark:hover:text-white hover:bg-black/5 dark:hover:bg-white/5 rounded-xl"
 										type="button"
 										on:click={() => {
 											selectedModelId = model.id;


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Relates to #27177
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable — no behavior or configuration change requiring docs.
- [ ] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Manual tests have been performed to verify the fix works correctly and does not introduce regressions.
- [x] **No Unchecked AI Code:** This PR has undergone thorough human review AND manual testing.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. No new settings introduced.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses the **fix** prefix.

---

## Summary

In **Admin Settings → Models**, every row renders an edit pencil button in its action group. Tapping the row itself already opens the model editor — the pencil triggers exactly the same handler (`selectedModelId = model.id`), so it is a duplicate affordance.

On desktop that's harmless. On narrow/mobile viewports it costs scarce horizontal space in each row's action cluster (pencil + item menu + enable toggle), squeezing the model name/label area for a control that adds nothing the row tap doesn't already provide.

This PR hides the pencil below the `sm` breakpoint and keeps it on `sm+` screens — a one-class change:

```diff
- class="self-center w-fit text-sm p-1.5 …"
+ class="hidden sm:flex self-center w-fit text-sm p-1.5 …"
```

- **Mobile:** row tap opens the editor (unchanged behavior, no functionality lost); the action cluster slims down and the model name gets the space back.
- **Desktop:** identical to today — the pencil remains as an explicit affordance.

### Context

This is the surviving piece of a broader mobile-usability pass on the Models list (#27023, closed) — the rest of that work (truncation chain, `shrink-0` anchors, badge placement) was independently implemented by the Models page redesign on `dev`. Only this pencil tweak remained unaddressed. See the linked discussion #27177 for details.

# Changelog Entry

### Description

- Hide the redundant per-row edit pencil in the admin Models list on mobile viewports, where tapping the row already opens the model editor

### Fixed

- Fixed the admin Models list rows on narrow viewports rendering a redundant edit pencil that duplicated the row tap while crowding the action cluster; the pencil remains on `sm+` screens

---

### Additional Information

- One file, one line changed: `src/lib/components/admin/Settings/Models.svelte`
- Manually verified on a narrow viewport: pencil hidden below `sm`, row tap opens the editor; on `sm+` the pencil renders and behaves exactly as before

### Screenshots or Videos

#### Before:
<img width="417" height="843" alt="image" src="https://github.com/user-attachments/assets/8716f5f3-40c7-493d-8db2-59722875f941" />

#### After:
<img width="417" height="843" alt="image" src="https://github.com/user-attachments/assets/362f1e9f-87bd-4133-ab1f-9c8b71ffe5b7" />

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [[Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
