### PR TITLE
perf: lazily load branched chat history

### DIFF
--- a/.github/workflows/lazy-history-image.yml
+++ b/.github/workflows/lazy-history-image.yml
@@ -1,0 +1,98 @@
+name: Publish lazy history image
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - perf/lazy-branched-chat-history
+
+concurrency:
+  group: lazy-history-image-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/open-webui
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install frontend dependencies
+        run: npm ci --force
+
+      - name: Run lazy history frontend tests
+        run: >-
+          npm run test:frontend -- --run
+          src/lib/apis/chats/index.test.ts
+          src/lib/utils/chatHistoryWindow.test.ts
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Install backend test dependencies
+        run: uv sync --frozen --group dev --no-install-project
+
+      - name: Run lazy history backend tests
+        env:
+          PYTHONPATH: backend
+        run: >-
+          uv run --no-sync pytest -q
+          backend/tests/test_chat_history.py
+          backend/tests/test_chat_messages.py
+          backend/tests/test_chat_storage.py
+          backend/tests/test_context_compaction.py
+          backend/tests/test_message_output_context.py
+          backend/tests/test_middleware_message_files.py
+
+  build:
+    needs: verify
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and publish slim image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64
+          tags: |
+            ${{ env.IMAGE_NAME }}:lazy-history
+            ${{ env.IMAGE_NAME }}:lazy-history-${{ github.sha }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+          build-args: |
+            BUILD_HASH=${{ github.sha }}
+            USE_SLIM=true
+          cache-from: type=gha,scope=lazy-history-slim-amd64
+          cache-to: type=gha,mode=max,scope=lazy-history-slim-amd64
+
+      - name: Inspect published image
+        run: docker buildx imagetools inspect ${{ env.IMAGE_NAME }}:lazy-history

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ FROM --platform=$BUILDPLATFORM node:22-alpine3.20 AS build
 ARG BUILD_HASH
 
 # Set Node.js options (heap limit Allocation failed - JavaScript heap out of memory)
-# ENV NODE_OPTIONS="--max-old-space-size=4096"
+ENV NODE_OPTIONS="--max-old-space-size=8192"
 
 WORKDIR /app
 

--- a/backend/open_webui/functions.py
+++ b/backend/open_webui/functions.py
@@ -221,7 +221,7 @@ async def generate_function_chat_completion(request, form_data, user, models: di
 
     metadata = form_data.pop('metadata', {})
 
-    files = metadata.get('files', [])
+    files = metadata.get('files') or []
     tool_ids = metadata.get('tool_ids', [])
     # Check if tool_ids is None
     if tool_ids is None:

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -1170,7 +1170,9 @@ async def chat_completion(
         chat_id = form_data.get('chat_id') or ''
         chat_variables = form_data.pop('chat_variables', None)
         if chat_variables is None:
-            existing_chat = await Chats.get_chat_by_id(chat_id) if is_saved_chat_id(chat_id) else None
+            existing_chat = (
+                await Chats.get_chat_by_id(chat_id, include_messages=False) if is_saved_chat_id(chat_id) else None
+            )
             chat_variables = existing_chat.variables if existing_chat else {}
 
         chat_variables = normalize_chat_variables(chat_variables)
@@ -1420,14 +1422,19 @@ async def chat_completion(
                     # now the backend owns persistence.
                     chat_files = metadata.get('files')
                     if chat_files is not None or selected_chat_models:
-                        existing_chat = await Chats.get_chat_by_id(chat_id)
+                        existing_chat = await Chats.get_chat_by_id(chat_id, include_messages=False)
                         if existing_chat:
                             updated = {**existing_chat.chat}
                             if chat_files is not None:
                                 updated['files'] = chat_files
                             if selected_chat_models:
                                 updated['models'] = selected_chat_models
-                            await Chats.update_chat_by_id(chat_id, updated, touch=False)
+                            await Chats.update_chat_by_id(
+                                chat_id,
+                                updated,
+                                touch=False,
+                                include_messages=False,
+                            )
 
                     await Chats.update_chat_variables_by_id(chat_id, chat_variables)
 
@@ -1465,7 +1472,7 @@ async def chat_completion(
                         if grandparent_id:
                             grandparent = await Chats.get_message_by_id_and_message_id(chat_id, grandparent_id)
                             if grandparent:
-                                child_ids = grandparent.get('childrenIds', [])
+                                child_ids = grandparent.get('childrenIds') or []
                                 if user_message['id'] not in child_ids:
                                     child_ids.append(user_message['id'])
                                     await Chats.upsert_message_to_chat_by_id_and_message_id(
@@ -1498,7 +1505,7 @@ async def chat_completion(
                     if user_message_id and all_assistant_ids:
                         existing_user_message = await Chats.get_message_by_id_and_message_id(chat_id, user_message_id)
                         if existing_user_message:
-                            child_ids = existing_user_message.get('childrenIds', [])
+                            child_ids = existing_user_message.get('childrenIds') or []
                             for assistant_id in all_assistant_ids:
                                 if assistant_id not in child_ids:
                                     child_ids.append(assistant_id)
@@ -2045,7 +2052,7 @@ async def list_tasks_by_chat_id_endpoint(request: Request, chat_id: str, user=De
         if owner_id != user.id and user.role != 'admin':
             return {'task_ids': []}
     else:
-        chat = await Chats.get_chat_by_id(chat_id)
+        chat = await Chats.get_chat_by_id(chat_id, include_messages=False)
         if chat is None or (chat.user_id != user.id and user.role != 'admin'):
             return {'task_ids': []}
 
@@ -2063,7 +2070,7 @@ async def stop_tasks_by_chat_id_endpoint(request: Request, chat_id: str, user=De
         if owner_id != user.id and user.role != 'admin':
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
     else:
-        chat = await Chats.get_chat_by_id(chat_id)
+        chat = await Chats.get_chat_by_id(chat_id, include_messages=False)
         if chat is None or (chat.user_id != user.id and user.role != 'admin'):
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
     result = await stop_item_tasks(request.app.state.redis, chat_id)

--- a/backend/open_webui/migrations/versions/9c0e2f4a6b81_add_data_to_chat_message.py
+++ b/backend/open_webui/migrations/versions/9c0e2f4a6b81_add_data_to_chat_message.py
@@ -1,0 +1,256 @@
+"""add lossless data to chat message
+
+Revision ID: 9c0e2f4a6b81
+Revises: 9a1b2c3d4e5f
+Create Date: 2026-07-19 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = '9c0e2f4a6b81'
+down_revision: str | None = '9a1b2c3d4e5f'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+BATCH_SIZE = 1000
+CHAT_BATCH_SIZE = 100
+
+PROJECTION_TO_DATA_KEY = {
+    'role': 'role',
+    'parent_id': 'parentId',
+    'children_ids': 'childrenIds',
+    'content': 'content',
+    'output': 'output',
+    'model_id': 'model',
+    'files': 'files',
+    'sources': 'sources',
+    'embeds': 'embeds',
+    'meta': 'meta',
+    'done': 'done',
+    'status_history': 'statusHistory',
+    'error': 'error',
+    'usage': 'usage',
+    'context_summary': 'contextSummary',
+    'created_at': 'timestamp',
+}
+
+
+def _original_message_id(row_id: str, chat_id: str) -> str:
+    prefix = f'{chat_id}-'
+    return row_id[len(prefix) :] if row_id.startswith(prefix) else row_id
+
+
+def _build_message_data(row) -> dict:
+    values = row._mapping
+    data = {'id': _original_message_id(values['id'], values['chat_id'])}
+
+    for column_name, data_key in PROJECTION_TO_DATA_KEY.items():
+        value = values[column_name]
+        if value is not None:
+            data[data_key] = value
+
+    if values['usage'] is not None:
+        data['info'] = {'usage': values['usage']}
+
+    data.setdefault('content', '')
+    return data
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    columns = {column['name'] for column in inspector.get_columns('chat_message')}
+
+    if 'data' not in columns:
+        op.add_column('chat_message', sa.Column('data', sa.JSON(), nullable=True))
+    if 'children_ids' not in columns:
+        op.add_column('chat_message', sa.Column('children_ids', sa.JSON(), nullable=True))
+
+    chat_message = sa.table(
+        'chat_message',
+        sa.column('id', sa.Text()),
+        sa.column('chat_id', sa.Text()),
+        sa.column('role', sa.Text()),
+        sa.column('parent_id', sa.Text()),
+        sa.column('children_ids', sa.JSON()),
+        sa.column('data', sa.JSON()),
+        sa.column('content', sa.JSON()),
+        sa.column('output', sa.JSON()),
+        sa.column('model_id', sa.Text()),
+        sa.column('files', sa.JSON()),
+        sa.column('sources', sa.JSON()),
+        sa.column('embeds', sa.JSON()),
+        sa.column('meta', sa.JSON()),
+        sa.column('done', sa.Boolean()),
+        sa.column('status_history', sa.JSON()),
+        sa.column('error', sa.JSON()),
+        sa.column('usage', sa.JSON()),
+        sa.column('context_summary', sa.Text()),
+        sa.column('created_at', sa.BigInteger()),
+    )
+
+    select_columns = [chat_message.c.id, chat_message.c.chat_id]
+    select_columns.extend(getattr(chat_message.c, column_name) for column_name in PROJECTION_TO_DATA_KEY)
+    result = conn.execute(
+        sa.select(*select_columns)
+        .where(chat_message.c.data.is_(None))
+        .execution_options(yield_per=BATCH_SIZE, stream_results=True)
+    )
+    update_stmt = (
+        sa.update(chat_message)
+        .where(chat_message.c.id == sa.bindparam('message_row_id'))
+        .values(data=sa.bindparam('message_data'))
+    )
+
+    for rows in result.partitions(BATCH_SIZE):
+        conn.execute(
+            update_stmt,
+            [
+                {
+                    'message_row_id': row._mapping['id'],
+                    'message_data': _build_message_data(row),
+                }
+                for row in rows
+            ],
+        )
+
+
+def _json_value(value, default):
+    if value is None:
+        return default
+    if isinstance(value, str):
+        try:
+            import json
+
+            return json.loads(value)
+        except (TypeError, ValueError):
+            return default
+    return value
+
+
+def _active_branch(messages: dict[str, dict], current_id: str | None) -> list[dict]:
+    branch = []
+    visited = set()
+    while current_id and current_id not in visited:
+        visited.add(current_id)
+        message = messages.get(current_id)
+        if not isinstance(message, dict):
+            break
+        branch.append(message)
+        current_id = message.get('parentId')
+    branch.reverse()
+    return branch
+
+
+def _restore_compacted_chats(conn) -> None:  # noqa: C901
+    inspector = sa.inspect(conn)
+    if 'chat' not in inspector.get_table_names():
+        return
+
+    chat = sa.table(
+        'chat',
+        sa.column('id', sa.Text()),
+        sa.column('chat', sa.JSON()),
+    )
+    chat_message = sa.table(
+        'chat_message',
+        sa.column('id', sa.Text()),
+        sa.column('chat_id', sa.Text()),
+        sa.column('parent_id', sa.Text()),
+        sa.column('children_ids', sa.JSON()),
+        sa.column('role', sa.Text()),
+        sa.column('created_at', sa.BigInteger()),
+        sa.column('data', sa.JSON()),
+    )
+
+    last_chat_id = None
+    while True:
+        stmt = sa.select(chat.c.id, chat.c.chat).order_by(chat.c.id).limit(CHAT_BATCH_SIZE)
+        if last_chat_id is not None:
+            stmt = stmt.where(chat.c.id > last_chat_id)
+        chat_rows = conn.execute(stmt).all()
+        if not chat_rows:
+            break
+
+        for chat_id, chat_data_value in chat_rows:
+            chat_data = _json_value(chat_data_value, {})
+            history = chat_data.get('history') if isinstance(chat_data, dict) else None
+            storage = history.get('messageStorage') if isinstance(history, dict) else None
+            if not isinstance(storage, dict) or storage.get('version') != 1 or 'messages' in history:
+                continue
+
+            rows = conn.execute(
+                sa.select(
+                    chat_message.c.id,
+                    chat_message.c.parent_id,
+                    chat_message.c.children_ids,
+                    chat_message.c.role,
+                    chat_message.c.created_at,
+                    chat_message.c.data,
+                )
+                .where(chat_message.c.chat_id == chat_id)
+                .order_by(chat_message.c.created_at, chat_message.c.id)
+            ).all()
+
+            prefix = f'{chat_id}-'
+            messages = {}
+            projected_children = {}
+            fallback_children = {}
+            for row_id, parent_id, children_ids, role, created_at, data_value in rows:
+                message_id = row_id[len(prefix) :] if row_id.startswith(prefix) else row_id
+                message = _json_value(data_value, {})
+                message = dict(message) if isinstance(message, dict) else {}
+                message['id'] = message_id
+                message.setdefault('parentId', parent_id)
+                message.setdefault('role', role)
+                message.setdefault('timestamp', created_at)
+                message.setdefault('content', '')
+                messages[message_id] = message
+                projected_children[message_id] = _json_value(children_ids, None)
+                fallback_children[message_id] = []
+
+            for message_id, message in messages.items():
+                parent_id = message.get('parentId')
+                if parent_id in fallback_children:
+                    fallback_children[parent_id].append(message_id)
+
+            for message_id, message in messages.items():
+                ordered_children = projected_children[message_id]
+                if not isinstance(ordered_children, list):
+                    ordered_children = []
+                children = [
+                    child_id
+                    for child_id in ordered_children
+                    if child_id in messages and messages[child_id].get('parentId') == message_id
+                ]
+                children.extend(child_id for child_id in fallback_children[message_id] if child_id not in children)
+                message['childrenIds'] = children
+
+            history = dict(history)
+            history.pop('messageStorage', None)
+            history.pop('messageWindow', None)
+            history['messages'] = messages
+            restored_chat = dict(chat_data)
+            restored_chat['history'] = history
+            restored_chat['messages'] = _active_branch(messages, history.get('currentId'))
+            conn.execute(sa.update(chat).where(chat.c.id == chat_id).values(chat=restored_chat))
+
+        last_chat_id = chat_rows[-1][0]
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    columns = {column['name'] for column in inspector.get_columns('chat_message')}
+
+    if 'data' in columns:
+        _restore_compacted_chats(conn)
+
+    if 'children_ids' in columns:
+        op.drop_column('chat_message', 'children_ids')
+    if 'data' in columns:
+        op.drop_column('chat_message', 'data')

--- a/backend/open_webui/migrations/versions/b8f1c2d3e4a5_merge_lazy_history_with_dev.py
+++ b/backend/open_webui/migrations/versions/b8f1c2d3e4a5_merge_lazy_history_with_dev.py
@@ -1,0 +1,22 @@
+"""merge lazy history storage with current dev migrations
+
+Revision ID: b8f1c2d3e4a5
+Revises: 9c0e2f4a6b81, 1ce6ade7d93b
+Create Date: 2026-08-01 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+revision: str = 'b8f1c2d3e4a5'
+down_revision: tuple[str, str] = ('9c0e2f4a6b81', '1ce6ade7d93b')
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/backend/open_webui/models/chat_messages.py
+++ b/backend/open_webui/models/chat_messages.py
@@ -1,13 +1,17 @@
 import time
-import uuid
 from collections import Counter
+from collections.abc import Sequence
+from copy import deepcopy
 from datetime import datetime, timedelta
 from typing import Any, Optional
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
-from sqlalchemy import select, delete, func, cast, Integer, distinct
-from sqlalchemy.ext.asyncio import AsyncSession
 from open_webui.internal.db import Base, get_async_db_context
+from open_webui.utils.chat_history import (
+    has_embedded_messages,
+    split_chat_messages,
+    uses_normalized_message_storage,
+)
 from open_webui.utils.response import merge_usage, normalize_usage
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy import (
@@ -21,7 +25,9 @@ from sqlalchemy import (
     Text,
     cast,
     delete,
+    distinct,
     func,
+    or_,
     select,
 )
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -29,6 +35,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 ####################
 # Helpers
 ####################
+
+_UNSET = object()
 
 
 def _normalize_timestamp(timestamp: int) -> float:
@@ -135,8 +143,10 @@ class ChatMessage(Base):
     # Structure
     role = Column(Text, nullable=False)  # user, assistant, system
     parent_id = Column(Text, nullable=True)
+    children_ids = Column(JSON, nullable=True)
 
     # Content
+    data = Column(JSON, nullable=True)
     content = Column(JSON, nullable=True)  # Can be str or list of blocks
     output = Column(JSON, nullable=True)
 
@@ -184,6 +194,8 @@ class ChatMessageModel(BaseModel):
     user_id: str
     role: str
     parent_id: Optional[str] = None
+    children_ids: Optional[list[str]] = None
+    data: Optional[dict] = None
     content: Optional[Any] = None  # str or list of blocks
     output: Optional[list] = None
     model_id: Optional[str] = None
@@ -206,6 +218,196 @@ class ChatMessageModel(BaseModel):
 
 
 class ChatMessageTable:
+    DB_TO_JSON_KEY_MAP = {
+        'parent_id': 'parentId',
+        'children_ids': 'childrenIds',
+        'model_id': 'model',
+        'status_history': 'statusHistory',
+        'context_summary': 'contextSummary',
+        'created_at': 'timestamp',
+    }
+    PROJECTION_FIELDS = (
+        'role',
+        'parent_id',
+        'children_ids',
+        'content',
+        'output',
+        'model_id',
+        'files',
+        'sources',
+        'embeds',
+        'meta',
+        'done',
+        'status_history',
+        'error',
+        'usage',
+        'context_summary',
+        'created_at',
+    )
+    PROJECTION_INPUT_KEYS = (
+        ('role', ('role',)),
+        ('parent_id', ('parent_id', 'parentId')),
+        ('children_ids', ('children_ids', 'childrenIds')),
+        ('content', ('content',)),
+        ('output', ('output',)),
+        ('model_id', ('model_id', 'model')),
+        ('files', ('files',)),
+        ('sources', ('sources',)),
+        ('embeds', ('embeds',)),
+        ('meta', ('meta',)),
+        ('done', ('done',)),
+        ('status_history', ('status_history', 'statusHistory')),
+        ('error', ('error',)),
+        ('context_summary', ('context_summary', 'contextSummary')),
+        ('created_at', ('timestamp',)),
+    )
+    PROJECTION_SOURCE_KEYS = dict(PROJECTION_INPUT_KEYS)
+
+    @staticmethod
+    def _composite_id(chat_id: str, message_id: str) -> str:
+        return f'{chat_id}-{message_id}'
+
+    @staticmethod
+    def _original_message_id(row_id: str, chat_id: str) -> str:
+        prefix = f'{chat_id}-'
+        return row_id[len(prefix) :] if row_id.startswith(prefix) else row_id
+
+    @staticmethod
+    def _aliased_value(data: dict, *keys: str) -> tuple[bool, Any]:
+        for key in keys:
+            if key in data:
+                return True, data[key]
+        return False, None
+
+    @staticmethod
+    def _valid_projected_children(
+        parent_id: str,
+        children_ids: Sequence[str],
+        parent_by_message_id: dict[str, str | None],
+        fallback_children: Sequence[str] = (),
+    ) -> list[str]:
+        children = []
+        seen = set()
+        for child_id in children_ids:
+            if child_id in seen or parent_by_message_id.get(child_id) != parent_id:
+                continue
+            seen.add(child_id)
+            children.append(child_id)
+        for child_id in fallback_children:
+            if child_id not in seen and parent_by_message_id.get(child_id) == parent_id:
+                seen.add(child_id)
+                children.append(child_id)
+        return children
+
+    @staticmethod
+    def _usage_is_explicitly_null(data: dict) -> bool:
+        return data.get('usage', ...) is None or (
+            isinstance(data.get('info'), dict) and data['info'].get('usage', ...) is None
+        )
+
+    def _merge_stored_message_data(
+        self,
+        message: ChatMessage,
+        message_id: str,
+        data: dict,
+        *,
+        usage_is_explicitly_null: bool,
+    ) -> dict:
+        stored_data = deepcopy(message.data) if isinstance(message.data, dict) else {}
+        stored_data.update(deepcopy(data))
+        stored_data['id'] = message_id
+
+        # Keep canonical JSON keys synchronized when callers use snake_case aliases.
+        for attribute in self.PROJECTION_FIELDS:
+            value = getattr(message, attribute)
+            json_key = self.DB_TO_JSON_KEY_MAP.get(attribute, attribute)
+            source_keys = self.PROJECTION_SOURCE_KEYS.get(attribute, (json_key,))
+            if json_key not in stored_data or any(key in data for key in source_keys):
+                stored_data[json_key] = deepcopy(value)
+
+        if usage_is_explicitly_null:
+            stored_data['usage'] = None
+        elif message.usage is not None:
+            stored_data['usage'] = deepcopy(message.usage)
+            if isinstance(stored_data.get('info'), dict):
+                stored_data['info'] = {**stored_data['info'], 'usage': deepcopy(message.usage)}
+
+        return stored_data
+
+    def _apply_message_data(
+        self,
+        message: ChatMessage,
+        message_id: str,
+        user_id: str,
+        data: dict,
+        now: int,
+        *,
+        is_new: bool,
+    ) -> None:
+        """Apply raw message data to lossless storage and indexed projections."""
+        message.user_id = user_id
+
+        for attribute, keys in self.PROJECTION_INPUT_KEYS:
+            present, value = self._aliased_value(data, *keys)
+            if present:
+                setattr(message, attribute, value)
+
+        if is_new:
+            message.role = message.role or 'user'
+            message.done = data.get('done', True)
+            message.created_at = message.created_at or now
+
+        usage_is_explicitly_null = self._usage_is_explicitly_null(data)
+        incoming_usage = get_usage(data)
+        storage_data = data
+        if usage_is_explicitly_null:
+            message.usage = None
+            storage_data = {**data, 'lastRequestUsage': None}
+        elif incoming_usage:
+            existing_usage = normalize_usage(message.usage or {}) if message.usage else {}
+            message.usage = (
+                existing_usage if incoming_usage == existing_usage else merge_usage(existing_usage, incoming_usage)
+            )
+            storage_data = {**data, 'lastRequestUsage': incoming_usage}
+
+        message.data = self._merge_stored_message_data(
+            message,
+            message_id,
+            storage_data,
+            usage_is_explicitly_null=usage_is_explicitly_null,
+        )
+        message.updated_at = now
+
+    async def upsert_message_in_session(
+        self,
+        db: AsyncSession,
+        message_id: str,
+        chat_id: str,
+        user_id: str,
+        data: dict,
+        *,
+        existing: Any = _UNSET,
+    ) -> ChatMessage:
+        now = int(time.time())
+        composite_id = self._composite_id(chat_id, message_id)
+        message = await db.get(ChatMessage, composite_id) if existing is _UNSET else existing
+        is_new = message is None
+
+        if message is None:
+            message = ChatMessage(
+                id=composite_id,
+                chat_id=chat_id,
+                user_id=user_id,
+                role=data.get('role') or 'user',
+                done=data.get('done', True),
+                created_at=data.get('timestamp') or now,
+                updated_at=now,
+            )
+            db.add(message)
+
+        self._apply_message_data(message, message_id, user_id, data, now, is_new=is_new)
+        return message
+
     async def upsert_message(
         self,
         message_id: str,
@@ -215,78 +417,138 @@ class ChatMessageTable:
         db: Optional[AsyncSession] = None,
     ) -> Optional[ChatMessageModel]:
         """Insert or update a chat message."""
-        async with get_async_db_context(db) as db:
-            now = int(time.time())
-            timestamp = data.get('timestamp', now)
+        if not isinstance(data, dict):
+            raise TypeError('data must be a dict')
 
-            # Use composite ID: {chat_id}-{message_id}
-            composite_id = f'{chat_id}-{message_id}'
+        async with get_async_db_context(db) as session:
+            try:
+                message = await self.upsert_message_in_session(session, message_id, chat_id, user_id, data)
+                await session.flush()
+                result = ChatMessageModel.model_validate(message)
+                await session.commit()
+                return result
+            except Exception:
+                await session.rollback()
+                raise
 
-            existing = await db.get(ChatMessage, composite_id)
-            if existing:
-                # Update existing
-                if 'role' in data:
-                    existing.role = data['role']
-                if 'parent_id' in data or 'parentId' in data:
-                    existing.parent_id = data.get('parent_id') or data.get('parentId')
-                if 'content' in data:
-                    existing.content = data.get('content')
-                if 'output' in data:
-                    existing.output = data.get('output')
-                if 'model_id' in data or 'model' in data:
-                    existing.model_id = data.get('model_id') or data.get('model')
-                if 'files' in data:
-                    existing.files = data.get('files')
-                if 'sources' in data:
-                    existing.sources = data.get('sources')
-                if 'embeds' in data:
-                    existing.embeds = data.get('embeds')
-                if 'meta' in data:
-                    existing.meta = data.get('meta')
-                if 'done' in data:
-                    existing.done = data.get('done', True)
-                if 'status_history' in data or 'statusHistory' in data:
-                    existing.status_history = data.get('status_history') or data.get('statusHistory')
-                if 'error' in data:
-                    existing.error = data.get('error')
-                if 'context_summary' in data or 'contextSummary' in data:
-                    existing.context_summary = data.get('context_summary') or data.get('contextSummary')
-                # Extract and normalize usage
-                usage = get_usage(data)
-                if usage:
-                    existing_usage = normalize_usage(existing.usage or {}) if existing.usage else {}
-                    existing.usage = existing_usage if usage == existing_usage else merge_usage(existing_usage, usage)
-                existing.updated_at = now
-                await db.commit()
-                return ChatMessageModel.model_validate(existing)
-            else:
-                # Insert new
-                # Extract and normalize usage
-                usage = get_usage(data)
-                message = ChatMessage(
-                    id=composite_id,
-                    chat_id=chat_id,
-                    user_id=user_id,
-                    role=data.get('role', 'user'),
-                    parent_id=data.get('parent_id') or data.get('parentId'),
-                    content=data.get('content'),
-                    output=data.get('output'),
-                    model_id=data.get('model_id') or data.get('model'),
-                    files=data.get('files'),
-                    sources=data.get('sources'),
-                    embeds=data.get('embeds'),
-                    meta=data.get('meta'),
-                    done=data.get('done', True),
-                    status_history=data.get('status_history') or data.get('statusHistory'),
-                    error=data.get('error'),
-                    usage=usage,
-                    context_summary=data.get('context_summary') or data.get('contextSummary'),
-                    created_at=timestamp,
-                    updated_at=now,
-                )
-                db.add(message)
-                await db.commit()
-                return ChatMessageModel.model_validate(message)
+    async def bulk_upsert_messages(
+        self,
+        chat_id: str,
+        user_id: str,
+        messages: dict[str, dict],
+        db: Optional[AsyncSession] = None,
+    ) -> list[ChatMessageModel]:
+        """Upsert a message map atomically using one session and one commit."""
+        if not isinstance(messages, dict):
+            raise TypeError('messages must be a dict')
+        if any(not isinstance(message, dict) for message in messages.values()):
+            raise TypeError('every message must be a dict')
+        if not messages:
+            return []
+
+        async with get_async_db_context(db) as session:
+            try:
+                rows = await self.bulk_upsert_messages_in_session(session, chat_id, user_id, messages)
+                results = [ChatMessageModel.model_validate(row) for row in rows]
+                await session.commit()
+                return results
+            except Exception:
+                await session.rollback()
+                raise
+
+    async def bulk_upsert_messages_in_session(
+        self,
+        db: AsyncSession,
+        chat_id: str,
+        user_id: str,
+        messages: dict[str, dict],
+    ) -> list[ChatMessage]:
+        if not messages:
+            return []
+
+        composite_ids = [self._composite_id(chat_id, message_id) for message_id in messages]
+        result = await db.execute(
+            select(ChatMessage).where(
+                ChatMessage.chat_id == chat_id,
+                ChatMessage.id.in_(composite_ids),
+            )
+        )
+        existing_by_id = {message.id: message for message in result.scalars().all()}
+
+        rows = []
+        for message_id, data in messages.items():
+            composite_id = self._composite_id(chat_id, message_id)
+            row = await self.upsert_message_in_session(
+                db,
+                message_id,
+                chat_id,
+                user_id,
+                data,
+                existing=existing_by_id.get(composite_id),
+            )
+            rows.append(row)
+
+        await db.flush()
+        return rows
+
+    async def replace_messages_in_session(
+        self,
+        db: AsyncSession,
+        chat_id: str,
+        user_id: str,
+        messages: dict[str, dict],
+    ) -> list[ChatMessage]:
+        """Replace a chat's normalized snapshot without committing the caller's session."""
+        rows = await self.bulk_upsert_messages_in_session(db, chat_id, user_id, messages)
+
+        delete_stmt = delete(ChatMessage).where(ChatMessage.chat_id == chat_id)
+        if messages:
+            retained_ids = [self._composite_id(chat_id, message_id) for message_id in messages]
+            delete_stmt = delete_stmt.where(ChatMessage.id.not_in(retained_ids))
+        await db.execute(delete_stmt)
+        await db.flush()
+        return rows
+
+    async def compact_legacy_chat_in_session(
+        self,
+        db: AsyncSession,
+        chat_id: str,
+        user_id: str,
+        chat: dict | None,
+    ) -> dict:
+        """Normalize an embedded legacy history without committing the caller's session."""
+        embedded_messages = has_embedded_messages(chat)
+        if uses_normalized_message_storage(chat) and not embedded_messages:
+            return deepcopy(chat or {})
+
+        compact_chat, legacy_messages = split_chat_messages(chat)
+        if embedded_messages:
+            await self.replace_messages_in_session(db, chat_id, user_id, legacy_messages)
+        return compact_chat
+
+    async def replace_messages_by_chat_id(
+        self,
+        chat_id: str,
+        user_id: str,
+        messages: dict[str, dict],
+        db: Optional[AsyncSession] = None,
+    ) -> list[ChatMessageModel]:
+        """Atomically replace one chat's normalized message snapshot."""
+        if not isinstance(messages, dict):
+            raise TypeError('messages must be a dict')
+        if any(not isinstance(message, dict) for message in messages.values()):
+            raise TypeError('every message must be a dict')
+
+        async with get_async_db_context(db) as session:
+            try:
+                rows = await self.replace_messages_in_session(session, chat_id, user_id, messages)
+
+                results = [ChatMessageModel.model_validate(row) for row in rows]
+                await session.commit()
+                return results
+            except Exception:
+                await session.rollback()
+                raise
 
     async def get_message_by_id(self, id: str, db: Optional[AsyncSession] = None) -> Optional[ChatMessageModel]:
         async with get_async_db_context(db) as db:
@@ -311,21 +573,411 @@ class ChatMessageTable:
     async def get_messages_by_chat_id(self, chat_id: str, db: Optional[AsyncSession] = None) -> list[ChatMessageModel]:
         async with get_async_db_context(db) as db:
             result = await db.execute(
-                select(ChatMessage).filter_by(chat_id=chat_id).order_by(ChatMessage.created_at.asc())
+                select(ChatMessage)
+                .filter_by(chat_id=chat_id)
+                .order_by(ChatMessage.created_at.asc(), ChatMessage.id.asc())
             )
             messages = result.scalars().all()
             return [ChatMessageModel.model_validate(message) for message in messages]
 
-    # DB column names that differ from the JSON message keys.
-    DB_TO_JSON_KEY_MAP = {
-        'parent_id': 'parentId',
-        'model_id': 'model',
-        'status_history': 'statusHistory',
-        'context_summary': 'contextSummary',
-        'created_at': 'timestamp',
-    }
-    # DB-internal columns excluded from the reconstructed message dict.
-    EXCLUDED_COLUMNS = frozenset({'id', 'chat_id', 'user_id', 'updated_at'})
+    def row_to_message_data(self, row: ChatMessage) -> tuple[str, dict]:
+        message_id = self._original_message_id(row.id, row.chat_id)
+        message = deepcopy(row.data) if isinstance(row.data, dict) else {}
+        message['id'] = message_id
+
+        for attribute in self.PROJECTION_FIELDS:
+            value = getattr(row, attribute)
+            if value is None:
+                continue
+            json_key = self.DB_TO_JSON_KEY_MAP.get(attribute, attribute)
+            message.setdefault(json_key, deepcopy(value))
+
+        message.setdefault('content', '')
+        message.setdefault('childrenIds', [])
+
+        if row.usage is not None:
+            message.setdefault('usage', deepcopy(row.usage))
+            if 'info' not in message:
+                message['info'] = {'usage': deepcopy(message['usage'])}
+            elif isinstance(message['info'], dict) and 'usage' not in message['info']:
+                message['info'] = {**message['info'], 'usage': deepcopy(message['usage'])}
+
+        return message_id, message
+
+    def _rows_to_message_map(self, rows: Sequence[ChatMessage]) -> dict[str, dict]:
+        row_by_message_id = {self._original_message_id(row.id, row.chat_id): row for row in rows}
+        messages_map = dict(self.row_to_message_data(row) for row in rows)
+        parent_by_message_id = {message_id: message.get('parentId') for message_id, message in messages_map.items()}
+        fallback_children = {message_id: [] for message_id in messages_map}
+
+        for message_id, message in messages_map.items():
+            parent_id = message.get('parentId')
+            if parent_id in fallback_children:
+                fallback_children[parent_id].append(message_id)
+
+        for message_id, message in messages_map.items():
+            projected_children = row_by_message_id[message_id].children_ids
+            if isinstance(projected_children, list):
+                message['childrenIds'] = self._valid_projected_children(
+                    message_id,
+                    projected_children,
+                    parent_by_message_id,
+                    fallback_children[message_id],
+                )
+            else:
+                message['childrenIds'] = fallback_children[message_id]
+
+        return messages_map
+
+    async def _get_message_rows(
+        self,
+        db: AsyncSession,
+        chat_id: str,
+        message_ids: Optional[Sequence[str]] = None,
+    ) -> list[ChatMessage]:
+        if message_ids is not None and not message_ids:
+            return []
+
+        stmt = select(ChatMessage).where(ChatMessage.chat_id == chat_id)
+        if message_ids is not None:
+            composite_ids = [self._composite_id(chat_id, message_id) for message_id in dict.fromkeys(message_ids)]
+            stmt = stmt.where(ChatMessage.id.in_(composite_ids))
+        stmt = stmt.order_by(ChatMessage.created_at.asc(), ChatMessage.id.asc())
+        result = await db.execute(stmt)
+        return list(result.scalars().all())
+
+    async def get_message_data_map_by_chat_id(
+        self,
+        chat_id: str,
+        message_ids: Optional[Sequence[str]] = None,
+        db: Optional[AsyncSession] = None,
+    ) -> dict[str, dict]:
+        """Return lossless message data keyed by original message ID."""
+        async with get_async_db_context(db) as session:
+            rows = await self._get_message_rows(session, chat_id, message_ids)
+            messages_map = self._rows_to_message_map(rows)
+
+        if message_ids is None:
+            return messages_map
+        return {
+            message_id: messages_map[message_id]
+            for message_id in dict.fromkeys(message_ids)
+            if message_id in messages_map
+        }
+
+    async def get_pending_internal_leaf_messages_in_session(
+        self,
+        db: AsyncSession,
+        chat_id: str,
+    ) -> list[dict]:
+        """Return pending internal user leaves using normalized message rows only."""
+        result = await db.execute(
+            select(ChatMessage)
+            .where(
+                ChatMessage.chat_id == chat_id,
+                ChatMessage.role == 'user',
+                ChatMessage.meta.isnot(None),
+                ChatMessage.meta['internal'].as_boolean().is_(True),
+                ChatMessage.meta['type'].as_string().in_(('subagent', 'timer')),
+            )
+            .order_by(ChatMessage.created_at.asc(), ChatMessage.id.asc())
+        )
+        candidates = []
+        for row in result.scalars().all():
+            meta = row.meta if isinstance(row.meta, dict) else {}
+            kind = meta.get('type')
+            if kind == 'subagent' and meta.get('status') not in (None, 'pending'):
+                continue
+            if kind not in ('subagent', 'timer'):
+                continue
+            candidates.append(row)
+
+        if not candidates:
+            return []
+
+        candidate_ids = [self._original_message_id(row.id, chat_id) for row in candidates]
+        result = await db.execute(
+            select(ChatMessage.parent_id).where(
+                ChatMessage.chat_id == chat_id,
+                ChatMessage.parent_id.in_(candidate_ids),
+            )
+        )
+        parent_ids = {parent_id for parent_id in result.scalars().all() if parent_id is not None}
+
+        pending = []
+        for row, message_id in zip(candidates, candidate_ids, strict=True):
+            if message_id in parent_ids:
+                continue
+            message = self.row_to_message_data(row)[1]
+            message['childrenIds'] = []
+            pending.append(message)
+        return pending
+
+    async def get_latest_eligible_assistant_id_in_session(
+        self,
+        db: AsyncSession,
+        chat_id: str,
+    ) -> Optional[str]:
+        """Return the newest completed-or-legacy assistant message ID."""
+        result = await db.execute(
+            select(ChatMessage.id)
+            .where(
+                ChatMessage.chat_id == chat_id,
+                ChatMessage.role == 'assistant',
+                or_(ChatMessage.done.is_(True), ChatMessage.done.is_(None)),
+            )
+            .order_by(ChatMessage.created_at.desc(), ChatMessage.id.desc())
+            .limit(1)
+        )
+        row_id = result.scalar_one_or_none()
+        return self._original_message_id(row_id, chat_id) if row_id is not None else None
+
+    async def get_message_topology_in_session(
+        self,
+        db: AsyncSession,
+        chat_id: str,
+    ) -> dict[str, dict]:
+        result = await db.execute(
+            select(
+                ChatMessage.id,
+                ChatMessage.parent_id,
+                ChatMessage.children_ids,
+                ChatMessage.role,
+                ChatMessage.created_at,
+            )
+            .where(ChatMessage.chat_id == chat_id)
+            .order_by(ChatMessage.created_at.asc(), ChatMessage.id.asc())
+        )
+        rows = result.all()
+        topology: dict[str, dict] = {}
+
+        projected_children: dict[str, Optional[list[str]]] = {}
+        fallback_children: dict[str, list[str]] = {}
+
+        for row_id, parent_id, children_ids, role, timestamp in rows:
+            message_id = self._original_message_id(row_id, chat_id)
+            topology[message_id] = {
+                'id': message_id,
+                'parentId': parent_id,
+                'childrenIds': [],
+                'role': role,
+                'timestamp': timestamp,
+            }
+            projected_children[message_id] = children_ids if isinstance(children_ids, list) else None
+            fallback_children[message_id] = []
+
+        for message_id, message in topology.items():
+            parent_id = message['parentId']
+            if parent_id in fallback_children:
+                fallback_children[parent_id].append(message_id)
+
+        parent_by_message_id = {message_id: message['parentId'] for message_id, message in topology.items()}
+        for message_id, message in topology.items():
+            children_ids = projected_children[message_id]
+            if children_ids is None:
+                message['childrenIds'] = fallback_children[message_id]
+                continue
+
+            message['childrenIds'] = self._valid_projected_children(
+                message_id,
+                children_ids,
+                parent_by_message_id,
+                fallback_children[message_id],
+            )
+
+        return topology
+
+    async def get_message_topology_by_chat_id(
+        self,
+        chat_id: str,
+        db: Optional[AsyncSession] = None,
+    ) -> dict[str, dict]:
+        async with get_async_db_context(db) as session:
+            return await self.get_message_topology_in_session(session, chat_id)
+
+    async def get_message_window_by_chat_id(
+        self,
+        chat_id: str,
+        current_id: Optional[str],
+        limit: int = 32,
+        before_id: Optional[str] = None,
+        db: Optional[AsyncSession] = None,
+    ) -> dict:
+        """Return topology and one ancestor page ending at ``current_id``."""
+        if limit < 1:
+            raise ValueError('limit must be at least 1')
+
+        async with get_async_db_context(db) as session:
+            topology = await self.get_message_topology_in_session(session, chat_id)
+            if not topology:
+                return {
+                    'topology': {},
+                    'messages': {},
+                    'loaded_ids': [],
+                    'has_more': False,
+                    'current_id': None,
+                }
+
+            if current_id is None:
+                leaf_ids = [message_id for message_id, message in topology.items() if not message['childrenIds']]
+                current_id = leaf_ids[-1] if leaf_ids else next(reversed(topology))
+
+            if current_id not in topology:
+                raise ValueError('current_id does not exist in this chat')
+
+            ancestor_ids = []
+            seen = set()
+            cursor: Optional[str] = current_id
+            while cursor is not None and cursor in topology:
+                if cursor in seen:
+                    raise ValueError('message ancestry contains a cycle')
+                seen.add(cursor)
+                ancestor_ids.append(cursor)
+                cursor = topology[cursor]['parentId']
+
+            if cursor is not None:
+                raise ValueError(f'message ancestry references missing parent: {cursor}')
+
+            start = 0
+            if before_id is not None:
+                if before_id not in ancestor_ids:
+                    raise ValueError('before_id must be on the current message ancestry')
+                start = ancestor_ids.index(before_id) + 1
+
+            page_ids = ancestor_ids[start : start + limit]
+            loaded_ids = list(reversed(page_ids))
+            rows = await self._get_message_rows(session, chat_id, loaded_ids)
+            row_map = self._rows_to_message_map(rows)
+            missing_ids = [message_id for message_id in loaded_ids if message_id not in row_map]
+            if missing_ids:
+                raise ValueError(f'message ancestry is missing rows: {", ".join(missing_ids)}')
+
+            messages = {}
+            for message_id in loaded_ids:
+                if message_id not in row_map:
+                    continue
+                messages[message_id] = {**row_map[message_id], **topology[message_id]}
+
+            return {
+                'topology': topology,
+                'messages': messages,
+                'loaded_ids': loaded_ids,
+                'has_more': start + len(page_ids) < len(ancestor_ids),
+                'current_id': current_id,
+            }
+
+    async def get_message_branch_in_session(
+        self,
+        db: AsyncSession,
+        chat_id: str,
+        current_id: str,
+    ) -> list[dict]:
+        """Return one complete branch without committing or opening another session."""
+        topology = await self.get_message_topology_in_session(db, chat_id)
+        if current_id not in topology:
+            return []
+
+        branch_ids = []
+        seen = set()
+        cursor: Optional[str] = current_id
+        while cursor is not None and cursor in topology:
+            if cursor in seen:
+                raise ValueError('message ancestry contains a cycle')
+            seen.add(cursor)
+            branch_ids.append(cursor)
+            cursor = topology[cursor]['parentId']
+
+        if cursor is not None:
+            raise ValueError(f'message ancestry references missing parent: {cursor}')
+
+        branch_ids.reverse()
+        rows = await self._get_message_rows(db, chat_id, branch_ids)
+        row_map = self._rows_to_message_map(rows)
+        missing_ids = [message_id for message_id in branch_ids if message_id not in row_map]
+        if missing_ids:
+            raise ValueError(f'message ancestry is missing rows: {", ".join(missing_ids)}')
+        return [{**row_map[message_id], **topology[message_id]} for message_id in branch_ids]
+
+    async def get_message_branch_by_chat_id(
+        self,
+        chat_id: str,
+        current_id: str,
+        db: Optional[AsyncSession] = None,
+    ) -> list[dict]:
+        """Return full message bodies for one root-to-leaf branch only."""
+        async with get_async_db_context(db) as session:
+            return await self.get_message_branch_in_session(session, chat_id, current_id)
+
+    @staticmethod
+    def _build_content_snippet(content: Any, search_text: str, max_length: int) -> Optional[str]:
+        if not isinstance(content, str):
+            return None
+
+        index = content.lower().find(search_text.lower())
+        if index == -1:
+            return None
+
+        start = max(index - max_length // 2, 0)
+        end = min(start + max_length, len(content))
+        if index + len(search_text) > end:
+            end = min(index + len(search_text), len(content))
+            start = max(end - max_length, 0)
+
+        snippet = ' '.join(content[start:end].split())
+        return f'{"..." if start else ""}{snippet}{"..." if end < len(content) else ""}'
+
+    async def get_content_snippets_by_chat_ids(
+        self,
+        chat_ids: Sequence[str],
+        search_text: str,
+        max_length: int = 200,
+        db: Optional[AsyncSession] = None,
+    ) -> dict[str, str]:
+        """Fetch at most one bounded content snippet for each requested chat."""
+        if max_length < 1:
+            raise ValueError('max_length must be at least 1')
+
+        unique_chat_ids = list(dict.fromkeys(chat_ids))
+        normalized_search_text = search_text.strip()
+        if not unique_chat_ids or not normalized_search_text:
+            return {}
+
+        escaped_search_text = normalized_search_text.replace('\\', '\\\\').replace('%', '\\%').replace('_', '\\_')
+        ranked_matches = (
+            select(
+                ChatMessage.chat_id.label('chat_id'),
+                ChatMessage.content.label('content'),
+                func.row_number()
+                .over(
+                    partition_by=ChatMessage.chat_id,
+                    order_by=(ChatMessage.created_at.asc(), ChatMessage.id.asc()),
+                )
+                .label('match_rank'),
+            )
+            .where(
+                ChatMessage.chat_id.in_(unique_chat_ids),
+                ChatMessage.content.isnot(None),
+                cast(ChatMessage.content, Text).ilike(f'%{escaped_search_text}%', escape='\\'),
+            )
+            .subquery()
+        )
+        stmt = (
+            select(ranked_matches.c.chat_id, ranked_matches.c.content)
+            .where(ranked_matches.c.match_rank == 1)
+            .order_by(ranked_matches.c.chat_id.asc())
+            .limit(len(unique_chat_ids))
+        )
+
+        async with get_async_db_context(db) as session:
+            result = await session.execute(stmt)
+            rows = result.all()
+
+        snippets = {}
+        for chat_id, content in rows:
+            snippet = self._build_content_snippet(content, normalized_search_text, max_length)
+            if snippet is not None:
+                snippets[chat_id] = snippet
+        return snippets
 
     async def get_messages_map_by_chat_id(self, chat_id: str, db: Optional[AsyncSession] = None) -> Optional[dict]:
         """Build a {message_id: message_dict} map from chat_message rows.
@@ -335,60 +987,8 @@ class ChatMessageTable:
         no rows exist for the chat (caller should fall back to the
         embedded JSON blob for legacy chats).
         """
-        async with get_async_db_context(db) as db:
-            result = await db.execute(select(ChatMessage).filter_by(chat_id=chat_id))
-            rows = result.scalars().all()
-
-        if not rows:
-            return None
-
-        # Strip the composite-id prefix ("{chat_id}-") to recover the
-        # original message_id used as map key.
-        prefix = f'{chat_id}-'
-        prefix_len = len(prefix)
-        col_keys = [c.key for c in ChatMessage.__table__.columns]
-
-        messages_map: dict[str, dict] = {}
-        for row in rows:
-            msg_id = row.id[prefix_len:] if row.id.startswith(prefix) else row.id
-
-            msg: dict = {'id': msg_id}
-            for key in col_keys:
-                if key in self.EXCLUDED_COLUMNS:
-                    continue
-                val = getattr(row, key)
-                if val is None:
-                    continue
-                json_key = self.DB_TO_JSON_KEY_MAP.get(key, key)
-                msg[json_key] = val
-
-            # Ensure content always has a value
-            msg.setdefault('content', '')
-
-            # Mirror usage into info.usage for callers that read it there
-            if 'usage' in msg:
-                msg['info'] = {'usage': msg['usage']}
-
-            messages_map[msg_id] = msg
-
-        # Reconstruct childrenIds from parentId links so that the map
-        # is fully navigable (callers like the frontend rely on this).
-        for msg_id, msg in messages_map.items():
-            parent_id = msg.get('parentId')
-            if parent_id and parent_id in messages_map:
-                parent = messages_map[parent_id]
-                children = parent.get('childrenIds')
-                if children is None:
-                    parent['childrenIds'] = [msg_id]
-                elif msg_id not in children:
-                    children.append(msg_id)
-
-        # Ensure every message has a childrenIds list (leaf nodes get [])
-        for msg in messages_map.values():
-            if 'childrenIds' not in msg:
-                msg['childrenIds'] = []
-
-        return messages_map
+        messages_map = await self.get_message_data_map_by_chat_id(chat_id, db=db)
+        return messages_map or None
 
     async def get_messages_by_user_id(
         self,
@@ -477,13 +1077,25 @@ class ChatMessageTable:
         if not message_ids:
             return True
         async with get_async_db_context(db) as db:
-            await db.execute(
-                delete(ChatMessage)
-                .where(ChatMessage.chat_id == chat_id)
-                .where(ChatMessage.id.in_({f'{chat_id}-{mid}' for mid in message_ids}))
-            )
+            await self.delete_message_ids_in_session(db, chat_id, message_ids)
             await db.commit()
             return True
+
+    async def delete_message_ids_in_session(
+        self,
+        db: AsyncSession,
+        chat_id: str,
+        message_ids: set[str],
+    ) -> None:
+        """Delete selected normalized rows without committing the caller's session."""
+        if not message_ids:
+            return
+        await db.execute(
+            delete(ChatMessage)
+            .where(ChatMessage.chat_id == chat_id)
+            .where(ChatMessage.id.in_({self._composite_id(chat_id, message_id) for message_id in message_ids}))
+        )
+        await db.flush()
 
     # Analytics methods
     async def get_message_count_by_model(

--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import time
 import uuid
+from copy import deepcopy
 
 # local imports
 from open_webui.internal.db import Base, JSONField, get_async_db_context
@@ -12,6 +13,14 @@ from open_webui.models.automations import AutomationRun
 from open_webui.models.chat_messages import ChatMessage, ChatMessages
 from open_webui.models.folders import Folders
 from open_webui.models.tags import Tag, TagModel, Tags
+from open_webui.utils.chat_history import (
+    MESSAGE_LOADED_KEY,
+    MESSAGE_WINDOW_KEY,
+    build_window_chat,
+    create_message_list,
+    create_message_window,
+    prepare_messages_for_storage,
+)
 from open_webui.utils.misc import get_output_text, sanitize_data_for_db, sanitize_text_for_db
 from pydantic import BaseModel, ConfigDict, field_validator
 from sqlalchemy import (
@@ -598,7 +607,7 @@ class ChatTable:
         """Persist updated chat content, sanitizing null bytes."""
         try:  # load the chat record for in-place mutation
             async with get_async_db_context(db) as session:
-                chat_item = await session.get(Chat, id)
+                chat_item = await session.get(Chat, id, with_for_update=True)
                 if chat_item is None:
                     return None
 
@@ -613,7 +622,8 @@ class ChatTable:
                 await session.commit()
 
                 return ChatModel.model_validate(chat_item)
-        except Exception:
+        except Exception as exc:
+            log.exception('Failed to update chat %s: %s', id, exc)
             return
 
     async def update_chat_variables_by_id(
@@ -637,6 +647,132 @@ class ChatTable:
                 await session.commit()
                 return ChatModel.model_validate(chat_item)
         except Exception:
+            return None
+
+    async def update_chat_window_by_id(
+        self,
+        id: str,
+        chat: dict,
+        db: AsyncSession | None = None,
+        *,
+        touch: bool = True,
+    ) -> ChatModel | None:
+        """Merge a window save without replacing already-persisted message bodies."""
+        try:
+            async with get_async_db_context(db) as session:
+                chat_item = await session.get(Chat, id, with_for_update=True)
+                if chat_item is None:
+                    return None
+
+                existing_chat = deepcopy(chat_item.chat or {})
+                incoming_chat = self._clean_null_bytes(chat)
+                merged_chat = {**existing_chat, **incoming_chat}
+
+                existing_history = existing_chat.get('history') or {}
+                incoming_history = incoming_chat.get('history') or {}
+                existing_messages = prepare_messages_for_storage(existing_history.get('messages'))
+                incoming_messages = prepare_messages_for_storage(incoming_history.get('messages'))
+
+                # Existing messages are authoritative. Window saves may append messages,
+                # while edits to existing messages must use the single-message PATCH API.
+                merged_messages = {
+                    **existing_messages,
+                    **{
+                        message_id: message
+                        for message_id, message in incoming_messages.items()
+                        if message_id not in existing_messages
+                    },
+                }
+
+                for message in merged_messages.values():
+                    message['childrenIds'] = []
+                for message_id, message in merged_messages.items():
+                    parent_id = message.get('parentId')
+                    if parent_id in merged_messages:
+                        merged_messages[parent_id]['childrenIds'].append(message_id)
+
+                current_id = incoming_history.get('currentId')
+                if current_id not in merged_messages:
+                    current_id = existing_history.get('currentId')
+                if current_id not in merged_messages:
+                    current_id = None
+
+                merged_history = {**existing_history, **incoming_history}
+                merged_history.pop(MESSAGE_WINDOW_KEY, None)
+                merged_history['messages'] = merged_messages
+                merged_history['currentId'] = current_id
+                merged_chat['history'] = merged_history
+
+                # Rebuild the canonical branch list from authoritative message bodies;
+                # the top-level list in a window response is only a partial snapshot.
+                merged_chat['messages'] = create_message_list(merged_messages, current_id)
+
+                chat_item.chat = merged_chat
+                flag_modified(chat_item, 'chat')
+                if 'title' in incoming_chat:
+                    chat_item.title = self._clean_null_bytes(incoming_chat['title'])
+                chat_item.current_message_id = current_id
+                if touch:
+                    chat_item.updated_at = int(time.time())
+
+                await session.commit()
+                await session.refresh(chat_item)
+                return ChatModel.model_validate(chat_item)
+        except Exception as exc:
+            log.exception('Failed to update chat window %s: %s', id, exc)
+            return None
+
+    async def patch_message_by_chat_id_and_message_id(
+        self,
+        id: str,
+        message_id: str,
+        patch: dict,
+        *,
+        touch: bool = True,
+        db: AsyncSession | None = None,
+    ) -> dict | None:
+        """Patch one existing embedded message under the chat row lock."""
+        protected_fields = {
+            MESSAGE_LOADED_KEY,
+            'childrenIds',
+            'id',
+            'parentId',
+            'role',
+            'timestamp',
+        }
+        clean_patch = {
+            key: value for key, value in self._clean_null_bytes(patch).items() if key not in protected_fields
+        }
+
+        try:
+            async with get_async_db_context(db) as session:
+                chat_item = await session.get(Chat, id, with_for_update=True)
+                if chat_item is None:
+                    return None
+
+                chat_data = deepcopy(chat_item.chat or {})
+                history = chat_data.get('history') or {}
+                messages = history.get('messages') or {}
+                message = messages.get(message_id)
+                if not isinstance(message, dict):
+                    return None
+
+                for key, value in clean_patch.items():
+                    if value is None:
+                        message.pop(key, None)
+                    else:
+                        message[key] = value
+
+                chat_item.chat = chat_data
+                chat_item.current_message_id = history.get('currentId')
+                flag_modified(chat_item, 'chat')
+                if clean_patch and touch:
+                    chat_item.updated_at = int(time.time())
+
+                await session.commit()
+                return deepcopy(message)
+        except Exception as exc:
+            log.exception('Failed to patch message %s for chat %s: %s', message_id, id, exc)
             return None
 
     async def update_chat_last_read_at_by_id(
@@ -966,7 +1102,13 @@ class ChatTable:
         return chat.chat.get('history', {}).get('messages', {}).get(message_id, {})
 
     async def upsert_message_to_chat_by_id_and_message_id(
-        self, id: str, message_id: str, message: dict, *, touch: bool = True
+        self,
+        id: str,
+        message_id: str,
+        message: dict,
+        *,
+        touch: bool = True,
+        include_messages: bool = False,
     ) -> ChatModel | None:
         if not message.get('content'):
             output_text = get_output_text(message.get('output'))
@@ -977,88 +1119,158 @@ class ChatTable:
         if isinstance(message.get('content'), str):
             message['content'] = sanitize_text_for_db(message['content'])
 
+        clean_message = self._clean_null_bytes(message)
+
         try:
             async with get_async_db_context() as session:
-                chat_item = await session.get(Chat, id)
+                chat_item = await session.get(Chat, id, with_for_update=True)
                 if chat_item is None:
                     return None
 
                 self._sanitize_chat_row(chat_item)
-                chat = chat_item.chat or {}
-                self._repair_chat_current_id(chat)
+                chat_data = deepcopy(chat_item.chat or {})
+                self._repair_chat_current_id(chat_data)
+                history = chat_data.setdefault('history', {})
+                messages = history.setdefault('messages', {})
+                existing_message = messages.get(message_id)
+                is_new_message = not isinstance(existing_message, dict)
 
-                history = chat.get('history', {})
-                saved_message = self.upsert_message_to_history(history, message_id, message)
-                chat['history'] = history
-                clean_chat = self._clean_null_bytes(chat)
-                chat_item.chat = clean_chat
-                chat_item.title = self._clean_null_bytes(clean_chat['title']) if 'title' in clean_chat else 'New Chat'
-                chat_item.current_message_id = self.get_current_message_id(clean_chat)
+                old_parent_id = existing_message.get('parentId') if not is_new_message else None
+                payload = dict(clean_message)
+                if is_new_message:
+                    parent_id = payload.get('parentId')
+                    if parent_id is None:
+                        parent_id = next(
+                            (
+                                candidate_id
+                                for candidate_id, candidate in messages.items()
+                                if message_id in (candidate.get('childrenIds') or [])
+                            ),
+                            None,
+                        )
+
+                    parent = messages.get(parent_id) if parent_id else None
+                    output = payload.get('output') or []
+                    output_role = next(
+                        (item.get('role') for item in output if isinstance(item, dict) and item.get('role')),
+                        None,
+                    )
+                    role = payload.get('role') or output_role
+                    if not role:
+                        parent_role = parent.get('role') if parent else None
+                        role = (
+                            'assistant'
+                            if parent_role == 'user'
+                            else 'user'
+                            if parent_role == 'assistant'
+                            else 'assistant'
+                        )
+
+                    payload = {
+                        **payload,
+                        'id': message_id,
+                        'parentId': parent_id,
+                        'childrenIds': (
+                            payload.get('childrenIds') if isinstance(payload.get('childrenIds'), list) else []
+                        ),
+                        'role': role,
+                        'timestamp': payload.get('timestamp') or int(time.time()),
+                    }
+                    messages[message_id] = payload
+                else:
+                    messages[message_id] = {**existing_message, **payload}
+
+                new_parent_id = messages[message_id].get('parentId')
+                if old_parent_id and old_parent_id != new_parent_id and old_parent_id in messages:
+                    messages[old_parent_id]['childrenIds'] = [
+                        child_id
+                        for child_id in (messages[old_parent_id].get('childrenIds') or [])
+                        if child_id != message_id
+                    ]
+                if new_parent_id and (is_new_message or old_parent_id != new_parent_id) and new_parent_id in messages:
+                    children_ids = [
+                        child_id
+                        for child_id in (messages[new_parent_id].get('childrenIds') or [])
+                        if child_id != message_id
+                    ]
+                    messages[new_parent_id]['childrenIds'] = [*children_ids, message_id]
+
+                if is_new_message:
+                    history['currentId'] = message_id
+                chat_item.current_message_id = history.get('currentId')
+
+                chat_item.chat = chat_data
+                chat_item.title = self._clean_null_bytes(chat_data['title']) if 'title' in chat_data else 'New Chat'
                 flag_modified(chat_item, 'chat')
-
                 if touch:
                     chat_item.updated_at = int(time.time())
 
                 await session.commit()
-                updated_chat = ChatModel.model_validate(chat_item)
-                user_id = chat_item.user_id
+                await session.refresh(chat_item)
+                result = ChatModel.model_validate(chat_item)
 
-            # Dual-write to chat_message table
             try:
                 await ChatMessages.upsert_message(
                     message_id=message_id,
                     chat_id=id,
-                    user_id=user_id,
-                    data=saved_message,
+                    user_id=result.user_id,
+                    data=messages[message_id],
                 )
-            except Exception as e:
-                log.warning(f'Failed to write to chat_message table: {e}')
+            except Exception as exc:
+                log.warning('Failed to mirror message %s for chat %s: %s', message_id, id, exc)
 
-            return updated_chat
-        except Exception:
+            if not include_messages:
+                return result
+            return result
+        except Exception as exc:
+            log.exception('Failed to upsert message %s for chat %s: %s', message_id, id, exc)
             return None
 
-    async def delete_message_from_chat_by_id_and_message_id(self, id: str, message_id: str) -> ChatModel | None:
+    async def delete_message_from_chat_by_id_and_message_id(
+        self,
+        id: str,
+        message_id: str,
+        *,
+        include_messages: bool = True,
+        db: AsyncSession | None = None,
+    ) -> ChatModel | None:
+        del include_messages
         try:
-            async with get_async_db_context() as session:
-                chat_item = await session.get(Chat, id)
+            async with get_async_db_context(db) as session:
+                chat_item = await session.get(Chat, id, with_for_update=True)
                 if chat_item is None:
                     return None
 
                 self._sanitize_chat_row(chat_item)
-                chat = chat_item.chat or {}
-                self._repair_chat_current_id(chat)
-
-                history = chat.get('history', {})
+                chat_data = deepcopy(chat_item.chat or {})
+                self._repair_chat_current_id(chat_data)
+                history = chat_data.get('history') or {}
                 deleted_ids = self.delete_message_from_history(history, message_id)
                 if not deleted_ids:
-                    clean_chat = self._clean_null_bytes(chat)
-                    chat_item.chat = clean_chat
-                    chat_item.title = (
-                        self._clean_null_bytes(clean_chat['title']) if 'title' in clean_chat else 'New Chat'
-                    )
-                    chat_item.current_message_id = self.get_current_message_id(clean_chat)
+                    chat_item.chat = self._clean_null_bytes(chat_data)
+                    chat_item.current_message_id = self.get_current_message_id(chat_data)
                     flag_modified(chat_item, 'chat')
                     await session.commit()
                     return ChatModel.model_validate(chat_item)
 
-                messages = history.get('messages') or {}
-                chat['history'] = history
-                clean_chat = self._clean_null_bytes(chat)
+                chat_data['history'] = history
+                clean_chat = self._clean_null_bytes(chat_data)
                 chat_item.chat = clean_chat
                 chat_item.title = self._clean_null_bytes(clean_chat['title']) if 'title' in clean_chat else 'New Chat'
                 chat_item.current_message_id = self.get_current_message_id(clean_chat)
-                flag_modified(chat_item, 'chat')
                 chat_item.updated_at = int(time.time())
+                flag_modified(chat_item, 'chat')
                 await session.commit()
-                updated_chat = ChatModel.model_validate(chat_item)
+                await session.refresh(chat_item)
+                result = ChatModel.model_validate(chat_item)
                 user_id = chat_item.user_id
+                messages = history.get('messages') or {}
 
             await self.backfill_messages_by_chat_id(id, user_id, messages)
             await ChatMessages.delete_message_ids_by_chat_id(id, deleted_ids)
-
-            return updated_chat
-        except Exception:
+            return result
+        except Exception as exc:
+            log.exception('Failed to delete message %s from chat %s: %s', message_id, id, exc)
             return None
 
     async def add_message_status_to_chat_by_id_and_message_id(
@@ -1492,13 +1704,46 @@ class ChatTable:
                 'total': total,
             }
 
+    async def get_chat_window(
+        self,
+        chat: ChatModel,
+        limit: int = 32,
+        current_id: str | None = None,
+        before_id: str | None = None,
+        db: AsyncSession | None = None,
+    ) -> ChatModel:
+        """Return full branch topology with only one bounded page of message bodies."""
+        del db
+        history = chat.chat.get('history') or {}
+        messages = history.get('messages') or {}
+        current_id = current_id or history.get('currentId')
+        window = create_message_window(
+            messages,
+            current_id=current_id,
+            limit=limit,
+            before_id=before_id,
+        )
+        window_chat = build_window_chat(
+            chat.chat,
+            topology=window['topology'],
+            loaded_messages=window['messages'],
+            loaded_ids=window['loaded_ids'],
+            has_more=window['has_more'],
+            limit=limit,
+            current_id=window['current_id'],
+        )
+        return chat.model_copy(update={'chat': window_chat})
+
     # retrieve conversation
     async def get_chat_by_id(
         self,
         id: str,
         db: AsyncSession | None = None,
+        *,
+        include_messages: bool = True,
     ) -> ChatModel | None:
         """Fetch a chat by PK, auto-sanitizing null bytes on read."""
+        del include_messages
         try:
             async with get_async_db_context(db) as session:
                 chat_item = await session.get(Chat, id)
@@ -1508,7 +1753,11 @@ class ChatTable:
                 repaired_history = self._repair_chat_current_id(chat_item.chat or {})
                 if repaired_history:
                     flag_modified(chat_item, 'chat')
-                if self._sanitize_chat_row(chat_item) or repaired_history:
+                current_message_id = self.get_current_message_id(chat_item.chat or {})
+                repaired_column = chat_item.current_message_id != current_message_id
+                if repaired_column:
+                    chat_item.current_message_id = current_message_id
+                if self._sanitize_chat_row(chat_item) or repaired_history or repaired_column:
                     await session.commit()
 
                 return ChatModel.model_validate(chat_item)
@@ -1537,8 +1786,14 @@ class ChatTable:
             return None
 
     async def get_chat_by_id_and_user_id(
-        self, id: str, user_id: str, db: AsyncSession | None = None
+        self,
+        id: str,
+        user_id: str,
+        db: AsyncSession | None = None,
+        *,
+        include_messages: bool = True,
     ) -> ChatModel | None:
+        del include_messages
         try:
             async with get_async_db_context(db) as session:
                 result = await session.execute(select(Chat).filter_by(id=id, user_id=user_id))
@@ -1549,7 +1804,11 @@ class ChatTable:
                 repaired_history = self._repair_chat_current_id(chat.chat or {})
                 if repaired_history:
                     flag_modified(chat, 'chat')
-                if self._sanitize_chat_row(chat) or repaired_history:
+                current_message_id = self.get_current_message_id(chat.chat or {})
+                repaired_column = chat.current_message_id != current_message_id
+                if repaired_column:
+                    chat.current_message_id = current_message_id
+                if self._sanitize_chat_row(chat) or repaired_history or repaired_column:
                     await session.commit()
 
                 return ChatModel.model_validate(chat)

--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -14,12 +14,13 @@ from open_webui.models.chat_messages import ChatMessage, ChatMessages
 from open_webui.models.folders import Folders
 from open_webui.models.tags import Tag, TagModel, Tags
 from open_webui.utils.chat_history import (
-    MESSAGE_LOADED_KEY,
-    MESSAGE_WINDOW_KEY,
     build_window_chat,
-    create_message_list,
     create_message_window,
-    prepare_messages_for_storage,
+    has_embedded_messages,
+    hydrate_chat,
+    merge_compact_chat,
+    split_chat_messages,
+    uses_normalized_message_storage,
 )
 from open_webui.utils.misc import get_output_text, sanitize_data_for_db, sanitize_text_for_db
 from pydantic import BaseModel, ConfigDict, field_validator
@@ -34,6 +35,7 @@ from sqlalchemy import (
     Text,
     UniqueConstraint,
     and_,
+    cast,
     delete,
     exists,
     func,
@@ -431,6 +433,8 @@ class ChatTable:
         internal_meta: dict | None = None,
     ) -> ChatModel | None:
         async with get_async_db_context(db) as session:
+            clean_chat = self._clean_null_bytes(form_data.chat)
+            compact_chat, messages = split_chat_messages(clean_chat)
             chat = ChatModel(
                 **{
                     'id': id,
@@ -438,7 +442,7 @@ class ChatTable:
                     'title': self._clean_null_bytes(
                         form_data.chat['title'] if 'title' in form_data.chat else 'New Chat'
                     ),
-                    'chat': self._clean_null_bytes(form_data.chat),
+                    'chat': compact_chat,
                     'folder_id': form_data.folder_id,
                     'meta': internal_meta or {},
                     'variables': form_data.variables or {},
@@ -450,31 +454,30 @@ class ChatTable:
             )
 
             chat_item = Chat(**chat.model_dump())
-            session.add(chat_item)
-            await session.commit()
-
-            # Dual-write initial messages to chat_message table
             try:
-                history = form_data.chat.get('history') if isinstance(form_data.chat.get('history'), dict) else {}
-                messages = history.get('messages') if isinstance(history.get('messages'), dict) else {}
-                if not messages and isinstance(form_data.chat.get('messages'), list):
-                    messages = {
-                        message.get('id'): message
-                        for message in form_data.chat['messages']
-                        if isinstance(message, dict) and message.get('id')
-                    }
-                for message_id, message in messages.items():
-                    if isinstance(message, dict) and message.get('role'):
-                        await ChatMessages.upsert_message(
-                            message_id=message_id,
-                            chat_id=id,
-                            user_id=user_id,
-                            data=message,
-                        )
+                session.add(chat_item)
+                await session.flush()
+                if messages:
+                    await ChatMessages.bulk_upsert_messages_in_session(
+                        session,
+                        id,
+                        user_id,
+                        messages,
+                    )
+                await session.commit()
+                await session.refresh(chat_item)
             except Exception as e:
-                log.warning(f'Failed to write initial messages to chat_message table: {e}')
+                await session.rollback()
+                log.exception('Failed to insert normalized chat %s: %s', id, e)
+                return None
 
-            return ChatModel.model_validate(chat_item) if chat_item else None
+            if not chat_item:
+                return None
+
+            result = ChatModel.model_validate(chat_item)
+            if messages:
+                result = result.model_copy(update={'chat': hydrate_chat(result.chat, messages)})
+            return result
 
     async def get_internal_chat_ids_by_parent_id(self, parent_chat_id: str, user_id: str) -> list[str]:
         async with get_async_db_context() as session:
@@ -570,31 +573,30 @@ class ChatTable:
             session.add_all(chats)
             await session.commit()
 
-            # Dual-write messages to chat_message table
-            for form_data, imported_chat in zip(chat_import_forms, chats):
-                history = form_data.chat.get('history') if isinstance(form_data.chat.get('history'), dict) else {}
-                messages = history.get('messages') if isinstance(history.get('messages'), dict) else {}
-                if not messages and isinstance(form_data.chat.get('messages'), list):
-                    messages = {
-                        message.get('id'): message
-                        for message in form_data.chat['messages']
-                        if isinstance(message, dict) and message.get('id')
-                    }
-                for message_id, message in messages.items():
-                    if isinstance(message, dict) and message.get('role'):
-                        try:
-                            await ChatMessages.upsert_message(
-                                message_id=message_id,
-                                chat_id=imported_chat.id,
-                                user_id=user_id,
-                                data=message,
-                            )
-                        except Exception as e:
-                            log.warning(
-                                f'Failed to write imported message {message_id} for chat {imported_chat.id}: {e}'
-                            )
+            for form_data, chat_obj in zip(chat_import_forms, chats):
+                compact_chat, messages = split_chat_messages(form_data.chat)
+                try:
+                    if messages:
+                        await ChatMessages.bulk_upsert_messages_in_session(
+                            session,
+                            chat_obj.id,
+                            user_id,
+                            messages,
+                        )
+                    chat_obj.chat = compact_chat
+                    flag_modified(chat_obj, 'chat')
+                    await session.commit()
+                except Exception as e:
+                    await session.rollback()
+                    await session.refresh(chat_obj)
+                    log.warning('Failed to normalize imported chat %s: %s', chat_obj.id, e)
 
-            return [ChatModel.model_validate(chat) for chat in chats]
+            return [
+                ChatModel.model_validate(chat).model_copy(
+                    update={'chat': hydrate_chat(chat.chat, split_chat_messages(form.chat)[1])}
+                )
+                for form, chat in zip(chat_import_forms, chats)
+            ]
 
     async def update_chat_by_id(
         self,
@@ -603,25 +605,63 @@ class ChatTable:
         db: AsyncSession | None = None,
         *,
         touch: bool = True,
+        include_messages: bool = True,
+        deleted_message_ids: set[str] | None = None,
     ) -> ChatModel | None:
-        """Persist updated chat content, sanitizing null bytes."""
+        """Persist compact chat metadata and lossless normalized messages."""
         try:  # load the chat record for in-place mutation
             async with get_async_db_context(db) as session:
                 chat_item = await session.get(Chat, id, with_for_update=True)
                 if chat_item is None:
                     return None
 
-                chat_item.chat = self._clean_null_bytes(chat)
-                chat_item.title = self._clean_null_bytes(chat['title']) if 'title' in chat else 'New Chat'
-                if any(key in chat for key in ('history', 'messages', 'currentId', 'branchPointMessageId')):
-                    chat_item.current_message_id = self.get_current_message_id(chat)
+                clean_chat = self._clean_null_bytes(chat)
+                legacy_storage_present = has_embedded_messages(chat_item.chat)
+                _, legacy_messages = split_chat_messages(chat_item.chat)
+                compact_chat, incoming_messages = merge_compact_chat(chat_item.chat, clean_chat)
+                messages_to_sync = {**legacy_messages, **incoming_messages}
+
+                if messages_to_sync or legacy_storage_present:
+                    if legacy_storage_present:
+                        await ChatMessages.replace_messages_in_session(
+                            session,
+                            id,
+                            chat_item.user_id,
+                            messages_to_sync,
+                        )
+                    else:
+                        await ChatMessages.bulk_upsert_messages_in_session(
+                            session,
+                            id,
+                            chat_item.user_id,
+                            messages_to_sync,
+                        )
+
+                if deleted_message_ids:
+                    await session.execute(
+                        delete(ChatMessage).where(
+                            ChatMessage.chat_id == id,
+                            ChatMessage.id.in_({f'{id}-{message_id}' for message_id in deleted_message_ids}),
+                        )
+                    )
+
+                chat_item.chat = compact_chat
+                flag_modified(chat_item, 'chat')
+                chat_item.title = self._clean_null_bytes(chat['title']) if 'title' in chat else chat_item.title
+                if any(key in clean_chat for key in ('history', 'messages', 'currentId', 'branchPointMessageId')):
+                    chat_item.current_message_id = self.get_current_message_id(clean_chat)
 
                 if touch:
                     chat_item.updated_at = int(time.time())
 
                 await session.commit()
+                await session.refresh(chat_item)
 
-                return ChatModel.model_validate(chat_item)
+                result = ChatModel.model_validate(chat_item)
+                if include_messages:
+                    messages = await ChatMessages.get_message_data_map_by_chat_id(id, db=session)
+                    result = result.model_copy(update={'chat': hydrate_chat(result.chat, messages or {})})
+                return result
         except Exception as exc:
             log.exception('Failed to update chat %s: %s', id, exc)
             return
@@ -664,53 +704,58 @@ class ChatTable:
                 if chat_item is None:
                     return None
 
-                existing_chat = deepcopy(chat_item.chat or {})
-                incoming_chat = self._clean_null_bytes(chat)
-                merged_chat = {**existing_chat, **incoming_chat}
+                clean_chat = self._clean_null_bytes(chat)
+                legacy_storage_present = has_embedded_messages(chat_item.chat)
+                _, legacy_messages = split_chat_messages(chat_item.chat)
+                compact_chat, incoming_messages = merge_compact_chat(chat_item.chat, clean_chat)
 
-                existing_history = existing_chat.get('history') or {}
-                incoming_history = incoming_chat.get('history') or {}
-                existing_messages = prepare_messages_for_storage(existing_history.get('messages'))
-                incoming_messages = prepare_messages_for_storage(incoming_history.get('messages'))
+                if legacy_storage_present:
+                    await ChatMessages.replace_messages_in_session(
+                        session,
+                        id,
+                        chat_item.user_id,
+                        legacy_messages,
+                    )
+                    existing_message_ids = set(legacy_messages)
+                else:
+                    composite_ids = [f'{id}-{message_id}' for message_id in incoming_messages]
+                    if composite_ids:
+                        result = await session.execute(
+                            select(ChatMessage.id).where(
+                                ChatMessage.chat_id == id,
+                                ChatMessage.id.in_(composite_ids),
+                            )
+                        )
+                        existing_message_ids = {row_id.removeprefix(f'{id}-') for row_id in result.scalars().all()}
+                    else:
+                        existing_message_ids = set()
 
-                # Existing messages are authoritative. Window saves may append messages,
-                # while edits to existing messages must use the single-message PATCH API.
-                merged_messages = {
-                    **existing_messages,
-                    **{
-                        message_id: message
-                        for message_id, message in incoming_messages.items()
-                        if message_id not in existing_messages
-                    },
+                new_messages = {
+                    message_id: message
+                    for message_id, message in incoming_messages.items()
+                    if message_id not in existing_message_ids
                 }
+                if new_messages:
+                    await ChatMessages.bulk_upsert_messages_in_session(
+                        session,
+                        id,
+                        chat_item.user_id,
+                        new_messages,
+                    )
 
-                for message in merged_messages.values():
-                    message['childrenIds'] = []
-                for message_id, message in merged_messages.items():
-                    parent_id = message.get('parentId')
-                    if parent_id in merged_messages:
-                        merged_messages[parent_id]['childrenIds'].append(message_id)
-
-                current_id = incoming_history.get('currentId')
-                if current_id not in merged_messages:
-                    current_id = existing_history.get('currentId')
-                if current_id not in merged_messages:
+                topology = await ChatMessages.get_message_topology_in_session(session, id)
+                history = compact_chat.setdefault('history', {})
+                current_id = history.get('currentId')
+                if current_id not in topology:
+                    current_id = chat_item.current_message_id
+                if current_id not in topology:
                     current_id = None
+                history['currentId'] = current_id
 
-                merged_history = {**existing_history, **incoming_history}
-                merged_history.pop(MESSAGE_WINDOW_KEY, None)
-                merged_history['messages'] = merged_messages
-                merged_history['currentId'] = current_id
-                merged_chat['history'] = merged_history
-
-                # Rebuild the canonical branch list from authoritative message bodies;
-                # the top-level list in a window response is only a partial snapshot.
-                merged_chat['messages'] = create_message_list(merged_messages, current_id)
-
-                chat_item.chat = merged_chat
+                chat_item.chat = compact_chat
                 flag_modified(chat_item, 'chat')
-                if 'title' in incoming_chat:
-                    chat_item.title = self._clean_null_bytes(incoming_chat['title'])
+                if 'title' in clean_chat:
+                    chat_item.title = self._clean_null_bytes(clean_chat['title'])
                 chat_item.current_message_id = current_id
                 if touch:
                     chat_item.updated_at = int(time.time())
@@ -720,59 +765,6 @@ class ChatTable:
                 return ChatModel.model_validate(chat_item)
         except Exception as exc:
             log.exception('Failed to update chat window %s: %s', id, exc)
-            return None
-
-    async def patch_message_by_chat_id_and_message_id(
-        self,
-        id: str,
-        message_id: str,
-        patch: dict,
-        *,
-        touch: bool = True,
-        db: AsyncSession | None = None,
-    ) -> dict | None:
-        """Patch one existing embedded message under the chat row lock."""
-        protected_fields = {
-            MESSAGE_LOADED_KEY,
-            'childrenIds',
-            'id',
-            'parentId',
-            'role',
-            'timestamp',
-        }
-        clean_patch = {
-            key: value for key, value in self._clean_null_bytes(patch).items() if key not in protected_fields
-        }
-
-        try:
-            async with get_async_db_context(db) as session:
-                chat_item = await session.get(Chat, id, with_for_update=True)
-                if chat_item is None:
-                    return None
-
-                chat_data = deepcopy(chat_item.chat or {})
-                history = chat_data.get('history') or {}
-                messages = history.get('messages') or {}
-                message = messages.get(message_id)
-                if not isinstance(message, dict):
-                    return None
-
-                for key, value in clean_patch.items():
-                    if value is None:
-                        message.pop(key, None)
-                    else:
-                        message[key] = value
-
-                chat_item.chat = chat_data
-                chat_item.current_message_id = history.get('currentId')
-                flag_modified(chat_item, 'chat')
-                if clean_patch and touch:
-                    chat_item.updated_at = int(time.time())
-
-                await session.commit()
-                return deepcopy(message)
-        except Exception as exc:
-            log.exception('Failed to patch message %s for chat %s: %s', message_id, id, exc)
             return None
 
     async def update_chat_last_read_at_by_id(
@@ -959,11 +951,11 @@ class ChatTable:
         child_ids = (
             [child_id for child_id, child in messages.items() if child.get('parentId') is None]
             if current_id is None
-            else messages.get(current_id, {}).get('childrenIds', [])
+            else messages.get(current_id, {}).get('childrenIds') or []
         )
         while child_ids:
             current_id = child_ids[-1]
-            child_ids = messages.get(current_id, {}).get('childrenIds', [])
+            child_ids = messages.get(current_id, {}).get('childrenIds') or []
         history['currentId'] = current_id if current_id in messages else None
         return deleted_ids
 
@@ -1017,18 +1009,18 @@ class ChatTable:
         """Write messages to the ``chat_message`` table so future lookups
         use the fast path.  Errors are logged but never raised.
         """
-        for message_id, message in messages.items():
-            if not isinstance(message, dict) or not message.get('role'):
-                continue
-            try:
-                await ChatMessages.upsert_message(
-                    message_id=message_id,
-                    chat_id=chat_id,
-                    user_id=user_id,
-                    data=message,
-                )
-            except Exception as e:
-                log.warning('Backfill failed for message %s in chat %s: %s', message_id, chat_id, e)
+        valid_messages = {message_id: message for message_id, message in messages.items() if isinstance(message, dict)}
+        if not valid_messages:
+            return
+
+        try:
+            await ChatMessages.bulk_upsert_messages(
+                chat_id=chat_id,
+                user_id=user_id,
+                messages=valid_messages,
+            )
+        except Exception as e:
+            log.warning('Backfill failed for %d messages in chat %s: %s', len(valid_messages), chat_id, e)
 
     async def reconcile_messages_by_chat_id(self, chat_id: str, user_id: str, messages: dict[str, dict]) -> None:
         """Sync ``chat_message`` rows with the committed JSON blob.
@@ -1095,11 +1087,78 @@ class ChatTable:
         return history_messages
 
     async def get_message_by_id_and_message_id(self, id: str, message_id: str) -> dict | None:
-        chat = await self.get_chat_by_id(id)
-        if chat is None:
-            return None
+        async with get_async_db_context() as session:
+            chat_item = await session.get(Chat, id)
+            if chat_item is None:
+                return None
 
-        return chat.chat.get('history', {}).get('messages', {}).get(message_id, {})
+            _, legacy_messages, normalized = await self._normalize_chat_item(chat_item, session)
+            if not normalized:
+                return legacy_messages.get(message_id)
+
+            row = await session.get(ChatMessage, f'{id}-{message_id}')
+            return ChatMessages.row_to_message_data(row)[1] if row is not None else None
+
+    async def patch_message_by_chat_id_and_message_id(
+        self,
+        id: str,
+        message_id: str,
+        patch: dict,
+        *,
+        touch: bool = True,
+        db: AsyncSession | None = None,
+    ) -> dict | None:
+        """Update one existing normalized message without hydrating the chat."""
+        protected_fields = {
+            '__loaded',
+            'childrenIds',
+            'id',
+            'parentId',
+            'role',
+            'timestamp',
+        }
+        clean_patch = {
+            key: value for key, value in self._clean_null_bytes(patch).items() if key not in protected_fields
+        }
+
+        try:
+            async with get_async_db_context(db) as session:
+                chat_item = await session.get(Chat, id, with_for_update=True)
+                if chat_item is None:
+                    return None
+
+                compact_chat, legacy_messages = split_chat_messages(chat_item.chat)
+                if has_embedded_messages(chat_item.chat):
+                    await ChatMessages.replace_messages_in_session(
+                        session,
+                        id,
+                        chat_item.user_id,
+                        legacy_messages,
+                    )
+                    chat_item.chat = compact_chat
+                    flag_modified(chat_item, 'chat')
+
+                row = await session.get(ChatMessage, f'{id}-{message_id}')
+                if row is None:
+                    return None
+
+                if clean_patch:
+                    await ChatMessages.upsert_message_in_session(
+                        session,
+                        message_id,
+                        id,
+                        chat_item.user_id,
+                        clean_patch,
+                        existing=row,
+                    )
+                    if touch:
+                        chat_item.updated_at = int(time.time())
+
+                await session.commit()
+                return ChatMessages.row_to_message_data(row)[1]
+        except Exception as exc:
+            log.exception('Failed to patch message %s for chat %s: %s', message_id, id, exc)
+            return None
 
     async def upsert_message_to_chat_by_id_and_message_id(
         self,
@@ -1127,29 +1186,38 @@ class ChatTable:
                 if chat_item is None:
                     return None
 
-                self._sanitize_chat_row(chat_item)
-                chat_data = deepcopy(chat_item.chat or {})
-                self._repair_chat_current_id(chat_data)
-                history = chat_data.setdefault('history', {})
-                messages = history.setdefault('messages', {})
-                existing_message = messages.get(message_id)
-                is_new_message = not isinstance(existing_message, dict)
+                compact_chat, legacy_messages = split_chat_messages(chat_item.chat)
+                if has_embedded_messages(chat_item.chat):
+                    await ChatMessages.replace_messages_in_session(
+                        session,
+                        id,
+                        chat_item.user_id,
+                        legacy_messages,
+                    )
 
-                old_parent_id = existing_message.get('parentId') if not is_new_message else None
+                composite_id = f'{id}-{message_id}'
+                existing_row = await session.get(ChatMessage, composite_id)
+                existing_message = (
+                    ChatMessages.row_to_message_data(existing_row)[1] if existing_row is not None else None
+                )
+                old_parent_id = existing_message.get('parentId') if existing_message else None
+
                 payload = dict(clean_message)
-                if is_new_message:
+                if existing_row is None:
                     parent_id = payload.get('parentId')
                     if parent_id is None:
+                        topology = await ChatMessages.get_message_topology_in_session(session, id)
                         parent_id = next(
                             (
                                 candidate_id
-                                for candidate_id, candidate in messages.items()
+                                for candidate_id, candidate in topology.items()
                                 if message_id in (candidate.get('childrenIds') or [])
                             ),
                             None,
                         )
 
-                    parent = messages.get(parent_id) if parent_id else None
+                    parent_row = await session.get(ChatMessage, f'{id}-{parent_id}') if parent_id else None
+                    parent = ChatMessages.row_to_message_data(parent_row)[1] if parent_row is not None else None
                     output = payload.get('output') or []
                     output_role = next(
                         (item.get('role') for item in output if isinstance(item, dict) and item.get('role')),
@@ -1176,31 +1244,47 @@ class ChatTable:
                         'role': role,
                         'timestamp': payload.get('timestamp') or int(time.time()),
                     }
-                    messages[message_id] = payload
-                else:
-                    messages[message_id] = {**existing_message, **payload}
 
-                new_parent_id = messages[message_id].get('parentId')
-                if old_parent_id and old_parent_id != new_parent_id and old_parent_id in messages:
-                    messages[old_parent_id]['childrenIds'] = [
-                        child_id
-                        for child_id in (messages[old_parent_id].get('childrenIds') or [])
-                        if child_id != message_id
-                    ]
-                if new_parent_id and (is_new_message or old_parent_id != new_parent_id) and new_parent_id in messages:
+                await ChatMessages.upsert_message_in_session(
+                    session,
+                    message_id,
+                    id,
+                    chat_item.user_id,
+                    payload,
+                    existing=existing_row,
+                )
+
+                new_parent_id = payload.get('parentId', old_parent_id)
+                parent_changes = []
+                if old_parent_id and old_parent_id != new_parent_id:
+                    parent_changes.append((old_parent_id, False))
+                if new_parent_id and (existing_row is None or old_parent_id != new_parent_id):
+                    parent_changes.append((new_parent_id, True))
+
+                for parent_id, add_child in parent_changes:
+                    parent_row = await session.get(ChatMessage, f'{id}-{parent_id}')
+                    if parent_row is None:
+                        continue
+                    parent = ChatMessages.row_to_message_data(parent_row)[1]
                     children_ids = [
-                        child_id
-                        for child_id in (messages[new_parent_id].get('childrenIds') or [])
-                        if child_id != message_id
+                        child_id for child_id in (parent.get('childrenIds') or []) if child_id != message_id
                     ]
-                    messages[new_parent_id]['childrenIds'] = [*children_ids, message_id]
+                    if add_child:
+                        children_ids.append(message_id)
+                    await ChatMessages.upsert_message_in_session(
+                        session,
+                        parent_id,
+                        id,
+                        chat_item.user_id,
+                        {'childrenIds': children_ids},
+                        existing=parent_row,
+                    )
 
-                if is_new_message:
+                history = compact_chat.setdefault('history', {})
+                if existing_row is None:
                     history['currentId'] = message_id
-                chat_item.current_message_id = history.get('currentId')
-
-                chat_item.chat = chat_data
-                chat_item.title = self._clean_null_bytes(chat_data['title']) if 'title' in chat_data else 'New Chat'
+                    chat_item.current_message_id = message_id
+                chat_item.chat = compact_chat
                 flag_modified(chat_item, 'chat')
                 if touch:
                     chat_item.updated_at = int(time.time())
@@ -1209,19 +1293,10 @@ class ChatTable:
                 await session.refresh(chat_item)
                 result = ChatModel.model_validate(chat_item)
 
-            try:
-                await ChatMessages.upsert_message(
-                    message_id=message_id,
-                    chat_id=id,
-                    user_id=result.user_id,
-                    data=messages[message_id],
-                )
-            except Exception as exc:
-                log.warning('Failed to mirror message %s for chat %s: %s', message_id, id, exc)
-
-            if not include_messages:
+                if include_messages:
+                    messages = await ChatMessages.get_message_data_map_by_chat_id(id, db=session)
+                    result = result.model_copy(update={'chat': hydrate_chat(result.chat, messages)})
                 return result
-            return result
         except Exception as exc:
             log.exception('Failed to upsert message %s for chat %s: %s', message_id, id, exc)
             return None
@@ -1234,95 +1309,163 @@ class ChatTable:
         include_messages: bool = True,
         db: AsyncSession | None = None,
     ) -> ChatModel | None:
-        del include_messages
+        """Delete one message branch using normalized topology only."""
         try:
             async with get_async_db_context(db) as session:
                 chat_item = await session.get(Chat, id, with_for_update=True)
                 if chat_item is None:
                     return None
 
-                self._sanitize_chat_row(chat_item)
-                chat_data = deepcopy(chat_item.chat or {})
-                self._repair_chat_current_id(chat_data)
-                history = chat_data.get('history') or {}
-                deleted_ids = self.delete_message_from_history(history, message_id)
-                if not deleted_ids:
-                    chat_item.chat = self._clean_null_bytes(chat_data)
-                    chat_item.current_message_id = self.get_current_message_id(chat_data)
-                    flag_modified(chat_item, 'chat')
-                    await session.commit()
-                    return ChatModel.model_validate(chat_item)
+                compact_chat, legacy_messages = split_chat_messages(chat_item.chat)
+                if has_embedded_messages(chat_item.chat):
+                    await ChatMessages.replace_messages_in_session(
+                        session,
+                        id,
+                        chat_item.user_id,
+                        legacy_messages,
+                    )
 
-                chat_data['history'] = history
-                clean_chat = self._clean_null_bytes(chat_data)
-                chat_item.chat = clean_chat
-                chat_item.title = self._clean_null_bytes(clean_chat['title']) if 'title' in clean_chat else 'New Chat'
-                chat_item.current_message_id = self.get_current_message_id(clean_chat)
-                chat_item.updated_at = int(time.time())
+                topology = await ChatMessages.get_message_topology_in_session(session, id)
+                history = {
+                    'currentId': (compact_chat.get('history') or {}).get('currentId'),
+                    'messages': deepcopy(topology),
+                }
+                deleted_ids = self.delete_message_from_history(history, message_id)
+
+                if deleted_ids:
+                    remaining = history['messages']
+                    for remaining_id, message in remaining.items():
+                        previous = topology[remaining_id]
+                        if message.get('parentId') == previous.get('parentId') and message.get(
+                            'childrenIds'
+                        ) == previous.get('childrenIds'):
+                            continue
+
+                        row = await session.get(ChatMessage, f'{id}-{remaining_id}')
+                        if row is not None:
+                            await ChatMessages.upsert_message_in_session(
+                                session,
+                                remaining_id,
+                                id,
+                                chat_item.user_id,
+                                {
+                                    'parentId': message.get('parentId'),
+                                    'childrenIds': message.get('childrenIds') or [],
+                                },
+                                existing=row,
+                            )
+
+                    await session.execute(
+                        delete(ChatMessage).where(
+                            ChatMessage.chat_id == id,
+                            ChatMessage.id.in_({f'{id}-{deleted_id}' for deleted_id in deleted_ids}),
+                        )
+                    )
+
+                compact_history = compact_chat.setdefault('history', {})
+                compact_history['currentId'] = history['currentId']
+                chat_item.chat = compact_chat
+                chat_item.current_message_id = history['currentId']
                 flag_modified(chat_item, 'chat')
+                chat_item.updated_at = int(time.time())
+
                 await session.commit()
                 await session.refresh(chat_item)
                 result = ChatModel.model_validate(chat_item)
-                user_id = chat_item.user_id
-                messages = history.get('messages') or {}
-
-            await self.backfill_messages_by_chat_id(id, user_id, messages)
-            await ChatMessages.delete_message_ids_by_chat_id(id, deleted_ids)
-            return result
+                if include_messages:
+                    messages = await ChatMessages.get_message_data_map_by_chat_id(id, db=session)
+                    result = result.model_copy(update={'chat': hydrate_chat(result.chat, messages)})
+                return result
         except Exception as exc:
             log.exception('Failed to delete message %s from chat %s: %s', message_id, id, exc)
+            return None
+
+    async def append_message_items_by_chat_id_and_message_id(
+        self,
+        id: str,
+        message_id: str,
+        field: str,
+        items: list,
+        *,
+        deduplicate: bool = False,
+        touch: bool = False,
+    ) -> list | None:
+        """Append a list field while holding the chat transaction lock."""
+        try:
+            async with get_async_db_context() as session:
+                chat_item = await session.get(Chat, id, with_for_update=True)
+                if chat_item is None:
+                    return None
+
+                compact_chat, legacy_messages = split_chat_messages(chat_item.chat)
+                if has_embedded_messages(chat_item.chat):
+                    await ChatMessages.replace_messages_in_session(
+                        session,
+                        id,
+                        chat_item.user_id,
+                        legacy_messages,
+                    )
+                    chat_item.chat = compact_chat
+                    flag_modified(chat_item, 'chat')
+
+                row = await session.get(ChatMessage, f'{id}-{message_id}')
+                if row is None:
+                    return None
+
+                message = ChatMessages.row_to_message_data(row)[1]
+                values = [*(message.get(field) or []), *(items or [])]
+                if deduplicate:
+                    unique_values = []
+                    for value in values:
+                        if value not in unique_values:
+                            unique_values.append(value)
+                    values = unique_values
+
+                await ChatMessages.upsert_message_in_session(
+                    session,
+                    message_id,
+                    id,
+                    chat_item.user_id,
+                    {field: values},
+                    existing=row,
+                )
+                if touch:
+                    chat_item.updated_at = int(time.time())
+
+                await session.commit()
+                return values
+        except Exception as exc:
+            log.exception(
+                'Failed to append %s for message %s in chat %s: %s',
+                field,
+                message_id,
+                id,
+                exc,
+            )
             return None
 
     async def add_message_status_to_chat_by_id_and_message_id(
         self, id: str, message_id: str, status: dict
     ) -> ChatModel | None:
-        try:
-            async with get_async_db_context() as session:
-                chat_item = await session.get(Chat, id)
-                if chat_item is None:
-                    return None
-
-                self._sanitize_chat_row(chat_item)
-                chat = chat_item.chat or {}
-                self._repair_chat_current_id(chat)
-                history = chat.get('history', {})
-
-                if message_id in history.get('messages', {}):
-                    status_history = history['messages'][message_id].get('statusHistory', [])
-                    status_history.append(status)
-                    history['messages'][message_id]['statusHistory'] = status_history
-
-                chat['history'] = history
-                clean_chat = self._clean_null_bytes(chat)
-                chat_item.chat = clean_chat
-                chat_item.title = self._clean_null_bytes(clean_chat['title']) if 'title' in clean_chat else 'New Chat'
-                chat_item.current_message_id = self.get_current_message_id(clean_chat)
-                flag_modified(chat_item, 'chat')
-                await session.commit()
-
-                return ChatModel.model_validate(chat_item)
-        except Exception:
-            return None
+        status_history = await self.append_message_items_by_chat_id_and_message_id(
+            id,
+            message_id,
+            'statusHistory',
+            [status],
+            touch=False,
+        )
+        return await self.get_chat_by_id(id, include_messages=False) if status_history is not None else None
 
     async def add_message_files_by_id_and_message_id(self, id: str, message_id: str, files: list[dict]) -> list[dict]:
-        async with get_async_db_context() as session:
-            chat = await self.get_chat_by_id(id, db=session)
-            if chat is None:
-                return None
-
-            chat = chat.chat
-            history = chat.get('history', {})
-
-            message_files = []
-
-            if message_id in history.get('messages', {}):
-                message_files = history['messages'][message_id].get('files', [])
-                message_files = message_files + files
-                history['messages'][message_id]['files'] = message_files
-
-            chat['history'] = history
-            await self.update_chat_by_id(id, chat, db=session)
-            return message_files
+        message_files = await self.append_message_items_by_chat_id_and_message_id(
+            id,
+            message_id,
+            'files',
+            files,
+            deduplicate=True,
+            touch=False,
+        )
+        return message_files or []
 
     async def insert_shared_chat_by_chat_id(self, chat_id: str, db: AsyncSession | None = None) -> ChatModel | None:
         """Create a shared snapshot for a chat. Returns the original chat with share_id set."""
@@ -1344,7 +1487,8 @@ class ChatTable:
             # Set share_id on the original chat
             chat.share_id = shared.id
             await session.commit()
-            return ChatModel.model_validate(chat)  # return the updated original
+            await session.refresh(chat)
+            return await self.get_chat_by_id(chat_id, db=session, include_messages=True)
 
     # refresh helper
     async def update_shared_chat_by_chat_id(
@@ -1360,7 +1504,7 @@ class ChatTable:
             if not record or not record.share_id:
                 return await self.insert_shared_chat_by_chat_id(chat_id, db=session)
             await SharedChats.update(record.share_id, db=session)
-            return ChatModel.model_validate(record)
+            return await self.get_chat_by_id(chat_id, db=session, include_messages=True)
         # unreachable — context manager above always returns
         return
 
@@ -1704,6 +1848,60 @@ class ChatTable:
                 'total': total,
             }
 
+    async def _normalize_chat_item(
+        self,
+        chat_item: Chat,
+        session: AsyncSession,
+    ) -> tuple[ChatModel, dict[str, dict], bool]:
+        """Move legacy embedded messages into chat_message before compacting JSON."""
+        if uses_normalized_message_storage(chat_item.chat) and not has_embedded_messages(chat_item.chat):
+            return ChatModel.model_validate(chat_item), {}, True
+
+        result = await session.execute(select(Chat).where(Chat.id == chat_item.id).with_for_update())
+        chat_item = result.scalar_one()
+        legacy_storage_present = has_embedded_messages(chat_item.chat)
+        compact_chat, legacy_messages = split_chat_messages(chat_item.chat)
+
+        try:
+            if legacy_storage_present:
+                await ChatMessages.replace_messages_in_session(
+                    session,
+                    chat_item.id,
+                    chat_item.user_id,
+                    legacy_messages,
+                )
+
+            if chat_item.chat != compact_chat:
+                chat_item.chat = compact_chat
+                flag_modified(chat_item, 'chat')
+                await session.commit()
+                await session.refresh(chat_item)
+
+            return ChatModel.model_validate(chat_item), legacy_messages, True
+        except Exception as exc:
+            await session.rollback()
+            await session.refresh(chat_item)
+            log.warning(
+                'Chat %s normalization failed; retaining embedded message fallback: %s',
+                chat_item.id,
+                exc,
+            )
+            return ChatModel.model_validate(chat_item), legacy_messages, False
+
+    async def _include_normalized_messages(
+        self,
+        chat: ChatModel,
+        legacy_messages: dict[str, dict],
+        session: AsyncSession,
+        prefer_legacy: bool = False,
+    ) -> ChatModel:
+        messages = await ChatMessages.get_message_data_map_by_chat_id(chat.id, db=session)
+        if prefer_legacy and legacy_messages:
+            messages = legacy_messages
+        elif legacy_messages:
+            messages = {**legacy_messages, **(messages or {})}
+        return chat.model_copy(update={'chat': hydrate_chat(chat.chat, messages or {})})
+
     async def get_chat_window(
         self,
         chat: ChatModel,
@@ -1712,17 +1910,50 @@ class ChatTable:
         before_id: str | None = None,
         db: AsyncSession | None = None,
     ) -> ChatModel:
-        """Return full branch topology with only one bounded page of message bodies."""
-        del db
         history = chat.chat.get('history') or {}
-        messages = history.get('messages') or {}
+        explicit_current_id = current_id is not None
         current_id = current_id or history.get('currentId')
-        window = create_message_window(
-            messages,
-            current_id=current_id,
-            limit=limit,
-            before_id=before_id,
-        )
+        embedded_messages = history.get('messages') or {}
+        if embedded_messages:
+            window = create_message_window(
+                embedded_messages,
+                current_id=current_id,
+                limit=limit,
+                before_id=before_id,
+            )
+        else:
+            try:
+                window = await ChatMessages.get_message_window_by_chat_id(
+                    chat_id=chat.id,
+                    current_id=current_id,
+                    limit=limit,
+                    before_id=before_id,
+                    db=db,
+                )
+            except ValueError as exc:
+                if explicit_current_id or 'current_id does not exist' not in str(exc):
+                    raise
+                window = await ChatMessages.get_message_window_by_chat_id(
+                    chat_id=chat.id,
+                    current_id=None,
+                    limit=limit,
+                    before_id=before_id,
+                    db=db,
+                )
+
+            repaired_current_id = window['current_id']
+            if not explicit_current_id and repaired_current_id != history.get('currentId'):
+                repaired_chat = deepcopy(chat.chat)
+                repaired_chat.setdefault('history', {})['currentId'] = repaired_current_id
+                updated = await self.update_chat_by_id(
+                    chat.id,
+                    repaired_chat,
+                    db=db,
+                    touch=False,
+                    include_messages=False,
+                )
+                if updated:
+                    chat = updated
         window_chat = build_window_chat(
             chat.chat,
             topology=window['topology'],
@@ -1743,7 +1974,6 @@ class ChatTable:
         include_messages: bool = True,
     ) -> ChatModel | None:
         """Fetch a chat by PK, auto-sanitizing null bytes on read."""
-        del include_messages
         try:
             async with get_async_db_context(db) as session:
                 chat_item = await session.get(Chat, id)
@@ -1760,8 +1990,17 @@ class ChatTable:
                 if self._sanitize_chat_row(chat_item) or repaired_history or repaired_column:
                     await session.commit()
 
-                return ChatModel.model_validate(chat_item)
-        except Exception:
+                chat, legacy_messages, normalized = await self._normalize_chat_item(chat_item, session)
+                if include_messages:
+                    chat = await self._include_normalized_messages(
+                        chat,
+                        legacy_messages,
+                        session,
+                        prefer_legacy=not normalized,
+                    )
+                return chat
+        except Exception as exc:
+            log.exception('Failed to get chat %s: %s', id, exc)
             return None
 
     async def get_chat_by_share_id(self, id: str, db: AsyncSession | None = None) -> ChatModel | None:
@@ -1793,7 +2032,6 @@ class ChatTable:
         *,
         include_messages: bool = True,
     ) -> ChatModel | None:
-        del include_messages
         try:
             async with get_async_db_context(db) as session:
                 result = await session.execute(select(Chat).filter_by(id=id, user_id=user_id))
@@ -1811,8 +2049,17 @@ class ChatTable:
                 if self._sanitize_chat_row(chat) or repaired_history or repaired_column:
                     await session.commit()
 
-                return ChatModel.model_validate(chat)
-        except Exception:
+                chat_model, legacy_messages, normalized = await self._normalize_chat_item(chat, session)
+                if include_messages:
+                    chat_model = await self._include_normalized_messages(
+                        chat_model,
+                        legacy_messages,
+                        session,
+                        prefer_legacy=not normalized,
+                    )
+                return chat_model
+        except Exception as exc:
+            log.exception('Failed to get chat %s for user %s: %s', id, user_id, exc)
             return None
 
     async def is_chat_owner(self, id: str, user_id: str, db: AsyncSession | None = None) -> bool:
@@ -1998,10 +2245,8 @@ class ChatTable:
         skip: int = 0,
         limit: int = 60,
         db: AsyncSession | None = None,
-    ) -> list[ChatModel]:
-        """
-        Filters chats based on a search query using Python, allowing pagination using skip and limit.
-        """
+    ) -> list[ChatTitleIdResponse]:
+        """Search chat titles and message content with database-level pagination."""
         search_text = sanitize_text_for_db(search_text).lower().strip()
 
         if not search_text:
@@ -2056,7 +2301,13 @@ class ChatTable:
         search_text = ' '.join(search_text_words)
 
         async with get_async_db_context(db) as session:
-            stmt = select(Chat).filter(Chat.user_id == user_id)
+            stmt = select(
+                Chat.id,
+                Chat.title,
+                Chat.updated_at,
+                Chat.created_at,
+                Chat.last_read_at,
+            ).filter(Chat.user_id == user_id)
             stmt = stmt.where(Chat.meta['internal'].as_boolean().is_not(True))
 
             if is_archived is not None:
@@ -2081,22 +2332,72 @@ class ChatTable:
             # Check if the database dialect is either 'sqlite' or 'postgresql'
             bind = await session.connection()
             dialect_name = bind.dialect.name
-            if dialect_name == 'sqlite':
-                # SQLite case: using JSON1 extension for JSON searching
-                sqlite_content_sql = (
-                    'EXISTS ('
-                    '    SELECT 1 '
-                    "    FROM json_each(Chat.chat, '$.messages') AS message "
-                    "    WHERE LOWER(message.value->>'content') LIKE '%' || :content_key || '%'"
-                    ')'
-                )
-                sqlite_content_clause = text(sqlite_content_sql)
-                stmt = stmt.filter(
-                    or_(Chat.title.ilike(bindparam('title_key')), sqlite_content_clause).params(
-                        title_key=f'%{search_text}%', content_key=search_text
+            if search_text:
+                message_content_match = exists().where(
+                    and_(
+                        ChatMessage.chat_id == Chat.id,
+                        cast(ChatMessage.content, Text).ilike(bindparam('content_key')),
                     )
                 )
 
+                if dialect_name == 'sqlite':
+                    legacy_content_match = text("""
+                        json_extract(Chat.chat, '$.history.messageStorage.version') IS NULL
+                        AND (
+                            EXISTS (
+                                SELECT 1
+                                FROM json_each(Chat.chat, '$.history.messages') AS message
+                                WHERE LOWER(message.value->>'content') LIKE :content_key
+                            )
+                            OR EXISTS (
+                                SELECT 1
+                                FROM json_each(Chat.chat, '$.messages') AS message
+                                WHERE LOWER(message.value->>'content') LIKE :content_key
+                            )
+                        )
+                        """)
+                elif dialect_name == 'postgresql':
+                    legacy_content_match = text("""
+                        Chat.chat->'history'->'messageStorage'->>'version' IS NULL
+                        AND (
+                            EXISTS (
+                                SELECT 1
+                                FROM json_each(
+                                    CASE
+                                        WHEN json_typeof(Chat.chat->'history'->'messages') = 'object'
+                                        THEN Chat.chat->'history'->'messages'
+                                        ELSE '{}'::json
+                                    END
+                                ) AS message
+                                WHERE json_typeof(message.value->'content') = 'string'
+                                AND LOWER(message.value->>'content') LIKE :content_key
+                            )
+                            OR EXISTS (
+                                SELECT 1
+                                FROM json_array_elements(
+                                    CASE
+                                        WHEN json_typeof(Chat.chat->'messages') = 'array'
+                                        THEN Chat.chat->'messages'
+                                        ELSE '[]'::json
+                                    END
+                                ) AS message
+                                WHERE json_typeof(message->'content') = 'string'
+                                AND LOWER(message->>'content') LIKE :content_key
+                            )
+                        )
+                        """)
+                else:
+                    raise NotImplementedError(f'Unsupported dialect: {dialect_name}')
+
+                stmt = stmt.filter(
+                    or_(
+                        Chat.title.ilike(bindparam('title_key')),
+                        message_content_match,
+                        legacy_content_match,
+                    )
+                ).params(title_key=f'%{search_text}%', content_key=f'%{search_text}%')
+
+            if dialect_name == 'sqlite':
                 # Check if there are any tags to filter
                 if 'none' in tag_ids:
                     stmt = stmt.filter(
@@ -2130,38 +2431,6 @@ class ChatTable:
                 # Safety filter: title must not contain actual null bytes
                 stmt = stmt.filter(text("Chat.title::text NOT LIKE '%\\x00%'"))
 
-                postgres_content_sql = """
-                EXISTS (
-                    SELECT 1
-                    FROM chat_message AS message
-                    WHERE message.chat_id = Chat.id
-                    AND message.user_id = Chat.user_id
-                    AND json_typeof(message.content) = 'string'
-                    AND LOWER(message.content #>> '{}') LIKE '%' || :content_key || '%'
-                )
-                OR EXISTS (
-                    SELECT 1
-                    FROM json_each(Chat.chat#>'{history,messages}') AS history_message
-                    WHERE json_typeof(history_message.value->'content') = 'string'
-                    AND LOWER(history_message.value->>'content') LIKE '%' || :content_key || '%'
-                )
-                OR EXISTS (
-                    SELECT 1
-                    FROM json_array_elements(Chat.chat->'messages') AS legacy_message
-                    WHERE json_typeof(legacy_message->'content') = 'string'
-                    AND LOWER(legacy_message->>'content') LIKE '%' || :content_key || '%'
-                )
-                """
-
-                postgres_content_clause = text(postgres_content_sql)
-
-                stmt = stmt.filter(
-                    or_(
-                        Chat.title.ilike(bindparam('title_key')),
-                        postgres_content_clause,
-                    )
-                ).params(title_key=f'%{search_text}%', content_key=search_text.lower())
-
                 if 'none' in tag_ids:
                     stmt = stmt.filter(
                         text("""
@@ -2192,12 +2461,44 @@ class ChatTable:
             # Perform pagination at the SQL level
             stmt = stmt.offset(skip).limit(limit)
             result = await session.execute(stmt)
-            all_chats = result.scalars().all()
+            all_chats = result.all()
 
             log.info(f'The number of chats: {len(all_chats)}')
 
-            # Validate and return chats
-            return [ChatModel.model_validate(chat) for chat in all_chats]
+            snippets = await ChatMessages.get_content_snippets_by_chat_ids(
+                [chat.id for chat in all_chats],
+                search_text,
+                db=session,
+            )
+            legacy_match_ids = [
+                chat.id
+                for chat in all_chats
+                if search_text and chat.id not in snippets and search_text not in (chat.title or '').lower()
+            ]
+            for chat_id in legacy_match_ids:
+                await self.get_chat_by_id(chat_id, db=session, include_messages=False)
+            if legacy_match_ids:
+                snippets.update(
+                    await ChatMessages.get_content_snippets_by_chat_ids(
+                        legacy_match_ids,
+                        search_text,
+                        db=session,
+                    )
+                )
+
+            return [
+                ChatTitleIdResponse.model_validate(
+                    {
+                        'id': chat.id,
+                        'title': chat.title,
+                        'updated_at': chat.updated_at,
+                        'created_at': chat.created_at,
+                        'last_read_at': chat.last_read_at,
+                        'snippet': snippets.get(chat.id),
+                    }
+                )
+                for chat in all_chats
+            ]
 
     async def get_chats_by_folder_id_and_user_id(
         self,

--- a/backend/open_webui/models/shared_chats.py
+++ b/backend/open_webui/models/shared_chats.py
@@ -64,9 +64,9 @@ class SharedChatsTable:
         Returns the SharedChatModel with the share token as its id.
         """
         async with get_async_db_context(db) as db:
-            from open_webui.models.chats import Chat
+            from open_webui.models.chats import Chats
 
-            chat = await db.get(Chat, chat_id)
+            chat = await Chats.get_chat_by_id(chat_id, db=db, include_messages=True)
             if not chat:
                 return None
 
@@ -93,13 +93,17 @@ class SharedChatsTable:
         Re-snapshot: update the shared chat with the current state of the original chat.
         """
         async with get_async_db_context(db) as db:
-            from open_webui.models.chats import Chat
+            from open_webui.models.chats import Chats
 
             shared_chat = await db.get(SharedChat, share_id)
             if not shared_chat:
                 return None
 
-            chat = await db.get(Chat, shared_chat.chat_id)
+            chat = await Chats.get_chat_by_id(
+                shared_chat.chat_id,
+                db=db,
+                include_messages=True,
+            )
             if not chat:
                 return None
 

--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -34,6 +34,7 @@ from open_webui.env import (
     OFFLINE_MODE,
 )
 from open_webui.models.access_grants import AccessGrants
+from open_webui.models.chat_messages import ChatMessages
 from open_webui.models.chats import Chats
 from open_webui.models.files import Files
 from open_webui.models.folders import Folders
@@ -50,7 +51,7 @@ from open_webui.retrieval.web.utils import get_web_loader
 from open_webui.utils.access_control.files import get_owner_accessible_folder_files, has_access_to_file
 from open_webui.utils.access_control.folders import has_folder_access
 from open_webui.utils.headers import include_user_info_headers
-from open_webui.utils.misc import get_content_from_message, get_message_list
+from open_webui.utils.misc import expand_messages_with_output, get_content_from_message
 
 log = logging.getLogger(__name__)
 
@@ -1415,27 +1416,25 @@ async def get_sources_from_items(
 
         elif item.get('type') == 'chat':
             # Chat Attached
-            chat = await Chats.get_chat_by_id(item.get('id'))
+            chat = await Chats.get_chat_by_id(item.get('id'), include_messages=False)
 
             if chat and (user.role == 'admin' or chat.user_id == user.id):
-                messages_map = chat.chat.get('history', {}).get('messages', {})
                 message_id = chat.chat.get('history', {}).get('currentId')
 
-                if messages_map and message_id:
-                    # Reconstruct the message list in order
-                    message_list = get_message_list(messages_map, message_id)
+                if message_id:
+                    message_list = await ChatMessages.get_message_branch_by_chat_id(chat.id, message_id)
                     message_history = '\n'.join(
-                        [
-                            f'#### {m.get("role", "user").capitalize()}\n{get_content_from_message(m) or ""}\n'
-                            for m in message_list
-                        ]
+                        f'#### {message.get("role", "user").capitalize()}\n{content}\n'
+                        for message in expand_messages_with_output(message_list)
+                        for content in [get_content_from_message(message)]
+                        if isinstance(content, str) and content.strip()
                     )
 
-                    # User has access to the chat
-                    query_result = {
-                        'documents': [[message_history]],
-                        'metadatas': [[{'file_id': chat.id, 'name': chat.title}]],
-                    }
+                    if message_list:
+                        query_result = {
+                            'documents': [[message_history]],
+                            'metadatas': [[{'file_id': chat.id, 'name': chat.title}]],
+                        }
 
         elif item.get('type') == 'url':
             content, docs = await get_content_from_url(request, item.get('url'))

--- a/backend/open_webui/routers/chats.py
+++ b/backend/open_webui/routers/chats.py
@@ -1301,35 +1301,115 @@ async def compact_chat_by_id(
 ############################
 
 
-@router.get('/{id}', response_model=ChatResponse | None)
-async def get_chat_by_id(id: str, user=Depends(get_verified_user), db: AsyncSession = Depends(get_async_session)):
-    chat = await Chats.get_chat_by_id_and_user_id(id, user.id, db=db)
+async def get_accessible_chat_by_id(
+    id: str,
+    user,
+    db: AsyncSession,
+    *,
+    include_messages: bool,
+):
+    chat = await Chats.get_chat_by_id_and_user_id(
+        id,
+        user.id,
+        db=db,
+        include_messages=include_messages,
+    )
 
-    if not chat and user.role == 'admin':
-        candidate = await Chats.get_chat_by_id(id, db=db)
+    if chat:
+        return chat
+
+    candidate = None
+    if user.role == 'admin':
+        candidate = await Chats.get_chat_by_id(id, db=db, include_messages=include_messages)
         if ENABLE_ADMIN_CHAT_ACCESS or (candidate and is_internal_chat(candidate.meta)):
-            chat = candidate
+            return candidate
 
-    # Access explicitly granted to this user applies to admins too, so an admin
-    # does not lose a chat shared with them when ENABLE_ADMIN_CHAT_ACCESS is off.
+    has_grant = await AccessGrants.has_access(
+        user_id=user.id,
+        resource_type='shared_chat',
+        resource_id=id,
+        permission='read',
+        db=db,
+    )
+    if has_grant:
+        return await Chats.get_chat_by_id(id, db=db, include_messages=include_messages)
+
+    if candidate is None:
+        candidate = await Chats.get_chat_by_id(id, db=db, include_messages=include_messages)
+    if candidate and candidate.folder_id:
+        folder = await Folders.get_folder_by_id(candidate.folder_id, db=db)
+        if folder and await has_folder_access(user.id, folder, 'read', db):
+            return candidate
+
+    return None
+
+
+@router.get('/{id}/window', response_model=ChatResponse | None)
+async def get_chat_window_by_id(
+    id: str,
+    limit: int = 32,
+    current_id: str | None = None,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    limit = max(1, min(limit, 128))
+    chat = await get_accessible_chat_by_id(id, user, db, include_messages=False)
     if not chat:
-        has_grant = await AccessGrants.has_access(
-            user_id=user.id,
-            resource_type='shared_chat',
-            resource_id=id,
-            permission='read',
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=ERROR_MESSAGES.NOT_FOUND)
+
+    try:
+        chat = await Chats.get_chat_window(chat, limit=limit, current_id=current_id, db=db)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+    data = ChatResponse(**chat.model_dump()).model_dump()
+    data['context_usage'] = await get_chat_context_usage(chat)
+    return data
+
+
+@router.get('/{id}/history/window')
+async def get_chat_history_window_by_id(
+    id: str,
+    current_id: str,
+    limit: int = 32,
+    before_id: str | None = None,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    limit = max(1, min(limit, 128))
+    chat = await get_accessible_chat_by_id(id, user, db, include_messages=False)
+    if not chat:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=ERROR_MESSAGES.NOT_FOUND)
+
+    try:
+        window_chat = await Chats.get_chat_window(
+            chat,
+            current_id=current_id,
+            limit=limit,
+            before_id=before_id,
             db=db,
         )
-        if has_grant:
-            chat = await Chats.get_chat_by_id(id, db=db)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
 
-        # Check folder-based access (shared folders)
-        if not chat:
-            candidate = await Chats.get_chat_by_id(id, db=db)
-            if candidate and candidate.folder_id:
-                folder = await Folders.get_folder_by_id(candidate.folder_id, db=db)
-                if folder and await has_folder_access(user.id, folder, 'read', db):
-                    chat = candidate
+    history = window_chat.chat.get('history') or {}
+    metadata = history.get('messageWindow') or {}
+    loaded_ids = metadata.get('loadedIds') or []
+    return {
+        'messages': {
+            message_id: history['messages'][message_id]
+            for message_id in loaded_ids
+            if message_id in (history.get('messages') or {})
+        },
+        'loadedIds': loaded_ids,
+        'hasMore': metadata.get('hasMore', False),
+        'currentId': history.get('currentId'),
+    }
+
+
+@router.get('/{id}', response_model=ChatResponse | None)
+async def get_chat_by_id(id: str, user=Depends(get_verified_user), db: AsyncSession = Depends(get_async_session)):
+    chat = await get_accessible_chat_by_id(id, user, db, include_messages=True)
 
     if chat:
         data = ChatResponse.model_validate(chat, from_attributes=True).model_dump()
@@ -1342,6 +1422,39 @@ async def get_chat_by_id(id: str, user=Depends(get_verified_user), db: AsyncSess
 ############################
 # UpdateChatById
 ############################
+
+
+@router.post('/{id}/window', response_model=ChatResponse | None)
+async def update_chat_window_by_id(
+    request: Request,
+    id: str,
+    form_data: ChatForm,
+    limit: int = 32,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    limit = max(1, min(limit, 128))
+    if not await Chats.is_chat_owner(id, user.id, db=db):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
+        )
+
+    chat = await Chats.update_chat_window_by_id(id, form_data.chat, db=db)
+    if not chat:
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=ERROR_MESSAGES.DEFAULT())
+
+    chat = await Chats.get_chat_window(chat, limit=limit, db=db)
+    await publish_event(
+        request,
+        EVENTS.CHAT_UPDATED,
+        actor=user,
+        subject_id=id,
+        data={'title': chat.title},
+    )
+    data = ChatResponse(**chat.model_dump()).model_dump()
+    data['context_usage'] = await get_chat_context_usage(chat)
+    return data
 
 
 @router.post('/{id}', response_model=ChatResponse | None)
@@ -1400,6 +1513,78 @@ async def update_chat_by_id(
 ############################
 class MessageForm(BaseModel):
     content: str
+
+
+class MessagePatchForm(BaseModel):
+    message: dict
+
+
+@router.patch('/{id}/messages/{message_id}', response_model=dict | None)
+async def patch_chat_message_by_id(
+    request: Request,
+    id: str,
+    message_id: str,
+    form_data: MessagePatchForm,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    chat = await Chats.get_chat_by_id(id, db=db, include_messages=False)
+
+    if not chat or (chat.user_id != user.id and user.role != 'admin'):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
+        )
+
+    message = await Chats.patch_message_by_chat_id_and_message_id(
+        id,
+        message_id,
+        form_data.message,
+        db=db,
+    )
+    if message is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=ERROR_MESSAGES.NOT_FOUND,
+        )
+
+    event_emitter = await get_event_emitter(
+        {
+            'user_id': chat.user_id,
+            'chat_id': id,
+            'message_id': message_id,
+        },
+        False,
+    )
+    protected_fields = {'__loaded', 'childrenIds', 'id', 'parentId', 'role', 'timestamp'}
+    response_patch = {
+        key: message.get(key) for key in form_data.message if key not in protected_fields and key in message
+    }
+
+    if event_emitter:
+        await event_emitter(
+            {
+                'type': 'chat:message',
+                'data': {
+                    'chat_id': id,
+                    'message_id': message_id,
+                    **response_patch,
+                },
+            }
+        )
+
+    content = form_data.message.get('content')
+    await publish_event(
+        request,
+        EVENTS.MESSAGE_UPDATED,
+        actor=user,
+        subject_id=message_id,
+        data={
+            'chat_id': id,
+            'content_preview': content[:300] if isinstance(content, str) else '',
+        },
+    )
+    return {'id': message_id, **response_patch}
 
 
 @router.post('/{id}/messages/{message_id}', response_model=ChatResponse | None)
@@ -1469,10 +1654,11 @@ async def delete_chat_message_by_id(
     request: Request,
     id: str,
     message_id: str,
+    compact: bool = False,
     user=Depends(get_verified_user),
     db: AsyncSession = Depends(get_async_session),
 ):
-    chat = await Chats.get_chat_by_id(id, db=db)
+    chat = await Chats.get_chat_by_id(id, db=db, include_messages=False)
 
     if not chat:
         raise HTTPException(
@@ -1486,7 +1672,18 @@ async def delete_chat_message_by_id(
             detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
         )
 
-    chat = await Chats.delete_message_from_chat_by_id_and_message_id(id, message_id)
+    if await has_active_tasks(request.app.state.redis, id):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail='Wait for the current response to finish before deleting messages.',
+        )
+
+    chat = await Chats.delete_message_from_chat_by_id_and_message_id(
+        id,
+        message_id,
+        include_messages=not compact,
+        db=db,
+    )
     if not chat:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
@@ -1500,6 +1697,8 @@ async def delete_chat_message_by_id(
         subject_id=message_id,
         data={'chat_id': id},
     )
+    if compact:
+        chat = await Chats.get_chat_window(chat, limit=32, db=db)
     return ChatResponse.model_validate(chat, from_attributes=True)
 
 

--- a/backend/open_webui/routers/chats.py
+++ b/backend/open_webui/routers/chats.py
@@ -49,7 +49,6 @@ log = logging.getLogger(__name__)
 
 router = APIRouter()
 
-SEARCH_FILTER_PREFIXES = ('tag:', 'folder:', 'pinned:', 'archived:', 'shared:')
 
 CHAT_CONFIG_KEYS = {
     'CONTEXT_COMPACTION_MODEL': 'chat.context_compaction.model',
@@ -144,43 +143,6 @@ class ChatConfigForm(BaseModel):
 
 class CompactChatForm(BaseModel):
     model: str | None = None
-
-
-def chat_search_content_text(text: str) -> str:
-    words = text.lower().strip().split(' ')
-    return ' '.join(word for word in words if not word.startswith(SEARCH_FILTER_PREFIXES)).strip()
-
-
-def chat_search_snippet(chat: dict, search_text: str, max_length: int = 200) -> str | None:
-    if not search_text:
-        return None
-
-    messages = chat.get('messages', [])
-    if isinstance(messages, dict):
-        messages = messages.values()
-
-    for message in messages:
-        if not isinstance(message, dict):
-            continue
-
-        content = message.get('content')
-        if not isinstance(content, str):
-            continue
-
-        index = content.lower().find(search_text)
-        if index == -1:
-            continue
-
-        start = max(index - max_length // 2, 0)
-        end = min(start + max_length, len(content))
-        if index + len(search_text) > end:
-            end = min(index + len(search_text), len(content))
-            start = max(end - max_length, 0)
-
-        snippet = ' '.join(content[start:end].split())
-        return f'{"..." if start else ""}{snippet}{"..." if end < len(content) else ""}'
-
-    return None
 
 
 async def get_chat_config_values() -> dict:
@@ -533,7 +495,8 @@ async def calculate_chat_stats(user_id, skip=0, limit=10, filter=None):
 
     chat_stats_export_list = []
     for chat in result.items:
-        chat_stat = _process_chat_for_export(chat)
+        hydrated = await Chats.get_chat_by_id(chat.id, include_messages=True)
+        chat_stat = _process_chat_for_export(hydrated) if hydrated else None
         if chat_stat:
             chat_stats_export_list.append(chat_stat)
 
@@ -568,7 +531,8 @@ async def generate_chat_stats_jsonl_generator(user_id, filter):
 
         for chat in result.items:
             try:
-                chat_stat = _process_chat_for_export(chat)
+                hydrated = await Chats.get_chat_by_id(chat.id, include_messages=True)
+                chat_stat = _process_chat_for_export(hydrated) if hydrated else None
                 if chat_stat:
                     yield chat_stat.model_dump_json() + '\n'
             except Exception as e:
@@ -856,20 +820,14 @@ async def search_user_chats(
     limit = 60
     skip = (page - 1) * limit
 
-    search_text = chat_search_content_text(text)
-    chat_list = []
-    for chat in await Chats.get_chats_by_user_id_and_search_text(user.id, text, skip=skip, limit=limit, db=db):
-        # Explicit fields: model_dump() would deep-copy the entire chat blob per row
-        chat_list.append(
-            ChatTitleIdResponse(
-                id=chat.id,
-                title=chat.title,
-                updated_at=chat.updated_at,
-                created_at=chat.created_at,
-                last_read_at=chat.last_read_at,
-                snippet=chat_search_snippet(chat.chat, search_text),
-            )
-        )
+    chats = await Chats.get_chats_by_user_id_and_search_text(
+        user.id,
+        text,
+        skip=skip,
+        limit=limit,
+        db=db,
+    )
+    chat_list = [ChatTitleIdResponse.model_validate(chat, from_attributes=True) for chat in chats]
 
     # Delete tag if no chat is found
     words = text.strip().split(' ')
@@ -897,10 +855,9 @@ async def get_chats_by_folder_id(
     if children_folders:
         folder_ids.extend([folder.id for folder in children_folders])
 
-    return [
-        ChatResponse.model_validate(chat, from_attributes=True)
-        for chat in await Chats.get_chats_by_folder_ids_and_user_id(folder_ids, user.id, db=db)
-    ]
+    chats = await Chats.get_chats_by_folder_ids_and_user_id(folder_ids, user.id, db=db)
+    hydrated = [await Chats.get_chat_by_id(chat.id, db=db, include_messages=True) for chat in chats]
+    return [ChatResponse.model_validate(chat, from_attributes=True) for chat in hydrated if chat]
 
 
 @router.get('/folder/{folder_id}/list', response_model=list[ChatTitleIdResponse])
@@ -974,7 +931,9 @@ async def generate_chat_export_ndjson(user_id: str):
 
         for chat in result.items:
             try:
-                yield ChatResponse.model_validate(chat, from_attributes=True).model_dump_json() + '\n'
+                hydrated = await Chats.get_chat_by_id(chat.id, include_messages=True)
+                if hydrated:
+                    yield ChatResponse.model_validate(hydrated, from_attributes=True).model_dump_json() + '\n'
             except Exception as e:
                 log.exception(f'Error serializing chat {chat.id}: {e}')
 
@@ -999,10 +958,9 @@ async def get_user_chats(user=Depends(get_verified_user)):
 
 @router.get('/all/archived', response_model=list[ChatResponse])
 async def get_user_archived_chats(user=Depends(get_verified_user), db: AsyncSession = Depends(get_async_session)):
-    return [
-        ChatResponse.model_validate(chat, from_attributes=True)
-        for chat in await Chats.get_archived_chats_by_user_id(user.id, db=db)
-    ]
+    chats = await Chats.get_archived_chats_by_user_id(user.id, db=db)
+    hydrated = [await Chats.get_chat_by_id(chat.id, db=db, include_messages=True) for chat in chats]
+    return [ChatResponse.model_validate(chat, from_attributes=True) for chat in hydrated if chat]
 
 
 ############################
@@ -1029,7 +987,9 @@ async def get_all_user_tags(user=Depends(get_verified_user), db: AsyncSession = 
 async def get_all_user_chats_in_db(user=Depends(get_admin_user), db: AsyncSession = Depends(get_async_session)):
     if not ENABLE_ADMIN_EXPORT:
         raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail=ERROR_MESSAGES.ACCESS_PROHIBITED)
-    return [ChatResponse.model_validate(chat, from_attributes=True) for chat in await Chats.get_chats(db=db)]
+    chats = await Chats.get_chats(db=db)
+    hydrated = [await Chats.get_chat_by_id(chat.id, db=db, include_messages=True) for chat in chats]
+    return [ChatResponse.model_validate(chat, from_attributes=True) for chat in hydrated if chat]
 
 
 ############################
@@ -1255,7 +1215,7 @@ async def compact_chat_by_id(
     user=Depends(get_verified_user),
     db: AsyncSession = Depends(get_async_session),
 ):
-    chat = await Chats.get_chat_by_id_and_user_id(id, user.id, db=db)
+    chat = await Chats.get_chat_by_id_and_user_id(id, user.id, db=db, include_messages=False)
     if not chat:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=ERROR_MESSAGES.NOT_FOUND)
 
@@ -1269,9 +1229,8 @@ async def compact_chat_by_id(
         await get_all_models(request, user=user)
 
     history = (chat.chat or {}).get('history') or {}
-    messages_map = await Chats.get_messages_map_by_chat_id(id)
     current_message_id = chat.current_message_id or history.get('currentId')
-    message_list = get_message_list(messages_map or history.get('messages') or {}, current_message_id)
+    message_list = await ChatMessages.get_message_branch_by_chat_id(id, current_message_id, db=db)
     model_id = (form_data.model if form_data else None) or next(
         (message.get('model') for message in reversed(message_list) if message.get('model')),
         None,
@@ -1357,11 +1316,7 @@ async def get_chat_window_by_id(
     if not chat:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=ERROR_MESSAGES.NOT_FOUND)
 
-    try:
-        chat = await Chats.get_chat_window(chat, limit=limit, current_id=current_id, db=db)
-    except ValueError as exc:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
-
+    chat = await Chats.get_chat_window(chat, limit=limit, current_id=current_id, db=db)
     data = ChatResponse(**chat.model_dump()).model_dump()
     data['context_usage'] = await get_chat_context_usage(chat)
     return data
@@ -1381,7 +1336,8 @@ async def get_chat_history_window_by_id(
     if not chat:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=ERROR_MESSAGES.NOT_FOUND)
 
-    try:
+    embedded_messages = ((chat.chat or {}).get('history') or {}).get('messages') or {}
+    if embedded_messages:
         window_chat = await Chats.get_chat_window(
             chat,
             current_id=current_id,
@@ -1389,21 +1345,32 @@ async def get_chat_history_window_by_id(
             before_id=before_id,
             db=db,
         )
-    except ValueError as exc:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+        history = window_chat.chat.get('history') or {}
+        metadata = history.get('messageWindow') or {}
+        loaded_ids = metadata.get('loadedIds') or []
+        return {
+            'messages': {
+                message_id: history['messages'][message_id]
+                for message_id in loaded_ids
+                if message_id in (history.get('messages') or {})
+            },
+            'loadedIds': loaded_ids,
+            'hasMore': metadata.get('hasMore', False),
+            'currentId': history.get('currentId'),
+        }
 
-    history = window_chat.chat.get('history') or {}
-    metadata = history.get('messageWindow') or {}
-    loaded_ids = metadata.get('loadedIds') or []
+    window = await ChatMessages.get_message_window_by_chat_id(
+        chat_id=id,
+        current_id=current_id,
+        limit=limit,
+        before_id=before_id,
+        db=db,
+    )
     return {
-        'messages': {
-            message_id: history['messages'][message_id]
-            for message_id in loaded_ids
-            if message_id in (history.get('messages') or {})
-        },
-        'loadedIds': loaded_ids,
-        'hasMore': metadata.get('hasMore', False),
-        'currentId': history.get('currentId'),
+        'messages': window['messages'],
+        'loadedIds': window['loaded_ids'],
+        'hasMore': window['has_more'],
+        'currentId': window['current_id'],
     }
 
 
@@ -1434,7 +1401,13 @@ async def update_chat_window_by_id(
     db: AsyncSession = Depends(get_async_session),
 ):
     limit = max(1, min(limit, 128))
-    if not await Chats.is_chat_owner(id, user.id, db=db):
+    existing = await Chats.get_chat_by_id_and_user_id(
+        id,
+        user.id,
+        db=db,
+        include_messages=False,
+    )
+    if not existing:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
@@ -1486,12 +1459,6 @@ async def update_chat_by_id(
                 )
                 or chat
             )
-
-        # Reconcile chat_message rows without inferring deletes from missing IDs.
-        # Message deletion has its own endpoint below.
-        messages = (updated_chat.get('history') or {}).get('messages') or {}
-        if messages:
-            await Chats.reconcile_messages_by_chat_id(id, user.id, messages)
 
         await publish_event(
             request,
@@ -1596,7 +1563,7 @@ async def update_chat_message_by_id(
     user=Depends(get_verified_user),
     db: AsyncSession = Depends(get_async_session),
 ):
-    chat = await Chats.get_chat_by_id(id, db=db)
+    chat = await Chats.get_chat_by_id(id, db=db, include_messages=False)
 
     if not chat:
         raise HTTPException(
@@ -1616,6 +1583,7 @@ async def update_chat_message_by_id(
         {
             'content': form_data.content,
         },
+        include_messages=True,
     )
 
     event_emitter = await get_event_emitter(
@@ -1719,7 +1687,7 @@ async def send_chat_message_event_by_id(
     user=Depends(get_verified_user),
     db: AsyncSession = Depends(get_async_session),
 ):
-    chat = await Chats.get_chat_by_id(id, db=db)
+    chat = await Chats.get_chat_by_id(id, db=db, include_messages=False)
 
     if not chat:
         raise HTTPException(
@@ -1773,14 +1741,14 @@ async def delete_chat_by_id(
     # Authorize before any side effect: cancelling a chat's in-flight tasks must
     # not be reachable for a chat the caller may not delete.
     if user.role == 'admin':
-        chat = await Chats.get_chat_by_id(id, db=db)
+        chat = await Chats.get_chat_by_id(id, db=db, include_messages=False)
     else:
         if not await has_permission(user.id, 'chat.delete', await Config.get('user.permissions')):
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
             )
-        chat = await Chats.get_chat_by_id_and_user_id(id, user.id, db=db)
+        chat = await Chats.get_chat_by_id_and_user_id(id, user.id, db=db, include_messages=False)
 
     if not chat:
         raise HTTPException(
@@ -1823,7 +1791,7 @@ async def delete_chat_by_id(
 async def get_pinned_status_by_id(
     id: str, user=Depends(get_verified_user), db: AsyncSession = Depends(get_async_session)
 ):
-    chat = await Chats.get_chat_by_id_and_user_id(id, user.id, db=db)
+    chat = await Chats.get_chat_by_id_and_user_id(id, user.id, db=db, include_messages=False)
     if chat:
         return chat.pinned
     else:
@@ -1839,7 +1807,7 @@ async def get_pinned_status_by_id(
 async def pin_chat_by_id(
     request: Request, id: str, user=Depends(get_verified_user), db: AsyncSession = Depends(get_async_session)
 ):
-    chat = await Chats.get_chat_by_id_and_user_id(id, user.id, db=db)
+    chat = await Chats.get_chat_by_id_and_user_id(id, user.id, db=db, include_messages=False)
     if chat:
         chat = await Chats.toggle_chat_pinned_by_id(id, db=db)
         await publish_event(
@@ -2099,7 +2067,7 @@ async def archive_chat_by_id(
     user=Depends(get_verified_user),
     db: AsyncSession = Depends(get_async_session),
 ):
-    chat = await Chats.get_chat_by_id_and_user_id(id, user.id, db=db)
+    chat = await Chats.get_chat_by_id_and_user_id(id, user.id, db=db, include_messages=False)
     if chat:
         chat = await Chats.toggle_chat_archive_by_id(id, db=db)
 
@@ -2138,7 +2106,7 @@ async def share_chat_by_id(
     if user.role != 'admin' and not await has_permission(user.id, 'chat.share', await Config.get('user.permissions')):
         raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail=ERROR_MESSAGES.ACCESS_PROHIBITED)
 
-    chat = await Chats.get_chat_by_id_and_user_id(id, user.id, db=db)
+    chat = await Chats.get_chat_by_id_and_user_id(id, user.id, db=db, include_messages=False)
     if not chat:
         raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail=ERROR_MESSAGES.ACCESS_PROHIBITED)
 
@@ -2182,7 +2150,7 @@ async def share_chat_by_id(
 async def delete_shared_chat_by_id(
     request: Request, id: str, user=Depends(get_verified_user), db: AsyncSession = Depends(get_async_session)
 ):
-    chat = await Chats.get_chat_by_id_and_user_id(id, user.id, db=db)
+    chat = await Chats.get_chat_by_id_and_user_id(id, user.id, db=db, include_messages=False)
     if not chat:
         raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail=ERROR_MESSAGES.ACCESS_PROHIBITED)
 
@@ -2221,9 +2189,9 @@ async def update_shared_chat_access_by_id(
     db: AsyncSession = Depends(get_async_session),
 ):
     if user.role == 'admin':
-        chat = await Chats.get_chat_by_id(id, db=db)
+        chat = await Chats.get_chat_by_id(id, db=db, include_messages=False)
     else:
-        chat = await Chats.get_chat_by_id_and_user_id(id, user.id, db=db)
+        chat = await Chats.get_chat_by_id_and_user_id(id, user.id, db=db, include_messages=False)
     if not chat:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -2257,9 +2225,9 @@ async def get_shared_chat_access_by_id(
     db: AsyncSession = Depends(get_async_session),
 ):
     if user.role == 'admin':
-        chat = await Chats.get_chat_by_id(id, db=db)
+        chat = await Chats.get_chat_by_id(id, db=db, include_messages=False)
     else:
-        chat = await Chats.get_chat_by_id_and_user_id(id, user.id, db=db)
+        chat = await Chats.get_chat_by_id_and_user_id(id, user.id, db=db, include_messages=False)
     if not chat:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -2317,7 +2285,7 @@ async def update_chat_folder_id_by_id(
     user=Depends(get_verified_user),
     db: AsyncSession = Depends(get_async_session),
 ):
-    chat = await Chats.get_chat_by_id_and_user_id(id, user.id, db=db)
+    chat = await Chats.get_chat_by_id_and_user_id(id, user.id, db=db, include_messages=False)
     if chat:
         # Same ownership check as the create path — reject foreign / dangling
         # folder_id values. None is allowed (moves the chat out of any folder).
@@ -2351,7 +2319,7 @@ async def update_chat_folder_id_by_id(
 
 @router.get('/{id}/tags', response_model=list[TagModel])
 async def get_chat_tags_by_id(id: str, user=Depends(get_verified_user), db: AsyncSession = Depends(get_async_session)):
-    chat = await Chats.get_chat_by_id_and_user_id(id, user.id, db=db)
+    chat = await Chats.get_chat_by_id_and_user_id(id, user.id, db=db, include_messages=False)
     if chat:
         tags = chat.meta.get('tags', [])
         return await Tags.get_tags_by_ids_and_user_id(tags, user.id, db=db)
@@ -2372,7 +2340,7 @@ async def add_tag_by_id_and_tag_name(
     user=Depends(get_verified_user),
     db: AsyncSession = Depends(get_async_session),
 ):
-    chat = await Chats.get_chat_by_id_and_user_id(id, user.id, db=db)
+    chat = await Chats.get_chat_by_id_and_user_id(id, user.id, db=db, include_messages=False)
     if chat:
         tags = chat.meta.get('tags', [])
         tag_id = form_data.name.replace(' ', '_').lower()
@@ -2393,7 +2361,7 @@ async def add_tag_by_id_and_tag_name(
                 data={'tag': form_data.name},
             )
 
-        chat = await Chats.get_chat_by_id_and_user_id(id, user.id, db=db)
+        chat = await Chats.get_chat_by_id_and_user_id(id, user.id, db=db, include_messages=False)
         tags = chat.meta.get('tags', [])
         return await Tags.get_tags_by_ids_and_user_id(tags, user.id, db=db)
     else:
@@ -2413,7 +2381,7 @@ async def delete_tag_by_id_and_tag_name(
     user=Depends(get_verified_user),
     db: AsyncSession = Depends(get_async_session),
 ):
-    chat = await Chats.get_chat_by_id_and_user_id(id, user.id, db=db)
+    chat = await Chats.get_chat_by_id_and_user_id(id, user.id, db=db, include_messages=False)
     if chat:
         await Chats.delete_tag_by_id_and_user_id_and_tag_name(id, user.id, form_data.name, db=db)
         await publish_event(
@@ -2427,7 +2395,7 @@ async def delete_tag_by_id_and_tag_name(
         if await Chats.count_chats_by_tag_name_and_user_id(form_data.name, user.id, db=db) == 0:
             await Tags.delete_tag_by_name_and_user_id(form_data.name, user.id, db=db)
 
-        chat = await Chats.get_chat_by_id_and_user_id(id, user.id, db=db)
+        chat = await Chats.get_chat_by_id_and_user_id(id, user.id, db=db, include_messages=False)
         tags = chat.meta.get('tags', [])
         return await Tags.get_tags_by_ids_and_user_id(tags, user.id, db=db)
     else:

--- a/backend/open_webui/routers/notes.py
+++ b/backend/open_webui/routers/notes.py
@@ -361,7 +361,13 @@ async def get_note_chat_by_id(
 
         payload['params'] = params
         if changed:
-            updated_chat = await Chats.update_chat_by_id(chat.id, payload, db=db, touch=False)
+            updated_chat = await Chats.update_chat_by_id(
+                chat.id,
+                payload,
+                db=db,
+                touch=False,
+                include_messages=False,
+            )
             if updated_chat:
                 return updated_chat
 
@@ -456,7 +462,16 @@ async def get_note_chats_by_id(
 
         payload['params'] = params
         if changed:
-            chat = await Chats.update_chat_by_id(chat.id, payload, db=db, touch=False) or chat
+            chat = (
+                await Chats.update_chat_by_id(
+                    chat.id,
+                    payload,
+                    db=db,
+                    touch=False,
+                    include_messages=False,
+                )
+                or chat
+            )
 
         normalized_chats.append(chat)
 

--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -1035,60 +1035,52 @@ async def get_event_emitter(request_info, update_db=True):
 
             elif event_type == 'embeds':
                 event_payload = event_data.get('data', {})
-                embeds = event_payload.get('embeds', [])
+                embeds = event_payload.get('embeds') or []
 
-                if not event_payload.get('replace', False):
-                    message = await Chats.get_message_by_id_and_message_id(
+                if event_payload.get('replace', False):
+                    await Chats.patch_message_by_chat_id_and_message_id(
                         request_info['chat_id'],
                         request_info['message_id'],
+                        {'embeds': embeds},
+                        touch=False,
                     )
-                    embeds.extend(message.get('embeds', []))
-
-                await Chats.upsert_message_to_chat_by_id_and_message_id(
-                    request_info['chat_id'],
-                    request_info['message_id'],
-                    {
-                        'embeds': embeds,
-                    },
-                    touch=False,
-                )
+                else:
+                    await Chats.append_message_items_by_chat_id_and_message_id(
+                        request_info['chat_id'],
+                        request_info['message_id'],
+                        'embeds',
+                        embeds,
+                        deduplicate=True,
+                    )
 
             elif event_type == 'files':
-                message = await Chats.get_message_by_id_and_message_id(
-                    request_info['chat_id'],
-                    request_info['message_id'],
-                )
-
-                files = event_data.get('data', {}).get('files', [])
-                files.extend(message.get('files', []))
-
-                await Chats.upsert_message_to_chat_by_id_and_message_id(
-                    request_info['chat_id'],
-                    request_info['message_id'],
-                    {
-                        'files': files,
-                    },
-                    touch=False,
-                )
+                event_payload = event_data.get('data', {})
+                files = event_payload.get('files') or []
+                if event_payload.get('replace', False):
+                    await Chats.patch_message_by_chat_id_and_message_id(
+                        request_info['chat_id'],
+                        request_info['message_id'],
+                        {'files': files},
+                        touch=False,
+                    )
+                else:
+                    await Chats.append_message_items_by_chat_id_and_message_id(
+                        request_info['chat_id'],
+                        request_info['message_id'],
+                        'files',
+                        files,
+                        deduplicate=True,
+                    )
 
             elif event_type in ('source', 'citation'):
                 data = event_data.get('data', {})
                 if data.get('type') is None:
-                    message = await Chats.get_message_by_id_and_message_id(
+                    await Chats.append_message_items_by_chat_id_and_message_id(
                         request_info['chat_id'],
                         request_info['message_id'],
-                    )
-
-                    sources = message.get('sources', [])
-                    sources.append(data)
-
-                    await Chats.upsert_message_to_chat_by_id_and_message_id(
-                        request_info['chat_id'],
-                        request_info['message_id'],
-                        {
-                            'sources': sources,
-                        },
-                        touch=False,
+                        'sources',
+                        [data],
+                        deduplicate=True,
                     )
 
     if 'user_id' in request_info and 'chat_id' in request_info and 'message_id' in request_info:

--- a/backend/open_webui/tools/builtin.py
+++ b/backend/open_webui/tools/builtin.py
@@ -21,6 +21,7 @@ from open_webui.env import (
 )
 from open_webui.events import EVENTS, publish_event
 from open_webui.models.channels import Channel, ChannelMember, Channels
+from open_webui.models.chat_messages import ChatMessages
 from open_webui.models.chats import Chats
 from open_webui.models.config import Config
 from open_webui.models.groups import Groups
@@ -68,6 +69,7 @@ from open_webui.utils.chat_id import is_saved_chat_id
 from open_webui.utils.json_codec import JSONCodec
 from open_webui.utils.notifications import notify_target
 from open_webui.utils.sanitize import sanitize_code
+from open_webui.utils.misc import expand_messages_with_output, get_content_from_message
 
 log = logging.getLogger(__name__)
 
@@ -573,7 +575,7 @@ async def execute_code(
                         'id': str(uuid4()),
                         'code': code,
                         'session_id': (__metadata__.get('session_id') if __metadata__ else None),
-                        'files': (__metadata__.get('files', []) if __metadata__ else []),
+                        'files': ((__metadata__.get('files') or []) if __metadata__ else []),
                     },
                 }
             )
@@ -1422,21 +1424,8 @@ async def search_chats(
             if end_timestamp and chat.updated_at > end_timestamp:
                 continue
 
-            # Find a matching message snippet
-            snippet = ''
-            messages = (getattr(chat, 'chat', None) or {}).get('history', {}).get('messages', {})
-            lower_query = query.lower()
-
-            for msg_id, msg in messages.items():
-                content = msg.get('content', '')
-                if isinstance(content, str) and lower_query in content.lower():
-                    idx = content.lower().find(lower_query)
-                    start = max(0, idx - 50)
-                    end = min(len(content), idx + len(query) + 100)
-                    snippet = ('...' if start > 0 else '') + content[start:end] + ('...' if end < len(content) else '')
-                    break
-
-            if not snippet and lower_query in chat.title.lower():
+            snippet = chat.snippet or ''
+            if not snippet and query.lower() in chat.title.lower():
                 snippet = f'Title match: {chat.title}'
 
             results.append(
@@ -1478,34 +1467,20 @@ async def view_chat(
     try:
         user_id = __user__.get('id')
 
-        chat = await Chats.get_chat_by_id_and_user_id(chat_id, user_id)
+        chat = await Chats.get_chat_by_id_and_user_id(chat_id, user_id, include_messages=False)
 
         if not chat:
             return JSONCodec.dumps({'error': 'Chat not found or access denied'})
 
-        # Extract messages from history
-        messages = []
         history = chat.chat.get('history', {})
-        msg_dict = history.get('messages', {})
-
-        # Build message chain from currentId
         current_id = history.get('currentId')
-        visited = set()
-
-        while current_id and current_id not in visited:
-            visited.add(current_id)
-            msg = msg_dict.get(current_id)
-            if msg:
-                messages.append(
-                    {
-                        'role': msg.get('role', ''),
-                        'content': msg.get('content', ''),
-                    }
-                )
-            current_id = msg.get('parentId') if msg else None
-
-        # Reverse to get chronological order
-        messages.reverse()
+        branch = await ChatMessages.get_message_branch_by_chat_id(chat_id, current_id) if current_id else []
+        messages = [
+            {'role': message.get('role', ''), 'content': content}
+            for message in expand_messages_with_output(branch)
+            for content in [get_content_from_message(message)]
+            if isinstance(content, str) and content.strip()
+        ]
 
         return JSONCodec.dumps(
             {

--- a/backend/open_webui/utils/chat_history.py
+++ b/backend/open_webui/utils/chat_history.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+MESSAGE_STORAGE_VERSION = 1
+MESSAGE_STORAGE_KEY = 'messageStorage'
+MESSAGE_WINDOW_KEY = 'messageWindow'
+MESSAGE_LOADED_KEY = '__loaded'
+TOPOLOGY_KEYS = (
+    'id',
+    'parentId',
+    'childrenIds',
+    'role',
+    'timestamp',
+    'model',
+    'modelIdx',
+    'modelName',
+    'models',
+    'done',
+)
+
+
+def _message_map(value: Any) -> dict[str, dict]:
+    if isinstance(value, dict):
+        return {str(message_id): message for message_id, message in value.items() if isinstance(message, dict)}
+
+    if isinstance(value, list):
+        return {str(message['id']): message for message in value if isinstance(message, dict) and message.get('id')}
+
+    return {}
+
+
+def has_embedded_messages(chat: dict | None) -> bool:
+    if not isinstance(chat, dict):
+        return False
+    history = chat.get('history')
+    return (isinstance(history, dict) and 'messages' in history) or 'messages' in chat
+
+
+def uses_normalized_message_storage(chat: dict | None) -> bool:
+    if not isinstance(chat, dict):
+        return False
+    history = chat.get('history')
+    storage = history.get(MESSAGE_STORAGE_KEY) if isinstance(history, dict) else None
+    return isinstance(storage, dict) and storage.get('version') == MESSAGE_STORAGE_VERSION
+
+
+def prepare_messages_for_storage(messages: Any) -> dict[str, dict]:
+    """Return lossless message copies without response-only window markers."""
+    prepared: dict[str, dict] = {}
+    for message_id, message in _message_map(messages).items():
+        clean_message = deepcopy(message)
+        clean_message.pop(MESSAGE_LOADED_KEY, None)
+        clean_message.setdefault('id', message_id)
+        prepared[message_id] = clean_message
+    return prepared
+
+
+def copy_chat_without_messages(chat: dict | None) -> dict:
+    """Copy chat metadata without adding storage-specific response markers."""
+    compact = deepcopy(chat or {})
+    history = compact.get('history')
+    if not isinstance(history, dict):
+        history = {}
+    else:
+        history = deepcopy(history)
+
+    history.pop('messages', None)
+    history.pop(MESSAGE_WINDOW_KEY, None)
+    compact.pop('messages', None)
+    compact['history'] = history
+    return compact
+
+
+def split_chat_messages(chat: dict | None) -> tuple[dict, dict[str, dict]]:
+    """Separate embedded messages from compact chat metadata."""
+    source = deepcopy(chat or {})
+    source_history = source.get('history') if isinstance(source.get('history'), dict) else {}
+    messages = _message_map(source_history.get('messages'))
+    top_level_messages = source.get('messages')
+    if not messages:
+        messages = _message_map(top_level_messages)
+
+    compact = copy_chat_without_messages(source)
+    history = compact['history']
+    history[MESSAGE_STORAGE_KEY] = {'version': MESSAGE_STORAGE_VERSION}
+    return compact, prepare_messages_for_storage(messages)
+
+
+def merge_compact_chat(existing: dict | None, incoming: dict | None) -> tuple[dict, dict[str, dict]]:
+    """Merge chat metadata while returning only messages supplied by the caller."""
+    existing_compact, _ = split_chat_messages(existing)
+    incoming_compact, incoming_messages = split_chat_messages(incoming)
+
+    merged = {**existing_compact, **incoming_compact}
+    existing_history = existing_compact.get('history') or {}
+    incoming_history = incoming_compact.get('history') or {}
+    merged['history'] = {**existing_history, **incoming_history}
+    merged['history'][MESSAGE_STORAGE_KEY] = {'version': MESSAGE_STORAGE_VERSION}
+    return merged, incoming_messages
+
+
+def create_message_list(messages: dict[str, dict], current_id: str | None) -> list[dict]:
+    message_list: list[dict] = []
+    visited: set[str] = set()
+
+    while current_id and current_id not in visited:
+        visited.add(current_id)
+        message = messages.get(current_id)
+        if not isinstance(message, dict):
+            break
+        message_list.append(message)
+        current_id = message.get('parentId')
+
+    message_list.reverse()
+    return message_list
+
+
+def create_message_window(
+    messages: dict[str, dict],
+    current_id: str | None,
+    limit: int,
+    before_id: str | None = None,
+) -> dict:
+    """Create a branch window from a legacy in-memory message map."""
+    if limit < 1:
+        raise ValueError('limit must be at least 1')
+
+    clean_messages = prepare_messages_for_storage(messages)
+    if current_id is not None and current_id not in clean_messages:
+        raise ValueError('current_id does not exist in this chat')
+
+    topology = {
+        message_id: {key: message[key] for key in TOPOLOGY_KEYS if key in message}
+        for message_id, message in clean_messages.items()
+    }
+
+    branch_ids = [message.get('id') for message in create_message_list(clean_messages, current_id) if message.get('id')]
+    if before_id is not None:
+        if before_id not in branch_ids:
+            raise ValueError('before_id is not an ancestor of current_id')
+        branch_ids = branch_ids[: branch_ids.index(before_id)]
+
+    loaded_ids = branch_ids[-limit:]
+    return {
+        'topology': topology,
+        'messages': {message_id: clean_messages[message_id] for message_id in loaded_ids},
+        'loaded_ids': loaded_ids,
+        'has_more': len(branch_ids) > len(loaded_ids),
+        'current_id': current_id,
+    }
+
+
+def hydrate_chat(chat: dict | None, messages: dict[str, dict]) -> dict:
+    """Rebuild the legacy full-chat shape for compatibility endpoints."""
+    hydrated, _ = split_chat_messages(chat)
+    history = hydrated.setdefault('history', {})
+    clean_messages = prepare_messages_for_storage(messages)
+    history['messages'] = clean_messages
+    hydrated['messages'] = create_message_list(clean_messages, history.get('currentId'))
+    return hydrated
+
+
+def build_window_chat(
+    chat: dict | None,
+    topology: dict[str, dict],
+    loaded_messages: dict[str, dict],
+    loaded_ids: list[str],
+    has_more: bool,
+    limit: int,
+    current_id: str | None = None,
+) -> dict:
+    """Build a response containing full topology and only a window of message bodies."""
+    window_chat = copy_chat_without_messages(chat)
+    history = window_chat.setdefault('history', {})
+    if current_id is not None:
+        history['currentId'] = current_id
+
+    clean_loaded = prepare_messages_for_storage(loaded_messages)
+    messages: dict[str, dict] = {}
+
+    for message_id, topology_message in topology.items():
+        topology_copy = deepcopy(topology_message)
+        if message_id in clean_loaded:
+            messages[message_id] = {
+                **clean_loaded[message_id],
+                **topology_copy,
+                MESSAGE_LOADED_KEY: True,
+            }
+        else:
+            messages[message_id] = {
+                **topology_copy,
+                MESSAGE_LOADED_KEY: False,
+            }
+
+    for message_id, message in clean_loaded.items():
+        if message_id not in messages:
+            messages[message_id] = {**message, MESSAGE_LOADED_KEY: True}
+
+    unique_loaded_ids = list(dict.fromkeys(loaded_ids))
+    history['messages'] = messages
+    history[MESSAGE_WINDOW_KEY] = {
+        'loadedIds': [message_id for message_id in unique_loaded_ids if message_id in messages],
+        'hasMore': has_more,
+        'limit': limit,
+    }
+    return window_chat
+
+
+def inline_message_images_from_files(messages: list[dict]) -> list[dict]:
+    """Move attached images into message content and remove storage-only files."""
+    for message in messages:
+        raw_files = message.get('files')
+        files = raw_files if isinstance(raw_files, list) else []
+        image_files = [
+            file
+            for file in files
+            if isinstance(file, dict)
+            and (file.get('type') == 'image' or (file.get('content_type') or '').startswith('image/'))
+        ]
+        if message.get('role') == 'user' and image_files:
+            text_content = message.get('content', '')
+            if isinstance(text_content, str):
+                message['content'] = [
+                    {'type': 'text', 'text': text_content},
+                    *[
+                        {
+                            'type': 'image_url',
+                            'image_url': {'url': file['url']},
+                        }
+                        for file in image_files
+                        if file.get('url')
+                    ],
+                ]
+        message.pop('files', None)
+
+    return messages

--- a/backend/open_webui/utils/context_compaction.py
+++ b/backend/open_webui/utils/context_compaction.py
@@ -4,11 +4,17 @@ import logging
 from typing import Any
 
 from fastapi.responses import JSONResponse
+from open_webui.models.chat_messages import ChatMessages
 from open_webui.models.chats import Chats
 from open_webui.models.config import Config
 from open_webui.utils.chat_id import is_saved_chat_id
 from open_webui.utils.json_codec import JSONCodec
-from open_webui.utils.misc import get_content_from_message, get_last_user_message, get_message_list
+from open_webui.utils.misc import (
+    expand_messages_with_output,
+    get_content_from_message,
+    get_last_user_message,
+    get_message_list,
+)
 from open_webui.utils.task import (
     get_task_model_id,
     prompt_template,
@@ -52,19 +58,30 @@ async def compact_messages_for_request(
     if not config['enable']:
         return messages, None, False
 
-    system_messages = [messages[0]] if messages and messages[0].get('role') == 'system' else []
-    messages = messages[1:] if system_messages else messages
-
-    messages, previous_summary = _apply_latest_summary_checkpoint(messages)
+    original_messages = messages
+    system_messages = [message for message in messages if message.get('role') == 'system']
+    conversation_messages = [message for message in messages if message.get('role') != 'system']
+    conversation_messages, previous_summary = _apply_latest_summary_checkpoint(conversation_messages)
     token_threshold = _resolve_token_threshold(config['token_threshold'], config['token_cap'], metadata)
-    if not _exceeds_token_threshold(messages, system_prompt, previous_summary, token_threshold) or len(messages) <= 3:
-        return [*system_messages, *messages], previous_summary, False
+    if (
+        not _exceeds_token_threshold(
+            conversation_messages,
+            system_prompt,
+            previous_summary,
+            token_threshold,
+        )
+        or len(conversation_messages) <= 3
+    ):
+        return original_messages, previous_summary, False
 
-    boundary = _find_compaction_boundary(messages, config['retention_percentage'])
-    compacted_messages = messages[:boundary]
-    recent_messages = messages[boundary:]
+    boundary = _find_compaction_boundary(
+        conversation_messages,
+        config.get('retention_percentage', 40),
+    )
+    compacted_messages = conversation_messages[:boundary]
+    recent_messages = conversation_messages[boundary:]
     if not compacted_messages or not recent_messages:
-        return [*system_messages, *messages], previous_summary, False
+        return original_messages, previous_summary, False
 
     event_emitter = None
     if metadata.get('chat_id') and metadata.get('message_id'):
@@ -162,11 +179,10 @@ async def compact_chat_branch(request, user, chat: Any, model_id: str, models: d
     if not current_id:
         return {'ok': True, 'compacted': False, 'reason': 'empty'}
 
-    messages_map = await Chats.get_messages_map_by_chat_id(chat.id)
-    if not messages_map:
-        messages_map = history.get('messages') or {}
-
-    messages, previous_summary = _apply_latest_summary_checkpoint(get_message_list(messages_map, current_id))
+    messages = get_message_list(history.get('messages') or {}, current_id) if not history.get('messageWindow') else []
+    if not messages:
+        messages = await ChatMessages.get_message_branch_by_chat_id(chat.id, current_id)
+    messages, previous_summary = _apply_latest_summary_checkpoint(messages)
     compacted_messages = messages[:-1]
     recent_messages = messages[-1:]
     if not compacted_messages or not recent_messages:
@@ -245,13 +261,23 @@ async def get_chat_context_usage(chat: Any, model_id: str | None = None) -> dict
     if not current_id:
         return None
 
-    messages_map = await Chats.get_messages_map_by_chat_id(chat.id)
-    messages = get_message_list(messages_map or history.get('messages') or {}, current_id)
-    if not messages:
-        return None
-
     config = await _load_config()
     if not config['enable']:
+        return None
+
+    message_window = history.get('messageWindow') or {}
+    if message_window:
+        messages = [
+            message
+            for message in get_message_list(history.get('messages') or {}, current_id)
+            if message.get('__loaded') is not False
+        ]
+    else:
+        messages = get_message_list(history.get('messages') or {}, current_id)
+
+    if not messages and not message_window:
+        messages = await ChatMessages.get_message_branch_by_chat_id(chat.id, current_id)
+    if not messages:
         return None
 
     params = ((chat.chat or {}).get('params') or {}).copy()
@@ -261,9 +287,13 @@ async def get_chat_context_usage(chat: Any, model_id: str | None = None) -> dict
     messages, previous_summary = _apply_latest_summary_checkpoint(messages)
 
     for idx in range(len(messages) - 1, -1, -1):
-        usage = messages[idx].get('usage') or (messages[idx].get('info') or {}).get('usage')
-        if isinstance(usage, dict) and (
-            tokens := (
+        usage = (
+            messages[idx].get('lastRequestUsage')
+            or messages[idx].get('usage')
+            or (messages[idx].get('info') or {}).get('usage')
+        )
+        if isinstance(usage, dict):
+            tokens = (
                 int(
                     usage.get('prompt_tokens')
                     or usage.get('input_tokens')
@@ -280,9 +310,16 @@ async def get_chat_context_usage(chat: Any, model_id: str | None = None) -> dict
                 )
                 + int(usage.get('cache_n') or 0)
             )
-        ):
+        else:
+            tokens = 0
+        if tokens:
             tokens += _estimate_messages_tokens(messages[idx + 1 :])
             return _build_context_usage(tokens, threshold)
+
+    # A lazy window without usage cannot produce a trustworthy whole-context
+    # estimate without reloading the complete branch, which defeats the API.
+    if message_window.get('hasMore'):
+        return None
 
     tokens = _estimate_tokens(previous_summary or '') + _estimate_messages_tokens(messages)
     return _build_context_usage(tokens, threshold)
@@ -318,9 +355,13 @@ def _exceeds_token_threshold(messages: list[dict], system_prompt: str, summary: 
         return False
 
     for idx in range(len(messages) - 1, -1, -1):
-        usage = messages[idx].get('usage') or (messages[idx].get('info') or {}).get('usage')
-        if isinstance(usage, dict) and (
-            tokens := (
+        usage = (
+            messages[idx].get('lastRequestUsage')
+            or messages[idx].get('usage')
+            or (messages[idx].get('info') or {}).get('usage')
+        )
+        if isinstance(usage, dict):
+            total = (
                 int(
                     usage.get('prompt_tokens')
                     or usage.get('input_tokens')
@@ -337,8 +378,10 @@ def _exceeds_token_threshold(messages: list[dict], system_prompt: str, summary: 
                 )
                 + int(usage.get('cache_n') or 0)
             )
-        ):
-            return tokens + _estimate_messages_tokens(messages[idx + 1 :]) > threshold
+        else:
+            total = 0
+        if total:
+            return total + _estimate_messages_tokens(messages[idx + 1 :]) > threshold
 
     estimated = _estimate_tokens(system_prompt) + _estimate_tokens(summary or '') + _estimate_messages_tokens(messages)
     return estimated > threshold
@@ -386,11 +429,13 @@ async def _generate_summary(
         raise ValueError('No available model for context compaction')
 
     summary_prompt_template = summary_prompt_template.strip() or DEFAULT_CONTEXT_COMPACTION_PROMPT
-    all_messages = [*compacted_messages, *recent_messages]
+    compacted_messages_for_summary = expand_messages_with_output(compacted_messages)
+    recent_messages_for_summary = expand_messages_with_output(recent_messages)
+    all_messages = [*compacted_messages_for_summary, *recent_messages_for_summary]
     prompt = replace_prompt_variable(summary_prompt_template, get_last_user_message(all_messages) or '')
     prompt = replace_messages_variable(prompt, all_messages)
-    prompt = replace_messages_variable(prompt, compacted_messages, 'COMPACTED_MESSAGES')
-    prompt = replace_messages_variable(prompt, recent_messages, 'RECENT_MESSAGES')
+    prompt = replace_messages_variable(prompt, compacted_messages_for_summary, 'COMPACTED_MESSAGES')
+    prompt = replace_messages_variable(prompt, recent_messages_for_summary, 'RECENT_MESSAGES')
     prompt = prompt_variables_template(prompt, {'{{PREVIOUS_SUMMARY}}': previous_summary or ''})
     prompt = await prompt_template(prompt, user)
 
@@ -416,7 +461,7 @@ async def _generate_summary(
         return summary
 
     parts = [previous_summary] if previous_summary else []
-    for message in compacted_messages:
+    for message in compacted_messages_for_summary:
         content = get_content_from_message(message)
         if content:
             parts.append(f'- {message.get("role", "unknown")}: {content[:500]}')

--- a/backend/open_webui/utils/memory.py
+++ b/backend/open_webui/utils/memory.py
@@ -9,7 +9,11 @@ from fastapi import HTTPException
 from open_webui.models.config import Config
 from open_webui.models.memories import Memories
 from open_webui.utils.json_codec import JSONCodec
-from open_webui.utils.misc import add_or_update_system_message, get_content_from_message
+from open_webui.utils.misc import (
+    add_or_update_system_message,
+    expand_messages_with_output,
+    get_content_from_message,
+)
 
 log = logging.getLogger(__name__)
 
@@ -421,8 +425,13 @@ async def review_memory_after_turn(
     if not features.get('memory'):
         return
 
-    assistant_content = get_content_from_message(assistant_message)
-    if not isinstance(assistant_content, str) or not assistant_content.strip():
+    assistant_content = '\n'.join(
+        content.strip()
+        for message in expand_messages_with_output([assistant_message])
+        for content in [get_content_from_message(message)]
+        if message.get('role') == 'assistant' and isinstance(content, str) and content.strip()
+    )
+    if not assistant_content:
         return
 
     config = await Config.get_many(
@@ -478,18 +487,21 @@ async def _review_memory(
         for memory in (existing_memories or [])[:80]
     ]
 
-    assistant_content = get_content_from_message(assistant_message)
-    if not isinstance(assistant_content, str):
-        assistant_content = ''
+    assistant_content = '\n'.join(
+        content.strip()
+        for message in expand_messages_with_output([assistant_message])
+        for content in [get_content_from_message(message)]
+        if message.get('role') == 'assistant' and isinstance(content, str) and content.strip()
+    )
 
     transcript_lines = []
-    for message in messages[-16:]:
+    for message in expand_messages_with_output(messages[-16:]):
         role = message.get('role', '')
-        content = message.get('content', '')
+        content = get_content_from_message(message)
         if not isinstance(content, str):
-            content = get_content_from_message(message)
+            continue
         content = content.strip()
-        if role not in {'user', 'assistant'} or not content:
+        if role not in {'user', 'assistant', 'tool'} or not content:
             continue
         if len(content) > 1600:
             content = f'{content[:1000]}\n...(truncated)...\n{content[-400:]}'

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -42,6 +42,7 @@ from open_webui.env import (
 )
 from open_webui.events import EVENTS, publish_event
 from open_webui.models.access_grants import AccessGrants
+from open_webui.models.chat_messages import ChatMessages
 from open_webui.models.chats import Chats
 from open_webui.models.config import Config
 from open_webui.models.folders import Folders
@@ -81,6 +82,7 @@ from open_webui.utils.access_control.files import get_owner_accessible_folder_fi
 from open_webui.utils.access_control.folders import has_folder_access
 from open_webui.utils.chat import generate_chat_completion
 from open_webui.utils.chat_id import is_saved_chat_id
+from open_webui.utils.chat_history import inline_message_images_from_files
 from open_webui.utils.code_interpreter import execute_code_jupyter
 from open_webui.utils.context_compaction import compact_messages_for_request
 from open_webui.utils.files import (
@@ -103,6 +105,7 @@ from open_webui.utils.misc import (
     convert_logit_bias_input_to_json,
     convert_output_to_messages,
     deep_update,
+    expand_messages_with_output,
     extract_urls,
     get_content_from_message,
     get_last_assistant_message,
@@ -1457,7 +1460,7 @@ async def chat_web_search_handler(request: Request, form_data: dict, extra_param
         )
 
         if results:
-            files = form_data.get('files', [])
+            files = form_data.get('files') or []
 
             if results.get('collection_names'):
                 for col_idx, collection_name in enumerate(results.get('collection_names')):
@@ -1534,7 +1537,7 @@ def get_images_from_messages(message_list):
 
     for message in reversed(message_list):
         message_images = []
-        for file in message.get('files', []):
+        for file in message.get('files') or []:
             if file.get('type') == 'image':
                 message_images.append(file.get('url'))
             elif file.get('content_type', '').startswith('image/'):
@@ -1567,19 +1570,20 @@ async def get_image_urls(delta_images, request, metadata, user) -> list[str]:
     return image_urls
 
 
-async def add_file_context(messages: list, chat_id: str, user) -> list:
+async def add_file_context(messages: list, chat_id: str, user, message_id: str | None = None) -> list:
     """
     Add file URLs to messages for native function calling.
     """
     if not is_saved_chat_id(chat_id):
         return messages
 
-    chat = await Chats.get_chat_by_id_and_user_id(chat_id, user.id)
+    chat = await Chats.get_chat_by_id_and_user_id(chat_id, user.id, include_messages=False)
     if not chat:
         return messages
 
     history = chat.chat.get('history', {})
-    stored_messages = get_message_list(history.get('messages', {}), history.get('currentId'))
+    current_id = message_id or history.get('currentId')
+    stored_messages = await ChatMessages.get_message_branch_by_chat_id(chat_id, current_id) if current_id else []
 
     def format_file_tag(file):
         file_id = file.get('id') or file.get('url')
@@ -1599,13 +1603,19 @@ async def add_file_context(messages: list, chat_id: str, user) -> list:
     # the payload message list longer than the stored message list. A naive
     # positional zip() would pair user messages with wrong stored messages,
     # causing later images to lose their file context (see #21878).
-    user_messages = [m for m in messages if m.get('role') == 'user']
+    user_messages = [
+        message
+        for message in messages
+        if message.get('role') == 'user' and not message.get('_skip_stored_file_context')
+    ]
     stored_user_messages = [m for m in stored_messages if m.get('role') == 'user']
 
-    for message, stored_message in zip(user_messages, stored_user_messages):
+    # Context compaction may keep only a suffix of the branch, so align from
+    # the newest user message backwards instead of pairing from the root.
+    for message, stored_message in zip(reversed(user_messages), reversed(stored_user_messages)):
         files_with_urls = [
             file
-            for file in stored_message.get('files', [])
+            for file in stored_message.get('files') or []
             if file.get('url') and not file.get('url').startswith('data:')
         ]
         if not files_with_urls:
@@ -1620,6 +1630,9 @@ async def add_file_context(messages: list, chat_id: str, user) -> list:
         else:
             message['content'] = file_context + content
 
+    for message in messages:
+        message.pop('_skip_stored_file_context', None)
+
     return messages
 
 
@@ -1631,20 +1644,14 @@ async def chat_image_generation_handler(request: Request, form_data: dict, extra
     if not chat_id or not isinstance(chat_id, str) or not __event_emitter__:
         return form_data
 
-    if not is_saved_chat_id(chat_id):
-        message_list = form_data.get('messages', [])
-    else:
-        chat = await Chats.get_chat_by_id_and_user_id(chat_id, user.id)
+    message_list = form_data.get('messages', [])
+    if is_saved_chat_id(chat_id):
         await __event_emitter__(
             {
                 'type': 'status',
                 'data': {'description': 'Creating image', 'done': False},
             }
         )
-
-        messages_map = chat.chat.get('history', {}).get('messages', {})
-        message_id = chat.chat.get('history', {}).get('currentId')
-        message_list = get_message_list(messages_map, message_id)
 
     user_message = get_last_user_message(message_list)
 
@@ -2042,11 +2049,10 @@ async def load_messages_from_db(chat_id: str, message_id: str) -> Optional[list[
     Load the message chain from DB up to message_id,
     keeping only LLM-relevant fields (role, content, output).
     """
-    messages_map = await Chats.get_messages_map_by_chat_id(chat_id)
-    if not messages_map:
-        return None
-
-    db_messages = get_message_list(messages_map, message_id)
+    db_messages = await ChatMessages.get_message_branch_by_chat_id(chat_id, message_id)
+    if not db_messages:
+        messages_map = await Chats.get_messages_map_by_chat_id(chat_id)
+        db_messages = get_message_list(messages_map, message_id) if messages_map else []
     if not db_messages:
         return None
 
@@ -2083,26 +2089,12 @@ def process_messages_with_output(
     For assistant messages with 'output' field, produces properly formatted
     OpenAI-style messages (tool_calls + tool results). Strips 'output' before LLM.
     """
-    processed = []
-
-    for message in messages:
-        if message.get('role') == 'assistant' and message.get('output'):
-            # Use output items for clean OpenAI-format messages
-            output_messages = convert_output_to_messages(
-                message['output'],
-                raw=True,
-                reasoning_format=reasoning_format,
-                flatten_tool_images=True,
-            )
-            if output_messages:
-                processed.extend(output_messages)
-                continue
-
-        # Strip 'output' field before adding (LLM shouldn't see it)
-        clean_message = {k: v for k, v in message.items() if k != 'output'}
-        processed.append(clean_message)
-
-    return processed
+    return expand_messages_with_output(
+        messages,
+        raw=True,
+        reasoning_format=reasoning_format,
+        flatten_tool_images=True,
+    )
 
 
 def strip_compaction_fields(messages: list[dict]) -> list[dict]:
@@ -2291,6 +2283,7 @@ async def process_chat_payload(request, form_data, user, metadata, model):
 
     # Guided regeneration: extract before it reaches the LLM provider
     regeneration_prompt = form_data.pop('regeneration_prompt', None)
+    regeneration_source_message_id = form_data.pop('regeneration_source_message_id', None)
 
     # Load messages from DB when available — DB preserves structured 'output' items
     # which the frontend strips, causing tool calls to be merged into content.
@@ -2317,32 +2310,36 @@ async def process_chat_payload(request, form_data, user, metadata, model):
             system_message = get_system_message(form_data.get('messages', []))
             form_data['messages'] = [system_message, *db_messages] if system_message else db_messages
 
-            # Inject image files into content as image_url parts (mirrors frontend logic)
-            for message in form_data['messages']:
-                image_files = [
-                    f
-                    for f in message.get('files', [])
-                    if f.get('type') == 'image' or (f.get('content_type') or '').startswith('image/')
-                ]
-                if message.get('role') == 'user' and image_files:
-                    text_content = message.get('content', '')
-                    if isinstance(text_content, str):
-                        message['content'] = [
-                            {'type': 'text', 'text': text_content},
-                            *[
-                                {
-                                    'type': 'image_url',
-                                    'image_url': {'url': f['url']},
-                                }
-                                for f in image_files
-                                if f.get('url')
-                            ],
-                        ]
-                # Strip files field — it's been incorporated into content
-                message.pop('files', None)
+            if regeneration_source_message_id:
+                source_message = await Chats.get_message_by_id_and_message_id(
+                    chat_id,
+                    regeneration_source_message_id,
+                )
+                if (
+                    source_message
+                    and source_message.get('role') == 'assistant'
+                    and source_message.get('parentId') == user_message_id
+                    and (source_message.get('content') or source_message.get('output'))
+                ):
+                    form_data['messages'].append(
+                        {
+                            key: value
+                            for key, value in source_message.items()
+                            if key in ('id', 'role', 'content', 'output', 'files', 'contextSummary')
+                        }
+                    )
+
+            # Inject image files into content as image_url parts (mirrors frontend logic).
+            form_data['messages'] = inline_message_images_from_files(form_data['messages'])
 
     if regeneration_prompt:
-        form_data['messages'].append({'role': 'user', 'content': regeneration_prompt})
+        form_data['messages'].append(
+            {
+                'role': 'user',
+                'content': regeneration_prompt,
+                '_skip_stored_file_context': True,
+            }
+        )
 
     if is_saved_chat_id(chat_id) and user_message_id:
         if getattr(request.state, 'direct', False) and hasattr(request.state, 'model'):
@@ -2452,7 +2449,7 @@ async def process_chat_payload(request, form_data, user, metadata, model):
                 if metadata.get('params', {}).get('function_calling') == 'legacy':
                     form_data['files'] = [
                         {'type': 'folder', 'id': folder.id},
-                        *form_data.get('files', []),
+                        *(form_data.get('files') or []),
                     ]
                 else:
                     # Native FC: skip RAG injection, builtin tools
@@ -2497,7 +2494,7 @@ async def process_chat_payload(request, form_data, user, metadata, model):
             else:
                 knowledge_files.append(item)
 
-        files = form_data.get('files', [])
+        files = form_data.get('files') or []
         files.extend(knowledge_files)
         form_data['files'] = files
 
@@ -2615,7 +2612,7 @@ async def process_chat_payload(request, form_data, user, metadata, model):
     view_skill_ids = []
     chat = None
     if is_saved_chat_id(metadata.get('chat_id')):
-        chat = await Chats.get_chat_by_id(metadata['chat_id'])
+        chat = await Chats.get_chat_by_id(metadata['chat_id'], include_messages=False)
 
     if chat and (chat.meta or {}).get('internal') is True and (chat.meta or {}).get('type') == 'note':
         note_id = (chat.meta or {}).get('note_id')
@@ -2799,7 +2796,7 @@ async def process_chat_payload(request, form_data, user, metadata, model):
                         **extra_params,
                         '__model__': models[task_model_id],
                         '__messages__': form_data['messages'],
-                        '__files__': metadata.get('files', []),
+                        '__files__': metadata.get('files') or [],
                     },
                 )
 
@@ -2862,7 +2859,12 @@ async def process_chat_payload(request, form_data, user, metadata, model):
         if use_builtin_tools:
             # Add file context to user messages
             chat_id = metadata.get('chat_id')
-            form_data['messages'] = await add_file_context(form_data.get('messages', []), chat_id, user)
+            form_data['messages'] = await add_file_context(
+                form_data.get('messages', []),
+                chat_id,
+                user,
+                metadata.get('user_message_id'),
+            )
 
             if (model.get('info', {}).get('meta', {}).get('builtinTools') or {}).get('knowledge', True):
                 from html import escape
@@ -2898,6 +2900,9 @@ async def process_chat_payload(request, form_data, user, metadata, model):
             for name, tool_dict in builtin_tools.items():
                 if name not in tools_dict:
                     tools_dict[name] = tool_dict
+
+        for message in form_data.get('messages', []):
+            message.pop('_skip_stored_file_context', None)
 
         if tools_dict:
             # Always store resolved tools in metadata so downstream consumers
@@ -3203,20 +3208,22 @@ async def background_tasks_handler(ctx):
     messages = []
 
     if is_saved_chat_id(metadata.get('chat_id')):
-        messages_map = await Chats.get_messages_map_by_chat_id(metadata['chat_id'])
-        if not messages_map:
+        message_list = await ChatMessages.get_message_branch_by_chat_id(
+            metadata['chat_id'],
+            metadata['message_id'],
+        )
+        if not message_list:
             # Chat was deleted while the response was streaming — skip background tasks
             return
+        messages_map = {item['id']: item for item in message_list if item.get('id')}
         message = messages_map.get(metadata['message_id'])
-
-        message_list = get_message_list(messages_map, metadata['message_id'])
 
         # Remove details tags and files from the messages.
         # as get_message_list creates a new list, it does not affect
         # the original messages outside of this handler
 
         messages = []
-        for message in message_list:
+        for message in expand_messages_with_output(message_list):
             content = message.get('content', '')
             if isinstance(content, list):
                 for item in content:
@@ -3462,13 +3469,10 @@ async def outlet_filter_handler(ctx):
             if not message_list:
                 return
         else:
-            messages_map = await Chats.get_messages_map_by_chat_id(chat_id)
-            if not messages_map:
-                return
-
-            message_list = get_message_list(messages_map, message_id)
+            message_list = await ChatMessages.get_message_branch_by_chat_id(chat_id, message_id)
             if not message_list:
                 return
+            messages_map = {message['id']: message for message in message_list if message.get('id')}
 
         model_id = model.get('id') if isinstance(model, dict) else model
 
@@ -4541,7 +4545,7 @@ async def streaming_chat_response_handler(response, ctx):
                                         await event_emitter(
                                             {
                                                 'type': 'files',
-                                                'data': {'files': message_files},
+                                                'data': {'files': message_files, 'replace': True},
                                             }
                                         )
 
@@ -4998,7 +5002,7 @@ async def streaming_chat_response_handler(response, ctx):
                                     function=tool['callable'],
                                     extra_params={
                                         '__messages__': form_data.get('messages', []),
-                                        '__files__': metadata.get('files', []),
+                                        '__files__': metadata.get('files') or [],
                                     },
                                 )
                                 result = await function(**params)
@@ -5106,7 +5110,7 @@ async def streaming_chat_response_handler(response, ctx):
                         # Separate image data URIs (for LLM via input_image) from
                         # other files (for frontend display via files attribute).
                         display_files = []
-                        for file_item in result.get('files', []):
+                        for file_item in result.get('files') or []:
                             if file_item.get('type') == 'image' and file_item.get('url', '').startswith('data:'):
                                 # LLM-only: add as input_image part, not frontend display output.
                                 output_parts.append({'type': 'input_image', 'image_url': file_item['url']})
@@ -5376,7 +5380,7 @@ async def streaming_chat_response_handler(response, ctx):
                                                 'id': str(uuid4()),
                                                 'code': code,
                                                 'session_id': metadata.get('session_id', None),
-                                                'files': metadata.get('files', []),
+                                                'files': metadata.get('files') or [],
                                             },
                                         }
                                     )
@@ -5511,29 +5515,17 @@ async def streaming_chat_response_handler(response, ctx):
                 }
 
                 if save_to_chat:
-                    if not ENABLE_REALTIME_CHAT_SAVE:
-                        # Save message in the database
-                        await Chats.upsert_message_to_chat_by_id_and_message_id(
-                            metadata['chat_id'],
-                            metadata['message_id'],
-                            {
-                                'done': True,
-                                'output': output,
-                                **({'usage': usage} if usage else {}),
-                            },
-                        )
-                    elif usage:
-                        await Chats.upsert_message_to_chat_by_id_and_message_id(
-                            metadata['chat_id'],
-                            metadata['message_id'],
-                            {'done': True, 'usage': usage},
-                        )
-                    else:
-                        await Chats.upsert_message_to_chat_by_id_and_message_id(
-                            metadata['chat_id'],
-                            metadata['message_id'],
-                            {'done': True},
-                        )
+                    # Realtime saving only improves incremental durability; the
+                    # canonical final output is persisted for every protocol.
+                    await Chats.upsert_message_to_chat_by_id_and_message_id(
+                        metadata['chat_id'],
+                        metadata['message_id'],
+                        {
+                            'done': True,
+                            'output': output,
+                            **({'usage': usage} if usage else {}),
+                        },
+                    )
 
                 await publish_chat_finished_event(request, user, metadata, title, ''.join(content_parts), output)
 
@@ -5567,22 +5559,15 @@ async def streaming_chat_response_handler(response, ctx):
                 async def save_cancelled_state():
                     await event_emitter({'type': 'chat:tasks:cancel'})
                     if save_to_chat:
-                        if not ENABLE_REALTIME_CHAT_SAVE:
-                            await Chats.upsert_message_to_chat_by_id_and_message_id(
-                                metadata['chat_id'],
-                                metadata['message_id'],
-                                {
-                                    'done': True,
-                                    'output': output,
-                                },
-                            )
-                        else:
-                            await Chats.upsert_message_to_chat_by_id_and_message_id(
-                                metadata['chat_id'],
-                                metadata['message_id'],
-                                {'done': True},
-                                touch=False,
-                            )
+                        await Chats.upsert_message_to_chat_by_id_and_message_id(
+                            metadata['chat_id'],
+                            metadata['message_id'],
+                            {
+                                'done': True,
+                                'output': output,
+                            },
+                            touch=False,
+                        )
 
                 try:
                     await asyncio.shield(save_cancelled_state())

--- a/backend/open_webui/utils/misc.py
+++ b/backend/open_webui/utils/misc.py
@@ -472,6 +472,31 @@ def convert_output_to_messages(
     return reconcile_tool_pairs(messages)
 
 
+def expand_messages_with_output(
+    messages: list[dict],
+    raw: bool = True,
+    reasoning_format: str | None = None,
+    flatten_tool_images: bool = False,
+) -> list[dict]:
+    """Expand stored Responses API output into ordinary assistant/tool messages."""
+    expanded = []
+    for message in messages:
+        if message.get('role') == 'assistant' and message.get('output'):
+            output_messages = convert_output_to_messages(
+                message['output'],
+                raw=raw,
+                reasoning_format=reasoning_format,
+                flatten_tool_images=flatten_tool_images,
+            )
+            if output_messages:
+                expanded.extend(output_messages)
+                continue
+
+        expanded.append({key: value for key, value in message.items() if key != 'output'})
+
+    return expanded
+
+
 def get_last_user_message(messages: list[dict]) -> str | None:
     message = get_last_user_message_item(messages)
     if message is None:

--- a/backend/open_webui/utils/subagents.py
+++ b/backend/open_webui/utils/subagents.py
@@ -16,7 +16,6 @@ from open_webui.models.users import UserModel, Users
 from open_webui.tasks import create_task, has_active_tasks
 from open_webui.utils.auth import create_token
 from open_webui.utils.json_codec import JSONCodec
-from open_webui.utils.misc import get_message_list
 from sqlalchemy import select
 from starlette.datastructures import Headers
 
@@ -88,144 +87,136 @@ async def process_pending_internal_messages(
             return
 
         async with get_async_db() as db:
-            stmt = select(Chat).where(Chat.id == parent_chat_id, Chat.user_id == user_id)
-            if db.bind.dialect.name == 'postgresql':
-                stmt = stmt.with_for_update()
-            result = await db.execute(stmt)
-            chat = result.scalar_one_or_none()
-            if not chat:
-                return
+            try:
+                stmt = select(Chat).where(Chat.id == parent_chat_id, Chat.user_id == user_id)
+                if db.bind.dialect.name == 'postgresql':
+                    stmt = stmt.with_for_update()
+                result = await db.execute(stmt)
+                chat = result.scalar_one_or_none()
+                if not chat:
+                    return
 
-            history = copy.deepcopy((chat.chat or {}).get('history') or {})
-            messages = history.get('messages') or {}
-            pending = [
-                message
-                for message in messages.values()
-                for meta in [message.get('meta') or {}]
-                if message.get('role') == 'user'
-                and not message.get('childrenIds')
-                and (
-                    (
-                        meta.get('internal') is True
-                        and meta.get('type') == 'subagent'
-                        and meta.get('status') in (None, 'pending')
-                    )
-                    or (meta.get('internal') is True and meta.get('type') == 'timer')
+                compact_chat = await ChatMessages.compact_legacy_chat_in_session(
+                    db,
+                    parent_chat_id,
+                    user_id,
+                    chat.chat,
                 )
-            ]
-            if not pending:
-                return
+                normalized_legacy = compact_chat != (chat.chat or {})
 
-            first = pending[0]
-            first_meta = first.get('meta') or {}
-            kind = 'timer' if first_meta.get('internal') is True and first_meta.get('type') == 'timer' else 'subagent'
-            parent_id = first.get('parentId')
-            if kind == 'timer' and first_meta.get('timer_id'):
-                timer = await Chats.get_chat_by_id(first_meta['timer_id'])
-                run = {**run, **(((timer.meta or {}).get('run') if timer else None) or {})}
-            model_id = first.get('model') or run['model_id']
-            if kind == 'timer':
-                batch = [first]
-            else:
-                batch = [
-                    message
-                    for message in pending
-                    for meta in [message.get('meta') or {}]
-                    if message.get('parentId') == parent_id
-                    and (message.get('model') or model_id) == model_id
-                    and (
-                        meta.get('internal') is True
+                pending = await ChatMessages.get_pending_internal_leaf_messages_in_session(db, parent_chat_id)
+                if not pending:
+                    if normalized_legacy:
+                        chat.chat = compact_chat
+                        await db.commit()
+                    return
+
+                first = pending[0]
+                first_meta = first.get('meta') or {}
+                kind = (
+                    'timer' if first_meta.get('internal') is True and first_meta.get('type') == 'timer' else 'subagent'
+                )
+                parent_id = first.get('parentId')
+                if kind == 'timer' and first_meta.get('timer_id'):
+                    timer = await db.get(Chat, first_meta['timer_id'])
+                    run = {**run, **(((timer.meta or {}).get('run') if timer else None) or {})}
+                model_id = first.get('model') or run['model_id']
+                if kind == 'timer':
+                    batch = [first]
+                else:
+                    batch = [
+                        message
+                        for message in pending
+                        for meta in [message.get('meta') or {}]
+                        if message.get('parentId') == parent_id
+                        and (message.get('model') or model_id) == model_id
+                        and meta.get('internal') is True
                         and meta.get('type') == 'subagent'
                         and meta.get('status') in (None, 'pending')
-                    )
-                ]
-            combined_content = '\n\n'.join(message.get('content', '') for message in batch if message.get('content'))
-            if kind == 'timer':
-                timer_ids = [
-                    message['meta']['timer_id'] for message in batch if (message.get('meta') or {}).get('timer_id')
-                ]
-                combined_meta = {'internal': True, 'type': 'timer'}
-                if len(timer_ids) == 1:
-                    combined_meta['timer_id'] = timer_ids[0]
-                elif timer_ids:
-                    combined_meta['timer_ids'] = timer_ids
-            else:
-                delegation_ids = [
-                    message['meta']['delegation_id']
-                    for message in batch
-                    if (message.get('meta') or {}).get('delegation_id')
-                ]
-                subagent_chat_ids = [
-                    message['meta']['subagent_chat_id']
-                    for message in batch
-                    if (message.get('meta') or {}).get('subagent_chat_id')
-                ]
-                combined_meta = {'internal': True, 'type': 'subagent'}
-                if len(delegation_ids) == 1:
-                    combined_meta['delegation_id'] = delegation_ids[0]
-                elif delegation_ids:
-                    combined_meta['delegation_ids'] = delegation_ids
-                if len(subagent_chat_ids) == 1:
-                    combined_meta['subagent_chat_id'] = subagent_chat_ids[0]
-                elif subagent_chat_ids:
-                    combined_meta['subagent_chat_ids'] = subagent_chat_ids
-
-            reuse_message = len(batch) == 1 and (first.get('meta') or {}).get('status') != 'pending'
-            user_message_id = first['id'] if reuse_message else str(uuid4())
-            removed_ids = set()
-            if not reuse_message:
-                removed_ids = {message['id'] for message in batch}
-                for message_id in removed_ids:
-                    messages.pop(message_id, None)
-                if parent_id and parent_id in messages:
-                    messages[parent_id]['childrenIds'] = [
-                        child_id
-                        for child_id in messages[parent_id].get('childrenIds', [])
-                        if child_id not in removed_ids
                     ]
+                combined_content = '\n\n'.join(
+                    message.get('content', '') for message in batch if message.get('content')
+                )
+                if kind == 'timer':
+                    timer_ids = [
+                        message['meta']['timer_id'] for message in batch if (message.get('meta') or {}).get('timer_id')
+                    ]
+                    combined_meta = {'internal': True, 'type': 'timer'}
+                    if len(timer_ids) == 1:
+                        combined_meta['timer_id'] = timer_ids[0]
+                    elif timer_ids:
+                        combined_meta['timer_ids'] = timer_ids
+                else:
+                    delegation_ids = [
+                        message['meta']['delegation_id']
+                        for message in batch
+                        if (message.get('meta') or {}).get('delegation_id')
+                    ]
+                    subagent_chat_ids = [
+                        message['meta']['subagent_chat_id']
+                        for message in batch
+                        if (message.get('meta') or {}).get('subagent_chat_id')
+                    ]
+                    combined_meta = {'internal': True, 'type': 'subagent'}
+                    if len(delegation_ids) == 1:
+                        combined_meta['delegation_id'] = delegation_ids[0]
+                    elif delegation_ids:
+                        combined_meta['delegation_ids'] = delegation_ids
+                    if len(subagent_chat_ids) == 1:
+                        combined_meta['subagent_chat_id'] = subagent_chat_ids[0]
+                    elif subagent_chat_ids:
+                        combined_meta['subagent_chat_ids'] = subagent_chat_ids
 
-            assistant_message_id = str(uuid4())
-            message_list = get_message_list(messages, parent_id)
-            system_prompt = run.get('system_prompt')
-            user_message = {
-                'id': user_message_id,
-                'parentId': parent_id,
-                'childrenIds': [assistant_message_id],
-                'role': 'user',
-                'content': combined_content,
-                'model': model_id,
-                'meta': combined_meta,
-                'timestamp': int(time.time()),
-            }
-            assistant_message = {
-                'id': assistant_message_id,
-                'parentId': user_message_id,
-                'childrenIds': [],
-                'role': 'assistant',
-                'content': '',
-                'done': False,
-                'model': model_id,
-                'timestamp': int(time.time()),
-            }
+                reuse_message = len(batch) == 1 and (first.get('meta') or {}).get('status') != 'pending'
+                user_message_id = first['id'] if reuse_message else str(uuid4())
+                removed_ids = set() if reuse_message else {message['id'] for message in batch}
+                assistant_message_id = str(uuid4())
+                message_list = (
+                    await ChatMessages.get_message_branch_in_session(db, parent_chat_id, parent_id) if parent_id else []
+                )
+                system_prompt = run.get('system_prompt')
+                user_message = {
+                    'id': user_message_id,
+                    'parentId': parent_id,
+                    'childrenIds': [assistant_message_id],
+                    'role': 'user',
+                    'content': combined_content,
+                    'model': model_id,
+                    'meta': combined_meta,
+                    'timestamp': int(time.time()),
+                }
+                assistant_message = {
+                    'id': assistant_message_id,
+                    'parentId': user_message_id,
+                    'childrenIds': [],
+                    'role': 'assistant',
+                    'content': '',
+                    'done': False,
+                    'model': model_id,
+                    'timestamp': int(time.time()),
+                }
 
-            if parent_id and parent_id in messages:
-                parent_children = [
-                    child_id for child_id in messages[parent_id].get('childrenIds', []) if child_id != user_message_id
-                ]
-                parent_children.append(user_message_id)
-                messages[parent_id]['childrenIds'] = parent_children
-            messages[user_message_id] = {**messages.get(user_message_id, {}), **user_message}
-            messages[assistant_message_id] = assistant_message
-            history['messages'] = messages
-            history['currentId'] = assistant_message_id
-            chat.chat = {**(chat.chat or {}), 'history': history}
-            chat.updated_at = int(time.time())
-            await db.commit()
-
-        if removed_ids:
-            await ChatMessages.delete_message_ids_by_chat_id(parent_chat_id, removed_ids)
-        await ChatMessages.upsert_message(user_message_id, parent_chat_id, user_id, user_message)
-        await ChatMessages.upsert_message(assistant_message_id, parent_chat_id, user_id, assistant_message)
+                await ChatMessages.delete_message_ids_in_session(db, parent_chat_id, removed_ids)
+                await ChatMessages.bulk_upsert_messages_in_session(
+                    db,
+                    parent_chat_id,
+                    user_id,
+                    {
+                        user_message_id: user_message,
+                        assistant_message_id: assistant_message,
+                    },
+                )
+                updated_chat = copy.deepcopy(compact_chat)
+                updated_chat['history'] = {
+                    **(updated_chat.get('history') or {}),
+                    'currentId': assistant_message_id,
+                }
+                chat.chat = updated_chat
+                chat.updated_at = int(time.time())
+                await db.commit()
+            except Exception:
+                await db.rollback()
+                raise
 
         from open_webui.socket.main import sio
 
@@ -571,48 +562,45 @@ async def delegate(
         lock = _parent_locks.setdefault(parent_chat_id, asyncio.Lock())
         async with lock:
             async with get_async_db() as db:
-                stmt = select(Chat).where(Chat.id == parent_chat_id, Chat.user_id == user.id)
-                if db.bind.dialect.name == 'postgresql':
-                    stmt = stmt.with_for_update()
-                result_row = await db.execute(stmt)
-                parent = result_row.scalar_one_or_none()
-                if not parent:
-                    if cancelled:
-                        raise asyncio.CancelledError
-                    return result
+                try:
+                    stmt = select(Chat).where(Chat.id == parent_chat_id, Chat.user_id == user.id)
+                    if db.bind.dialect.name == 'postgresql':
+                        stmt = stmt.with_for_update()
+                    result_row = await db.execute(stmt)
+                    parent = result_row.scalar_one_or_none()
+                    if not parent:
+                        if cancelled:
+                            raise asyncio.CancelledError
+                        return result
 
-                updated_chat = copy.deepcopy(parent.chat or {})
-                updated_history = updated_chat.setdefault('history', {})
-                updated_messages = updated_history.setdefault('messages', {})
-                done_assistants = [
-                    message
-                    for message in updated_messages.values()
-                    if message.get('role') == 'assistant' and message.get('done') is not False
-                ]
-                result_parent_id = (
-                    max(done_assistants, key=lambda message: message.get('timestamp', 0)).get('id')
-                    if done_assistants
-                    else parent_message_id
-                )
-                pending_message['parentId'] = result_parent_id
-                if await has_active_tasks(request.app.state.redis, parent_chat_id):
-                    pending_message['meta']['status'] = 'pending'
-                updated_messages[pending_message_id] = pending_message
-                if result_parent_id and result_parent_id in updated_messages:
-                    children = updated_messages[result_parent_id].setdefault('childrenIds', [])
-                    if pending_message_id not in children:
-                        children.append(pending_message_id)
-                updated_history['messages'] = updated_messages
-                parent.chat = {**(parent.chat or {}), **updated_chat, 'history': updated_history}
-                parent.updated_at = int(time.time())
-                await db.commit()
+                    compact_chat = await ChatMessages.compact_legacy_chat_in_session(
+                        db,
+                        parent_chat_id,
+                        user.id,
+                        parent.chat,
+                    )
+                    result_parent_id = await ChatMessages.get_latest_eligible_assistant_id_in_session(
+                        db,
+                        parent_chat_id,
+                    )
+                    result_parent_id = result_parent_id or parent_message_id
+                    pending_message['parentId'] = result_parent_id
+                    if await has_active_tasks(request.app.state.redis, parent_chat_id):
+                        pending_message['meta']['status'] = 'pending'
 
-            await ChatMessages.upsert_message(
-                message_id=pending_message_id,
-                chat_id=parent_chat_id,
-                user_id=user.id,
-                data=pending_message,
-            )
+                    await ChatMessages.upsert_message_in_session(
+                        db,
+                        pending_message_id,
+                        parent_chat_id,
+                        user.id,
+                        pending_message,
+                    )
+                    parent.chat = compact_chat
+                    parent.updated_at = int(time.time())
+                    await db.commit()
+                except Exception:
+                    await db.rollback()
+                    raise
 
         if pending_message['meta'].get('status') == 'pending':
             from open_webui.socket.main import sio

--- a/backend/open_webui/utils/timers.py
+++ b/backend/open_webui/utils/timers.py
@@ -18,7 +18,6 @@ from open_webui.models.chats import Chat, ChatForm, Chats
 from open_webui.models.users import UserModel, Users
 from open_webui.tasks import has_active_tasks
 from open_webui.utils.json_codec import JSONCodec
-from open_webui.utils.misc import get_message_list
 from sqlalchemy import select
 from starlette.datastructures import Headers
 
@@ -232,7 +231,7 @@ async def execute_due_timer(app, timer_id: str, claim_id: str | None = None) -> 
         from open_webui.socket.main import sio
         from open_webui.utils.subagents import _parent_locks
 
-        timer = await Chats.get_chat_by_id(timer_id)
+        timer = await Chats.get_chat_by_id(timer_id, include_messages=False)
         if not timer:
             return
         meta = timer.meta or {}
@@ -242,7 +241,11 @@ async def execute_due_timer(app, timer_id: str, claim_id: str | None = None) -> 
             return
 
         parent_chat_id = meta.get('parent_chat_id') or ''
-        parent = await Chats.get_chat_by_id_and_user_id(parent_chat_id, timer.user_id)
+        parent = await Chats.get_chat_by_id_and_user_id(
+            parent_chat_id,
+            timer.user_id,
+            include_messages=False,
+        )
         if not parent:
             await _set_timer_state(timer_id, 'error', timer_error='parent chat no longer exists')
             return
@@ -278,83 +281,96 @@ async def execute_due_timer(app, timer_id: str, claim_id: str | None = None) -> 
         parent_lock = _parent_locks.setdefault(parent_chat_id, asyncio.Lock())
         async with parent_lock:
             async with get_async_db() as db:
-                stmt = select(Chat).where(Chat.id == parent_chat_id, Chat.user_id == timer.user_id)
-                if db.bind.dialect.name == 'postgresql':
-                    stmt = stmt.with_for_update()
-                result = await db.execute(stmt)
-                parent = result.scalar_one_or_none()
-                if not parent:
-                    await _set_timer_state(timer_id, 'error', timer_error='parent chat no longer exists')
-                    return
-                if await has_active_tasks(app.state.redis, parent_chat_id):
+                try:
+                    stmt = select(Chat).where(Chat.id == parent_chat_id, Chat.user_id == timer.user_id)
+                    if db.bind.dialect.name == 'postgresql':
+                        stmt = stmt.with_for_update()
+                    result = await db.execute(stmt)
+                    parent = result.scalar_one_or_none()
+                    if not parent:
+                        await _set_timer_state(timer_id, 'error', timer_error='parent chat no longer exists')
+                        return
+
+                    compact_chat = await ChatMessages.compact_legacy_chat_in_session(
+                        db,
+                        parent_chat_id,
+                        timer.user_id,
+                        parent.chat,
+                    )
+                    if await has_active_tasks(app.state.redis, parent_chat_id):
+                        parent.chat = compact_chat
+                        timer_row = await db.get(Chat, timer_id)
+                        if timer_row:
+                            timer_row.meta = {
+                                **(timer_row.meta or {}),
+                                'status': 'pending',
+                                'timer_claim_id': None,
+                                'timer_started_at': None,
+                            }
+                            timer_row.updated_at = int(time.time())
+                        await db.commit()
+                        return
+
+                    parent_id = await ChatMessages.get_latest_eligible_assistant_id_in_session(
+                        db,
+                        parent_chat_id,
+                    )
+                    parent_id = parent_id or meta.get('parent_message_id')
+                    message_list = (
+                        await ChatMessages.get_message_branch_in_session(db, parent_chat_id, parent_id)
+                        if parent_id
+                        else []
+                    )
+
+                    user_message = {
+                        'id': user_message_id,
+                        'parentId': parent_id,
+                        'childrenIds': [assistant_message_id],
+                        'role': 'user',
+                        'content': prompt,
+                        'model': model_id,
+                        'meta': {'internal': True, 'type': 'timer', 'timer_id': timer_id},
+                        'timestamp': int(time.time()),
+                    }
+                    assistant_message = {
+                        'id': assistant_message_id,
+                        'parentId': user_message_id,
+                        'childrenIds': [],
+                        'role': 'assistant',
+                        'content': '',
+                        'done': False,
+                        'model': model_id,
+                        'timestamp': int(time.time()),
+                    }
+                    await ChatMessages.bulk_upsert_messages_in_session(
+                        db,
+                        parent_chat_id,
+                        timer.user_id,
+                        {
+                            user_message_id: user_message,
+                            assistant_message_id: assistant_message,
+                        },
+                    )
+
+                    updated_chat = copy.deepcopy(compact_chat)
+                    updated_chat['history'] = {
+                        **(updated_chat.get('history') or {}),
+                        'currentId': assistant_message_id,
+                    }
+                    parent.chat = updated_chat
+                    parent.updated_at = int(time.time())
                     timer_row = await db.get(Chat, timer_id)
                     if timer_row:
                         timer_row.meta = {
                             **(timer_row.meta or {}),
-                            'status': 'pending',
-                            'timer_claim_id': None,
-                            'timer_started_at': None,
+                            'status': 'completed',
+                            'timer_completed_at': int(time.time_ns()),
                         }
                         timer_row.updated_at = int(time.time())
                     await db.commit()
-                    return
-
-                parent_chat = copy.deepcopy(parent.chat or {})
-                history = parent_chat.setdefault('history', {})
-                messages = history.setdefault('messages', {})
-                done_assistants = [
-                    message
-                    for message in messages.values()
-                    if message.get('role') == 'assistant' and message.get('done') is not False
-                ]
-                parent_id = (
-                    max(done_assistants, key=lambda message: message.get('timestamp', 0)).get('id')
-                    if done_assistants
-                    else meta.get('parent_message_id')
-                )
-                message_list = get_message_list(messages, parent_id)
-
-                user_message = {
-                    'id': user_message_id,
-                    'parentId': parent_id,
-                    'childrenIds': [assistant_message_id],
-                    'role': 'user',
-                    'content': prompt,
-                    'model': model_id,
-                    'meta': {'internal': True, 'type': 'timer', 'timer_id': timer_id},
-                    'timestamp': int(time.time()),
-                }
-                assistant_message = {
-                    'id': assistant_message_id,
-                    'parentId': user_message_id,
-                    'childrenIds': [],
-                    'role': 'assistant',
-                    'content': '',
-                    'done': False,
-                    'model': model_id,
-                    'timestamp': int(time.time()),
-                }
-                messages[user_message_id] = user_message
-                messages[assistant_message_id] = assistant_message
-                if parent_id and parent_id in messages:
-                    children = messages[parent_id].setdefault('childrenIds', [])
-                    if user_message_id not in children:
-                        children.append(user_message_id)
-
-                parent.chat = parent_chat
-                history['currentId'] = assistant_message_id
-                parent.updated_at = int(time.time())
-                timer_row = await db.get(Chat, timer_id)
-                if timer_row:
-                    timer_row.meta = {
-                        **(timer_row.meta or {}),
-                        'status': 'completed',
-                        'timer_completed_at': int(time.time_ns()),
-                    }
-                    timer_row.updated_at = int(time.time())
-                await db.commit()
-            await ChatMessages.upsert_message(user_message_id, parent_chat_id, timer.user_id, user_message)
-            await ChatMessages.upsert_message(assistant_message_id, parent_chat_id, timer.user_id, assistant_message)
+                except Exception:
+                    await db.rollback()
+                    raise
 
         await sio.emit(
             'events',

--- a/backend/open_webui/utils/tools.py
+++ b/backend/open_webui/utils/tools.py
@@ -712,7 +712,7 @@ async def get_builtin_tools(
     chat_id = metadata.get('chat_id') or ''
     chat = None
     if is_saved_chat_id(chat_id):
-        chat = await Chats.get_chat_by_id(chat_id)
+        chat = await Chats.get_chat_by_id(chat_id, include_messages=False)
 
     # Notes tools - search, view, create, and update user's notes
     if (chat and (chat.meta or {}).get('internal') is True and (chat.meta or {}).get('type') == 'note') or (
@@ -1297,7 +1297,9 @@ async def get_terminal_servers(request: Request):
     terminal_servers = []
     if request.app.state.redis is not None:
         try:
-            terminal_servers = JSONCodec.loads(await request.app.state.redis.get(f'{REDIS_KEY_PREFIX}:terminal_servers'))
+            terminal_servers = JSONCodec.loads(
+                await request.app.state.redis.get(f'{REDIS_KEY_PREFIX}:terminal_servers')
+            )
             request.app.state.TERMINAL_SERVERS = terminal_servers
         except Exception as e:
             log.error(f'Error fetching terminal_servers from Redis: {e}')

--- a/backend/tests/test_chat_history.py
+++ b/backend/tests/test_chat_history.py
@@ -1,0 +1,111 @@
+from open_webui.utils.chat_history import (
+    MESSAGE_LOADED_KEY,
+    build_window_chat,
+    create_message_window,
+    has_embedded_messages,
+    hydrate_chat,
+    merge_compact_chat,
+    prepare_messages_for_storage,
+    split_chat_messages,
+)
+
+
+def message(message_id, parent_id, content):
+    return {
+        'id': message_id,
+        'parentId': parent_id,
+        'childrenIds': [],
+        'role': 'user',
+        'content': content,
+        'customField': {'kept': True},
+    }
+
+
+def test_split_and_hydrate_preserve_arbitrary_message_fields():
+    original = {
+        'title': 'chat',
+        'history': {
+            'currentId': 'child',
+            'messages': {
+                'root': message('root', None, 'one'),
+                'child': message('child', 'root', 'two'),
+            },
+        },
+    }
+
+    compact, messages = split_chat_messages(original)
+
+    assert 'messages' not in compact['history']
+    assert messages['child']['customField'] == {'kept': True}
+    assert hydrate_chat(compact, messages)['messages'][1]['id'] == 'child'
+    assert original['history']['messages']['child']['content'] == 'two'
+
+
+def test_embedded_message_presence_distinguishes_empty_legacy_from_compact_chat():
+    assert has_embedded_messages({'history': {'messages': {}}}) is True
+    assert has_embedded_messages({'messages': []}) is True
+    assert has_embedded_messages({'history': {'messageStorage': {'version': 1}}}) is False
+
+
+def test_merge_compact_chat_only_returns_incoming_messages():
+    existing = {
+        'title': 'old',
+        'history': {'currentId': 'old', 'messages': {'old': message('old', None, 'old')}},
+    }
+    incoming = {
+        'title': 'new',
+        'history': {'currentId': 'new', 'messages': {'new': message('new', 'old', 'new')}},
+    }
+
+    compact, messages = merge_compact_chat(existing, incoming)
+
+    assert compact['title'] == 'new'
+    assert compact['history']['currentId'] == 'new'
+    assert 'messages' not in compact['history']
+    assert set(messages) == {'new'}
+
+
+def test_window_contains_topology_stubs_and_loaded_bodies():
+    topology = {
+        'root': {'id': 'root', 'parentId': None, 'childrenIds': ['child'], 'role': 'user', 'timestamp': 1},
+        'child': {'id': 'child', 'parentId': 'root', 'childrenIds': [], 'role': 'user', 'timestamp': 2},
+    }
+    loaded = {'child': message('child', 'root', 'body')}
+
+    result = build_window_chat(
+        {'history': {'currentId': 'child'}},
+        topology,
+        loaded,
+        ['child'],
+        True,
+        1,
+    )
+
+    assert result['history']['messages']['root'][MESSAGE_LOADED_KEY] is False
+    assert result['history']['messages']['child'][MESSAGE_LOADED_KEY] is True
+    assert result['history']['messages']['child']['content'] == 'body'
+    assert result['history']['messageWindow']['hasMore'] is True
+
+
+def test_storage_preparation_removes_internal_marker_without_mutation():
+    messages = {'id': {**message('id', None, 'body'), MESSAGE_LOADED_KEY: True}}
+
+    prepared = prepare_messages_for_storage(messages)
+
+    assert MESSAGE_LOADED_KEY not in prepared['id']
+    assert messages['id'][MESSAGE_LOADED_KEY] is True
+
+
+def test_legacy_window_uses_parent_chain_and_before_cursor():
+    messages = {
+        'root': message('root', None, 'root'),
+        'middle': message('middle', 'root', 'middle'),
+        'leaf': message('leaf', 'middle', 'leaf'),
+        'sibling': message('sibling', 'root', 'sibling'),
+    }
+
+    window = create_message_window(messages, 'leaf', limit=1, before_id='leaf')
+
+    assert window['loaded_ids'] == ['middle']
+    assert window['has_more'] is True
+    assert set(window['topology']) == set(messages)

--- a/backend/tests/test_chat_messages.py
+++ b/backend/tests/test_chat_messages.py
@@ -1,0 +1,851 @@
+import importlib
+import json
+import os
+import sys
+from contextlib import asynccontextmanager
+from types import ModuleType, SimpleNamespace
+from unittest.mock import AsyncMock
+
+os.environ.setdefault('WEBUI_SECRET_KEY', 'chat-message-tests-only-secret-key')
+
+import open_webui.models.chat_messages as chat_messages_module
+import pytest
+import pytest_asyncio
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from open_webui.models.chat_messages import ChatMessage, ChatMessageTable
+from open_webui.models.chats import Chat
+from sqlalchemy import create_engine, event, func, inspect, select, text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+
+@pytest_asyncio.fixture
+async def session_factory(tmp_path, monkeypatch):
+    database_path = tmp_path / 'chat-messages.db'
+    engine = create_async_engine(f'sqlite+aiosqlite:///{database_path}')
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with engine.begin() as connection:
+        await connection.run_sync(Chat.__table__.create)
+        await connection.run_sync(ChatMessage.__table__.create)
+
+    @asynccontextmanager
+    async def test_db_context(db=None):
+        if db is not None:
+            yield db
+            return
+        async with factory() as session:
+            yield session
+
+    monkeypatch.setattr(chat_messages_module, 'get_async_db_context', test_db_context)
+    yield factory
+    await engine.dispose()
+
+
+def message(role, parent_id, content, timestamp, **extra):
+    return {
+        'role': role,
+        'parentId': parent_id,
+        'childrenIds': [],
+        'content': content,
+        'timestamp': timestamp,
+        **extra,
+    }
+
+
+@pytest.mark.asyncio
+async def test_lossless_bulk_upsert_uses_one_commit_and_preserves_usage(session_factory):
+    table = ChatMessageTable()
+    payload = message(
+        'assistant',
+        None,
+        'original',
+        100,
+        modelName='custom-model-name',
+        model='provider-model',
+        annotation={'rating': 5},
+        arbitrary={'nested': ['value', {'kept': True}]},
+        usage={'prompt_tokens': 4, 'completion_tokens': 2},
+    )
+
+    async with session_factory() as session:
+        commits = 0
+        select_count = 0
+
+        @event.listens_for(session.sync_session, 'after_commit')
+        def count_commit(_session):
+            nonlocal commits
+            commits += 1
+
+        @event.listens_for(session.bind.sync_engine, 'before_cursor_execute')
+        def count_select(_conn, _cursor, statement, _parameters, _context, _executemany):
+            nonlocal select_count
+            if statement.lstrip().upper().startswith('SELECT'):
+                select_count += 1
+
+        rows = await table.bulk_upsert_messages('chat', 'user', {'message': payload}, db=session)
+        assert commits == 1
+        assert select_count == 1
+        assert rows[0].data['arbitrary'] == payload['arbitrary']
+
+        await table.upsert_message(
+            'message',
+            'chat',
+            'user',
+            {'content': 'updated', 'model': None, 'usage': payload['usage']},
+            db=session,
+        )
+        data_map = await table.get_message_data_map_by_chat_id('chat', db=session)
+        model_id = await session.scalar(select(ChatMessage.model_id).where(ChatMessage.chat_id == 'chat'))
+
+    stored = data_map['message']
+    assert stored['content'] == 'updated'
+    assert stored['modelName'] == 'custom-model-name'
+    assert stored['annotation'] == {'rating': 5}
+    assert stored['arbitrary'] == payload['arbitrary']
+    assert stored['model'] is None
+    assert model_id is None
+    assert stored['usage']['input_tokens'] == 4
+    assert stored['usage']['output_tokens'] == 2
+
+
+@pytest.mark.asyncio
+async def test_bulk_upsert_rolls_back_the_whole_batch(session_factory, monkeypatch):
+    table = ChatMessageTable()
+    original_apply = table._apply_message_data
+
+    def fail_second(message_row, message_id, user_id, data, now, *, is_new):
+        original_apply(message_row, message_id, user_id, data, now, is_new=is_new)
+        if message_id == 'second':
+            raise RuntimeError('injected batch failure')
+
+    monkeypatch.setattr(table, '_apply_message_data', fail_second)
+
+    async with session_factory() as session:
+        with pytest.raises(RuntimeError, match='injected batch failure'):
+            await table.bulk_upsert_messages(
+                'chat',
+                'user',
+                {
+                    'first': message('user', None, 'first', 1),
+                    'second': message('assistant', 'first', 'second', 2),
+                },
+                db=session,
+            )
+
+    async with session_factory() as session:
+        count = await session.scalar(select(func.count()).select_from(ChatMessage))
+    assert count == 0
+
+
+@pytest.mark.asyncio
+async def test_replace_messages_repairs_missing_and_removes_stale_rows(session_factory):
+    table = ChatMessageTable()
+    async with session_factory() as session:
+        await table.bulk_upsert_messages(
+            'chat',
+            'user',
+            {
+                'keep': message('user', None, 'old', 1),
+                'stale': message('assistant', 'keep', 'stale', 2),
+            },
+            db=session,
+        )
+        await table.bulk_upsert_messages(
+            'other-chat',
+            'user',
+            {'other': message('user', None, 'other', 1)},
+            db=session,
+        )
+
+        commits = 0
+
+        @event.listens_for(session.sync_session, 'after_commit')
+        def count_commit(_session):
+            nonlocal commits
+            commits += 1
+
+        await table.replace_messages_by_chat_id(
+            'chat',
+            'user',
+            {
+                'keep': message('user', None, 'updated', 1),
+                'missing': message('assistant', 'keep', 'new', 3),
+            },
+            db=session,
+        )
+
+        data_map = await table.get_message_data_map_by_chat_id('chat', db=session)
+        other_map = await table.get_message_data_map_by_chat_id('other-chat', db=session)
+
+    assert commits == 1
+    assert set(data_map) == {'keep', 'missing'}
+    assert data_map['keep']['content'] == 'updated'
+    assert set(other_map) == {'other'}
+
+
+@pytest.mark.asyncio
+async def test_message_window_paginates_only_current_ancestry(session_factory):
+    table = ChatMessageTable()
+    messages = {
+        'root': message('user', None, 'root body', 1, custom='root'),
+        'assistant': message('assistant', 'root', 'assistant body', 2),
+        'left': message('user', 'assistant', 'left body', 3),
+        'right': message('user', 'assistant', 'right body', 3, custom='right'),
+        'leaf': message('assistant', 'right', 'leaf body', 4, custom='leaf'),
+    }
+
+    async with session_factory() as session:
+        await table.bulk_upsert_messages('chat', 'user', messages, db=session)
+        first = await table.get_message_window_by_chat_id('chat', 'leaf', limit=2, db=session)
+        second = await table.get_message_window_by_chat_id(
+            'chat',
+            'leaf',
+            limit=2,
+            before_id='right',
+            db=session,
+        )
+        branch = await table.get_message_branch_by_chat_id('chat', 'leaf', db=session)
+
+    assert set(first) == {'topology', 'messages', 'loaded_ids', 'has_more', 'current_id'}
+    assert set(first['topology']) == set(messages)
+    assert first['loaded_ids'] == ['right', 'leaf']
+    assert list(first['messages']) == ['right', 'leaf']
+    assert first['messages']['leaf']['custom'] == 'leaf'
+    assert first['has_more'] is True
+    assert first['current_id'] == 'leaf'
+    assert second['loaded_ids'] == ['root', 'assistant']
+    assert second['has_more'] is False
+    assert [item['id'] for item in branch] == ['root', 'assistant', 'right', 'leaf']
+    assert branch[-1]['custom'] == 'leaf'
+
+
+@pytest.mark.asyncio
+async def test_message_branch_fails_closed_when_parent_row_is_missing(session_factory):
+    table = ChatMessageTable()
+
+    async with session_factory() as session:
+        await table.bulk_upsert_messages(
+            'chat',
+            'user',
+            {'leaf': message('assistant', 'missing-parent', 'leaf', 2)},
+            db=session,
+        )
+        with pytest.raises(ValueError, match='missing parent: missing-parent'):
+            await table.get_message_branch_by_chat_id('chat', 'leaf', db=session)
+        with pytest.raises(ValueError, match='missing parent: missing-parent'):
+            await table.get_message_window_by_chat_id('chat', 'leaf', db=session)
+
+
+@pytest.mark.asyncio
+async def test_last_request_usage_is_kept_separate_from_accumulated_usage(session_factory):
+    table = ChatMessageTable()
+
+    async with session_factory() as session:
+        await table.upsert_message(
+            'assistant',
+            'chat',
+            'user',
+            message(
+                'assistant',
+                None,
+                'first',
+                1,
+                usage={'input_tokens': 100, 'output_tokens': 20},
+            ),
+            db=session,
+        )
+        await table.upsert_message(
+            'assistant',
+            'chat',
+            'user',
+            {'usage': {'input_tokens': 40, 'output_tokens': 10}},
+            db=session,
+        )
+        stored = await table.get_message_data_map_by_chat_id('chat', db=session)
+
+    assert stored['assistant']['usage']['input_tokens'] == 140
+    assert stored['assistant']['usage']['output_tokens'] == 30
+    assert stored['assistant']['usage']['total_tokens'] == 170
+    assert stored['assistant']['lastRequestUsage']['input_tokens'] == 40
+    assert stored['assistant']['lastRequestUsage']['output_tokens'] == 10
+
+
+@pytest.mark.asyncio
+async def test_internal_leaf_query_and_latest_parent_use_normalized_rows(session_factory):
+    table = ChatMessageTable()
+    internal_subagent = {'internal': True, 'type': 'subagent', 'status': 'pending'}
+    internal_timer = {'internal': True, 'type': 'timer', 'timer_id': 'timer'}
+
+    async with session_factory() as session:
+        await table.bulk_upsert_messages(
+            'chat',
+            'user',
+            {
+                'complete': message('assistant', None, 'complete', 1, done=True),
+                'legacy-complete': message('assistant', 'complete', 'legacy', 2, done=None),
+                'running': message('assistant', 'legacy-complete', 'running', 3, done=False),
+                'pending-leaf': message(
+                    'user',
+                    'legacy-complete',
+                    'pending',
+                    4,
+                    model='model',
+                    meta=internal_subagent,
+                ),
+                'pending-parent': message(
+                    'user',
+                    'legacy-complete',
+                    'not a leaf',
+                    5,
+                    model='model',
+                    meta=internal_subagent,
+                ),
+                'pending-child': message('assistant', 'pending-parent', '', 6, done=False),
+                'finished-subagent': message(
+                    'user',
+                    'legacy-complete',
+                    'finished',
+                    7,
+                    meta={'internal': True, 'type': 'subagent', 'status': 'complete'},
+                ),
+                'timer-leaf': message(
+                    'user',
+                    'legacy-complete',
+                    'timer',
+                    8,
+                    model='model',
+                    meta=internal_timer,
+                ),
+                'ordinary': message(
+                    'user',
+                    'legacy-complete',
+                    'ordinary',
+                    9,
+                    meta={'internal': False, 'type': 'subagent'},
+                ),
+            },
+            db=session,
+        )
+
+        pending = await table.get_pending_internal_leaf_messages_in_session(session, 'chat')
+        latest_parent = await table.get_latest_eligible_assistant_id_in_session(session, 'chat')
+
+    assert [item['id'] for item in pending] == ['pending-leaf', 'timer-leaf']
+    assert all(item['childrenIds'] == [] for item in pending)
+    assert latest_parent == 'legacy-complete'
+
+
+@pytest.mark.asyncio
+async def test_in_session_delete_does_not_commit_and_can_be_rolled_back(session_factory):
+    table = ChatMessageTable()
+
+    async with session_factory() as session:
+        await table.bulk_upsert_messages(
+            'chat',
+            'user',
+            {
+                'keep': message('user', None, 'keep', 1),
+                'delete': message('assistant', 'keep', 'delete', 2),
+            },
+            db=session,
+        )
+        commits = 0
+
+        @event.listens_for(session.sync_session, 'after_commit')
+        def count_commit(_session):
+            nonlocal commits
+            commits += 1
+
+        await table.delete_message_ids_in_session(session, 'chat', {'delete'})
+        assert commits == 0
+        assert await session.get(ChatMessage, 'chat-delete') is None
+        await session.rollback()
+
+    async with session_factory() as session:
+        remaining = await table.get_message_data_map_by_chat_id('chat', db=session)
+
+    assert set(remaining) == {'keep', 'delete'}
+
+
+@pytest.mark.asyncio
+async def test_subagent_pending_merge_normalizes_legacy_history_in_one_transaction(
+    session_factory,
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setenv('STATIC_DIR', str(tmp_path / 'static'))
+    import open_webui.utils.subagents as subagents
+
+    legacy_messages = {
+        'root': message('user', None, 'root', 1, childrenIds=['parent']),
+        'parent': message(
+            'assistant',
+            'root',
+            'parent',
+            2,
+            done=True,
+            childrenIds=['pending-1', 'pending-2'],
+        ),
+        'pending-1': message(
+            'user',
+            'parent',
+            'first result',
+            3,
+            model='model',
+            meta={
+                'internal': True,
+                'type': 'subagent',
+                'status': 'pending',
+                'delegation_id': 'first',
+            },
+        ),
+        'pending-2': message(
+            'user',
+            'parent',
+            'second result',
+            4,
+            model='model',
+            meta={
+                'internal': True,
+                'type': 'subagent',
+                'status': 'pending',
+                'delegation_id': 'second',
+            },
+        ),
+    }
+    async with session_factory() as session:
+        session.add(
+            Chat(
+                id='parent-chat',
+                user_id='user',
+                title='Parent',
+                chat={
+                    'history': {
+                        'currentId': 'pending-2',
+                        'messages': legacy_messages,
+                    }
+                },
+                meta={},
+                created_at=1,
+                updated_at=1,
+            )
+        )
+        await session.commit()
+
+    commits = 0
+
+    @asynccontextmanager
+    async def tracked_db():
+        nonlocal commits
+        async with session_factory() as session:
+
+            @event.listens_for(session.sync_session, 'after_commit')
+            def count_commit(_session):
+                nonlocal commits
+                commits += 1
+
+            yield session
+
+    handler = AsyncMock()
+    app = SimpleNamespace(state=SimpleNamespace(redis=object(), CHAT_COMPLETION_HANDLER=handler))
+    source_request = SimpleNamespace(app=app)
+    fake_socket = ModuleType('open_webui.socket.main')
+    fake_socket.sio = SimpleNamespace(emit=AsyncMock())
+
+    monkeypatch.setattr(subagents, 'get_async_db', tracked_db)
+    monkeypatch.setattr(subagents, 'has_active_tasks', AsyncMock(return_value=False))
+    monkeypatch.setattr(subagents.Users, 'get_user_by_id', AsyncMock(return_value=SimpleNamespace(id='user')))
+    monkeypatch.setattr(subagents, '_build_request', lambda source, *_args, **_kwargs: source)
+    monkeypatch.setitem(sys.modules, 'open_webui.socket.main', fake_socket)
+    subagents._parent_locks.pop('parent-chat', None)
+
+    await subagents.process_pending_internal_messages(
+        source_request,
+        'parent-chat',
+        'user',
+        {'model_id': 'model'},
+    )
+
+    table = ChatMessageTable()
+    async with session_factory() as session:
+        parent = await session.get(Chat, 'parent-chat')
+        stored = await table.get_message_data_map_by_chat_id('parent-chat', db=session)
+        topology = await table.get_message_topology_by_chat_id('parent-chat', db=session)
+
+    assert commits == 1
+    assert 'messages' not in parent.chat['history']
+    assert parent.chat['history']['messageStorage'] == {'version': 1}
+    assert {'pending-1', 'pending-2'}.isdisjoint(stored)
+    combined = [
+        item
+        for item in stored.values()
+        if item.get('role') == 'user' and (item.get('meta') or {}).get('type') == 'subagent'
+    ]
+    assert len(combined) == 1
+    assert combined[0]['content'] == 'first result\n\nsecond result'
+    current_id = parent.chat['history']['currentId']
+    assert stored[current_id]['role'] == 'assistant'
+    assert stored[current_id]['parentId'] == combined[0]['id']
+    assert topology['parent']['childrenIds'] == [combined[0]['id']]
+    handler.assert_awaited_once()
+    submitted = handler.await_args.args[1]
+    assert [item['content'] for item in submitted['messages']] == [
+        'root',
+        'parent',
+        'first result\n\nsecond result',
+    ]
+
+
+@pytest.mark.asyncio
+async def test_due_timer_appends_normalized_rows_and_current_id_in_one_transaction(
+    session_factory,
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setenv('STATIC_DIR', str(tmp_path / 'static'))
+    import open_webui.utils.subagents as subagents
+    import open_webui.utils.timers as timers
+
+    timer_meta = {
+        'status': 'running',
+        'timer_claim_id': 'claim',
+        'parent_chat_id': 'parent-chat',
+        'parent_message_id': 'eligible',
+        'timer_task_message_id': 'timer-task',
+        'run': {'model_id': 'model'},
+    }
+    async with session_factory() as session:
+        session.add_all(
+            [
+                Chat(
+                    id='parent-chat',
+                    user_id='user',
+                    title='Parent',
+                    chat={
+                        'history': {
+                            'currentId': 'running',
+                            'messageStorage': {'version': 1},
+                        }
+                    },
+                    meta={},
+                    created_at=1,
+                    updated_at=1,
+                ),
+                Chat(
+                    id='timer-chat',
+                    user_id='user',
+                    title='Timer',
+                    chat={'history': {'currentId': None, 'messageStorage': {'version': 1}}},
+                    meta=timer_meta,
+                    created_at=1,
+                    updated_at=1,
+                ),
+            ]
+        )
+        await session.commit()
+        await ChatMessageTable().bulk_upsert_messages(
+            'parent-chat',
+            'user',
+            {
+                'root': message('user', None, 'root', 1, childrenIds=['eligible', 'running']),
+                'eligible': message('assistant', 'root', 'eligible', 2, done=True),
+                'running': message('assistant', 'root', 'running', 3, done=False),
+            },
+            db=session,
+        )
+
+    commits = 0
+
+    @asynccontextmanager
+    async def tracked_db():
+        nonlocal commits
+        async with session_factory() as session:
+
+            @event.listens_for(session.sync_session, 'after_commit')
+            def count_commit(_session):
+                nonlocal commits
+                commits += 1
+
+            yield session
+
+    timer_model = SimpleNamespace(id='timer-chat', user_id='user', meta=timer_meta)
+    handler = AsyncMock()
+    app = SimpleNamespace(state=SimpleNamespace(redis=object(), CHAT_COMPLETION_HANDLER=handler))
+    fake_socket = ModuleType('open_webui.socket.main')
+    fake_socket.sio = SimpleNamespace(emit=AsyncMock())
+
+    monkeypatch.setattr(timers, 'get_async_db', tracked_db)
+    monkeypatch.setattr(timers.Chats, 'get_chat_by_id', AsyncMock(return_value=timer_model))
+    monkeypatch.setattr(timers.Chats, 'get_chat_by_id_and_user_id', AsyncMock(return_value=SimpleNamespace()))
+    monkeypatch.setattr(
+        timers.Chats,
+        'get_message_by_id_and_message_id',
+        AsyncMock(return_value={'content': 'timer prompt'}),
+    )
+    monkeypatch.setattr(timers.Users, 'get_user_by_id', AsyncMock(return_value=SimpleNamespace(id='user')))
+    monkeypatch.setattr(timers, 'has_active_tasks', AsyncMock(return_value=False))
+    monkeypatch.setitem(sys.modules, 'open_webui.socket.main', fake_socket)
+    timers._timer_locks.pop('timer-chat', None)
+    subagents._parent_locks.pop('parent-chat', None)
+
+    await timers.execute_due_timer(app, 'timer-chat', 'claim')
+
+    table = ChatMessageTable()
+    async with session_factory() as session:
+        parent = await session.get(Chat, 'parent-chat')
+        timer_row = await session.get(Chat, 'timer-chat')
+        stored = await table.get_message_data_map_by_chat_id('parent-chat', db=session)
+
+    assert commits == 1
+    assert 'messages' not in parent.chat['history']
+    assert timer_row.meta['status'] == 'completed'
+    timer_users = [
+        item
+        for item in stored.values()
+        if item.get('role') == 'user' and (item.get('meta') or {}).get('type') == 'timer'
+    ]
+    assert len(timer_users) == 1
+    assert timer_users[0]['parentId'] == 'eligible'
+    current_id = parent.chat['history']['currentId']
+    assert stored[current_id]['role'] == 'assistant'
+    assert stored[current_id]['parentId'] == timer_users[0]['id']
+    handler.assert_awaited_once()
+    submitted = handler.await_args.args[1]
+    assert submitted['parent_id'] == 'eligible'
+    assert [item['content'] for item in submitted['messages']] == ['root', 'eligible', 'timer prompt']
+
+
+@pytest.mark.asyncio
+async def test_message_window_handles_empty_chat_and_missing_current_id(session_factory):
+    table = ChatMessageTable()
+
+    async with session_factory() as session:
+        empty = await table.get_message_window_by_chat_id('chat', None, db=session)
+        await table.bulk_upsert_messages(
+            'chat',
+            'user',
+            {
+                'root': message('user', None, 'root', 1),
+                'leaf': message('assistant', 'root', 'leaf', 2),
+            },
+            db=session,
+        )
+        inferred = await table.get_message_window_by_chat_id('chat', None, db=session)
+
+    assert empty == {
+        'topology': {},
+        'messages': {},
+        'loaded_ids': [],
+        'has_more': False,
+        'current_id': None,
+    }
+    assert inferred['current_id'] == 'leaf'
+    assert inferred['loaded_ids'] == ['root', 'leaf']
+
+
+@pytest.mark.asyncio
+async def test_topology_keeps_messages_with_duplicate_timestamps(session_factory):
+    table = ChatMessageTable()
+    messages = {
+        'c': message('user', None, 'c', 10),
+        'a': message('user', None, 'a', 10),
+        'b': message('user', None, 'b', 10),
+    }
+
+    async with session_factory() as session:
+        await table.bulk_upsert_messages('chat', 'user', messages, db=session)
+        topology = await table.get_message_topology_by_chat_id('chat', db=session)
+
+    assert list(topology) == ['a', 'b', 'c']
+    assert len(topology) == 3
+
+
+@pytest.mark.asyncio
+async def test_topology_preserves_projected_sibling_order(session_factory):
+    table = ChatMessageTable()
+    messages = {
+        'root': message('assistant', None, 'root', 1, childrenIds=['z-child', 'a-child']),
+        'a-child': message('user', 'root', 'a', 2),
+        'm-child': message('user', 'root', 'm', 2),
+        'z-child': message('user', 'root', 'z', 2),
+    }
+
+    async with session_factory() as session:
+        await table.bulk_upsert_messages('chat', 'user', messages, db=session)
+        topology = await table.get_message_topology_by_chat_id('chat', db=session)
+
+    assert topology['root']['childrenIds'] == ['z-child', 'a-child', 'm-child']
+
+
+@pytest.mark.asyncio
+async def test_topology_rebuilds_missing_sibling_projection_stably(session_factory):
+    table = ChatMessageTable()
+    messages = {
+        'root': {'role': 'assistant', 'parentId': None, 'content': 'root', 'timestamp': 1},
+        'z-child': {'role': 'user', 'parentId': 'root', 'content': 'z', 'timestamp': 2},
+        'a-child': {'role': 'user', 'parentId': 'root', 'content': 'a', 'timestamp': 2},
+    }
+
+    async with session_factory() as session:
+        await table.bulk_upsert_messages('chat', 'user', messages, db=session)
+        topology = await table.get_message_topology_by_chat_id('chat', db=session)
+
+    assert topology['root']['childrenIds'] == ['a-child', 'z-child']
+
+
+@pytest.mark.asyncio
+async def test_content_snippets_return_one_match_per_chat_in_one_query(session_factory):
+    table = ChatMessageTable()
+    async with session_factory() as session:
+        await table.bulk_upsert_messages(
+            'chat-1',
+            'user',
+            {
+                'first': message('user', None, 'prefix needle first suffix', 1),
+                'second': message('assistant', 'first', 'needle second', 2),
+            },
+            db=session,
+        )
+        await table.bulk_upsert_messages(
+            'chat-2',
+            'user',
+            {'only': message('user', None, 'nothing relevant', 1)},
+            db=session,
+        )
+        await table.bulk_upsert_messages(
+            'chat-3',
+            'user',
+            {'only': message('user', None, 'another needle match', 1)},
+            db=session,
+        )
+
+        query_count = 0
+
+        @event.listens_for(session.bind.sync_engine, 'before_cursor_execute')
+        def count_query(_conn, _cursor, _statement, _parameters, _context, _executemany):
+            nonlocal query_count
+            query_count += 1
+
+        snippets = await table.get_content_snippets_by_chat_ids(
+            ['chat-1', 'chat-2', 'chat-3'],
+            'needle',
+            max_length=30,
+            db=session,
+        )
+        no_matches = await table.get_content_snippets_by_chat_ids(
+            ['chat-1', 'chat-2', 'chat-3'],
+            'absent',
+            db=session,
+        )
+
+    assert query_count == 2
+    assert snippets == {
+        'chat-1': 'prefix needle first suffix',
+        'chat-3': 'another needle match',
+    }
+    assert no_matches == {}
+
+
+def test_data_migration_backfills_and_downgrades(tmp_path, monkeypatch):
+    migration = importlib.import_module('open_webui.migrations.versions.9c0e2f4a6b81_add_data_to_chat_message')
+    engine = create_engine(f'sqlite:///{tmp_path / "migration.db"}')
+
+    with engine.begin() as connection:
+        connection.execute(text('CREATE TABLE chat (id TEXT PRIMARY KEY, chat JSON)'))
+        connection.execute(
+            text(
+                """
+                CREATE TABLE chat_message (
+                    id TEXT PRIMARY KEY,
+                    chat_id TEXT NOT NULL,
+                    user_id TEXT,
+                    role TEXT NOT NULL,
+                    parent_id TEXT,
+                    content JSON,
+                    output JSON,
+                    model_id TEXT,
+                    files JSON,
+                    sources JSON,
+                    embeds JSON,
+                    meta JSON,
+                    done BOOLEAN,
+                    status_history JSON,
+                    error JSON,
+                    usage JSON,
+                    context_summary TEXT,
+                    created_at BIGINT,
+                    updated_at BIGINT
+                )
+                """
+            )
+        )
+        connection.execute(
+            text(
+                """
+                INSERT INTO chat_message (
+                    id, chat_id, user_id, role, content, model_id, done, usage, created_at, updated_at
+                ) VALUES (
+                    :id, :chat_id, :user_id, :role, :content, :model_id, :done, :usage, :created_at, :updated_at
+                )
+                """
+            ),
+            {
+                'id': 'chat-message',
+                'chat_id': 'chat',
+                'user_id': 'user',
+                'role': 'assistant',
+                'content': json.dumps('hello'),
+                'model_id': 'model',
+                'done': True,
+                'usage': json.dumps({'prompt_tokens': 2}),
+                'created_at': 123,
+                'updated_at': 123,
+            },
+        )
+
+        context = MigrationContext.configure(connection)
+        monkeypatch.setattr(migration, 'op', Operations(context))
+        migration.upgrade()
+
+        columns = {column['name'] for column in inspect(connection).get_columns('chat_message')}
+        data, children_ids = connection.execute(
+            text('SELECT data, children_ids FROM chat_message WHERE id = :id'),
+            {'id': 'chat-message'},
+        ).one()
+        payload = json.loads(data)
+
+        assert {'data', 'children_ids'} <= columns
+        assert payload['id'] == 'message'
+        assert payload['content'] == 'hello'
+        assert payload['model'] == 'model'
+        assert payload['timestamp'] == 123
+        assert children_ids is None
+
+        connection.execute(
+            text('INSERT INTO chat (id, chat) VALUES (:id, :chat)'),
+            {
+                'id': 'chat',
+                'chat': json.dumps(
+                    {
+                        'title': 'Compacted',
+                        'history': {
+                            'currentId': 'message',
+                            'messageStorage': {'version': 1},
+                        },
+                    }
+                ),
+            },
+        )
+
+        migration.downgrade()
+        columns = {column['name'] for column in inspect(connection).get_columns('chat_message')}
+        restored_chat = connection.execute(text('SELECT chat FROM chat WHERE id = :id'), {'id': 'chat'}).scalar_one()
+        restored_chat = json.loads(restored_chat)
+        assert 'data' not in columns
+        assert 'children_ids' not in columns
+        assert restored_chat['history']['messages']['message']['content'] == 'hello'
+        assert restored_chat['messages'][0]['id'] == 'message'
+        assert 'messageStorage' not in restored_chat['history']
+
+    engine.dispose()

--- a/backend/tests/test_chat_storage.py
+++ b/backend/tests/test_chat_storage.py
@@ -1,0 +1,519 @@
+import os
+from contextlib import asynccontextmanager
+
+os.environ.setdefault('WEBUI_SECRET_KEY', 'chat-storage-tests-only-secret-key')
+
+import open_webui.models.chat_messages as chat_messages_module
+import open_webui.models.chats as chats_module
+import open_webui.models.shared_chats as shared_chats_module
+import pytest
+import pytest_asyncio
+from open_webui.models.chat_messages import ChatMessage, ChatMessages
+from open_webui.models.chats import Chat, ChatImportForm, Chats
+from open_webui.models.shared_chats import SharedChat, SharedChats
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+
+@pytest_asyncio.fixture
+async def session_factory(tmp_path, monkeypatch):
+    database_path = tmp_path / 'chat-storage.db'
+    engine = create_async_engine(f'sqlite+aiosqlite:///{database_path}')
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with engine.begin() as connection:
+        await connection.run_sync(Chat.__table__.create)
+        await connection.run_sync(ChatMessage.__table__.create)
+        await connection.run_sync(SharedChat.__table__.create)
+
+    @asynccontextmanager
+    async def test_db_context(db=None):
+        if db is not None:
+            yield db
+            return
+        async with factory() as session:
+            yield session
+
+    monkeypatch.setattr(chat_messages_module, 'get_async_db_context', test_db_context)
+    monkeypatch.setattr(chats_module, 'get_async_db_context', test_db_context)
+    monkeypatch.setattr(shared_chats_module, 'get_async_db_context', test_db_context)
+    yield factory
+    await engine.dispose()
+
+
+def legacy_chat():
+    return {
+        'title': 'Legacy',
+        'models': ['model'],
+        'history': {
+            'currentId': 'leaf',
+            'messages': {
+                'root': {
+                    'id': 'root',
+                    'parentId': None,
+                    'childrenIds': ['leaf'],
+                    'role': 'user',
+                    'content': 'root',
+                    'timestamp': 1,
+                    'arbitrary': {'kept': True},
+                },
+                'leaf': {
+                    'id': 'leaf',
+                    'parentId': 'root',
+                    'childrenIds': [],
+                    'role': 'assistant',
+                    'content': 'leaf',
+                    'timestamp': 2,
+                    'done': True,
+                },
+            },
+        },
+    }
+
+
+async def insert_chat(session, chat_id='chat'):
+    session.add(
+        Chat(
+            id=chat_id,
+            user_id='user',
+            title='Legacy',
+            chat=legacy_chat(),
+            created_at=1,
+            updated_at=1,
+            archived=False,
+            pinned=False,
+            meta={},
+        )
+    )
+    await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_legacy_chat_is_reconciled_compacted_and_windowed(session_factory):
+    async with session_factory() as session:
+        await insert_chat(session)
+        await ChatMessages.bulk_upsert_messages(
+            'chat',
+            'user',
+            {
+                'stale': {
+                    'id': 'stale',
+                    'parentId': None,
+                    'childrenIds': [],
+                    'role': 'user',
+                    'content': 'stale',
+                    'timestamp': 0,
+                }
+            },
+            db=session,
+        )
+
+        compact = await Chats.get_chat_by_id('chat', db=session, include_messages=False)
+        normalized = await ChatMessages.get_message_data_map_by_chat_id('chat', db=session)
+        full = await Chats.get_chat_by_id('chat', db=session, include_messages=True)
+        window = await Chats.get_chat_window(compact, limit=1, db=session)
+
+    assert 'messages' not in compact.chat['history']
+    assert compact.chat['history']['messageStorage'] == {'version': 1}
+    assert set(normalized) == {'root', 'leaf'}
+    assert normalized['root']['arbitrary'] == {'kept': True}
+    assert full.chat['history']['messages']['root']['content'] == 'root'
+    assert full.chat['messages'][-1]['id'] == 'leaf'
+    assert window.chat['history']['messages']['root']['__loaded'] is False
+    assert window.chat['history']['messages']['leaf']['__loaded'] is True
+
+
+@pytest.mark.asyncio
+async def test_window_update_only_appends_new_messages(session_factory):
+    async with session_factory() as session:
+        await insert_chat(session)
+        await Chats.get_chat_by_id('chat', db=session, include_messages=False)
+
+        await Chats.update_chat_window_by_id(
+            'chat',
+            {
+                'history': {
+                    'currentId': 'branch',
+                    'messages': {
+                        'leaf': {
+                            'id': 'leaf',
+                            'parentId': 'root',
+                            'childrenIds': [],
+                            'role': 'assistant',
+                            'content': 'stale browser copy',
+                            'timestamp': 2,
+                        },
+                        'branch': {
+                            'id': 'branch',
+                            'parentId': 'root',
+                            'childrenIds': [],
+                            'role': 'assistant',
+                            'content': 'new branch',
+                            'timestamp': 3,
+                        },
+                    },
+                    'messageWindow': {'loadedIds': ['leaf', 'branch']},
+                }
+            },
+            db=session,
+        )
+        messages = await ChatMessages.get_message_data_map_by_chat_id('chat', db=session)
+        persisted = await session.get(Chat, 'chat')
+
+    assert set(messages) == {'root', 'leaf', 'branch'}
+    assert messages['root']['content'] == 'root'
+    assert messages['leaf']['content'] == 'leaf'
+    assert messages['branch']['content'] == 'new branch'
+    assert persisted.chat['history']['currentId'] == 'branch'
+    assert persisted.current_message_id == 'branch'
+
+
+@pytest.mark.asyncio
+async def test_single_message_read_lazily_normalizes_legacy_chat(session_factory):
+    async with session_factory() as session:
+        await insert_chat(session)
+
+    message = await Chats.get_message_by_id_and_message_id('chat', 'root')
+
+    async with session_factory() as session:
+        persisted = await session.get(Chat, 'chat')
+        messages = await ChatMessages.get_message_data_map_by_chat_id('chat', db=session)
+
+    assert message['content'] == 'root'
+    assert message['arbitrary'] == {'kept': True}
+    assert 'messages' not in persisted.chat['history']
+    assert persisted.chat['history']['messageStorage'] == {'version': 1}
+    assert set(messages) == {'root', 'leaf'}
+
+
+@pytest.mark.asyncio
+async def test_search_falls_back_to_legacy_json_then_returns_normalized_snippet(session_factory):
+    async with session_factory() as session:
+        await insert_chat(session)
+        results = await Chats.get_chats_by_user_id_and_search_text(
+            'user',
+            'root',
+            db=session,
+        )
+        persisted = await session.get(Chat, 'chat')
+        messages = await ChatMessages.get_message_data_map_by_chat_id('chat', db=session)
+
+    assert [chat.id for chat in results] == ['chat']
+    assert results[0].snippet == 'root'
+    assert 'messages' not in persisted.chat['history']
+    assert set(messages) == {'root', 'leaf'}
+
+
+@pytest.mark.asyncio
+async def test_single_message_hot_path_preserves_history_and_updates_topology(session_factory):
+    async with session_factory() as session:
+        await insert_chat(session)
+        await Chats.get_chat_by_id('chat', db=session, include_messages=False)
+
+    compact = await Chats.upsert_message_to_chat_by_id_and_message_id(
+        'chat',
+        'leaf',
+        {'content': 'streamed update', 'partial': {'kept': True}},
+    )
+    created = await Chats.upsert_message_to_chat_by_id_and_message_id(
+        'chat',
+        'branch',
+        {'parentId': 'root', 'content': 'new branch'},
+    )
+
+    async with session_factory() as session:
+        messages = await ChatMessages.get_message_data_map_by_chat_id('chat', db=session)
+        persisted = await session.get(Chat, 'chat')
+
+    assert 'messages' not in compact.chat['history']
+    assert 'messages' not in created.chat['history']
+    assert persisted.chat['history']['currentId'] == 'branch'
+    assert persisted.current_message_id == 'branch'
+    assert messages['root']['arbitrary'] == {'kept': True}
+    assert messages['root']['childrenIds'] == ['leaf', 'branch']
+    assert messages['leaf']['content'] == 'streamed update'
+    assert messages['leaf']['done'] is True
+    assert messages['leaf']['partial'] == {'kept': True}
+    assert messages['branch']['parentId'] == 'root'
+    assert messages['branch']['role'] == 'assistant'
+
+    full = await Chats.upsert_message_to_chat_by_id_and_message_id(
+        'chat',
+        'branch',
+        {'content': 'final branch'},
+        include_messages=True,
+    )
+    assert full.chat['history']['messages']['branch']['content'] == 'final branch'
+    assert full.chat['history']['messages']['root']['arbitrary'] == {'kept': True}
+
+
+@pytest.mark.asyncio
+async def test_updating_an_existing_ancestor_does_not_change_the_active_branch(session_factory):
+    async with session_factory() as session:
+        await insert_chat(session)
+        await Chats.get_chat_by_id('chat', db=session, include_messages=False)
+
+        updated = await Chats.upsert_message_to_chat_by_id_and_message_id(
+            'chat',
+            'root',
+            {'status': {'done': True}},
+        )
+
+    assert updated.chat['history']['currentId'] == 'leaf'
+
+
+@pytest.mark.asyncio
+async def test_window_repairs_invalid_normalized_current_id(session_factory):
+    async with session_factory() as session:
+        await insert_chat(session)
+        compact = await Chats.get_chat_by_id('chat', db=session, include_messages=False)
+        row = await session.get(Chat, 'chat')
+        row.chat = {
+            **row.chat,
+            'history': {**row.chat['history'], 'currentId': 'missing'},
+        }
+        await session.commit()
+        await session.refresh(row)
+        compact = compact.model_copy(update={'chat': row.chat})
+
+        window = await Chats.get_chat_window(compact, limit=1, db=session)
+        await session.refresh(row)
+
+    assert window.chat['history']['currentId'] == 'leaf'
+    assert row.chat['history']['currentId'] == 'leaf'
+
+
+@pytest.mark.asyncio
+async def test_single_message_patch_preserves_topology_and_updates_only_message_data(session_factory):
+    async with session_factory() as session:
+        await insert_chat(session)
+        await Chats.get_chat_by_id('chat', db=session, include_messages=False)
+
+        updated = await Chats.patch_message_by_chat_id_and_message_id(
+            'chat',
+            'leaf',
+            {
+                'id': 'wrong-id',
+                'parentId': None,
+                'childrenIds': ['wrong-child'],
+                'role': 'user',
+                'timestamp': 999,
+                '__loaded': True,
+                'content': 'edited leaf',
+                'annotation': {'rating': 1},
+                'feedbackId': 'feedback-id',
+            },
+            db=session,
+        )
+        chat = await Chats.get_chat_by_id('chat', db=session, include_messages=False)
+        messages = await ChatMessages.get_message_data_map_by_chat_id('chat', db=session)
+
+    assert updated['id'] == 'leaf'
+    assert updated['parentId'] == 'root'
+    assert updated['childrenIds'] == []
+    assert updated['role'] == 'assistant'
+    assert updated['timestamp'] == 2
+    assert updated['content'] == 'edited leaf'
+    assert updated['annotation'] == {'rating': 1}
+    assert updated['feedbackId'] == 'feedback-id'
+    assert chat.chat['history']['currentId'] == 'leaf'
+    assert 'messages' not in chat.chat['history']
+    assert messages['root']['content'] == 'root'
+
+
+@pytest.mark.asyncio
+async def test_message_file_and_status_appends_handle_null_storage_without_hydrating_chat(session_factory):
+    async with session_factory() as session:
+        await insert_chat(session)
+        await Chats.get_chat_by_id('chat', db=session, include_messages=False)
+
+    await Chats.patch_message_by_chat_id_and_message_id('chat', 'leaf', {'files': None})
+    files = await Chats.add_message_files_by_id_and_message_id(
+        'chat',
+        'leaf',
+        [{'id': 'file-id', 'type': 'file'}],
+    )
+    files = await Chats.add_message_files_by_id_and_message_id(
+        'chat',
+        'leaf',
+        [{'id': 'file-id', 'type': 'file'}],
+    )
+    compact = await Chats.add_message_status_to_chat_by_id_and_message_id(
+        'chat',
+        'leaf',
+        {'done': True, 'description': 'complete'},
+    )
+    message = await Chats.get_message_by_id_and_message_id('chat', 'leaf')
+
+    assert files == [{'id': 'file-id', 'type': 'file'}]
+    assert message['files'] == files
+    assert message['statusHistory'] == [{'done': True, 'description': 'complete'}]
+    assert compact.chat['history']['currentId'] == 'leaf'
+    assert 'messages' not in compact.chat['history']
+
+
+@pytest.mark.asyncio
+async def test_explicit_delete_updates_chat_and_message_rows_together(session_factory):
+    async with session_factory() as session:
+        await insert_chat(session)
+        await Chats.get_chat_by_id('chat', db=session, include_messages=False)
+
+        updated = await Chats.delete_message_from_chat_by_id_and_message_id('chat', 'leaf')
+        messages = await ChatMessages.get_message_data_map_by_chat_id('chat', db=session)
+
+    assert set(messages) == {'root'}
+    assert updated.chat['history']['currentId'] == 'root'
+    assert updated.current_message_id == 'root'
+    assert updated.chat['history']['messages']['root']['childrenIds'] == []
+
+
+@pytest.mark.asyncio
+async def test_compact_delete_reparents_grandchildren_without_hydrating_all_messages(session_factory):
+    branched = legacy_chat()
+    branched['history'] = {
+        'currentId': 'grandchild',
+        'messages': {
+            'root': {
+                'id': 'root',
+                'parentId': None,
+                'childrenIds': ['target', 'sibling'],
+                'role': 'user',
+                'content': 'root',
+                'timestamp': 1,
+            },
+            'target': {
+                'id': 'target',
+                'parentId': 'root',
+                'childrenIds': ['child'],
+                'role': 'assistant',
+                'content': 'target',
+                'timestamp': 2,
+            },
+            'child': {
+                'id': 'child',
+                'parentId': 'target',
+                'childrenIds': ['grandchild'],
+                'role': 'user',
+                'content': 'child',
+                'timestamp': 3,
+            },
+            'grandchild': {
+                'id': 'grandchild',
+                'parentId': 'child',
+                'childrenIds': [],
+                'role': 'assistant',
+                'content': 'grandchild',
+                'timestamp': 4,
+            },
+            'sibling': {
+                'id': 'sibling',
+                'parentId': 'root',
+                'childrenIds': [],
+                'role': 'assistant',
+                'content': 'sibling',
+                'timestamp': 5,
+            },
+        },
+    }
+
+    async with session_factory() as session:
+        await insert_chat(session)
+        row = await session.get(Chat, 'chat')
+        row.chat = branched
+        await session.commit()
+
+        updated = await Chats.delete_message_from_chat_by_id_and_message_id(
+            'chat',
+            'target',
+            include_messages=False,
+            db=session,
+        )
+        messages = await ChatMessages.get_message_data_map_by_chat_id('chat', db=session)
+
+    assert 'messages' not in updated.chat['history']
+    assert updated.chat['history']['currentId'] == 'grandchild'
+    assert set(messages) == {'root', 'grandchild', 'sibling'}
+    assert messages['root']['childrenIds'] == ['sibling', 'grandchild']
+    assert messages['grandchild']['parentId'] == 'root'
+    assert messages['grandchild']['content'] == 'grandchild'
+
+
+@pytest.mark.asyncio
+async def test_empty_legacy_snapshot_removes_stale_normalized_rows(session_factory):
+    async with session_factory() as session:
+        await insert_chat(session)
+        row = await session.get(Chat, 'chat')
+        row.chat = {'title': 'Empty', 'history': {'currentId': None, 'messages': {}}}
+        await session.commit()
+        await ChatMessages.bulk_upsert_messages(
+            'chat',
+            'user',
+            {
+                'stale': {
+                    'id': 'stale',
+                    'parentId': None,
+                    'childrenIds': [],
+                    'role': 'user',
+                    'content': 'stale',
+                    'timestamp': 1,
+                }
+            },
+            db=session,
+        )
+
+        compact = await Chats.get_chat_by_id('chat', db=session, include_messages=False)
+        messages = await ChatMessages.get_message_data_map_by_chat_id('chat', db=session)
+
+    assert messages == {}
+    assert 'messages' not in compact.chat['history']
+
+
+@pytest.mark.asyncio
+async def test_shared_snapshot_rehydrates_compacted_chat(session_factory):
+    async with session_factory() as session:
+        await insert_chat(session)
+        compact = await Chats.get_chat_by_id('chat', db=session, include_messages=False)
+        assert 'messages' not in compact.chat['history']
+
+        shared = await SharedChats.create('chat', 'user', db=session)
+
+    assert shared.chat['history']['messages']['root']['content'] == 'root'
+    assert shared.chat['history']['messages']['leaf']['content'] == 'leaf'
+    assert shared.chat['messages'][-1]['id'] == 'leaf'
+
+
+@pytest.mark.asyncio
+async def test_import_writes_messages_under_new_chat_id(session_factory):
+    async with session_factory() as session:
+        await insert_chat(session)
+        full = await Chats.get_chat_by_id('chat', db=session, include_messages=True)
+        imported = await Chats.import_chats(
+            'user',
+            [ChatImportForm(chat={**full.chat, 'title': 'Imported'})],
+            db=session,
+        )
+        imported_messages = await ChatMessages.get_message_data_map_by_chat_id(
+            imported[0].id,
+            db=session,
+        )
+
+    assert imported[0].id != 'chat'
+    assert imported[0].chat['history']['messages']['root']['arbitrary'] == {'kept': True}
+    assert set(imported_messages) == {'root', 'leaf'}
+
+
+@pytest.mark.asyncio
+async def test_normalization_failure_retains_legacy_window(session_factory, monkeypatch):
+    async with session_factory() as session:
+        await insert_chat(session)
+
+        async def fail_replace(*args, **kwargs):
+            raise RuntimeError('injected failure')
+
+        monkeypatch.setattr(ChatMessages, 'replace_messages_in_session', fail_replace)
+        chat = await Chats.get_chat_by_id('chat', db=session, include_messages=False)
+        window = await Chats.get_chat_window(chat, limit=1, db=session)
+        persisted = await session.get(Chat, 'chat')
+
+    assert 'messages' in persisted.chat['history']
+    assert window.chat['history']['messages']['root']['__loaded'] is False
+    assert window.chat['history']['messages']['leaf']['content'] == 'leaf'

--- a/backend/tests/test_context_compaction.py
+++ b/backend/tests/test_context_compaction.py
@@ -1,0 +1,107 @@
+import os
+import tempfile
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+os.environ.setdefault('WEBUI_SECRET_KEY', 'context-compaction-tests-only-secret-key')
+os.environ.setdefault('STATIC_DIR', os.path.join(tempfile.gettempdir(), 'open-webui-test-static'))
+
+import pytest
+
+import open_webui.utils.context_compaction as context_compaction
+
+
+@pytest.mark.asyncio
+async def test_compaction_preserves_original_system_messages(monkeypatch):
+    generate_summary = AsyncMock(return_value='summary')
+    monkeypatch.setattr(
+        context_compaction,
+        '_load_config',
+        AsyncMock(
+            return_value={
+                'enable': True,
+                'token_threshold': 1,
+                'token_cap': 1,
+                'prompt_template': '',
+            }
+        ),
+    )
+    monkeypatch.setattr(context_compaction, '_generate_summary', generate_summary)
+
+    messages = [
+        {'role': 'system', 'content': 'Never lose this persona.'},
+        {'id': 'u1', 'role': 'user', 'content': 'one'},
+        {'id': 'a1', 'role': 'assistant', 'content': 'two'},
+        {'id': 'u2', 'role': 'user', 'content': 'three'},
+        {'id': 'a2', 'role': 'assistant', 'content': 'four'},
+    ]
+
+    compacted, summary, changed = await context_compaction.compact_messages_for_request(
+        request=object(),
+        user=object(),
+        messages=messages,
+        metadata={'params': {}},
+        model_id='model',
+        models={'model': {}},
+        system_prompt='Never lose this persona.',
+    )
+
+    assert changed is True
+    assert summary == 'summary'
+    assert compacted[0] == messages[0]
+    assert [message['id'] for message in compacted[1:]] == ['u2', 'a2']
+    summary_args = generate_summary.await_args.args
+    assert all(message.get('role') != 'system' for message in summary_args[4])
+
+
+@pytest.mark.asyncio
+async def test_window_context_usage_does_not_reload_full_branch(monkeypatch):
+    monkeypatch.setattr(
+        context_compaction,
+        '_load_config',
+        AsyncMock(
+            return_value={
+                'enable': True,
+                'token_threshold': 1000,
+                'token_cap': 1000,
+                'prompt_template': '',
+            }
+        ),
+    )
+    branch_loader = AsyncMock(side_effect=AssertionError('full branch should not load'))
+    monkeypatch.setattr(
+        context_compaction.ChatMessages,
+        'get_message_branch_by_chat_id',
+        branch_loader,
+    )
+    chat = SimpleNamespace(
+        id='chat',
+        chat={
+            'history': {
+                'currentId': 'assistant',
+                'messageWindow': {'hasMore': True},
+                'messages': {
+                    'root': {
+                        'id': 'root',
+                        'parentId': None,
+                        'childrenIds': ['assistant'],
+                        'role': 'user',
+                        '__loaded': False,
+                    },
+                    'assistant': {
+                        'id': 'assistant',
+                        'parentId': 'root',
+                        'childrenIds': [],
+                        'role': 'assistant',
+                        '__loaded': True,
+                        'lastRequestUsage': {'input_tokens': 120, 'output_tokens': 30},
+                    },
+                },
+            }
+        },
+    )
+
+    usage = await context_compaction.get_chat_context_usage(chat)
+
+    assert usage['tokens'] == 150
+    branch_loader.assert_not_awaited()

--- a/backend/tests/test_message_output_context.py
+++ b/backend/tests/test_message_output_context.py
@@ -1,0 +1,47 @@
+import os
+
+os.environ.setdefault('WEBUI_SECRET_KEY', 'message-output-context-tests-only-secret-key')
+
+from open_webui.utils.misc import expand_messages_with_output
+
+
+def test_expand_messages_with_output_preserves_tool_result_and_final_text():
+    messages = [
+        {'role': 'user', 'content': 'Look this up'},
+        {
+            'role': 'assistant',
+            'content': '',
+            'output': [
+                {
+                    'type': 'function_call',
+                    'call_id': 'call-1',
+                    'name': 'search',
+                    'arguments': {'query': 'answer'},
+                },
+                {
+                    'type': 'function_call_output',
+                    'call_id': 'call-1',
+                    'output': [{'type': 'input_text', 'text': 'tool result'}],
+                },
+                {
+                    'type': 'message',
+                    'content': [{'type': 'output_text', 'text': 'final answer'}],
+                },
+            ],
+        },
+    ]
+
+    expanded = expand_messages_with_output(messages)
+
+    assert [message['role'] for message in expanded] == ['user', 'assistant', 'tool', 'assistant']
+    assert expanded[1]['tool_calls'][0]['function']['arguments'] == '{"query": "answer"}'
+    assert expanded[2]['content'] == 'tool result'
+    assert expanded[3]['content'] == 'final answer'
+    assert all('output' not in message for message in expanded)
+
+
+def test_expand_messages_with_output_keeps_plain_message_without_output_field():
+    original = {'role': 'assistant', 'content': 'plain', 'output': []}
+
+    assert expand_messages_with_output([original]) == [{'role': 'assistant', 'content': 'plain'}]
+    assert 'output' in original

--- a/backend/tests/test_middleware_message_files.py
+++ b/backend/tests/test_middleware_message_files.py
@@ -1,0 +1,41 @@
+from open_webui.utils.chat_history import inline_message_images_from_files
+
+
+def test_inline_message_images_accepts_null_files():
+    messages = [
+        {'role': 'system', 'content': 'system'},
+        {'role': 'user', 'content': 'hello', 'files': None},
+        {'role': 'assistant', 'content': 'hi', 'files': None},
+    ]
+
+    assert inline_message_images_from_files(messages) == [
+        {'role': 'system', 'content': 'system'},
+        {'role': 'user', 'content': 'hello'},
+        {'role': 'assistant', 'content': 'hi'},
+    ]
+
+
+def test_inline_message_images_preserves_text_and_image_urls():
+    messages = [
+        {
+            'role': 'user',
+            'content': 'describe this',
+            'files': [
+                {'type': 'image', 'url': 'data:image/png;base64,abc'},
+                {'type': 'file', 'content_type': 'text/plain', 'url': '/files/note'},
+            ],
+        }
+    ]
+
+    assert inline_message_images_from_files(messages) == [
+        {
+            'role': 'user',
+            'content': [
+                {'type': 'text', 'text': 'describe this'},
+                {
+                    'type': 'image_url',
+                    'image_url': {'url': 'data:image/png;base64,abc'},
+                },
+            ],
+        }
+    ]

--- a/src/lib/apis/chats/index.test.ts
+++ b/src/lib/apis/chats/index.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+	deleteChatMessageById,
+	getChatByIdWindow,
+	getChatHistoryWindow,
+	updateChatByIdWindow,
+	updateChatMessageById
+} from './index';
+
+const jsonResponse = (body: unknown) =>
+	Promise.resolve({
+		ok: true,
+		json: () => Promise.resolve(body)
+	} as Response);
+
+describe('windowed chat APIs', () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('loads the initial chat window with a limit', async () => {
+		const fetchMock = vi.fn(() => jsonResponse({ id: 'chat-id' }));
+		vi.stubGlobal('fetch', fetchMock);
+
+		await getChatByIdWindow('token', 'chat-id');
+
+		expect(fetchMock).toHaveBeenCalledOnce();
+		const [url, init] = fetchMock.mock.calls[0];
+		expect(url).toContain('/chats/chat-id/window?limit=32');
+		expect(init).toMatchObject({ method: 'GET' });
+		expect(init.headers.authorization).toBe('Bearer token');
+	});
+
+	it('anchors a chat window to a requested message', async () => {
+		const fetchMock = vi.fn(() => jsonResponse({ id: 'chat-id' }));
+		vi.stubGlobal('fetch', fetchMock);
+
+		await getChatByIdWindow('token', 'chat-id', 24, 'rated-message');
+
+		const [url] = fetchMock.mock.calls[0];
+		expect(url).toContain('limit=24');
+		expect(url).toContain('current_id=rated-message');
+	});
+
+	it('loads a history window and conditionally includes before_id', async () => {
+		const fetchMock = vi.fn(() =>
+			jsonResponse({ messages: {}, loadedIds: [], hasMore: false, currentId: 'current' })
+		);
+		vi.stubGlobal('fetch', fetchMock);
+
+		await getChatHistoryWindow('token', 'chat-id', 'current', 16, 'before');
+
+		const [url] = fetchMock.mock.calls[0];
+		expect(url).toContain('/chats/chat-id/history/window?');
+		expect(url).toContain('current_id=current');
+		expect(url).toContain('limit=16');
+		expect(url).toContain('before_id=before');
+	});
+
+	it('posts the chat payload to the windowed update endpoint', async () => {
+		const fetchMock = vi.fn(() => jsonResponse({ id: 'chat-id' }));
+		vi.stubGlobal('fetch', fetchMock);
+		const chat = { history: { currentId: 'message-id' } };
+
+		await updateChatByIdWindow('token', 'chat-id', chat);
+
+		const [url, init] = fetchMock.mock.calls[0];
+		expect(url).toContain('/chats/chat-id/window');
+		expect(init).toMatchObject({ method: 'POST' });
+		expect(JSON.parse(init.body)).toEqual({ chat });
+	});
+
+	it('patches one message without posting the chat window', async () => {
+		const fetchMock = vi.fn(() => jsonResponse({ id: 'message-id', content: 'edited' }));
+		vi.stubGlobal('fetch', fetchMock);
+		const message = { content: 'edited', annotation: { rating: 1 } };
+
+		await updateChatMessageById('token', 'chat-id', 'message-id', message);
+
+		const [url, init] = fetchMock.mock.calls[0];
+		expect(url).toContain('/chats/chat-id/messages/message-id');
+		expect(init).toMatchObject({ method: 'PATCH' });
+		expect(JSON.parse(init.body)).toEqual({ message });
+	});
+
+	it('requests a compact response when deleting a message', async () => {
+		const fetchMock = vi.fn(() => jsonResponse({ id: 'chat-id' }));
+		vi.stubGlobal('fetch', fetchMock);
+
+		await deleteChatMessageById('token', 'chat-id', 'message-id');
+
+		const [url, init] = fetchMock.mock.calls[0];
+		expect(url).toContain('/chats/chat-id/messages/message-id?compact=true');
+		expect(init).toMatchObject({ method: 'DELETE' });
+	});
+});

--- a/src/lib/apis/chats/index.ts
+++ b/src/lib/apis/chats/index.ts
@@ -1,5 +1,9 @@
 import { WEBUI_API_BASE_URL } from '$lib/constants';
 import { getTimeRange } from '$lib/utils';
+import {
+	DEFAULT_CHAT_MESSAGE_WINDOW,
+	type ChatHistoryWindowResponse
+} from '$lib/utils/chatHistoryWindow';
 
 export const getChatConfig = async (token: string) => {
 	let error = null;
@@ -777,6 +781,87 @@ export const getChatById = async (token: string, id: string) => {
 	return res;
 };
 
+export const getChatByIdWindow = async (
+	token: string,
+	id: string,
+	limit: number = DEFAULT_CHAT_MESSAGE_WINDOW,
+	currentId?: string
+) => {
+	let error = null;
+	const searchParams = new URLSearchParams();
+	searchParams.set('limit', `${limit}`);
+	if (currentId) {
+		searchParams.set('current_id', currentId);
+	}
+
+	const res = await fetch(`${WEBUI_API_BASE_URL}/chats/${id}/window?${searchParams.toString()}`, {
+		method: 'GET',
+		headers: {
+			Accept: 'application/json',
+			'Content-Type': 'application/json',
+			...(token && { authorization: `Bearer ${token}` })
+		}
+	})
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			error = err?.detail ?? err;
+			console.error(err);
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
+
+	return res;
+};
+
+export const getChatHistoryWindow = async (
+	token: string,
+	id: string,
+	currentId: string,
+	limit: number = DEFAULT_CHAT_MESSAGE_WINDOW,
+	beforeId?: string
+): Promise<ChatHistoryWindowResponse> => {
+	let error = null;
+	const searchParams = new URLSearchParams();
+	searchParams.set('current_id', currentId);
+	searchParams.set('limit', `${limit}`);
+	if (beforeId) {
+		searchParams.set('before_id', beforeId);
+	}
+
+	const res = await fetch(
+		`${WEBUI_API_BASE_URL}/chats/${id}/history/window?${searchParams.toString()}`,
+		{
+			method: 'GET',
+			headers: {
+				Accept: 'application/json',
+				'Content-Type': 'application/json',
+				...(token && { authorization: `Bearer ${token}` })
+			}
+		}
+	)
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			error = err?.detail ?? err;
+			console.error(err);
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
+
+	return res;
+};
+
 export const getChatByShareId = async (token: string, share_id: string) => {
 	let error = null;
 
@@ -1300,6 +1385,37 @@ export const updateChatById = async (
 	return res;
 };
 
+export const updateChatByIdWindow = async (token: string, id: string, chat: object) => {
+	let error = null;
+
+	const res = await fetch(`${WEBUI_API_BASE_URL}/chats/${id}/window`, {
+		method: 'POST',
+		headers: {
+			Accept: 'application/json',
+			'Content-Type': 'application/json',
+			...(token && { authorization: `Bearer ${token}` })
+		},
+		body: JSON.stringify({
+			chat
+		})
+	})
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			error = err?.detail ?? err;
+			console.error(err);
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
+
+	return res;
+};
+
 export const compactChatById = async (token: string, id: string, model?: string | null) => {
 	let error = null;
 
@@ -1333,10 +1449,44 @@ export const compactChatById = async (token: string, id: string, model?: string 
 	return res;
 };
 
-export const deleteChatMessageById = async (token: string, id: string, messageId: string) => {
+export const updateChatMessageById = async (
+	token: string,
+	id: string,
+	messageId: string,
+	message: object
+) => {
 	let error = null;
 
 	const res = await fetch(`${WEBUI_API_BASE_URL}/chats/${id}/messages/${messageId}`, {
+		method: 'PATCH',
+		headers: {
+			Accept: 'application/json',
+			'Content-Type': 'application/json',
+			...(token && { authorization: `Bearer ${token}` })
+		},
+		body: JSON.stringify({ message })
+	})
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			error = err?.detail ?? err;
+			console.error(err);
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
+
+	return res;
+};
+
+export const deleteChatMessageById = async (token: string, id: string, messageId: string) => {
+	let error = null;
+
+	const res = await fetch(`${WEBUI_API_BASE_URL}/chats/${id}/messages/${messageId}?compact=true`, {
 		method: 'DELETE',
 		headers: {
 			Accept: 'application/json',

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -76,11 +76,20 @@
 		deleteChatById,
 		forkChatById,
 		getAllTags,
-		getChatById,
+		getChatByIdWindow,
+		getChatHistoryWindow,
 		getTagsById,
-		updateChatById,
+		updateChatByIdWindow,
 		updateChatFolderIdById
 	} from '$lib/apis/chats';
+	import {
+		DEFAULT_CHAT_MESSAGE_WINDOW,
+		isChatMessageLoaded,
+		mergeChatMessageEvent,
+		mergeChatHistoryWindow,
+		resolveLoadedCurrentMessageId,
+		serializeChatForWindowSave
+	} from '$lib/utils/chatHistoryWindow';
 	import { generateOpenAIChatCompletion } from '$lib/apis/openai';
 	import { processWeb, processWebSearch, processYoutubeVideo } from '$lib/apis/retrieval';
 	import { getAndUpdateUserLocation, getUserSettings } from '$lib/apis/users';
@@ -121,6 +130,17 @@
 	import EmbeddedChatHistoryDropdown from './EmbeddedChatHistoryDropdown.svelte';
 	import InputVariablesModal from './MessageInput/InputVariablesModal.svelte';
 
+	type ChatHistoryState = {
+		currentId: string | null;
+		messages: Record<string, any>;
+		messageWindow?: {
+			loadedIds?: string[];
+			hasMore?: boolean;
+			[key: string]: unknown;
+		};
+		[key: string]: unknown;
+	};
+
 	export let chatIdProp = '';
 	export let embedded = false;
 	export let embeddedTitle = '';
@@ -138,6 +158,84 @@
 		null;
 
 	let loading = true;
+	let chatDestroyed = false;
+	let loadChatGeneration = 0;
+	const historyWindowRequests = new Map<string, Promise<boolean>>();
+	let showMessageNavigationGeneration = 0;
+	onDestroy(() => {
+		chatDestroyed = true;
+		loadChatGeneration += 1;
+		showMessageNavigationGeneration += 1;
+		historyWindowRequests.clear();
+	});
+
+	const getWindowSavePayload = (payload: any) => {
+		const serialized = serializeChatForWindowSave(payload);
+
+		if (serialized.history && Array.isArray(serialized.messages)) {
+			const loadedMessageIds = new Set(Object.keys(serialized.history.messages ?? {}));
+			serialized.messages = serialized.messages.filter(
+				(message: any) => !message?.id || loadedMessageIds.has(message.id)
+			);
+		}
+
+		return serialized;
+	};
+
+	const updateChatWindow = async (id: string, payload: any) =>
+		await updateChatByIdWindow(localStorage.token, id, getWindowSavePayload(payload));
+
+	const hydrateBranchWindow = async (messageId: string, navigationGeneration: number) => {
+		if (
+			!messageId ||
+			!history?.messageWindow ||
+			$temporaryChatEnabled ||
+			!$chatId ||
+			$chatId.startsWith('local:')
+		) {
+			return true;
+		}
+
+		const requestChatId = $chatId;
+		const requestKey = `${navigationGeneration}:${requestChatId}:${messageId}`;
+		const pendingRequest = historyWindowRequests.get(requestKey);
+		if (pendingRequest) return await pendingRequest;
+
+		const request = (async () => {
+			try {
+				const window = await getChatHistoryWindow(
+					localStorage.token,
+					requestChatId,
+					messageId,
+					DEFAULT_CHAT_MESSAGE_WINDOW
+				);
+				if (
+					!window ||
+					chatDestroyed ||
+					$chatId !== requestChatId ||
+					navigationGeneration !== showMessageNavigationGeneration
+				) {
+					return false;
+				}
+
+				const activeCurrentId = history.currentId;
+				const mergedHistory = mergeChatHistoryWindow(history, window) as ChatHistoryState;
+				mergedHistory.currentId = activeCurrentId;
+				history = mergedHistory;
+				return true;
+			} catch (error) {
+				console.error('Failed to load chat history branch', error);
+				toast.error($i18n.t('Failed to load chat'));
+				return false;
+			} finally {
+				historyWindowRequests.delete(requestKey);
+			}
+		})();
+
+		historyWindowRequests.set(requestKey, request);
+		return await request;
+	};
+
 	$: chatContainerId = embedded ? 'note-chat-container' : 'chat-container';
 	$: messageInputDropzoneId = embedded ? 'note-chat-input-dropzone' : 'chat-pane';
 
@@ -375,7 +473,7 @@
 
 	let chatTasks = [];
 
-	let history = {
+	let history: ChatHistoryState = {
 		messages: {},
 		currentId: null
 	};
@@ -853,6 +951,7 @@
 	};
 
 	const showMessage = async (message, scroll = true, save = true) => {
+		const navigationGeneration = ++showMessageNavigationGeneration;
 		const _chatId = JSON.parse(JSON.stringify($chatId));
 		let _messageId = JSON.parse(JSON.stringify(message.id));
 
@@ -870,6 +969,9 @@
 			messageChildrenIds = history.messages[_messageId].childrenIds;
 		}
 
+		if (_messageId && !(await hydrateBranchWindow(_messageId, navigationGeneration))) return;
+		if (navigationGeneration !== showMessageNavigationGeneration) return;
+
 		history.currentId = _messageId;
 
 		await tick();
@@ -885,8 +987,8 @@
 		await tick();
 		await tick();
 
-		if (save) {
-			saveChatHandler(_chatId, history);
+		if (save && !readOnly) {
+			await saveChatHandler(_chatId, history);
 		}
 	};
 
@@ -997,15 +1099,29 @@
 						message.done = true;
 					}
 				} else if (type === 'chat:message:delta' || type === 'message') {
-					message.content += data.content;
-				} else if (type === 'chat:message' || type === 'replace') {
-					message.content = data.content;
+					message.content = `${message.content ?? ''}${data?.content ?? ''}`;
+				} else if (type === 'chat:message') {
+					message = mergeChatMessageEvent(message, data);
+				} else if (type === 'replace') {
+					message = mergeChatMessageEvent(message, data, true);
 				} else if (type === 'chat:message:files' || type === 'files') {
-					message.files = data.files;
+					const files = data?.files ?? [];
+					message.files = data?.replace
+						? files
+						: [...(message.files ?? []), ...files].filter(
+								(item, index, array) =>
+									array.findIndex((candidate) => equal(candidate, item)) === index
+							);
 				} else if (type === 'chat:message:tasks') {
 					chatTasks = data.tasks;
 				} else if (type === 'chat:message:embeds' || type === 'embeds') {
-					message.embeds = data.embeds;
+					const embeds = data?.embeds ?? [];
+					message.embeds = data?.replace
+						? embeds
+						: [...(message.embeds ?? []), ...embeds].filter(
+								(item, index, array) =>
+									array.findIndex((candidate) => equal(candidate, item)) === index
+							);
 
 					// Auto-scroll to the embed once it's rendered in the DOM
 					await tick();
@@ -1050,7 +1166,7 @@
 					}
 					await refreshChatList(localStorage.token);
 				} else if (type === 'chat:tags') {
-					chat = await getChatById(localStorage.token, $chatId);
+					chat = await getChatByIdWindow(localStorage.token, $chatId, DEFAULT_CHAT_MESSAGE_WINDOW);
 					allTags.set(await getAllTags(localStorage.token));
 				} else if (type === 'source' || type === 'citation') {
 					if (data?.type === 'code_execution') {
@@ -1940,9 +2056,11 @@
 	};
 
 	const loadChat = async () => {
+		const requestGeneration = ++loadChatGeneration;
+		const requestChatId = chatIdProp || $chatId;
 		noteChatDebug('loadChat start');
 		// chatIdProp is empty for chats started from the home page (URL set via replaceState)
-		chatId.set(chatIdProp || $chatId);
+		chatId.set(requestChatId);
 		noteChatDebug('loadChat set active chat id');
 
 		if ($temporaryChatEnabled) {
@@ -1950,18 +2068,26 @@
 			temporaryChatEnabled.set(false);
 		}
 
-		chat = await getChatById(localStorage.token, $chatId).catch(async (error) => {
-			console.error('[note-chat] getChatById failed', {
+		const loadedChat = await getChatByIdWindow(
+			localStorage.token,
+			requestChatId,
+			DEFAULT_CHAT_MESSAGE_WINDOW
+		).catch(async (error) => {
+			console.error('[note-chat] getChatByIdWindow failed', {
 				chatIdProp,
 				activeChatId: $chatId,
 				error
 			});
-			if (!embedded) {
+			if (!embedded && requestGeneration === loadChatGeneration) {
 				await goto('/');
 			}
 			return null;
 		});
-		noteChatDebug('getChatById completed', {
+		if (chatDestroyed || requestGeneration !== loadChatGeneration || $chatId !== requestChatId) {
+			return false;
+		}
+		chat = loadedChat;
+		noteChatDebug('getChatByIdWindow completed', {
 			found: !!chat,
 			chatId: chat?.id,
 			hasChatPayload: !!chat?.chat,
@@ -1969,7 +2095,7 @@
 		});
 
 		if (chat) {
-			tags = await getTagsById(localStorage.token, $chatId).catch(async (error) => {
+			tags = await getTagsById(localStorage.token, requestChatId).catch(async (error) => {
 				console.warn('[note-chat] getTagsById failed; continuing without tags', {
 					chatIdProp,
 					activeChatId: $chatId,
@@ -1977,6 +2103,9 @@
 				});
 				return [];
 			});
+			if (chatDestroyed || requestGeneration !== loadChatGeneration || $chatId !== requestChatId) {
+				return false;
+			}
 			noteChatDebug('getTagsById completed', { tagCount: tags?.length ?? 0 });
 
 			const chatContent = chat.chat;
@@ -2011,9 +2140,7 @@
 					(chatContent?.history ?? undefined) !== undefined
 						? chatContent.history
 						: convertMessagesToHistory(chatContent.messages);
-				if (chat?.current_message_id && history?.messages?.[chat.current_message_id]) {
-					history.currentId = chat.current_message_id;
-				}
+				history.currentId = resolveLoadedCurrentMessageId(history, chat?.current_message_id);
 
 				// Sanitize history: repair orphaned references and structurally-malformed
 				// nodes from failed regenerations (#24424, #24157, #20474)
@@ -2037,6 +2164,7 @@
 					for (const message of Object.values(history.messages)) {
 						if (
 							message &&
+							isChatMessageLoaded(history, message.id) &&
 							message.role === 'assistant' &&
 							message.id !== history.currentId &&
 							message.done !== false
@@ -2051,7 +2179,7 @@
 				// work (follow-ups, title gen) that shouldn't block the input.
 				const activeTaskIds = taskIds;
 				const currentMessage = history.currentId ? history.messages[history.currentId] : null;
-				const pendingTaskIds = await getTaskIdsByChatId(localStorage.token, $chatId)
+				const pendingTaskIds = await getTaskIdsByChatId(localStorage.token, requestChatId)
 					.then((res) => res?.task_ids ?? [])
 					.catch((error) => {
 						console.warn('[note-chat] getTaskIdsByChatId failed; continuing without tasks', {
@@ -2061,6 +2189,13 @@
 						});
 						return [];
 					});
+				if (
+					chatDestroyed ||
+					requestGeneration !== loadChatGeneration ||
+					$chatId !== requestChatId
+				) {
+					return false;
+				}
 				noteChatDebug('task reconciliation completed', {
 					pendingTaskCount: pendingTaskIds.length,
 					hasCurrentMessage: !!currentMessage
@@ -2093,7 +2228,7 @@
 				return null;
 			}
 		}
-		console.warn('[note-chat] no chat returned from getChatById', {
+		console.warn('[note-chat] no chat returned from getChatByIdWindow', {
 			chatIdProp,
 			activeChatId: $chatId
 		});
@@ -2223,7 +2358,7 @@
 
 		if ($chatId == _chatId) {
 			if (!$temporaryChatEnabled) {
-				chat = await updateChatById(localStorage.token, _chatId, {
+				chat = await updateChatWindow(_chatId, {
 					models: selectedModels,
 					messages: messages,
 					history: history,
@@ -2772,14 +2907,14 @@
 
 	const sendMessage = async (
 		_history,
-		parentId: string,
+		parentId: string | null,
 		{
-			messages = null,
+			messagesFromId = null,
 			modelId = null,
 			modelIdx = null,
 			regenerationPrompt = null
 		}: {
-			messages?: any[] | null;
+			messagesFromId?: string | null;
 			modelId?: string | null;
 			modelIdx?: number | null;
 			regenerationPrompt?: string | null;
@@ -2790,7 +2925,9 @@
 		}
 
 		let _chatId = JSON.parse(JSON.stringify($chatId));
-		_history = structuredClone(_history);
+		_history = structuredClone(history);
+		const messages =
+			$temporaryChatEnabled && messagesFromId ? createMessagesList(_history, messagesFromId) : null;
 
 		const responseMessageIds: Record<PropertyKey, string> = {};
 		// If modelId is provided, use it, else use selected model
@@ -2925,7 +3062,8 @@
 						// regenerations in a duplicate-model chat, which would otherwise lose their
 						// column identity and collapse on reload.
 						messageIdsList: messageIdsList.length > 0 ? messageIdsList : undefined,
-						regenerationPrompt
+						regenerationPrompt,
+						regenerationSourceMessageId: regenerationPrompt ? messagesFromId : null
 					}
 				);
 			} finally {
@@ -2980,25 +3118,28 @@
 		{
 			messageIdsList,
 			regenerationPrompt,
+			regenerationSourceMessageId,
 			continueResponse = false
 		}: {
 			messageIdsList?: Array<{ model_id: string; message_id: string }>;
 			regenerationPrompt?: string | null;
+			regenerationSourceMessageId?: string | null;
 			continueResponse?: boolean;
 		} = {}
 	) => {
 		const responseMessage = _history.messages[responseMessageId];
 		const userMessage = _history.messages[responseMessage.parentId];
 
-		const chatMessageFiles = _messages
-			.filter((message) => message.files)
-			.flatMap((message) => message.files);
+		if ($temporaryChatEnabled) {
+			const chatMessageFiles = _messages
+				.filter((message) => message.files)
+				.flatMap((message) => message.files);
 
-		// Filter chatFiles to only include files that are in the chatMessageFiles
-		chatFiles = chatFiles.filter((item) => {
-			const fileExists = chatMessageFiles.some((messageFile) => messageFile.id === item.id);
-			return fileExists;
-		});
+			// Temporary chats have no server-side branch to recover attachment state from.
+			chatFiles = chatFiles.filter((item) =>
+				chatMessageFiles.some((messageFile) => messageFile.id === item.id)
+			);
+		}
 
 		let files = structuredClone(chatFiles);
 		files.push(
@@ -3167,6 +3308,9 @@
 				parent_id: userMessage?.parentId ?? null,
 				user_message: userMessage,
 				...(regenerationPrompt ? { regeneration_prompt: regenerationPrompt } : {}),
+				...(regenerationSourceMessageId
+					? { regeneration_source_message_id: regenerationSourceMessageId }
+					: {}),
 				...(continueResponse ? { assistant_message_id: responseMessageId } : {}),
 
 				background_tasks: {
@@ -3244,7 +3388,7 @@
 						// chat completion request.  Files are now persisted
 						// by the backend at chat creation time.
 						if (Object.keys(params).length > 0) {
-							await updateChatById(localStorage.token, res.chat_id, {
+							await updateChatWindow(res.chat_id, {
 								params: params
 							});
 						}
@@ -3396,7 +3540,7 @@
 			await sendMessage(history, userMessage.id, {
 				...(suggestionPrompt
 					? {
-							messages: createMessagesList(history, message.id),
+							messagesFromId: message.id,
 							regenerationPrompt: suggestionPrompt
 						}
 					: {}),
@@ -3541,7 +3685,7 @@
 	const saveChatHandler = async (_chatId, history) => {
 		if ($chatId == _chatId) {
 			if (!$temporaryChatEnabled) {
-				chat = await updateChatById(localStorage.token, _chatId, {
+				chat = await updateChatWindow(_chatId, {
 					models: selectedModels,
 					history: history,
 					messages: createMessagesList(history, history.currentId),
@@ -3557,7 +3701,7 @@
 		const loaded = chat?.chat ?? {};
 		if (equal(params, loaded.params ?? {}) && equal(chatFiles, loaded.files ?? [])) return;
 
-		const res = await updateChatById(localStorage.token, $chatId, {
+		const res = await updateChatWindow($chatId, {
 			params,
 			files: chatFiles
 		}).catch((err) => {

--- a/src/lib/components/chat/ChatControls.svelte
+++ b/src/lib/components/chat/ChatControls.svelte
@@ -80,6 +80,10 @@
 		(codeInterpreterEnabled && $config?.code?.interpreter_engine !== 'jupyter');
 	$: showOverviewTab = hasMessages;
 
+	const openOverview = () => {
+		activeTab = 'overview';
+	};
+
 	// Tab fallback: if active tab becomes hidden, switch to next available
 	$: if (!showOverviewTab && activeTab === 'overview') activeTab = 'controls';
 	$: if (!showFilesTab && activeTab === 'files') activeTab = 'controls';
@@ -335,7 +339,7 @@
 										'overview'
 											? 'bg-gray-100/40 dark:bg-gray-800/25 font-normal text-gray-700 dark:text-gray-200'
 											: 'text-gray-500 dark:text-gray-400 hover:bg-gray-100/30 dark:hover:bg-gray-800/20 hover:text-gray-600 dark:hover:text-gray-300'}"
-										on:click={() => (activeTab = 'overview')}
+										on:click={openOverview}
 									>
 										{$i18n.t('Overview')}
 									</button>
@@ -479,7 +483,7 @@
 											'overview'
 												? 'bg-gray-100/40 dark:bg-gray-800/25 font-normal text-gray-700 dark:text-gray-200'
 												: 'text-gray-500 dark:text-gray-400 hover:bg-gray-100/30 dark:hover:bg-gray-800/20 hover:text-gray-600 dark:hover:text-gray-300'}"
-											on:click={() => (activeTab = 'overview')}
+											on:click={openOverview}
 										>
 											{$i18n.t('Overview')}
 										</button>

--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -56,7 +56,7 @@
 	import { uploadFile } from '$lib/apis/files';
 	import { generateAutoCompletion } from '$lib/apis';
 	import { deleteFileById } from '$lib/apis/files';
-	import { getChatById } from '$lib/apis/chats';
+	import { getChatByIdWindow } from '$lib/apis/chats';
 	import { getFolderById } from '$lib/apis/folders';
 	import { getNoteById } from '$lib/apis/notes';
 	import { getSessionUser } from '$lib/apis/auths';
@@ -1022,7 +1022,7 @@
 				const data = JSON.parse(textData);
 				if (data.type === 'chat' && data.id) {
 					// Fetch the chat to get its title, then add as a reference chat
-					const chat = await getChatById(localStorage.token, data.id);
+					const chat = await getChatByIdWindow(localStorage.token, data.id, 1);
 					if (chat) {
 						const chatItem = {
 							type: 'chat',

--- a/src/lib/components/chat/Messages.svelte
+++ b/src/lib/components/chat/Messages.svelte
@@ -6,8 +6,20 @@
 	const dispatch = createEventDispatcher();
 
 	import { toast } from 'svelte-sonner';
-	import { deleteChatMessageById, updateChatById } from '$lib/apis/chats';
+	import {
+		deleteChatMessageById,
+		getChatHistoryWindow,
+		updateChatByIdWindow,
+		updateChatMessageById
+	} from '$lib/apis/chats';
 	import { copyToClipboard, extractCurlyBraceWords } from '$lib/utils';
+	import {
+		createMessagePatch,
+		DEFAULT_CHAT_MESSAGE_WINDOW,
+		isChatMessageLoaded,
+		mergeChatHistoryWindow,
+		serializeChatForWindowSave
+	} from '$lib/utils/chatHistoryWindow';
 
 	import Message from './Messages/Message.svelte';
 	import Loader from '../common/Loader.svelte';
@@ -15,7 +27,18 @@
 
 	import ChatPlaceholder from './ChatPlaceholder.svelte';
 
-	const i18n = getContext('i18n');
+	const i18n: any = getContext('i18n');
+
+	type ChatHistoryState = {
+		currentId: string | null;
+		messages: Record<string, any>;
+		messageWindow?: {
+			loadedIds?: string[];
+			hasMore?: boolean;
+			[key: string]: unknown;
+		};
+		[key: string]: unknown;
+	};
 
 	export let className = 'h-full flex pt-18';
 
@@ -23,11 +46,11 @@
 	export let user = $_user;
 
 	export let prompt;
-	export let history = {};
+	export let history: ChatHistoryState = { messages: {}, currentId: null };
 	export let selectedModels;
 	export let atSelectedModel;
 
-	let messages = [];
+	let messages: any[] = [];
 
 	export let setInputText: Function = () => {};
 
@@ -49,45 +72,199 @@
 
 	export let topPadding = false;
 	export let bottomPadding = false;
-	export let autoScroll;
+	export let autoScroll: boolean;
 	export let messagesContainerId = 'messages-container';
 
-	export let onSelect = (e) => {};
+	export let onSelect = (e: any) => {};
 	export let onInsertToNote: ((content: string) => void) | null = null;
 
 	export let messagesCount: number | null = 8;
 	let messagesLoading = false;
+	let destroyed = false;
+	const historyWindowRequests = new Map<string, Promise<boolean>>();
+	const branchHasMoreByCurrentId = new Map<string, boolean>();
+	let pendingRebuild: number | null = null;
+	let lastCurrentId: string | null = null;
+	let branchNavigationGeneration = 0;
+	let historyGeneration = 0;
+	let observedHistory = history;
+	let observedChatId = chatId;
 
 	const getMessagesContainer = () => document.getElementById(messagesContainerId);
 
-	onDestroy(() => {
-		cancelAnimationFrame(pendingRebuild);
-	});
-
-	const loadMoreMessages = async () => {
-		// scroll slightly down to disable continuous loading
-		const element = getMessagesContainer();
-		if (element) {
-			element.scrollTop = element.scrollTop + 100;
-		}
-
-		messagesLoading = true;
-		messagesCount += 8;
-
-		buildMessages();
-
-		await tick();
-
+	const resetLazyPaginationState = () => {
+		messagesCount = 8;
 		messagesLoading = false;
+		branchNavigationGeneration += 1;
+		historyGeneration += 1;
+		historyWindowRequests.clear();
+		branchHasMoreByCurrentId.clear();
+		lastCurrentId = null;
+		if (pendingRebuild !== null) cancelAnimationFrame(pendingRebuild);
+		pendingRebuild = null;
 	};
 
-	let pendingRebuild = null;
-	let lastCurrentId = null;
+	const setMergedHistory = (nextHistory: ChatHistoryState) => {
+		observedHistory = nextHistory;
+		history = nextHistory;
+	};
+
+	const replaceHistory = (nextHistory: ChatHistoryState) => {
+		resetLazyPaginationState();
+		observedHistory = nextHistory;
+		observedChatId = chatId;
+		history = nextHistory;
+	};
+
+	const observeHistoryReplacement = (nextHistory: ChatHistoryState, nextChatId: string) => {
+		if (nextHistory === observedHistory && nextChatId === observedChatId) return;
+
+		resetLazyPaginationState();
+		observedHistory = nextHistory;
+		observedChatId = nextChatId;
+	};
+
+	onDestroy(() => {
+		destroyed = true;
+		branchNavigationGeneration += 1;
+		historyGeneration += 1;
+		historyWindowRequests.clear();
+		branchHasMoreByCurrentId.clear();
+		if (pendingRebuild !== null) cancelAnimationFrame(pendingRebuild);
+	});
+
+	$: observeHistoryReplacement(history, chatId);
+
+	const getBranchLoadState = (currentId = history?.currentId) => {
+		let loadedCount = 0;
+		let earliestLoadedId: string | null = null;
+		let blockedId: string | null = null;
+		let reachedRoot = false;
+		let messageId = currentId;
+		const visited = new Set<string>();
+
+		while (messageId) {
+			if (visited.has(messageId)) {
+				reachedRoot = true;
+				break;
+			}
+			visited.add(messageId);
+
+			const message = history?.messages?.[messageId];
+			if (!message || !isChatMessageLoaded(history, messageId)) {
+				blockedId = messageId;
+				break;
+			}
+
+			loadedCount += 1;
+			earliestLoadedId = messageId;
+			if (message.parentId === null || message.parentId === undefined) {
+				reachedRoot = true;
+				break;
+			}
+			messageId = message.parentId;
+		}
+
+		return { loadedCount, earliestLoadedId, blockedId, reachedRoot };
+	};
+
+	const hydrateHistoryWindow = async (currentId: string, beforeId?: string) => {
+		if (
+			!currentId ||
+			!history?.messageWindow ||
+			$temporaryChatEnabled ||
+			!chatId ||
+			chatId.startsWith('local:')
+		) {
+			return true;
+		}
+
+		const requestChatId = chatId;
+		const requestGeneration = historyGeneration;
+		const requestKey = `${requestGeneration}:${requestChatId}:${currentId}:${beforeId ?? ''}`;
+		const pendingRequest = historyWindowRequests.get(requestKey);
+		if (pendingRequest) return await pendingRequest;
+
+		const request = (async () => {
+			try {
+				const historyWindow = await getChatHistoryWindow(
+					localStorage.token,
+					requestChatId,
+					currentId,
+					DEFAULT_CHAT_MESSAGE_WINDOW,
+					beforeId
+				);
+				if (
+					!historyWindow ||
+					destroyed ||
+					chatId !== requestChatId ||
+					historyGeneration !== requestGeneration
+				) {
+					return false;
+				}
+
+				const activeCurrentId = history.currentId;
+				branchHasMoreByCurrentId.set(currentId, historyWindow.hasMore);
+				const mergedHistory = mergeChatHistoryWindow(history, historyWindow) as ChatHistoryState;
+				mergedHistory.currentId = activeCurrentId;
+				if (currentId !== activeCurrentId && mergedHistory.messageWindow) {
+					mergedHistory.messageWindow.hasMore = history.messageWindow?.hasMore;
+				}
+				setMergedHistory(mergedHistory);
+				return true;
+			} catch (error) {
+				console.error('Failed to load chat history window', error);
+				toast.error($i18n.t('Failed to load chat'));
+				return false;
+			} finally {
+				historyWindowRequests.delete(requestKey);
+			}
+		})();
+
+		historyWindowRequests.set(requestKey, request);
+		return await request;
+	};
+
+	const ensureLoadedAncestors = async (targetCount: number) => {
+		while (true) {
+			const state = getBranchLoadState();
+			if (state.loadedCount >= targetCount || state.reachedRoot) return true;
+			if (!state.earliestLoadedId || history?.messageWindow?.hasMore === false) return false;
+
+			const currentId = history.currentId;
+			if (!currentId) return false;
+			const loaded = await hydrateHistoryWindow(currentId, state.earliestLoadedId);
+			if (!loaded) return false;
+
+			const nextState = getBranchLoadState();
+			if (nextState.loadedCount <= state.loadedCount) return false;
+		}
+	};
+
+	const loadMoreMessages = async () => {
+		if (messagesLoading || messagesCount === null) return;
+
+		// scroll slightly down to disable continuous loading
+		const element = getMessagesContainer();
+		if (element) element.scrollTop += 100;
+
+		messagesLoading = true;
+		try {
+			const nextCount = messagesCount + 8;
+			if (!(await ensureLoadedAncestors(nextCount))) return;
+
+			messagesCount = nextCount;
+			buildMessages();
+			await tick();
+		} finally {
+			messagesLoading = false;
+		}
+	};
 
 	const buildMessages = () => {
 		let _messages = [];
 
-		let message = history.messages[history.currentId];
+		let message = history.currentId ? history.messages[history.currentId] : null;
 		const visitedMessageIds = new Set();
 
 		while (message && (messagesCount !== null ? _messages.length < messagesCount : true)) {
@@ -97,6 +274,7 @@
 			}
 			visitedMessageIds.add(message.id);
 
+			if (!isChatMessageLoaded(history, message.id)) break;
 			_messages.push(message);
 			message = message.parentId !== null ? history.messages[message.parentId] : null;
 		}
@@ -106,7 +284,7 @@
 
 	// Throttle message list rebuilds to once per animation frame during streaming.
 	// Structural changes (currentId change) always rebuild immediately.
-	const handleHistoryChange = (currentId, _messages) => {
+	const handleHistoryChange = (currentId: string | null, _messages: Record<string, any>) => {
 		if (!currentId) {
 			messages = [];
 			return;
@@ -117,7 +295,7 @@
 
 		if (currentIdChanged) {
 			// Structural change: new chat, navigation, new message — rebuild immediately
-			cancelAnimationFrame(pendingRebuild);
+			if (pendingRebuild !== null) cancelAnimationFrame(pendingRebuild);
 			pendingRebuild = null;
 			buildMessages();
 		} else if (_messages) {
@@ -155,14 +333,35 @@
 	};
 
 	export const scrollToTop = async () => {
-		messagesCount = null;
-		buildMessages();
-		await tick();
-		if (messages.length > 0) {
-			const firstMessageEl = document.getElementById(`message-${messages[0].id}`);
-			if (firstMessageEl) {
-				firstMessageEl.scrollIntoView({ behavior: 'smooth', block: 'start' });
+		if (messagesLoading) return;
+
+		messagesLoading = true;
+		try {
+			while (true) {
+				const state = getBranchLoadState();
+				if (state.reachedRoot) break;
+				if (!state.earliestLoadedId || history?.messageWindow?.hasMore === false) return;
+
+				const currentId = history.currentId;
+				if (!currentId) return;
+				const loaded = await hydrateHistoryWindow(currentId, state.earliestLoadedId);
+				if (!loaded) return;
+
+				const nextState = getBranchLoadState();
+				if (nextState.loadedCount <= state.loadedCount) return;
 			}
+
+			messagesCount = null;
+			buildMessages();
+			await tick();
+			if (messages.length > 0) {
+				const firstMessageEl = document.getElementById(`message-${messages[0].id}`);
+				if (firstMessageEl) {
+					firstMessageEl.scrollIntoView({ behavior: 'smooth', block: 'start' });
+				}
+			}
+		} finally {
+			messagesLoading = false;
 		}
 	};
 
@@ -170,181 +369,113 @@
 		if (!$temporaryChatEnabled) {
 			history = history;
 			await tick();
-			const res = await updateChatById(localStorage.token, chatId, {
+			const payload = serializeChatForWindowSave({
 				history: history,
 				messages: messages
 			});
-
-			// Keep local plain-content edits aligned with the saved chat response.
-			if (res?.chat?.history?.messages) {
-				for (const [id, msg] of Object.entries(res.chat.history.messages)) {
-					if (history.messages[id] && (msg as any).content) {
-						history.messages[id].content = (msg as any).content;
-					}
-				}
-				history = history;
-			}
+			await updateChatByIdWindow(localStorage.token, chatId, payload);
 
 			await refreshChatList(localStorage.token);
 		}
 	};
 
-	const gotoMessage = async (message, idx) => {
-		// Determine the correct sibling list (either parent's children or root messages)
-		let siblings;
-		if (message.parentId !== null) {
-			siblings = history.messages[message.parentId].childrenIds;
-		} else {
-			siblings = Object.values(history.messages)
-				.filter((msg) => msg.parentId === null)
-				.map((msg) => msg.id);
+	const getSiblingIds = (message: any): string[] =>
+		message.parentId !== null
+			? (history.messages[message.parentId]?.childrenIds ?? [])
+			: Object.values(history.messages)
+					.filter((candidate) => candidate.parentId === null)
+					.map((candidate) => candidate.id);
+
+	const getDeepestLeafId = (messageId: string) => {
+		const visited = new Set<string>();
+		let leafId = messageId;
+
+		while (leafId && !visited.has(leafId)) {
+			visited.add(leafId);
+			const childrenIds = history.messages[leafId]?.childrenIds ?? [];
+			if (childrenIds.length === 0) break;
+			leafId = childrenIds.at(-1);
 		}
 
-		// Clamp index to a valid range
-		idx = Math.max(0, Math.min(idx, siblings.length - 1));
-
-		let messageId = siblings[idx];
-
-		// If we're navigating to a different message
-		if (message.id !== messageId) {
-			// Drill down to the deepest child of that branch
-			let messageChildrenIds = history.messages[messageId].childrenIds;
-			while (messageChildrenIds.length !== 0) {
-				messageId = messageChildrenIds.at(-1);
-				messageChildrenIds = history.messages[messageId].childrenIds;
-			}
-
-			history.currentId = messageId;
-		}
-
-		await tick();
-
-		// Optional auto-scroll
-		if ($settings?.scrollOnBranchChange ?? true) {
-			const element = getMessagesContainer();
-			autoScroll = element
-				? element.scrollHeight - element.scrollTop <= element.clientHeight + 50
-				: false;
-
-			setTimeout(() => {
-				scrollToBottom();
-			}, 100);
-		}
+		return leafId;
 	};
 
-	const showPreviousMessage = async (message) => {
-		if (message.parentId !== null) {
-			let messageId =
-				history.messages[message.parentId].childrenIds[
-					Math.max(history.messages[message.parentId].childrenIds.indexOf(message.id) - 1, 0)
-				];
-
-			if (message.id !== messageId) {
-				let messageChildrenIds = history.messages[messageId].childrenIds;
-
-				while (messageChildrenIds.length !== 0) {
-					messageId = messageChildrenIds.at(-1);
-					messageChildrenIds = history.messages[messageId].childrenIds;
-				}
-
-				history.currentId = messageId;
-			}
-		} else {
-			let childrenIds = Object.values(history.messages)
-				.filter((message) => message.parentId === null)
-				.map((message) => message.id);
-			let messageId = childrenIds[Math.max(childrenIds.indexOf(message.id) - 1, 0)];
-
-			if (message.id !== messageId) {
-				let messageChildrenIds = history.messages[messageId].childrenIds;
-
-				while (messageChildrenIds.length !== 0) {
-					messageId = messageChildrenIds.at(-1);
-					messageChildrenIds = history.messages[messageId].childrenIds;
-				}
-
-				history.currentId = messageId;
-			}
-		}
-
-		await tick();
-
-		if ($settings?.scrollOnBranchChange ?? true) {
-			const element = getMessagesContainer();
-			autoScroll = element
-				? element.scrollHeight - element.scrollTop <= element.clientHeight + 50
-				: false;
-
-			setTimeout(() => {
-				scrollToBottom();
-			}, 100);
-		}
+	const ensureMessageLoaded = async (messageId: string) => {
+		if (!messageId || isChatMessageLoaded(history, messageId)) return true;
+		return await hydrateHistoryWindow(messageId);
 	};
 
-	const showNextMessage = async (message) => {
-		if (message.parentId !== null) {
-			let messageId =
-				history.messages[message.parentId].childrenIds[
-					Math.min(
-						history.messages[message.parentId].childrenIds.indexOf(message.id) + 1,
-						history.messages[message.parentId].childrenIds.length - 1
-					)
-				];
-
-			if (message.id !== messageId) {
-				let messageChildrenIds = history.messages[messageId].childrenIds;
-
-				while (messageChildrenIds.length !== 0) {
-					messageId = messageChildrenIds.at(-1);
-					messageChildrenIds = history.messages[messageId].childrenIds;
-				}
-
-				history.currentId = messageId;
-			}
-		} else {
-			let childrenIds = Object.values(history.messages)
-				.filter((message) => message.parentId === null)
-				.map((message) => message.id);
-			let messageId =
-				childrenIds[Math.min(childrenIds.indexOf(message.id) + 1, childrenIds.length - 1)];
-
-			if (message.id !== messageId) {
-				let messageChildrenIds = history.messages[messageId].childrenIds;
-
-				while (messageChildrenIds.length !== 0) {
-					messageId = messageChildrenIds.at(-1);
-					messageChildrenIds = history.messages[messageId].childrenIds;
-				}
-
-				history.currentId = messageId;
-			}
-		}
-
+	const scrollAfterBranchChange = async () => {
 		await tick();
+		if (!($settings?.scrollOnBranchChange ?? true)) return;
 
-		if ($settings?.scrollOnBranchChange ?? true) {
-			const element = getMessagesContainer();
-			autoScroll = element
-				? element.scrollHeight - element.scrollTop <= element.clientHeight + 50
-				: false;
-
-			setTimeout(() => {
-				scrollToBottom();
-			}, 100);
+		const element = getMessagesContainer();
+		if (element) {
+			autoScroll = element.scrollHeight - element.scrollTop <= element.clientHeight + 50;
 		}
+
+		setTimeout(() => {
+			scrollToBottom();
+		}, 100);
+	};
+
+	const switchToBranchLeaf = async (messageId: string) => {
+		if (!messageId) return false;
+		const navigationGeneration = ++branchNavigationGeneration;
+		if (messageId === history.currentId) return true;
+		if (!(await ensureMessageLoaded(messageId))) return false;
+		if (navigationGeneration !== branchNavigationGeneration) return false;
+
+		messagesCount = 8;
+		history.currentId = messageId;
+		const targetHasMore = branchHasMoreByCurrentId.get(messageId);
+		if (typeof targetHasMore === 'boolean' && history.messageWindow) {
+			history.messageWindow.hasMore = targetHasMore;
+		}
+		history = history;
+		await scrollAfterBranchChange();
+		return true;
+	};
+
+	const gotoMessage = async (message: any, idx: number) => {
+		const siblings = getSiblingIds(message);
+		if (siblings.length === 0) return;
+
+		const siblingIndex = Math.max(0, Math.min(idx, siblings.length - 1));
+		const leafId = getDeepestLeafId(siblings[siblingIndex]);
+		await switchToBranchLeaf(leafId);
+	};
+
+	const showPreviousMessage = async (message: any) => {
+		const siblings = getSiblingIds(message);
+		if (siblings.length === 0) return;
+
+		const siblingIndex = Math.max(siblings.indexOf(message.id) - 1, 0);
+		const leafId = getDeepestLeafId(siblings[siblingIndex]);
+		await switchToBranchLeaf(leafId);
+	};
+
+	const showNextMessage = async (message: any) => {
+		const siblings = getSiblingIds(message);
+		if (siblings.length === 0) return;
+
+		const siblingIndex = Math.min(siblings.indexOf(message.id) + 1, siblings.length - 1);
+		const leafId = getDeepestLeafId(siblings[siblingIndex]);
+		await switchToBranchLeaf(leafId);
 	};
 
 	const rateMessage = async (messageId, rating) => {
-		history.messages[messageId].annotation = {
-			...history.messages[messageId].annotation,
-			rating: rating
-		};
-
-		await updateChat();
+		await saveMessage(messageId, {
+			...history.messages[messageId],
+			annotation: {
+				...history.messages[messageId].annotation,
+				rating: rating
+			}
+		});
 	};
 
 	const editMessage = async (messageId, { content, files, output = undefined }, submit = true) => {
-		if ((selectedModels ?? []).filter((id) => id).length === 0) {
+		if (submit && (selectedModels ?? []).filter((id) => id).length === 0) {
 			toast.error($i18n.t('Model not selected'));
 			return;
 		}
@@ -381,9 +512,11 @@
 				await sendMessage(history, userMessageId);
 			} else {
 				// Edit user message
-				history.messages[messageId].content = content;
-				history.messages[messageId].files = files;
-				await updateChat();
+				await saveMessage(messageId, {
+					...history.messages[messageId],
+					content,
+					files
+				});
 			}
 		} else {
 			if (submit) {
@@ -417,15 +550,16 @@
 				await updateChat();
 			} else {
 				// Edit response message
+				const updatedMessage = { ...history.messages[messageId] };
 				if (content !== undefined) {
-					history.messages[messageId].originalContent = history.messages[messageId].content;
-					history.messages[messageId].content = content;
+					updatedMessage.originalContent = history.messages[messageId].content;
+					updatedMessage.content = content;
 				}
 				if (output !== undefined) {
-					history.messages[messageId].output = output;
-					history.messages[messageId].content = '';
+					updatedMessage.output = output;
+					updatedMessage.content = '';
 				}
-				await updateChat();
+				await saveMessage(messageId, updatedMessage);
 			}
 		}
 	};
@@ -436,15 +570,78 @@
 
 	const saveMessage = async (messageId, message) => {
 		if (!history.messages?.[messageId]) {
-			return;
+			return null;
 		}
 
-		history.messages[messageId] = message;
-		await updateChat();
+		const previousMessage = structuredClone(history.messages[messageId]);
+		const messagePatch = createMessagePatch(previousMessage, message);
+		history.messages[messageId] = { ...structuredClone(message), __loaded: true };
+		history = history;
+		await tick();
+
+		if ($temporaryChatEnabled) {
+			return history.messages[messageId];
+		}
+		if (Object.keys(messagePatch).length === 0) {
+			return history.messages[messageId];
+		}
+
+		try {
+			const savedMessage = await updateChatMessageById(
+				localStorage.token,
+				chatId,
+				messageId,
+				messagePatch
+			);
+
+			if (savedMessage) {
+				history.messages[messageId] = {
+					...history.messages[messageId],
+					...savedMessage,
+					__loaded: true
+				};
+				history = history;
+				await tick();
+			}
+
+			void refreshChatList(localStorage.token);
+			return savedMessage;
+		} catch (error) {
+			history.messages[messageId] = previousMessage;
+			history = history;
+			await tick();
+			toast.error(`${error}`);
+			throw error;
+		}
 	};
 
 	const deleteMessage = async (messageId) => {
 		const messageToDelete = history.messages[messageId];
+		if (!messageToDelete) return;
+
+		if (!$temporaryChatEnabled) {
+			try {
+				const response = await deleteChatMessageById(localStorage.token, chatId, messageId);
+				let nextHistory = response?.chat?.history as ChatHistoryState | undefined;
+
+				if (nextHistory?.currentId && !isChatMessageLoaded(nextHistory, nextHistory.currentId)) {
+					const historyWindow = await getChatHistoryWindow(
+						localStorage.token,
+						chatId,
+						nextHistory.currentId,
+						DEFAULT_CHAT_MESSAGE_WINDOW
+					);
+					nextHistory = mergeChatHistoryWindow(nextHistory, historyWindow) as ChatHistoryState;
+				}
+
+				if (nextHistory) replaceHistory(nextHistory);
+				void refreshChatList(localStorage.token);
+			} catch (error) {
+				toast.error(`${error}`);
+			}
+			return;
+		}
+
 		const parentMessageId = messageToDelete.parentId;
 		const childMessageIds = messageToDelete.childrenIds ?? [];
 
@@ -484,15 +681,6 @@
 		}
 		history.currentId = nextMessageId;
 		history = history;
-
-		if (!$temporaryChatEnabled) {
-			const res = await deleteChatMessageById(localStorage.token, chatId, messageId);
-			if (res?.chat?.history) {
-				history = res.chat.history;
-			}
-
-			await refreshChatList(localStorage.token);
-		}
 	};
 
 	const triggerScroll = () => {
@@ -544,6 +732,8 @@
 								{gotoMessage}
 								{showPreviousMessage}
 								{showNextMessage}
+								navigateToMessageId={switchToBranchLeaf}
+								{ensureMessageLoaded}
 								{updateChat}
 								{editMessage}
 								{deleteMessage}

--- a/src/lib/components/chat/Messages/Message.svelte
+++ b/src/lib/components/chat/Messages/Message.svelte
@@ -25,6 +25,8 @@
 	export let gotoMessage;
 	export let showPreviousMessage;
 	export let showNextMessage;
+	export let navigateToMessageId;
+	export let ensureMessageLoaded;
 	export let updateChat;
 
 	export let editMessage;
@@ -120,6 +122,8 @@
 					{chatId}
 					{messageId}
 					{selectedModels}
+					{navigateToMessageId}
+					{ensureMessageLoaded}
 					isLastMessage={messageId === history?.currentId}
 					{setInputText}
 					{updateChat}

--- a/src/lib/components/chat/Messages/MultiResponseMessages.svelte
+++ b/src/lib/components/chat/Messages/MultiResponseMessages.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
-	import { onMount, tick, getContext } from 'svelte';
+	import { onDestroy, onMount, tick, getContext } from 'svelte';
 	import { createEventDispatcher } from 'svelte';
 
 	import { mobile, models, settings } from '$lib/stores';
 
 	import { generateMoACompletion } from '$lib/apis';
-	import { updateChatById } from '$lib/apis/chats';
 	import { createOpenAITextStream } from '$lib/apis/streaming';
+	import { groupMessageIdsByModel, isChatMessageLoaded } from '$lib/utils/chatHistoryWindow';
 
 	import ResponseMessage from './ResponseMessage.svelte';
 	import Tooltip from '$lib/components/common/Tooltip.svelte';
@@ -25,6 +25,8 @@
 	export let history;
 	export let messageId;
 	export let selectedModels = [];
+	export let navigateToMessageId: (messageId: string) => Promise<boolean>;
+	export let ensureMessageLoaded: (messageId: string) => Promise<boolean>;
 
 	export let isLastMessage;
 	export let readOnly = false;
@@ -62,6 +64,10 @@
 	let groupedMessageIdsIdx = {};
 
 	let selectedModelIdx = null;
+	let destroyed = false;
+	onDestroy(() => {
+		destroyed = true;
+	});
 
 	let message = structuredClone(history.messages[messageId]);
 	$: if (history.messages) {
@@ -75,77 +81,42 @@
 		}
 	}
 
-	const gotoMessage = async (modelIdx, messageIdx) => {
-		// Clamp messageIdx to ensure it's within valid range
-		groupedMessageIdsIdx[modelIdx] = Math.max(
-			0,
-			Math.min(messageIdx, groupedMessageIds[modelIdx].messageIds.length - 1)
-		);
+	const getDeepestLeafId = (rootMessageId: string) => {
+		let leafId = rootMessageId;
+		const visited = new Set<string>();
 
-		// Get the messageId at the specified index
-		let messageId = groupedMessageIds[modelIdx].messageIds[groupedMessageIdsIdx[modelIdx]];
-		console.log(messageId);
-
-		// Traverse the branch to find the deepest child message
-		let messageChildrenIds = history.messages[messageId].childrenIds;
-		while (messageChildrenIds.length !== 0) {
-			messageId = messageChildrenIds.at(-1);
-			messageChildrenIds = history.messages[messageId].childrenIds;
+		while (leafId && !visited.has(leafId)) {
+			visited.add(leafId);
+			const childrenIds = history.messages[leafId]?.childrenIds ?? [];
+			if (childrenIds.length === 0) break;
+			leafId = childrenIds.at(-1);
 		}
 
-		// Update the current message ID in history
-		history.currentId = messageId;
-
-		// Await UI updates
-		await tick();
-		await updateChat();
-
-		// Trigger scrolling after navigation
-		triggerScroll();
+		return leafId;
 	};
 
-	const showPreviousMessage = async (modelIdx) => {
-		groupedMessageIdsIdx[modelIdx] = Math.max(0, groupedMessageIdsIdx[modelIdx] - 1);
+	const navigateToGroupedMessage = async (modelIdx, messageIdx) => {
+		const messageIds = groupedMessageIds[modelIdx]?.messageIds ?? [];
+		if (messageIds.length === 0) return false;
 
-		let messageId = groupedMessageIds[modelIdx].messageIds[groupedMessageIdsIdx[modelIdx]];
-		console.log(messageId);
+		const nextMessageIdx = Math.max(0, Math.min(messageIdx, messageIds.length - 1));
+		const leafId = getDeepestLeafId(messageIds[nextMessageIdx]);
+		if (!(await navigateToMessageId(leafId))) return false;
 
-		let messageChildrenIds = history.messages[messageId].childrenIds;
-
-		while (messageChildrenIds.length !== 0) {
-			messageId = messageChildrenIds.at(-1);
-			messageChildrenIds = history.messages[messageId].childrenIds;
-		}
-
-		history.currentId = messageId;
-
-		await tick();
-		await updateChat();
+		groupedMessageIdsIdx[modelIdx] = nextMessageIdx;
+		selectedModelIdx = Number(modelIdx);
 		triggerScroll();
+		return true;
 	};
 
-	const showNextMessage = async (modelIdx) => {
-		groupedMessageIdsIdx[modelIdx] = Math.min(
-			groupedMessageIds[modelIdx].messageIds.length - 1,
-			groupedMessageIdsIdx[modelIdx] + 1
-		);
+	const gotoMessage = async (modelIdx, messageIdx) =>
+		await navigateToGroupedMessage(modelIdx, messageIdx);
 
-		let messageId = groupedMessageIds[modelIdx].messageIds[groupedMessageIdsIdx[modelIdx]];
-		console.log(messageId);
+	const showPreviousMessage = async (modelIdx) =>
+		await navigateToGroupedMessage(modelIdx, groupedMessageIdsIdx[modelIdx] - 1);
 
-		let messageChildrenIds = history.messages[messageId].childrenIds;
-
-		while (messageChildrenIds.length !== 0) {
-			messageId = messageChildrenIds.at(-1);
-			messageChildrenIds = history.messages[messageId].childrenIds;
-		}
-
-		history.currentId = messageId;
-
-		await tick();
-		await updateChat();
-		triggerScroll();
-	};
+	const showNextMessage = async (modelIdx) =>
+		await navigateToGroupedMessage(modelIdx, groupedMessageIdsIdx[modelIdx] + 1);
 
 	const initHandler = async () => {
 		console.log('multiresponse:initHandler');
@@ -156,32 +127,17 @@
 			? history.messages[history.messages[messageId].parentId]
 			: null;
 
-		groupedMessageIds = parentMessage?.models.reduce((a, model, modelIdx) => {
-			// Find all messages that are children of the parent message and have the same model
-			let modelMessageIds = parentMessage?.childrenIds
-				.map((id) => history.messages[id])
-				.filter((m) => m?.modelIdx === modelIdx)
-				.map((m) => m.id);
+		const unloadedSiblingIds = (parentMessage?.childrenIds ?? []).filter(
+			(id) => !isChatMessageLoaded(history, id)
+		);
+		await Promise.all(unloadedSiblingIds.map((id) => ensureMessageLoaded(id)));
+		if (destroyed) return;
+		await tick();
 
-			// Legacy support for messages that don't have a modelIdx
-			// Find all messages that are children of the parent message and have the same model
-			if (modelMessageIds.length === 0) {
-				let modelMessages = parentMessage?.childrenIds
-					.map((id) => history.messages[id])
-					.filter((m) => m?.model === model);
-
-				modelMessages.forEach((m) => {
-					m.modelIdx = modelIdx;
-				});
-
-				modelMessageIds = modelMessages.map((m) => m.id);
-			}
-
-			return {
-				...a,
-				[modelIdx]: { messageIds: modelMessageIds }
-			};
-		}, {});
+		parentMessage = history.messages[messageId].parentId
+			? history.messages[history.messages[messageId].parentId]
+			: null;
+		groupedMessageIds = groupMessageIdsByModel(parentMessage, history.messages);
 
 		groupedMessageIdsIdx = parentMessage?.models.reduce((a, model, modelIdx) => {
 			const idx = groupedMessageIds[modelIdx].messageIds.findIndex((id) => id === messageId);
@@ -198,7 +154,13 @@
 			}
 		}, {});
 
-		selectedModelIdx = history.messages[messageId]?.modelIdx;
+		selectedModelIdx =
+			history.messages[messageId]?.modelIdx ??
+			Number(
+				Object.keys(groupedMessageIds).find((modelIdx) =>
+					groupedMessageIds[modelIdx].messageIds.includes(messageId)
+				) ?? 0
+			);
 
 		console.log(groupedMessageIds, groupedMessageIdsIdx);
 
@@ -207,18 +169,8 @@
 
 	const onGroupClick = async (_messageId, modelIdx) => {
 		if (messageId != _messageId) {
-			let currentMessageId = _messageId;
-			let messageChildrenIds = history.messages[currentMessageId].childrenIds;
-			while (messageChildrenIds.length !== 0) {
-				currentMessageId = messageChildrenIds.at(-1);
-				messageChildrenIds = history.messages[currentMessageId].childrenIds;
-			}
-			history.currentId = currentMessageId;
-			selectedModelIdx = modelIdx;
-
-			// await tick();
-			// await updateChat();
-			// triggerScroll();
+			const messageIdx = groupedMessageIds[modelIdx]?.messageIds.indexOf(_messageId) ?? -1;
+			if (messageIdx !== -1) await navigateToGroupedMessage(modelIdx, messageIdx);
 		}
 	};
 
@@ -272,7 +224,9 @@
 									{@const _messageId =
 										groupedMessageIds[modelIdx].messageIds[groupedMessageIdsIdx[modelIdx]]}
 
-									{@const model = $models.find((m) => m.id === history.messages[_messageId]?.model)}
+									{@const modelId =
+										history.messages[_messageId]?.model ?? parentMessage.models?.[Number(modelIdx)]}
+									{@const model = $models.find((m) => m.id === modelId)}
 
 									<button
 										class="min-w-fit {selectedModelIdx == modelIdx
@@ -283,12 +237,12 @@
 												selectedModelIdx = modelIdx;
 											}
 
-											onGroupClick(_messageId, modelIdx);
+											await onGroupClick(_messageId, modelIdx);
 										}}
 									>
 										<div class="flex items-center gap-1.5">
 											<div class="-translate-y-[1px]">
-												{model ? `${model.name}` : history.messages[_messageId]?.model}
+												{model?.name ?? history.messages[_messageId]?.modelName ?? modelId}
 											</div>
 										</div>
 									</button>
@@ -357,7 +311,7 @@
 												}`
 									}`}"
 							on:click={async () => {
-								onGroupClick(_messageId, modelIdx);
+								await onGroupClick(_messageId, modelIdx);
 							}}
 						>
 							{#key history.currentId}

--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -11,7 +11,7 @@
 	const dispatch = createEventDispatcher();
 
 	import { createNewFeedback, getFeedbackById, updateFeedbackById } from '$lib/apis/evaluations';
-	import { getChatById } from '$lib/apis/chats';
+	import { getChatByIdWindow } from '$lib/apis/chats';
 	import { generateTags } from '$lib/apis';
 
 	import {
@@ -410,11 +410,11 @@
 
 	const editMessageConfirmHandler = async () => {
 		if (editedOutput) {
-			editMessage(message.id, { output: editedOutput }, false);
+			await editMessage(message.id, { output: editedOutput }, false);
 		} else {
 			// Legacy text edit
 			const messageContent = postprocessAfterEditing(editedContent ?? '');
-			editMessage(message.id, { content: messageContent }, false);
+			await editMessage(message.id, { content: messageContent }, false);
 		}
 
 		edit = false;
@@ -426,10 +426,10 @@
 
 	const saveAsCopyHandler = async () => {
 		if (editedOutput) {
-			editMessage(message.id, { output: editedOutput });
+			await editMessage(message.id, { output: editedOutput });
 		} else {
 			const messageContent = postprocessAfterEditing(editedContent ?? '');
-			editMessage(message.id, { content: messageContent });
+			await editMessage(message.id, { content: messageContent });
 		}
 
 		edit = false;
@@ -447,127 +447,130 @@
 	};
 
 	let feedbackLoading = false;
+	let feedbackGeneration = 0;
 
 	const feedbackHandler = async (rating: number | null = null, details: object | null = null) => {
+		const requestGeneration = ++feedbackGeneration;
 		feedbackLoading = true;
 		console.log('Feedback', rating, details);
 
-		const updatedMessage = {
-			...message,
-			annotation: {
-				...(message?.annotation ?? {}),
-				...(rating !== null ? { rating: rating } : {}),
-				...(details ? details : {})
-			}
-		};
+		try {
+			const updatedMessage = {
+				...message,
+				annotation: {
+					...(message?.annotation ?? {}),
+					...(rating !== null ? { rating: rating } : {}),
+					...(details ? details : {})
+				}
+			};
 
-		const chat = await getChatById(localStorage.token, chatId).catch((error) => {
-			toast.error(`${error}`);
-		});
-		if (!chat) {
-			return;
-		}
+			const chat = await getChatByIdWindow(localStorage.token, chatId, 32, message.id);
+			if (!chat) return;
 
-		const messages = createMessagesList(history, message.id);
+			const snapshotHistory = chat?.chat?.history ?? history;
+			const messages = createMessagesList(snapshotHistory, message.id);
+			const siblingIds = history.messages[message.parentId]?.childrenIds ?? [];
 
-		let feedbackItem = {
-			type: 'rating',
-			data: {
-				...(updatedMessage?.annotation ? updatedMessage.annotation : {}),
-				model_id: message?.selectedModelId ?? message.model,
-				...(history.messages[message.parentId].childrenIds.length > 1
-					? {
-							sibling_model_ids: history.messages[message.parentId].childrenIds
-								.filter((id) => id !== message.id)
-								.map((id) => history.messages[id]?.selectedModelId ?? history.messages[id].model)
-						}
-					: {})
-			},
-			meta: {
-				arena: message ? message.arena : false,
-				model_id: message.model,
-				message_id: message.id,
-				message_index: messages.length,
-				chat_id: chatId
-			},
-			snapshot: {
-				chat: chat
-			}
-		};
+			let feedbackItem = {
+				type: 'rating',
+				data: {
+					...(updatedMessage?.annotation ? updatedMessage.annotation : {}),
+					model_id: message?.selectedModelId ?? message.model,
+					...(siblingIds.length > 1
+						? {
+								sibling_model_ids: siblingIds
+									.filter((id) => id !== message.id)
+									.map((id) => history.messages[id]?.selectedModelId ?? history.messages[id]?.model)
+									.filter(Boolean)
+							}
+						: {})
+				},
+				meta: {
+					arena: message ? message.arena : false,
+					model_id: message.model,
+					message_id: message.id,
+					message_index: messages.length,
+					chat_id: chatId
+				},
+				snapshot: {
+					chat
+				}
+			};
 
-		const baseModels = [
-			feedbackItem.data.model_id,
-			...(feedbackItem.data.sibling_model_ids ?? [])
-		].reduce((acc, modelId) => {
-			const model = $models.find((m) => m.id === modelId);
-			if (model) {
-				acc[model.id] = model?.info?.base_model_id ?? null;
+			const baseModels = [
+				feedbackItem.data.model_id,
+				...(feedbackItem.data.sibling_model_ids ?? [])
+			].reduce((acc, modelId) => {
+				const model = $models.find((m) => m.id === modelId);
+				if (model) {
+					acc[model.id] = model?.info?.base_model_id ?? null;
+				} else {
+					console.warn(`Model with ID ${modelId} not found`);
+				}
+				return acc;
+			}, {});
+			feedbackItem.meta.base_models = baseModels;
+
+			let feedback = null;
+			if (message?.feedbackId) {
+				feedback = await updateFeedbackById(localStorage.token, message.feedbackId, feedbackItem);
 			} else {
-				// Log or handle cases where corresponding model is not found
-				console.warn(`Model with ID ${modelId} not found`);
-			}
-			return acc;
-		}, {});
-		feedbackItem.meta.base_models = baseModels;
-
-		let feedback = null;
-		if (message?.feedbackId) {
-			feedback = await updateFeedbackById(
-				localStorage.token,
-				message.feedbackId,
-				feedbackItem
-			).catch((error) => {
-				toast.error(`${error}`);
-			});
-		} else {
-			feedback = await createNewFeedback(localStorage.token, feedbackItem).catch((error) => {
-				toast.error(`${error}`);
-			});
-
-			if (feedback) {
-				updatedMessage.feedbackId = feedback.id;
-			}
-		}
-
-		console.log(updatedMessage);
-		saveMessage(message.id, updatedMessage);
-
-		await tick();
-
-		if (!details) {
-			showRateComment = true;
-
-			if (!updatedMessage.annotation?.tags && (message?.content ?? '') !== '') {
-				// attempt to generate tags
-				const tags = await generateTags(localStorage.token, message.model, messages, chatId).catch(
-					(error) => {
-						console.error(error);
-						return [];
-					}
-				);
-				console.log(tags);
-
-				if (tags) {
-					updatedMessage.annotation.tags = tags;
-					feedbackItem.data.tags = tags;
-
-					saveMessage(message.id, updatedMessage);
-					await updateFeedbackById(
-						localStorage.token,
-						updatedMessage.feedbackId,
-						feedbackItem
-					).catch((error) => {
-						toast.error(`${error}`);
-					});
+				feedback = await createNewFeedback(localStorage.token, feedbackItem);
+				if (feedback) {
+					updatedMessage.feedbackId = feedback.id;
 				}
 			}
-		}
 
-		feedbackLoading = false;
+			if (!feedback) return;
+
+			await saveMessage(message.id, updatedMessage);
+			await tick();
+
+			if (!details) {
+				showRateComment = true;
+				if (requestGeneration === feedbackGeneration) feedbackLoading = false;
+
+				if (!updatedMessage.annotation?.tags && (message?.content ?? '') !== '') {
+					const tags = await generateTags(
+						localStorage.token,
+						message.model,
+						messages,
+						chatId
+					).catch((error) => {
+						console.error(error);
+						return [];
+					});
+
+					if (requestGeneration !== feedbackGeneration) return;
+
+					if (tags) {
+						const currentMessage = history.messages[message.id] ?? updatedMessage;
+						const taggedMessage = {
+							...currentMessage,
+							annotation: {
+								...(currentMessage?.annotation ?? {}),
+								tags
+							}
+						};
+						feedbackItem.data = {
+							...feedbackItem.data,
+							...taggedMessage.annotation
+						};
+						await saveMessage(message.id, taggedMessage);
+						if (requestGeneration !== feedbackGeneration) return;
+						await updateFeedbackById(localStorage.token, taggedMessage.feedbackId, feedbackItem);
+					}
+				}
+			}
+		} catch (error) {
+			toast.error(`${error}`);
+		} finally {
+			if (requestGeneration === feedbackGeneration) feedbackLoading = false;
+		}
 	};
 
 	const deleteMessageHandler = async () => {
-		deleteMessage(message.id);
+		await deleteMessage(message.id);
 	};
 
 	$: if (!edit) {
@@ -847,8 +850,8 @@
 									onSetInputText={(text) => {
 										setInputText(text);
 									}}
-									onSave={({ raw, oldContent, newContent }) => {
-										const sourceMessage = history.messages[message.id];
+									onSave={async ({ raw, oldContent, newContent }) => {
+										const sourceMessage = structuredClone(history.messages[message.id]);
 										if (sourceMessage.output?.length) {
 											const updatedOutput = replaceOutputMessageText(
 												sourceMessage.output,
@@ -870,7 +873,7 @@
 											);
 										}
 
-										updateChat();
+										await saveMessage(message.id, sourceMessage);
 									}}
 								/>
 							{/if}

--- a/src/lib/components/chat/Messages/UserMessage.svelte
+++ b/src/lib/components/chat/Messages/UserMessage.svelte
@@ -77,7 +77,7 @@
 	const editMessageHandler = async () => {
 		edit = true;
 		editedContent = message?.content ?? '';
-		editedFiles = message.files;
+		editedFiles = structuredClone(message.files ?? []);
 
 		await tick();
 
@@ -99,7 +99,7 @@
 			return;
 		}
 
-		editMessage(message.id, { content: editedContent, files: editedFiles }, submit);
+		await editMessage(message.id, { content: editedContent, files: editedFiles }, submit);
 
 		edit = false;
 		editedContent = '';
@@ -113,7 +113,7 @@
 	};
 
 	const deleteMessageHandler = async () => {
-		deleteMessage(message.id);
+		await deleteMessage(message.id);
 	};
 
 	onMount(() => {

--- a/src/lib/components/chat/ShareChatModal.svelte
+++ b/src/lib/components/chat/ShareChatModal.svelte
@@ -6,6 +6,7 @@
 	import {
 		deleteSharedChatById,
 		getChatById,
+		getChatByIdWindow,
 		shareChatById,
 		getChatAccessGrants,
 		updateChatAccessGrants
@@ -30,13 +31,14 @@
 		const sharedChat = await shareChatById(localStorage.token, chatId);
 		shareUrl = `${window.location.origin}/s/${sharedChat.share_id}`;
 		console.log(shareUrl);
-		chat = await getChatById(localStorage.token, chatId);
+		chat = await getChatByIdWindow(localStorage.token, chatId, 1);
 
 		return shareUrl;
 	};
 
 	const shareChat = async () => {
-		const _chat = chat.chat;
+		const fullChat = await getChatById(localStorage.token, chatId);
+		const _chat = fullChat.chat;
 		console.log('share', _chat);
 
 		// LICENSE covers this Open WebUI Community wordmark.
@@ -99,7 +101,7 @@
 	$: if (show) {
 		(async () => {
 			if (chatId) {
-				const _chat = await getChatById(localStorage.token, chatId);
+				const _chat = await getChatByIdWindow(localStorage.token, chatId, 1);
 				if (isDifferentChat(_chat)) {
 					chat = _chat;
 				}
@@ -142,7 +144,7 @@
 								const res = await deleteSharedChatById(localStorage.token, chatId);
 
 								if (res) {
-									chat = await getChatById(localStorage.token, chatId);
+									chat = await getChatByIdWindow(localStorage.token, chatId, 1);
 								}
 							}}
 							>{$i18n.t('delete this link')}

--- a/src/lib/components/chat/Tags.svelte
+++ b/src/lib/components/chat/Tags.svelte
@@ -4,7 +4,7 @@
 		deleteTagById,
 		getAllTags,
 		getTagsById,
-		updateChatById
+		updateChatByIdWindow
 	} from '$lib/apis/chats';
 	import { tags as _tags } from '$lib/stores';
 	import { createEventDispatcher, onMount } from 'svelte';
@@ -34,7 +34,7 @@
 		}
 
 		tags = await getTags();
-		await updateChatById(localStorage.token, chatId, {
+		await updateChatByIdWindow(localStorage.token, chatId, {
 			tags: tags
 		});
 
@@ -47,7 +47,7 @@
 	const deleteTag = async (tagName) => {
 		const res = await deleteTagById(localStorage.token, chatId, tagName);
 		tags = await getTags();
-		await updateChatById(localStorage.token, chatId, {
+		await updateChatByIdWindow(localStorage.token, chatId, {
 			tags: tags
 		});
 

--- a/src/lib/components/layout/SearchModal.svelte
+++ b/src/lib/components/layout/SearchModal.svelte
@@ -6,13 +6,13 @@
 	import Modal from '$lib/components/common/Modal.svelte';
 	import SearchInput from './Sidebar/SearchInput.svelte';
 	import {
-		getChatById,
+		getChatByIdWindow,
 		getChatList,
 		getChatListBySearchText,
 		cloneChatById,
 		deleteChatById,
 		archiveChatById,
-		updateChatById,
+		updateChatByIdWindow,
 		updateChatFolderIdById,
 		getAllTags
 	} from '$lib/apis/chats';
@@ -162,7 +162,7 @@
 			return;
 		}
 
-		await updateChatById(localStorage.token, editingChatId, { title: trimmed });
+		await updateChatByIdWindow(localStorage.token, editingChatId, { title: trimmed });
 
 		if (chatList) {
 			chatList = chatList.map((c) => (c.id === editingChatId ? { ...c, title: trimmed } : c));
@@ -182,7 +182,7 @@
 		if (!editingChatId || generating) return;
 
 		generating = true;
-		const chat = await getChatById(localStorage.token, editingChatId).catch(() => null);
+		const chat = await getChatByIdWindow(localStorage.token, editingChatId).catch(() => null);
 
 		if (!chat) {
 			toast.error($i18n.t('Failed to load chat'));
@@ -273,6 +273,7 @@
 	let messages = null;
 	let messagesContainerElement: HTMLElement | null = null;
 	const messagesContainerId = 'chat-preview';
+	let previewLoadToken = 0;
 
 	const searchFilterPrefixes = ['tag:', 'folder:', 'pinned:', 'archived:', 'shared:'];
 
@@ -334,6 +335,8 @@
 	};
 
 	const loadChatPreview = async (selectedIdx) => {
+		const loadToken = ++previewLoadToken;
+
 		if (!chatList || chatList.length === 0 || selectedIdx === null) {
 			selectedChat = null;
 			messages = null;
@@ -353,9 +356,10 @@
 
 		const chatId = chatList[selectedChatIdx].id;
 
-		const chat = await getChatById(localStorage.token, chatId).catch(async (error) => {
+		const chat = await getChatByIdWindow(localStorage.token, chatId).catch(async (error) => {
 			return null;
 		});
+		if (loadToken !== previewLoadToken) return;
 
 		if (chat) {
 			selectedChat = chat;
@@ -538,6 +542,7 @@
 	});
 
 	onDestroy(() => {
+		previewLoadToken += 1;
 		if (searchDebounceTimeout) {
 			clearTimeout(searchDebounceTimeout);
 		}
@@ -885,7 +890,7 @@
 					<div class="w-full h-full flex flex-col">
 						<Messages
 							className="h-full flex pt-4 pb-8 w-full"
-							chatId={`chat-preview-${selectedChat?.id ?? ''}`}
+							chatId={selectedChat?.id ?? ''}
 							user={$user}
 							readOnly={true}
 							{selectedModels}

--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -44,7 +44,7 @@
 	import {
 		getAllTags,
 		toggleChatPinnedStatusById,
-		getChatById,
+		getChatByIdWindow,
 		updateChatFolderIdById,
 		importChats,
 		deleteAllChats,
@@ -1414,7 +1414,7 @@
 						const { type, id, item } = e.detail;
 
 						if (type === 'chat') {
-							let chat = await getChatById(localStorage.token, id).catch((error) => {
+							let chat = await getChatByIdWindow(localStorage.token, id, 1).catch((error) => {
 								return null;
 							});
 							if (!chat && item) {
@@ -1512,9 +1512,11 @@
 										const { type, id, item } = e.detail;
 
 										if (type === 'chat') {
-											let chat = await getChatById(localStorage.token, id).catch((error) => {
-												return null;
-											});
+											let chat = await getChatByIdWindow(localStorage.token, id, 1).catch(
+												(error) => {
+													return null;
+												}
+											);
 											if (!chat && item) {
 												if (!canImportChats) {
 													toast.error($i18n.t('Access prohibited'));

--- a/src/lib/components/layout/Sidebar/ChatHoverPreview.svelte
+++ b/src/lib/components/layout/Sidebar/ChatHoverPreview.svelte
@@ -2,7 +2,7 @@
 	import { getContext, onDestroy, tick } from 'svelte';
 	import { LinkPreview } from 'bits-ui';
 
-	import { getChatById } from '$lib/apis/chats';
+	import { getChatByIdWindow } from '$lib/apis/chats';
 	import Messages from '$lib/components/chat/Messages.svelte';
 	import Spinner from '$lib/components/common/Spinner.svelte';
 	import { user } from '$lib/stores';
@@ -49,7 +49,7 @@
 	};
 
 	const loadChatPreview = async (id: string) => {
-		if (!id || loading || requestedChatId === id) return;
+		if (!id || requestedChatId === id) return;
 
 		const token = ++loadToken;
 		requestedChatId = id;
@@ -59,7 +59,7 @@
 		history = null;
 		selectedModels = [''];
 
-		const chat = await getChatById(localStorage.token, id).catch(() => null);
+		const chat = await getChatByIdWindow(localStorage.token, id, 8).catch(() => null);
 		if (token !== loadToken) return;
 
 		if (chat?.chat?.history) {
@@ -124,7 +124,7 @@
 				{:else if previewReady}
 					<Messages
 						className="flex w-full pt-2 pb-0 [&_.message-listitem]:!mb-1 [&_.message-listitem]:!max-w-none [&_.message-listitem]:!px-3 [&_.pb-18]:!pb-1.5 [&_.markdown-prose]:!text-xs [&_.markdown-prose]:!leading-snug [&_.whitespace-pre-wrap]:!text-xs [&_.whitespace-pre-wrap]:!leading-snug [&_.text-\[0\.9375rem\]]:!text-xs [&_.text-sm]:!text-xs [&_.tool-call-body_pre]:!text-[11px] [&_.rounded-3xl]:!rounded-2xl [&_.chat-user_.rounded-3xl]:!bg-gray-50 dark:[&_.chat-user_.rounded-3xl]:!bg-gray-800 [&_.px-4]:!px-3 [&_.py-3]:!py-2 [&_.py-1\.5]:!py-1"
-						chatId={`chat-hover-preview-${chatId}`}
+						{chatId}
 						user={$user}
 						prompt=""
 						readOnly={true}

--- a/src/lib/components/layout/Sidebar/ChatItem.svelte
+++ b/src/lib/components/layout/Sidebar/ChatItem.svelte
@@ -24,10 +24,10 @@
 		cloneChatById,
 		deleteChatById,
 		getAllTags,
-		getChatById,
+		getChatByIdWindow,
 		getChatListByTagName,
 		markChatUnreadById,
-		updateChatById,
+		updateChatByIdWindow,
 		updateChatFolderIdById
 	} from '$lib/apis/chats';
 	import {
@@ -133,14 +133,6 @@
 		(effectiveReadAt === null || (updatedAt !== null && updatedAt > effectiveReadAt));
 	$: showInlineActions = id === $chatId || confirmEdit || mouseOver || selected;
 
-	const loadChat = async () => {
-		if (!chat) {
-			draggable = false;
-			chat = await getChatById(localStorage.token, id);
-			draggable = true;
-		}
-	};
-
 	const markUnreadHandler = async () => {
 		const res = await markChatUnreadById(localStorage.token, id).catch((error) => {
 			toast.error(`${error}`);
@@ -162,7 +154,7 @@
 		if (title === '') {
 			toast.error($i18n.t('Title cannot be an empty string.'));
 		} else {
-			await updateChatById(localStorage.token, id, {
+			await updateChatByIdWindow(localStorage.token, id, {
 				title: title
 			});
 
@@ -386,7 +378,7 @@
 
 	const generateTitleHandler = async () => {
 		generating = true;
-		chat = await getChatById(localStorage.token, id);
+		chat = await getChatByIdWindow(localStorage.token, id);
 
 		const chatContent = chat.chat;
 

--- a/src/lib/components/layout/Sidebar/RecursiveFolder.svelte
+++ b/src/lib/components/layout/Sidebar/RecursiveFolder.svelte
@@ -24,7 +24,7 @@
 		markFolderChatsReadById
 	} from '$lib/apis/folders';
 	import {
-		getChatById,
+		getChatByIdWindow,
 		getChatsByFolderId,
 		getChatListByFolderId,
 		updateChatFolderIdById,
@@ -237,7 +237,7 @@
 							} else if (type === 'chat') {
 								open = true;
 
-								let chat = await getChatById(localStorage.token, id).catch((error) => {
+								let chat = await getChatByIdWindow(localStorage.token, id, 1).catch((error) => {
 									return null;
 								});
 								if (!chat && item) {

--- a/src/lib/utils/chatHistoryWindow.test.ts
+++ b/src/lib/utils/chatHistoryWindow.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, it } from 'vitest';
+import {
+	createMessagePatch,
+	DEFAULT_CHAT_MESSAGE_WINDOW,
+	getLoadedMessageIds,
+	groupMessageIdsByModel,
+	isChatMessageLoaded,
+	mergeChatMessageEvent,
+	mergeChatHistoryWindow,
+	resolveLoadedCurrentMessageId,
+	serializeChatForWindowSave,
+	serializeMessageForPatch
+} from './chatHistoryWindow';
+
+describe('chatHistoryWindow', () => {
+	it('uses a stable default window size', () => {
+		expect(DEFAULT_CHAT_MESSAGE_WINDOW).toBe(32);
+	});
+
+	it('reads and deduplicates loaded IDs from message window metadata', () => {
+		const history = {
+			messages: {
+				a: { id: 'a', content: 'A', __loaded: true },
+				b: { id: 'b', __loaded: false }
+			},
+			messageWindow: { loadedIds: ['a', 'a', 'c'] }
+		};
+
+		expect(getLoadedMessageIds(history)).toEqual(['a', 'c']);
+		expect(isChatMessageLoaded(history, 'a')).toBe(true);
+		expect(isChatMessageLoaded(history, 'b')).toBe(false);
+		expect(isChatMessageLoaded(history, 'missing')).toBe(false);
+	});
+
+	it('treats all messages in a legacy full history as loaded', () => {
+		const history = {
+			messages: { a: { id: 'a', content: 'A' }, b: { id: 'b', content: 'B' } }
+		};
+
+		expect(getLoadedMessageIds(history)).toEqual(['a', 'b']);
+		expect(isChatMessageLoaded(history, 'b')).toBe(true);
+	});
+
+	it('keeps the loaded window current ID when the persisted column points to a stub', () => {
+		const history = {
+			currentId: 'latest',
+			messages: {
+				latest: { id: 'latest', content: 'latest response', __loaded: true },
+				stale: { id: 'stale', role: 'assistant', __loaded: false }
+			}
+		};
+
+		expect(resolveLoadedCurrentMessageId(history, 'stale')).toBe('latest');
+	});
+
+	it('uses a loaded persisted current ID only when the window has no loaded current ID', () => {
+		const history = {
+			currentId: null,
+			messages: {
+				persisted: { id: 'persisted', content: 'response', __loaded: true }
+			}
+		};
+
+		expect(resolveLoadedCurrentMessageId(history, 'persisted')).toBe('persisted');
+	});
+
+	it('merges partial chat message events without clearing existing content', () => {
+		const message = { id: 'assistant', content: 'kept', annotation: { rating: -1 } };
+
+		expect(
+			mergeChatMessageEvent(message, {
+				chat_id: 'chat',
+				message_id: 'assistant',
+				annotation: { rating: 1 }
+			})
+		).toEqual({
+			id: 'assistant',
+			content: 'kept',
+			annotation: { rating: 1 }
+		});
+		expect(mergeChatMessageEvent(message, { content: 'replaced' }, true)).toEqual({
+			id: 'assistant',
+			content: 'replaced',
+			annotation: { rating: -1 }
+		});
+	});
+
+	it('keeps unloaded multi-model siblings grouped and labelled by parent model order', () => {
+		const parent = {
+			id: 'user',
+			models: ['model-a', 'model-b'],
+			childrenIds: ['loaded-a', 'stub-b', 'retry-a']
+		};
+		const messages = {
+			'loaded-a': { id: 'loaded-a', model: 'model-a', modelIdx: 0 },
+			'stub-b': { id: 'stub-b', __loaded: false },
+			'retry-a': { id: 'retry-a', model: 'model-a' }
+		};
+
+		expect(groupMessageIdsByModel(parent, messages)).toEqual({
+			0: { messageIds: ['loaded-a', 'retry-a'] },
+			1: { messageIds: ['stub-b'] }
+		});
+	});
+
+	it('hydrates stubs, merges loaded IDs, and does not mutate either input', () => {
+		const history = {
+			currentId: 'b',
+			messages: {
+				a: {
+					id: 'a',
+					parentId: null,
+					childrenIds: ['b'],
+					content: 'A',
+					__loaded: true
+				},
+				b: {
+					id: 'b',
+					parentId: 'a',
+					childrenIds: ['c'],
+					role: 'assistant',
+					__loaded: false
+				},
+				d: { id: 'd', parentId: 'a', childrenIds: [], __loaded: false }
+			},
+			messageWindow: { loadedIds: ['a'], source: 'initial' }
+		};
+		const window = {
+			messages: {
+				b: { id: 'b', role: 'assistant', content: 'B' },
+				c: { id: 'c', parentId: 'b', childrenIds: [], content: 'C' }
+			},
+			loadedIds: ['b', 'b'],
+			hasMore: false,
+			currentId: 'c'
+		};
+		const historySnapshot = structuredClone(history);
+		const windowSnapshot = structuredClone(window);
+
+		const merged = mergeChatHistoryWindow(history, window);
+
+		expect(merged.messages?.b).toEqual({
+			id: 'b',
+			parentId: 'a',
+			childrenIds: ['c'],
+			role: 'assistant',
+			content: 'B',
+			__loaded: true
+		});
+		expect(merged.messages?.c).toEqual({ ...window.messages.c, __loaded: true });
+		expect(merged.messages?.d?.__loaded).toBe(false);
+		expect(merged.currentId).toBe('c');
+		expect(merged.messageWindow).toEqual({
+			loadedIds: ['a', 'b', 'c'],
+			source: 'initial',
+			hasMore: false,
+			currentId: 'c'
+		});
+		expect(history).toEqual(historySnapshot);
+		expect(window).toEqual(windowSnapshot);
+	});
+
+	it('saves hydrated and new messages, strips markers, and retains window metadata', () => {
+		const chat = {
+			title: 'Windowed chat',
+			history: {
+				currentId: 'stub',
+				messages: {
+					loaded: { id: 'loaded', content: '', role: 'user', __loaded: true },
+					stub: {
+						id: 'stub',
+						parentId: 'loaded',
+						childrenIds: [],
+						__loaded: false
+					},
+					newMessage: { id: 'newMessage', content: 'new and not indexed yet' },
+					hydrated: { id: 'hydrated', content: 'full', __loaded: true }
+				},
+				messageWindow: {
+					loadedIds: ['loaded', 'stub', 'loaded'],
+					hasMore: true
+				}
+			}
+		};
+		const snapshot = structuredClone(chat);
+
+		const payload = serializeChatForWindowSave(chat);
+
+		expect(payload.history?.messages).toEqual({
+			loaded: { id: 'loaded', content: '', role: 'user' },
+			newMessage: { id: 'newMessage', content: 'new and not indexed yet' },
+			hydrated: { id: 'hydrated', content: 'full' }
+		});
+		expect(payload.history?.currentId).toBe('stub');
+		expect(payload.history?.messageWindow).toEqual({
+			loadedIds: ['loaded', 'stub'],
+			hasMore: true
+		});
+		expect(chat).toEqual(snapshot);
+	});
+
+	it('serializes a single-message patch without topology or UI-only fields', () => {
+		const message = {
+			id: 'assistant',
+			parentId: 'user',
+			childrenIds: ['next'],
+			role: 'assistant',
+			timestamp: 123,
+			content: 'edited',
+			annotation: { rating: 1 },
+			feedbackId: 'feedback',
+			__loaded: true
+		};
+
+		expect(serializeMessageForPatch(message)).toEqual({
+			content: 'edited',
+			annotation: { rating: 1 },
+			feedbackId: 'feedback'
+		});
+		expect(message).toHaveProperty('__loaded', true);
+	});
+
+	it('creates a minimal deep message patch and represents removed fields as null', () => {
+		const previous = {
+			id: 'assistant',
+			content: 'a long response',
+			annotation: { rating: -1 },
+			files: [{ id: 'file' }],
+			output: [{ type: 'message', content: 'unchanged' }]
+		};
+		const next = {
+			...previous,
+			annotation: { rating: 1 },
+			files: undefined
+		};
+
+		expect(createMessagePatch(previous, next)).toEqual({
+			annotation: { rating: 1 },
+			files: null
+		});
+	});
+});

--- a/src/lib/utils/chatHistoryWindow.ts
+++ b/src/lib/utils/chatHistoryWindow.ts
@@ -1,0 +1,277 @@
+import equal from 'fast-deep-equal';
+
+export type ChatHistoryMessage = {
+	id?: string;
+	[key: string]: unknown;
+};
+
+export type ChatHistoryMessageMap = Record<string, ChatHistoryMessage>;
+
+export type ChatMessageWindowState = {
+	loadedIds?: string[];
+	[key: string]: unknown;
+};
+
+export type WindowedChatHistory = {
+	currentId?: string | null;
+	messages?: ChatHistoryMessageMap;
+	messageWindow?: ChatMessageWindowState;
+	[key: string]: unknown;
+};
+
+export type ChatHistoryWindowResponse = {
+	messages: ChatHistoryMessageMap | ChatHistoryMessage[];
+	loadedIds: string[];
+	hasMore: boolean;
+	currentId: string | null;
+};
+
+export const DEFAULT_CHAT_MESSAGE_WINDOW = 32;
+
+type WindowedChat = {
+	history?: WindowedChatHistory;
+	[key: string]: unknown;
+};
+
+const uniqueIds = (ids: unknown[]): string[] => [
+	...new Set(ids.filter((id): id is string => typeof id === 'string'))
+];
+
+const normalizeMessages = (
+	messages: ChatHistoryWindowResponse['messages']
+): ChatHistoryMessageMap => {
+	if (Array.isArray(messages)) {
+		return Object.fromEntries(
+			messages
+				.filter((message): message is ChatHistoryMessage & { id: string } => {
+					return typeof message?.id === 'string';
+				})
+				.map((message) => [message.id, message])
+		);
+	}
+
+	return messages ?? {};
+};
+
+export const getLoadedMessageIds = (history?: WindowedChatHistory | null): string[] => {
+	if (Array.isArray(history?.messageWindow?.loadedIds)) {
+		return uniqueIds(history.messageWindow.loadedIds);
+	}
+
+	return Object.keys(history?.messages ?? {});
+};
+
+export const isChatMessageLoaded = (
+	history: WindowedChatHistory | null | undefined,
+	messageId: string
+): boolean => {
+	const message = history?.messages?.[messageId];
+	return message !== undefined && message.__loaded !== false;
+};
+
+export const resolveLoadedCurrentMessageId = (
+	history: WindowedChatHistory | null | undefined,
+	persistedCurrentId?: string | null
+): string | null => {
+	const windowCurrentId = history?.currentId;
+	if (windowCurrentId && isChatMessageLoaded(history, windowCurrentId)) {
+		return windowCurrentId;
+	}
+
+	if (persistedCurrentId && isChatMessageLoaded(history, persistedCurrentId)) {
+		return persistedCurrentId;
+	}
+
+	return windowCurrentId ?? persistedCurrentId ?? null;
+};
+
+export const mergeChatMessageEvent = (
+	message: ChatHistoryMessage,
+	data: unknown,
+	replace = false
+): ChatHistoryMessage => {
+	const eventData =
+		data !== null && typeof data === 'object' && !Array.isArray(data)
+			? (data as ChatHistoryMessage)
+			: {};
+	const patch = { ...eventData };
+	delete patch.chat_id;
+	delete patch.message_id;
+
+	if (replace) {
+		return {
+			...message,
+			...patch,
+			content: patch.content
+		};
+	}
+
+	return {
+		...message,
+		...patch
+	};
+};
+
+export const groupMessageIdsByModel = (
+	parentMessage: ChatHistoryMessage | null | undefined,
+	messages: ChatHistoryMessageMap
+): Record<number, { messageIds: string[] }> => {
+	const modelIds = Array.isArray(parentMessage?.models)
+		? parentMessage.models.filter((modelId): modelId is string => typeof modelId === 'string')
+		: [];
+	const groups = Object.fromEntries(
+		modelIds.map((_, modelIdx) => [modelIdx, { messageIds: [] as string[] }])
+	) as Record<number, { messageIds: string[] }>;
+
+	if (modelIds.length === 0) return groups;
+
+	const childIds = Array.isArray(parentMessage?.childrenIds)
+		? parentMessage.childrenIds.filter(
+				(messageId): messageId is string => typeof messageId === 'string'
+			)
+		: [];
+
+	for (const [childIndex, messageId] of childIds.entries()) {
+		const message = messages[messageId];
+		const declaredModelIdx = Number(message?.modelIdx);
+		let modelIdx =
+			Number.isInteger(declaredModelIdx) &&
+			declaredModelIdx >= 0 &&
+			declaredModelIdx < modelIds.length
+				? declaredModelIdx
+				: -1;
+
+		if (modelIdx === -1 && typeof message?.model === 'string') {
+			const matchingModelIndexes = modelIds
+				.map((modelId, index) => (modelId === message.model ? index : -1))
+				.filter((index) => index !== -1);
+
+			if (matchingModelIndexes.length > 0) {
+				modelIdx = matchingModelIndexes.reduce((leastUsedIndex, candidateIndex) =>
+					groups[candidateIndex].messageIds.length < groups[leastUsedIndex].messageIds.length
+						? candidateIndex
+						: leastUsedIndex
+				);
+			}
+		}
+
+		// Topology stubs intentionally omit model data. Child order follows the
+		// original multi-model request order, so keep every stub navigable until hydrated.
+		if (modelIdx === -1) modelIdx = childIndex % modelIds.length;
+		groups[modelIdx].messageIds.push(messageId);
+	}
+
+	return groups;
+};
+
+export const mergeChatHistoryWindow = (
+	history: WindowedChatHistory,
+	window: ChatHistoryWindowResponse
+): WindowedChatHistory => {
+	const incomingMessages = normalizeMessages(window.messages);
+	const messages: ChatHistoryMessageMap = Object.fromEntries(
+		Object.entries(history.messages ?? {}).map(([id, message]) => [id, { ...message }])
+	);
+
+	for (const [id, message] of Object.entries(incomingMessages)) {
+		messages[id] = {
+			...(messages[id] ?? {}),
+			...message,
+			id,
+			__loaded: true
+		};
+	}
+
+	const loadedIds = uniqueIds([
+		...getLoadedMessageIds(history),
+		...window.loadedIds,
+		...Object.keys(incomingMessages)
+	]);
+
+	return {
+		...history,
+		currentId: window.currentId,
+		messages,
+		messageWindow: {
+			...(history.messageWindow ?? {}),
+			loadedIds,
+			hasMore: window.hasMore,
+			currentId: window.currentId
+		}
+	};
+};
+
+export const serializeChatForWindowSave = <T extends WindowedChat>(chat: T): T => {
+	if (!chat.history) {
+		return { ...chat };
+	}
+
+	const loadedIds = getLoadedMessageIds(chat.history);
+	const messageEntries = Object.entries(chat.history.messages ?? {});
+	const messageIdsToSerialize = new Set([
+		...loadedIds,
+		...messageEntries
+			.filter(([, message]) => message.__loaded !== false)
+			.map(([messageId]) => messageId)
+	]);
+	const messages = Object.fromEntries(
+		messageEntries
+			.filter(([id, message]) => messageIdsToSerialize.has(id) && message.__loaded !== false)
+			.map(([id, message]) => {
+				const messageCopy = { ...message };
+				delete messageCopy.__loaded;
+				return [id, messageCopy];
+			})
+	);
+
+	return {
+		...chat,
+		history: {
+			...chat.history,
+			currentId: chat.history.currentId,
+			messages,
+			...(chat.history.messageWindow
+				? {
+						messageWindow: {
+							...chat.history.messageWindow,
+							loadedIds
+						}
+					}
+				: {})
+		}
+	} as T;
+};
+
+export const serializeMessageForPatch = (message: ChatHistoryMessage): ChatHistoryMessage => {
+	const messageCopy = { ...message };
+	delete messageCopy.__loaded;
+	delete messageCopy.childrenIds;
+	delete messageCopy.id;
+	delete messageCopy.parentId;
+	delete messageCopy.role;
+	delete messageCopy.timestamp;
+	return messageCopy;
+};
+
+export const createMessagePatch = (
+	previousMessage: ChatHistoryMessage,
+	nextMessage: ChatHistoryMessage
+): ChatHistoryMessage => {
+	const previous = serializeMessageForPatch(previousMessage);
+	const next = serializeMessageForPatch(nextMessage);
+	const patch: ChatHistoryMessage = {};
+
+	for (const [key, value] of Object.entries(next)) {
+		if (!equal(previous[key], value)) {
+			patch[key] = value === undefined ? null : value;
+		}
+	}
+
+	for (const key of Object.keys(previous)) {
+		if (!(key in next)) {
+			patch[key] = null;
+		}
+	}
+
+	return patch;
+};


### PR DESCRIPTION
<!--
CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE)
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Relates to #27187.
- [x] **Target branch:** This pull request targets the `dev` branch.
- [x] **Description:** This draft is retained as the complete reference implementation.
- [x] **Changelog:** A Keep a Changelog entry is included below.
- [x] **Documentation:** No user-facing setting or workflow was added.
- [x] **Dependencies:** No dependencies were added or updated.
- [x] **Testing:** Automated and manual regression coverage is documented below.
- [x] **No Unchecked AI Code:** The complete diff and affected chat consumers were reviewed.
- [x] **Self-Review:** Storage migration, fallback behavior, mutations, and integrations were reviewed.
- [x] **Architecture:** This branch is a strict descendant of the minimal upstream PR.
- [x] **Git Hygiene:** Three layered commits separate shared core, full storage/integrations, and private image CI.
- [x] **Title Prefix:** The title uses the `perf` prefix.

## Draft Reference Status

Following the maintainer feedback that this implementation is too large to review or merge and that test files should not be submitted, this PR remains a draft reference rather than the requested upstream merge path.

The minimized contribution is #27355. The branch relationship is now explicit:

```text
upstream dev
└─ #27355 minimal safe window core
   └─ this full reference branch
      ├─ normalized message storage and consumer integrations
      └─ private GHCR build workflow
```

This arrangement keeps the window protocol, topology hydration, branch navigation, and race guards identical in both branches. Fixes can land in the minimal branch first and then merge forward into the full branch without maintaining a second implementation.

## Summary

The full extension moves lossless message data into normalized `chat_message` rows, keeps `Chat.chat` compact, and adapts RAG, tools, memory, context compaction, subagents, timers, search, sharing, and related consumers. Existing embedded histories are lazily normalized with a compatibility fallback, and the migration supports downgrade reconstruction.

Window saves append only unseen messages and cannot overwrite existing normalized bodies with a stale browser snapshot. Message edits and ratings use a single-message patch, branch deletion is server-authoritative, and both active-message pointers remain synchronized.

## Testing

- Backend storage/window/integration suites: `43 passed`.
- Frontend API/window suites: `17 passed`.
- Python compilation passed for the backend tree; only pre-existing escape-sequence warnings were reported.
- `git diff --check` passed for both minimal and full branches.
- The rebuilt full branch differs from the previously tested deployment in only five files: cursor validation, initial-load race guards, safe normalized window persistence, synchronized deletion pointers, and their regression test.
- Earlier isolated manual testing covered production-scale loading, sending/streaming, branch switching, deletion, user/assistant edits, ratings, files, tools, RAG, memory, and context compaction.

# Changelog Entry

### Description

- Extend the bounded lazy-history core with normalized storage and compatibility adaptations for complete long-chat operation.

### Added

- Lossless normalized message data and ordered topology projections.
- Migration and downgrade reconstruction for normalized message storage.
- Backend/frontend regression coverage and a private GHCR image workflow.

### Changed

- Chat consumers use normalized branch/message access where complete hydration is unnecessary.
- Window persistence appends new messages without replacing existing message bodies.

### Deprecated

- None.

### Removed

- None.

### Fixed

- Long branched chats avoid full browser payloads during normal loading and common mutations.
- Stale initial-load responses cannot replace a newly selected chat.
- Invalid pagination cursors are rejected.
- Branch deletion synchronizes both active-message pointers.

### Security

- None.

### Breaking Changes

- **BREAKING CHANGE**: None.

---

### Additional Information

- Relates to #27187.
- Minimal upstream contribution: #27355.
- This draft intentionally retains tests and private deployment CI as a complete reference implementation.

### Screenshots or Videos

- Not included because there is no intended visual change.

### Contributor License Agreement

<!--
DO NOT DELETE THE TEXT BELOW.
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to invalidate the PR.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
