### PR TITLE
fix: wait for tool servers before URL auto-submit

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -38,6 +38,7 @@
 		tools,
 		skills,
 		toolServers,
+		toolServersReady,
 		terminalServers,
 		functions,
 		selectedFolder,
@@ -48,6 +49,7 @@
 		chatRequestQueues,
 		desktopEvent
 	} from '$lib/stores';
+	import { waitForStore } from '$lib/utils/store';
 	import { refreshChatList } from '$lib/stores/chatList';
 
 	import { WEBUI_API_BASE_URL } from '$lib/constants';
@@ -1799,6 +1801,7 @@
 
 			if (q) {
 				if (($page.url.searchParams.get('submit') ?? 'true') === 'true') {
+					await waitForStore(toolServersReady, (ready) => ready);
 					await tick();
 					submitHandler(q);
 				}

--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -94,6 +94,7 @@ export const adminLeaderboardCount: Writable<number | null> = writable(null);
 export const adminFeedbackCount: Writable<number | null> = writable(null);
 
 export const toolServers = writable([]);
+export const toolServersReady = writable(false);
 export const terminalServers = writable([]);
 
 // Persistent Pyodide worker for code interpreter FS

--- a/src/lib/utils/store.test.ts
+++ b/src/lib/utils/store.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from 'vitest';
+import { writable } from 'svelte/store';
+
+import { waitForStore } from './store';
+
+describe('waitForStore', () => {
+	it('resolves immediately when the current value matches', async () => {
+		const ready = writable(true);
+
+		await expect(waitForStore(ready, Boolean)).resolves.toBe(true);
+	});
+
+	it('waits until a later value matches and then unsubscribes', async () => {
+		const ready = writable(false);
+		const predicate = vi.fn(Boolean);
+		const pending = waitForStore(ready, predicate);
+
+		ready.set(true);
+		await expect(pending).resolves.toBe(true);
+
+		ready.set(false);
+		expect(predicate).toHaveBeenCalledTimes(2);
+	});
+});

--- a/src/lib/utils/store.ts
+++ b/src/lib/utils/store.ts
@@ -1,0 +1,11 @@
+import type { Readable } from 'svelte/store';
+
+export const waitForStore = <T>(store: Readable<T>, predicate: (value: T) => boolean) =>
+	new Promise<T>((resolve) => {
+		const unsubscribe = store.subscribe((value) => {
+			if (predicate(value)) {
+				resolve(value);
+				queueMicrotask(unsubscribe);
+			}
+		});
+	});

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -33,6 +33,7 @@
 		showChangelog,
 		temporaryChatEnabled,
 		toolServers,
+		toolServersReady,
 		terminalServers,
 		selectedTerminalId,
 		showSearch,
@@ -244,7 +245,10 @@
 		]);
 
 		// Tool servers can be slow or unreachable; they are not needed to initialize chat.
-		setToolServers().catch((e) => console.error('Failed to load tool servers:', e));
+		toolServersReady.set(false);
+		setToolServers()
+			.catch((e) => console.error('Failed to load tool servers:', e))
+			.finally(() => toolServersReady.set(true));
 
 		const setupKeyboardShortcuts = () => {
 			document.addEventListener('keydown', async (event) => {


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Closes #24176.
- [x] **Target branch:** This pull request targets `dev`.
- [x] **Description:** A concise description is provided below.
- [x] **Changelog:** A changelog entry is included below.
- [x] **Documentation:** No documentation changes are needed for this race-condition fix.
- [x] **Dependencies:** This change adds no dependencies.
- [ ] **Testing:** Manual end-to-end testing is still pending; focused automated tests pass.
- [ ] **No Unchecked AI Code:** Final human review and manual testing are still pending.
- [x] **Self-Review:** The code and diff have been reviewed for scope and consistency.
- [x] **Architecture:** Normal initialization stays non-blocking; only URL auto-submit waits for tool servers.
- [x] **Git Hygiene:** The change is atomic and based on `dev`.
- [x] **Title Prefix:** The title uses the `fix` prefix.

## Description

Opening a parameterized chat URL can submit its prompt before MCP/OpenAPI tool servers finish loading. The first request then goes out with an empty `tool_servers` list, even when the selected model has external tools enabled.

This waits for the existing tool-server initialization promise in the URL auto-submit path. Normal page startup and manually submitted chats remain non-blocking. A small store helper covers both the already-ready and later-ready cases.

## Changelog Entry

### Fixed

- Wait for MCP/OpenAPI tool servers before auto-submitting prompts from parameterized chat URLs.

### Testing

- `npm run test:frontend -- --run src/lib/utils/store.test.ts`
- ESLint on the helper and its test
- Prettier on all changed files
- `git diff --check`

The repository-wide `npm run check` still hits existing `dev` type errors; the focused test and static checks for this change pass.

### Additional Information

- Closes #24176
- No dependencies or settings added.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
