### PR TITLE
fix: cache Sentinel master client across Redis operations

### DIFF
--- a/backend/open_webui/utils/redis.py
+++ b/backend/open_webui/utils/redis.py
@@ -112,8 +112,10 @@ def get_redis_client(async_mode: bool = False) -> Any | None:
 class SentinelRedisProxy:
     """Transparent proxy that re-resolves the Sentinel master on connection errors.
 
-    Every call (sync or async) is wrapped with retry logic so that transient
-    Sentinel failovers are handled without caller intervention.
+    The master client is cached and reused so redis-py's connection pool can
+    amortize connections. Re-resolution only happens on connection errors
+    (matching this docstring's intent) — not on every attribute access, which
+    previously created a new SentinelConnectionPool per call (#27210).
     """
 
     def __init__(
@@ -126,10 +128,11 @@ class SentinelRedisProxy:
         self._sentinel = sentinel
         self._service_name = service_name
         self._async_mode = async_mode
+        self._master: Any | None = None
 
     def __getattr__(self, name: str) -> Any:
         """Proxy attribute access with automatic Sentinel failover retry."""
-        current_master = self._sentinel.master_for(self._service_name)
+        current_master = self._resolve_master()
         original = getattr(current_master, name)
 
         # Non-callable or factory attributes pass through without wrapping.
@@ -141,9 +144,15 @@ class SentinelRedisProxy:
             return self._wrap_sync(name)
         return self._wrap_async(name, original)
 
-    def _resolve_master(self) -> Any:
-        """Ask Sentinel for the current master connection."""
-        return self._sentinel.master_for(self._service_name)
+    def _resolve_master(self, *, force: bool = False) -> Any:
+        """Return a cached master client, re-resolving only when forced or empty."""
+        if force or self._master is None:
+            self._master = self._sentinel.master_for(self._service_name)
+        return self._master
+
+    def _invalidate_master(self) -> None:
+        """Drop the cached master so the next resolve hits Sentinel again."""
+        self._master = None
 
     def _should_retry(self, attempt: int) -> bool:
         return attempt < REDIS_SENTINEL_MAX_RETRY_COUNT - 1
@@ -184,6 +193,7 @@ class SentinelRedisProxy:
                     except _SENTINEL_RETRYABLE as exc:
                         if proxy._should_retry(attempt):
                             proxy._log_retry(exc, attempt)
+                            proxy._invalidate_master()
                             if REDIS_RECONNECT_DELAY:
                                 await asyncio.sleep(REDIS_RECONNECT_DELAY / 1000)
                             continue
@@ -208,6 +218,7 @@ class SentinelRedisProxy:
                 except _SENTINEL_RETRYABLE as exc:
                     if proxy._should_retry(attempt):
                         proxy._log_retry(exc, attempt)
+                        proxy._invalidate_master()
                         if REDIS_RECONNECT_DELAY:
                             await asyncio.sleep(REDIS_RECONNECT_DELAY / 1000)
                         continue
@@ -229,6 +240,7 @@ class SentinelRedisProxy:
                 except _SENTINEL_RETRYABLE as exc:
                     if proxy._should_retry(attempt):
                         proxy._log_retry(exc, attempt)
+                        proxy._invalidate_master()
                         if REDIS_RECONNECT_DELAY:
                             time.sleep(REDIS_RECONNECT_DELAY / 1000)
                         continue


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** `Closes #27210`
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following Keep a Changelog format is included at the bottom.
- [x] **Documentation:** N/A for this bugfix.
- [x] **Dependencies:** No new dependencies.
- [x] **Testing:** Code-level verification of the cache/invalidate paths; production impact described in the issue.
- [x] **No Unchecked AI Code:** Human-reviewed and validated against the issue root cause.
- [x] **Self-Review:** Completed.
- [x] **Architecture:** Uses smart defaults; no new settings.
- [x] **Git Hygiene:** Atomic single-purpose fix rebased on `dev`.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

- Cache the Redis Sentinel master client in `SentinelRedisProxy` so each operation no longer creates a new connection pool.

### Fixed

- Fixed Redis Sentinel connection churn / event-loop stalls under load caused by calling `master_for()` on every attribute access (`#27210`).

### Additional Information

- Issue #27210 documents production impact (~6.9 new Redis connections/sec under load, liveness kills from Sentinel timeouts).
- Fix matches the existing class docstring: re-resolve on connection errors, not every call.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and agree to the Contributor License Agreement (CLA) terms.
