### PR TITLE
fix: handle null tool_call arguments during stream processing

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -193,7 +193,15 @@ def _split_tool_calls(
     independently. Single-object arguments pass through unchanged.
     """
 
-    def split_json_objects(raw: str) -> list[str]:
+    def split_json_objects(raw: str | None) -> list[str]:
+        # Some providers stream tool_calls with arguments: null. Treat as empty.
+        if raw is None:
+            return ['{}']
+        if not isinstance(raw, str):
+            try:
+                raw = json.dumps(raw)
+            except Exception:
+                raw = str(raw)
         decoder = json.JSONDecoder()
         results = []
         position = 0
@@ -214,7 +222,17 @@ def _split_tool_calls(
 
     expanded = []
     for tool_call in tool_calls:
-        arguments = tool_call.get('function', {}).get('arguments', '')
+        arguments = tool_call.get('function', {}).get('arguments')
+        if arguments is None:
+            arguments = '{}'
+        elif not isinstance(arguments, str):
+            try:
+                arguments = json.dumps(arguments)
+            except Exception:
+                arguments = str(arguments)
+        # Normalize so downstream never sees None
+        tool_call.setdefault('function', {})
+        tool_call['function']['arguments'] = arguments
         split_arguments = split_json_objects(arguments)
 
         if len(split_arguments) <= 1:
@@ -4238,6 +4256,9 @@ async def streaming_chat_response_handler(response, ctx):
                                                     delta_tool_call.setdefault('function', {})
                                                     delta_tool_call['function'].setdefault('name', '')
                                                     delta_tool_call['function'].setdefault('arguments', '')
+                                                    # Providers may send arguments: null; setdefault won't replace null.
+                                                    if delta_tool_call['function'].get('arguments') is None:
+                                                        delta_tool_call['function']['arguments'] = ''
                                                     response_tool_calls.append(delta_tool_call)
                                                 else:
                                                     # Update the existing tool call
@@ -4250,8 +4271,13 @@ async def streaming_chat_response_handler(response, ctx):
                                                         current_response_tool_call['function']['name'] = delta_name
 
                                                     if delta_arguments:
-                                                        current_response_tool_call['function']['arguments'] += (
-                                                            delta_arguments
+                                                        existing_args = current_response_tool_call['function'].get(
+                                                            'arguments'
+                                                        )
+                                                        if existing_args is None:
+                                                            existing_args = ''
+                                                        current_response_tool_call['function']['arguments'] = (
+                                                            existing_args + delta_arguments
                                                         )
 
                                         # Emit pending tool calls in real-time


### PR DESCRIPTION
## Summary
- Guard `split_json_objects` / `_split_tool_calls` against `function.arguments: null`
- Normalize null tool-call arguments during streaming delta merge
- Prevents mid-stream crash: `TypeError: object of type 'NoneType' has no len()`

## Problem
Some OpenAI-compatible providers stream tool call deltas like:

```json
{"tool_calls":[{"function":{"name":"search_web","arguments":null}}]}
```

Open WebUI used `tool_call.get('function', {}).get('arguments', '')`, which still returns `None` when the key is present with a null value. That was passed into `split_json_objects`, which did `len(raw)` and crashed `process_chat` after partial assistant text had already been streamed.

Stack trace (v0.10.2):

```text
File "open_webui/utils/middleware.py", in stream_body_handler
    tool_calls.append(_split_tool_calls(response_tool_calls))
File "open_webui/utils/middleware.py", in _split_tool_calls
    split_arguments = split_json_objects(arguments)
File "open_webui/utils/middleware.py", in split_json_objects
    while position < len(raw):
TypeError: object of type 'NoneType' has no len()
```

## Reproduction
1. Enable native function calling + web search / builtin tools
2. Use a provider that emits null tool-call arguments (observed with DeepSeek V4 via DeepInfra)
3. Prompt something that triggers a tool call
4. Stream starts rendering text, then aborts with:
   `Error processing chat payload: object of type 'NoneType' has no len()`

## Test plan
- [ ] Streamed tool call with `arguments: null` no longer crashes
- [ ] Normal tool calls with JSON string arguments still work
- [ ] Multi-object concatenated arguments still split correctly
- [ ] Text-only replies still stream normally