### PR TITLE
fix: show progress while terminal downloads are prepared

### DIFF
--- a/src/lib/components/chat/FileNav.svelte
+++ b/src/lib/components/chat/FileNav.svelte
@@ -43,6 +43,7 @@
 	import FilePreview from './FileNav/FilePreview.svelte';
 	import FileEntryRow from './FileNav/FileEntryRow.svelte';
 	import BulkActionBar from './FileNav/BulkActionBar.svelte';
+	import { withDownloadLock } from './FileNav/downloadState';
 	import PortList from './FileNav/PortList.svelte';
 	import PortPreview from './FileNav/PortPreview.svelte';
 	import XTerminal from './XTerminal.svelte';
@@ -94,6 +95,9 @@
 	let entries: FileEntry[] = [];
 	let loading = false;
 	let error: string | null = null;
+	let downloadingPaths = new Set<string>();
+	let bulkDownloading = false;
+	const isDownloading = (path: string | null) => path !== null && downloadingPaths.has(path);
 
 	// ── Sort state ──────────────────────────────────────────────────────
 	type SortMode = 'name' | 'date';
@@ -525,18 +529,25 @@
 		const terminal = selectedTerminal;
 		if (!terminal) return;
 
-		// Directories end with '/' — download as ZIP archive
-		const isDir = path.endsWith('/');
-		const result = isDir
-			? await archiveFromTerminal(terminal.url, terminal.key, [path.replace(/\/$/, '')])
-			: await downloadFileBlob(terminal.url, terminal.key, path, chatId ?? undefined);
-		if (!result) return;
-		const url = URL.createObjectURL(result.blob);
-		const a = document.createElement('a');
-		a.href = url;
-		a.download = result.filename;
-		a.click();
-		URL.revokeObjectURL(url);
+		await withDownloadLock(
+			downloadingPaths,
+			path,
+			() => (downloadingPaths = new Set(downloadingPaths)),
+			async () => {
+				// Directories end with '/' — download as ZIP archive
+				const isDir = path.endsWith('/');
+				const result = isDir
+					? await archiveFromTerminal(terminal.url, terminal.key, [path.replace(/\/$/, '')])
+					: await downloadFileBlob(terminal.url, terminal.key, path, chatId ?? undefined);
+				if (!result) return;
+				const url = URL.createObjectURL(result.blob);
+				const a = document.createElement('a');
+				a.href = url;
+				a.download = result.filename;
+				a.click();
+				URL.revokeObjectURL(url);
+			}
+		);
 	};
 
 	// ── Drag-and-drop upload ─────────────────────────────────────────────
@@ -785,26 +796,31 @@
 
 	const bulkDownload = async () => {
 		const terminal = selectedTerminal;
-		if (!terminal) return;
+		if (!terminal || bulkDownloading) return;
 
 		const paths = [...selectedEntries].map((p) => p.replace(/\/$/, ''));
 		if (paths.length === 0) return;
 
-		// Single file (not dir) — use the regular downloadFile path
-		if (paths.length === 1 && ![...selectedEntries][0].endsWith('/')) {
-			await downloadFile([...selectedEntries][0]);
-			return;
-		}
+		bulkDownloading = true;
+		try {
+			// Single file (not dir) — use the regular downloadFile path
+			if (paths.length === 1 && ![...selectedEntries][0].endsWith('/')) {
+				await downloadFile([...selectedEntries][0]);
+				return;
+			}
 
-		// Archive everything into a single ZIP
-		const result = await archiveFromTerminal(terminal.url, terminal.key, paths);
-		if (!result) return;
-		const url = URL.createObjectURL(result.blob);
-		const a = document.createElement('a');
-		a.href = url;
-		a.download = result.filename;
-		a.click();
-		URL.revokeObjectURL(url);
+			// Archive everything into a single ZIP
+			const result = await archiveFromTerminal(terminal.url, terminal.key, paths);
+			if (!result) return;
+			const url = URL.createObjectURL(result.blob);
+			const a = document.createElement('a');
+			a.href = url;
+			a.download = result.filename;
+			a.click();
+			URL.revokeObjectURL(url);
+		} finally {
+			bulkDownloading = false;
+		}
 	};
 
 	// Escape to clear selection
@@ -1259,23 +1275,28 @@
 				<Tooltip content={$i18n.t('Download')}>
 					<button
 						class="shrink-0 p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 transition text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-400"
-						on:click={() => downloadFile(selectedFile)}
-						aria-label={$i18n.t('Download')}
+						on:click={() => selectedFile && downloadFile(selectedFile)}
+						disabled={isDownloading(selectedFile)}
+						aria-label={$i18n.t(isDownloading(selectedFile) ? 'Preparing download' : 'Download')}
 					>
-						<svg
-							xmlns="http://www.w3.org/2000/svg"
-							viewBox="0 0 24 24"
-							fill="none"
-							stroke="currentColor"
-							stroke-width="1.5"
-							class="size-3.5"
-						>
-							<path
-								stroke-linecap="round"
-								stroke-linejoin="round"
-								d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12m4.5 4.5V3"
-							/>
-						</svg>
+						{#if isDownloading(selectedFile)}
+							<Spinner className="size-3.5" />
+						{:else}
+							<svg
+								xmlns="http://www.w3.org/2000/svg"
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								stroke-width="1.5"
+								class="size-3.5"
+							>
+								<path
+									stroke-linecap="round"
+									stroke-linejoin="round"
+									d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12m4.5 4.5V3"
+								/>
+							</svg>
+						{/if}
 					</button>
 				</Tooltip>
 			</FileNavToolbar>
@@ -1285,6 +1306,7 @@
 				<BulkActionBar
 					count={selectedCount}
 					hasFiles={hasSelectedFiles}
+					downloading={bulkDownloading}
 					onDelete={() => {
 						deleteTarget = { path: '__bulk__', name: `${selectedCount} items` };
 						showDeleteConfirm = true;
@@ -1434,6 +1456,11 @@
 									selectedPaths={selectedEntries}
 									onOpen={openEntry}
 									onDownload={downloadFile}
+									downloading={downloadingPaths.has(
+										entry.type === 'directory'
+											? `${currentPath}${entry.name}/`
+											: `${currentPath}${entry.name}`
+									)}
 									onDelete={requestDelete}
 									onMove={handleMove}
 									onRename={handleRename}

--- a/src/lib/components/chat/FileNav/BulkActionBar.svelte
+++ b/src/lib/components/chat/FileNav/BulkActionBar.svelte
@@ -2,11 +2,13 @@
 	import { getContext } from 'svelte';
 	import GarbageBin from '../../icons/GarbageBin.svelte';
 	import Tooltip from '../../common/Tooltip.svelte';
+	import Spinner from '../../common/Spinner.svelte';
 
 	const i18n = getContext('i18n');
 
 	export let count: number = 0;
 	export let hasFiles: boolean = false;
+	export let downloading: boolean = false;
 
 	export let onDelete: () => void = () => {};
 	export let onDownload: () => void = () => {};
@@ -40,25 +42,30 @@
 		</button>
 	</Tooltip>
 
-	<Tooltip content={$i18n.t('Download')}>
+	<Tooltip content={$i18n.t(downloading ? 'Preparing download' : 'Download')}>
 		<button
 			class="p-1 rounded transition text-gray-400 dark:text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-600 dark:hover:text-gray-400"
 			on:click={onDownload}
-			aria-label={$i18n.t('Download')}
+			disabled={downloading}
+			aria-label={$i18n.t(downloading ? 'Preparing download' : 'Download')}
 		>
-			<svg
-				xmlns="http://www.w3.org/2000/svg"
-				viewBox="0 0 20 20"
-				fill="currentColor"
-				class="size-3.5"
-			>
-				<path
-					d="M10.75 2.75a.75.75 0 0 0-1.5 0v8.614L6.295 8.235a.75.75 0 1 0-1.09 1.03l4.25 4.5a.75.75 0 0 0 1.09 0l4.25-4.5a.75.75 0 0 0-1.09-1.03l-2.955 3.129V2.75Z"
-				/>
-				<path
-					d="M3.5 12.75a.75.75 0 0 0-1.5 0v2.5A2.75 2.75 0 0 0 4.75 18h10.5A2.75 2.75 0 0 0 18 15.25v-2.5a.75.75 0 0 0-1.5 0v2.5c0 .69-.56 1.25-1.25 1.25H4.75c-.69 0-1.25-.56-1.25-1.25v-2.5Z"
-				/>
-			</svg>
+			{#if downloading}
+				<Spinner className="size-3.5" />
+			{:else}
+				<svg
+					xmlns="http://www.w3.org/2000/svg"
+					viewBox="0 0 20 20"
+					fill="currentColor"
+					class="size-3.5"
+				>
+					<path
+						d="M10.75 2.75a.75.75 0 0 0-1.5 0v8.614L6.295 8.235a.75.75 0 1 0-1.09 1.03l4.25 4.5a.75.75 0 0 0 1.09 0l4.25-4.5a.75.75 0 0 0-1.09-1.03l-2.955 3.129V2.75Z"
+					/>
+					<path
+						d="M3.5 12.75a.75.75 0 0 0-1.5 0v2.5A2.75 2.75 0 0 0 4.75 18h10.5A2.75 2.75 0 0 0 18 15.25v-2.5a.75.75 0 0 0-1.5 0v2.5c0 .69-.56 1.25-1.25 1.25H4.75c-.69 0-1.25-.56-1.25-1.25v-2.5Z"
+					/>
+				</svg>
+			{/if}
 		</button>
 	</Tooltip>
 

--- a/src/lib/components/chat/FileNav/FileEntryRow.svelte
+++ b/src/lib/components/chat/FileNav/FileEntryRow.svelte
@@ -10,6 +10,7 @@
 	import GarbageBin from '../../icons/GarbageBin.svelte';
 	import Pencil from '../../icons/Pencil.svelte';
 	import Clipboard from '../../icons/Clipboard.svelte';
+	import Spinner from '../../common/Spinner.svelte';
 
 	const i18n = getContext('i18n');
 
@@ -23,6 +24,7 @@
 	export let onDelete: (path: string, name: string) => void = () => {};
 	export let onMove: (source: string, destFolder: string) => void = () => {};
 	export let onRename: (oldPath: string, newName: string) => void = () => {};
+	export let downloading: boolean = false;
 
 	// ── Selection ─────────────────────────────────────────────────────────
 	export let selected: boolean = false;
@@ -140,6 +142,7 @@
 			? 'bg-blue-50 dark:bg-blue-900/30 ring-1 ring-blue-400 dark:ring-blue-500 ring-inset'
 			: ''}"
 		role={entry.type === 'directory' ? 'button' : undefined}
+		aria-busy={downloading}
 		on:dragover={(e) => {
 			if (entry.type !== 'directory') return;
 			if (!e.dataTransfer?.types.includes('application/x-terminal-file-move')) return;
@@ -257,6 +260,9 @@
 					/>
 				</svg>
 			{/if}
+			{#if downloading}
+				<Spinner className="size-3.5 shrink-0" />
+			{/if}
 			{#if renaming}
 				<!-- svelte-ignore a11y-click-events-have-key-events -->
 				<input
@@ -318,21 +324,28 @@
 									: `${currentPath}${entry.name}`;
 							onDownload(path);
 						}}
+						disabled={downloading}
 					>
-						<svg
-							xmlns="http://www.w3.org/2000/svg"
-							viewBox="0 0 20 20"
-							fill="currentColor"
-							class="size-4"
-						>
-							<path
-								d="M10.75 2.75a.75.75 0 0 0-1.5 0v8.614L6.295 8.235a.75.75 0 1 0-1.09 1.03l4.25 4.5a.75.75 0 0 0 1.09 0l4.25-4.5a.75.75 0 0 0-1.09-1.03l-2.955 3.129V2.75Z"
-							/>
-							<path
-								d="M3.5 12.75a.75.75 0 0 0-1.5 0v2.5A2.75 2.75 0 0 0 4.75 18h10.5A2.75 2.75 0 0 0 18 15.25v-2.5a.75.75 0 0 0-1.5 0v2.5c0 .69-.56 1.25-1.25 1.25H4.75c-.69 0-1.25-.56-1.25-1.25v-2.5Z"
-							/>
-						</svg>
-						<div class="flex items-center">{$i18n.t('Download')}</div>
+						{#if downloading}
+							<Spinner className="size-4" />
+						{:else}
+							<svg
+								xmlns="http://www.w3.org/2000/svg"
+								viewBox="0 0 20 20"
+								fill="currentColor"
+								class="size-4"
+							>
+								<path
+									d="M10.75 2.75a.75.75 0 0 0-1.5 0v8.614L6.295 8.235a.75.75 0 1 0-1.09 1.03l4.25 4.5a.75.75 0 0 0 1.09 0l4.25-4.5a.75.75 0 0 0-1.09-1.03l-2.955 3.129V2.75Z"
+								/>
+								<path
+									d="M3.5 12.75a.75.75 0 0 0-1.5 0v2.5A2.75 2.75 0 0 0 4.75 18h10.5A2.75 2.75 0 0 0 18 15.25v-2.5a.75.75 0 0 0-1.5 0v2.5c0 .69-.56 1.25-1.25 1.25H4.75c-.69 0-1.25-.56-1.25-1.25v-2.5Z"
+								/>
+							</svg>
+						{/if}
+						<div class="flex items-center">
+							{$i18n.t(downloading ? 'Preparing download' : 'Download')}
+						</div>
 					</button>
 
 					<button

--- a/src/lib/components/chat/FileNav/downloadState.test.ts
+++ b/src/lib/components/chat/FileNav/downloadState.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { withDownloadLock } from './downloadState';
+
+describe('withDownloadLock', () => {
+	it('prevents duplicate concurrent downloads for the same path', async () => {
+		const inFlight = new Set<string>();
+		let resolveDownload: (value: string) => void = () => {};
+		const download = vi.fn(
+			() =>
+				new Promise<string>((resolve) => {
+					resolveDownload = resolve;
+				})
+		);
+
+		const first = withDownloadLock(inFlight, '/large-folder/', () => {}, download);
+		const duplicate = await withDownloadLock(inFlight, '/large-folder/', () => {}, download);
+
+		expect(duplicate).toBeUndefined();
+		expect(download).toHaveBeenCalledTimes(1);
+		expect(inFlight.has('/large-folder/')).toBe(true);
+
+		resolveDownload('archive');
+		await expect(first).resolves.toBe('archive');
+		expect(inFlight.has('/large-folder/')).toBe(false);
+	});
+
+	it('releases the path after a failed download', async () => {
+		const inFlight = new Set<string>();
+		const download = vi.fn().mockRejectedValue(new Error('archive failed'));
+
+		await expect(withDownloadLock(inFlight, '/large-folder/', () => {}, download)).rejects.toThrow(
+			'archive failed'
+		);
+		expect(inFlight.has('/large-folder/')).toBe(false);
+	});
+});

--- a/src/lib/components/chat/FileNav/downloadState.ts
+++ b/src/lib/components/chat/FileNav/downloadState.ts
@@ -1,0 +1,19 @@
+export const withDownloadLock = async <T>(
+	inFlight: Set<string>,
+	key: string,
+	onChange: () => void,
+	download: () => Promise<T>
+): Promise<T | undefined> => {
+	if (inFlight.has(key)) {
+		return undefined;
+	}
+
+	inFlight.add(key);
+	onChange();
+	try {
+		return await download();
+	} finally {
+		inFlight.delete(key);
+		onChange();
+	}
+};


### PR DESCRIPTION
## Summary

- show a spinner while Open Terminal prepares individual file or folder downloads
- disable repeated clicks for the same path to prevent duplicate archive generation
- show and lock the bulk-download action while its archive is being prepared
- release download locks after both success and failure

Fixes https://github.com/open-webui/open-webui/issues/27055

This work is associated with openjobs.bot listing 984b5307-46b9-4564-ae9f-4f586ae315c8: https://openjobs.bot/jobs/984b5307-46b9-4564-ae9f-4f586ae315c8

## Testing

- `npx vitest run src/lib/components/chat/FileNav/downloadState.test.ts --passWithNoTests` (2 tests passed)
- Prettier check passed for all five changed files

The regression tests cover concurrent duplicate suppression and lock cleanup after a failed archive request.