### PR TITLE
fix: sanitize UTF-16 surrogates in chat serialization

### DIFF
--- a/backend/open_webui/utils/misc.py
+++ b/backend/open_webui/utils/misc.py
@@ -711,15 +711,20 @@ def sanitize_filename(file_name):
     return final_file_name
 
 
+_SURROGATE_RE = re.compile('[\ud800-\udfff]')
+
+
 def sanitize_text_for_db(text: str) -> str:
     """Remove null bytes and invalid UTF-8 surrogates from text for PostgreSQL storage."""
     if not isinstance(text, str):
         return text
-    # Fast path: skip work when there are no null bytes (the common case)
-    if '\x00' not in text:
+    # Fast path: skip work when there are no null bytes or surrogates (the common case)
+    if '\x00' not in text and not _SURROGATE_RE.search(text):
         return text
     # Remove null bytes
     text = text.replace('\x00', '').replace('\u0000', '')
+    # Remove invalid UTF-8 surrogate characters
+    text = _SURROGATE_RE.sub('', text)
     # Remove invalid UTF-8 surrogate characters that can cause encoding errors
     # This handles cases where binary data or encoding issues introduced surrogates
     try:
@@ -744,19 +749,20 @@ def sanitize_data_for_db(obj):
     """Recursively sanitize all strings in a data structure for database storage.
 
     Performs a fast pre-check: serializes the structure once and scans for
-    null bytes.  If none are found (the overwhelmingly common case), the
-    original object is returned immediately, skipping the expensive
-    recursive walk.
+    null bytes or surrogate characters.  If none are found (the overwhelmingly
+    common case), the original object is returned immediately, skipping the
+    expensive recursive walk.
     """
     if isinstance(obj, str):
         return sanitize_text_for_db(obj)
-    # Fast path: check for null bytes in the serialized form.
+    # Fast path: check for null bytes/surrogates in the serialized form.
     # json.dumps is implemented in C and much faster than a Python-level
     # recursive walk over every leaf string.
     try:
-        if '\\u0000' not in json.dumps(obj, ensure_ascii=False):
+        dumped = json.dumps(obj, ensure_ascii=False)
+        if '\\u0000' not in dumped and not _SURROGATE_RE.search(dumped):
             return obj
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, UnicodeEncodeError):
         pass
     return _strip_null_bytes_deep(obj)
 


### PR DESCRIPTION
Closes #27081

## What

`sanitize_text_for_db` and `sanitize_data_for_db` in `backend/open_webui/utils/misc.py` only checked for null bytes in their fast path. UTF-16 surrogate characters (U+D800–U+DFFF) without null bytes escaped sanitization, reached pydantic serialization, and crashed with `UnicodeEncodeError: surrogates not allowed`. FastAPI then returned a 500 HTML body, which made the frontend `res.json()` throw `Unexpected token '<', "<!DOCTYPE "... is not valid JSON`.

Fix: add `_SURROGATE_RE = re.compile('[\ud800-\udfff]')` and check it in both fast paths. Strip surrogates explicitly with `_SURROGATE_RE.sub('', text)` when the slow path runs. The existing `encode/decode` round-trip is kept as defense in depth.

Same fix as #27084, which was closed without merge for targeting `main` and missing the CLA block (not for technical reasons). The bug is still live in v0.10.2.

## Checklist

- [x] **Linked Issue/Discussion:** Closes #27081
- [x] **Target branch:** `dev`
- [x] **Description:** provided above
- [x] **Changelog:** included below
- [ ] **Documentation:** N/A — backend-only bug fix, no user-facing behavior change
- [ ] **Dependencies:** none added
- [x] **Testing:** `ruff check` and `ruff format --check` pass with no new errors vs. baseline. Isolated logic test confirms surrogates are detected and stripped, and that normal text (e.g. `/etc/hosts` paths, the prompt that originally surfaced the bug) hits the fast path unchanged. Manual dogfood pending.
- [x] **No Unchecked AI Code:** Author reviewed the diff line by line before opening; patch mirrors a previously submitted upstream PR (#27084) that was already public.
- [x] **Self-Review:** done
- [x] **Architecture:** smallest correct change; no new settings, no API change
- [x] **Git Hygiene:** one atomic commit, rebased on `dev`
- [x] **Title Prefix:** `fix:` used

# Changelog Entry

### Description

Surrogate characters (U+D800–U+DFFF) escaped the `sanitize_text_for_db` / `sanitize_data_for_db` fast path because it only checked for null bytes. This caused `PydanticSerializationError` on chat serialization, surfacing in the UI as `Unexpected token '<', "<!DOCTYPE "... is not valid JSON`.

### Fixed

- Strip UTF-16 surrogate characters from strings before database storage and response serialization. Adds a `_SURROGATE_RE` check to the fast path of `sanitize_text_for_db` and `sanitize_data_for_db`; strips surrogates explicitly in the slow path.

### Security

- None.

### Breaking Changes

- None.

---

### Additional Information

- Upstream issue: #27081 (open in v0.10.2)
- Previous attempt: #27084 (closed without merge — targeted `main`, missing CLA). This PR targets `dev` and includes the CLA confirmation.
- Performance: `re.search` runs in C with early exit. Common case (no surrogates, no null bytes) pays one extra scan of the serialized string, same order as the existing `'\\u0000' not in dumped` check.

### Screenshots or Videos

N/A — backend-only fix; no UI change.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.