### PR TITLE
fix: handle null tool_call arguments during stream processing

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -238,7 +238,15 @@ def _split_tool_calls(
     independently. Single-object arguments pass through unchanged.
     """
 
-    def split_json_objects(raw: str) -> list[str]:
+    def split_json_objects(raw: str | None) -> list[str]:
+        # Some providers stream tool_calls with arguments: null. Treat as empty.
+        if raw is None:
+            return ['{}']
+        if not isinstance(raw, str):
+            try:
+                raw = json.dumps(raw)
+            except Exception:
+                raw = str(raw)
         decoder = json.JSONDecoder()
         results = []
         position = 0
@@ -259,7 +267,17 @@ def _split_tool_calls(
 
     expanded = []
     for tool_call in tool_calls:
-        arguments = tool_call.get('function', {}).get('arguments', '')
+        arguments = tool_call.get('function', {}).get('arguments')
+        if arguments is None:
+            arguments = '{}'
+        elif not isinstance(arguments, str):
+            try:
+                arguments = json.dumps(arguments)
+            except Exception:
+                arguments = str(arguments)
+        # Normalize so downstream never sees None
+        tool_call.setdefault('function', {})
+        tool_call['function']['arguments'] = arguments
         split_arguments = split_json_objects(arguments)
 
         if len(split_arguments) <= 1:
@@ -4331,6 +4349,9 @@ async def streaming_chat_response_handler(response, ctx):
                                                     delta_tool_call.setdefault('function', {})
                                                     delta_tool_call['function'].setdefault('name', '')
                                                     delta_tool_call['function'].setdefault('arguments', '')
+                                                    # Providers may send arguments: null; setdefault won't replace null.
+                                                    if delta_tool_call['function'].get('arguments') is None:
+                                                        delta_tool_call['function']['arguments'] = ''
                                                     response_tool_calls.append(delta_tool_call)
                                                 else:
                                                     # Update the existing tool call
@@ -4343,8 +4364,13 @@ async def streaming_chat_response_handler(response, ctx):
                                                         current_response_tool_call['function']['name'] = delta_name
 
                                                     if delta_arguments:
-                                                        current_response_tool_call['function']['arguments'] += (
-                                                            delta_arguments
+                                                        existing_args = current_response_tool_call['function'].get(
+                                                            'arguments'
+                                                        )
+                                                        if existing_args is None:
+                                                            existing_args = ''
+                                                        current_response_tool_call['function']['arguments'] = (
+                                                            existing_args + delta_arguments
                                                         )
 
                                         # Emit pending tool calls in real-time


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Closes #27195` / `Relates to #27195`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [x] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs). *(N/A — backend defensive fix only)*
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented. *(None)*
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

# Changelog Entry

### Description

- Prevent mid-stream crash when OpenAI-compatible providers emit tool call deltas with `function.arguments: null`.

### Added

- N/A

### Changed

- Normalize null / non-string tool-call `arguments` before JSON splitting and during stream delta merge.

### Deprecated

- N/A

### Removed

- N/A

### Fixed

- `TypeError: object of type 'NoneType' has no len()` in `split_json_objects` / `_split_tool_calls` when providers stream null tool-call arguments (observed with DeepSeek via DeepInfra).
- Stream delta accumulation no longer keeps `arguments: null` after `setdefault`, and no longer attempts `None + chunk` concatenation.

### Security

- N/A

### Breaking Changes

- N/A

---

### Additional Information

- **Closes #27195**
- Root cause: `.get('arguments', '')` returns `None` when the key is present with JSON `null` (default only applies when key is missing). That value is passed into `split_json_objects`, which calls `len(raw)`.
- Stack path: `stream_body_handler` → `_split_tool_calls` → `split_json_objects` → `len(None)`.
- Pure text replies were unaffected; failures occur when native function calling / tools trigger tool calls.
- Related closed PR targeting `main` (incorrect base): #27194

### Screenshots or Videos

- N/A (backend stream crash; verified via unit call of `_split_tool_calls` with `arguments=None` and live reproduction logs)

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.