### PR TITLE
feat: Enterprise Knowledge Base Management Dashboard

### DIFF
--- a/backend/open_webui/migrations/versions/a7b8c9d0e1f2_add_knowledge_management_tables.py
+++ b/backend/open_webui/migrations/versions/a7b8c9d0e1f2_add_knowledge_management_tables.py
@@ -1,0 +1,145 @@
+"""add knowledge management tables
+
+Revision ID: a7b8c9d0e1f2
+Revises: 42e2978c7933
+Create Date: 2026-07-20 12:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'a7b8c9d0e1f2'
+down_revision: Union[str, None] = '42e2978c7933'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    existing_tables = set(inspector.get_table_names())
+
+    # -- knowledge_chunk table --
+    if 'knowledge_chunk' not in existing_tables:
+        op.create_table(
+            'knowledge_chunk',
+            sa.Column('id', sa.Text(), nullable=False),
+            sa.Column('knowledge_id', sa.Text(), nullable=False),
+            sa.Column('file_id', sa.Text(), nullable=False),
+            sa.Column('chunk_index', sa.BigInteger(), nullable=False),
+            sa.Column('content', sa.Text(), nullable=False),
+            sa.Column('token_count', sa.BigInteger(), nullable=True),
+            sa.Column('meta', sa.JSON(), nullable=True),
+            sa.Column('content_hash', sa.Text(), nullable=True),
+            sa.Column('created_at', sa.BigInteger(), nullable=False),
+            sa.Column('updated_at', sa.BigInteger(), nullable=False),
+            sa.PrimaryKeyConstraint('id'),
+            sa.UniqueConstraint('file_id', 'chunk_index', name='uq_knowledge_chunk_file_index'),
+            sa.ForeignKeyConstraint(['knowledge_id'], ['knowledge.id'], ondelete='CASCADE'),
+            sa.ForeignKeyConstraint(['file_id'], ['file.id'], ondelete='CASCADE'),
+        )
+        op.create_index('ix_knowledge_chunk_knowledge_id', 'knowledge_chunk', ['knowledge_id'])
+        op.create_index('ix_knowledge_chunk_file_id', 'knowledge_chunk', ['file_id'])
+
+    # -- knowledge_processing_task table --
+    if 'knowledge_processing_task' not in existing_tables:
+        op.create_table(
+            'knowledge_processing_task',
+            sa.Column('id', sa.Text(), nullable=False),
+            sa.Column('knowledge_id', sa.Text(), nullable=False),
+            sa.Column('file_id', sa.Text(), nullable=True),
+            sa.Column('task_type', sa.Text(), nullable=False),
+            sa.Column('status', sa.Text(), nullable=False),
+            sa.Column('progress_pct', sa.BigInteger(), nullable=False, server_default='0'),
+            sa.Column('chunks_total', sa.BigInteger(), nullable=True),
+            sa.Column('chunks_processed', sa.BigInteger(), nullable=True),
+            sa.Column('error_message', sa.Text(), nullable=True),
+            sa.Column('created_at', sa.BigInteger(), nullable=False),
+            sa.Column('updated_at', sa.BigInteger(), nullable=False),
+            sa.PrimaryKeyConstraint('id'),
+            sa.ForeignKeyConstraint(['knowledge_id'], ['knowledge.id'], ondelete='CASCADE'),
+            sa.ForeignKeyConstraint(['file_id'], ['file.id'], ondelete='CASCADE'),
+        )
+        op.create_index('ix_knowledge_processing_knowledge_id', 'knowledge_processing_task', ['knowledge_id'])
+        op.create_index('ix_knowledge_processing_file_id', 'knowledge_processing_task', ['file_id'])
+
+    # -- knowledge_batch_task table --
+    if 'knowledge_batch_task' not in existing_tables:
+        op.create_table(
+            'knowledge_batch_task',
+            sa.Column('id', sa.Text(), nullable=False),
+            sa.Column('knowledge_id', sa.Text(), nullable=False),
+            sa.Column('total_files', sa.BigInteger(), nullable=False),
+            sa.Column('files_processed', sa.BigInteger(), nullable=False, server_default='0'),
+            sa.Column('total_chunks', sa.BigInteger(), nullable=True),
+            sa.Column('chunks_embedded', sa.BigInteger(), nullable=True, server_default='0'),
+            sa.Column('status', sa.Text(), nullable=False),
+            sa.Column('created_at', sa.BigInteger(), nullable=False),
+            sa.Column('updated_at', sa.BigInteger(), nullable=False),
+            sa.PrimaryKeyConstraint('id'),
+            sa.ForeignKeyConstraint(['knowledge_id'], ['knowledge.id'], ondelete='CASCADE'),
+        )
+        op.create_index('ix_knowledge_batch_knowledge_id', 'knowledge_batch_task', ['knowledge_id'])
+
+    # -- knowledge_relevance_judgment table --
+    if 'knowledge_relevance_judgment' not in existing_tables:
+        op.create_table(
+            'knowledge_relevance_judgment',
+            sa.Column('id', sa.Text(), nullable=False),
+            sa.Column('knowledge_id', sa.Text(), nullable=False),
+            sa.Column('query_text', sa.Text(), nullable=False),
+            sa.Column('chunk_id', sa.Text(), nullable=True),
+            sa.Column('document_text', sa.Text(), nullable=False),
+            sa.Column('rank_position', sa.BigInteger(), nullable=True),
+            sa.Column('relevance', sa.BigInteger(), nullable=False),
+            sa.Column('user_id', sa.Text(), nullable=False),
+            sa.Column('created_at', sa.BigInteger(), nullable=False),
+            sa.PrimaryKeyConstraint('id'),
+            sa.ForeignKeyConstraint(['knowledge_id'], ['knowledge.id'], ondelete='CASCADE'),
+        )
+        op.create_index('ix_knowledge_judgment_knowledge_id', 'knowledge_relevance_judgment', ['knowledge_id'])
+        op.create_index('ix_knowledge_judgment_query', 'knowledge_relevance_judgment', ['knowledge_id', 'query_text'])
+
+    # -- knowledge_snapshot table --
+    if 'knowledge_snapshot' not in existing_tables:
+        op.create_table(
+            'knowledge_snapshot',
+            sa.Column('id', sa.Text(), nullable=False),
+            sa.Column('knowledge_id', sa.Text(), nullable=False),
+            sa.Column('label', sa.Text(), nullable=True),
+            sa.Column('description', sa.Text(), nullable=True),
+            sa.Column('file_count', sa.BigInteger(), nullable=False),
+            sa.Column('chunk_count', sa.BigInteger(), nullable=True),
+            sa.Column('snapshot_data', sa.JSON(), nullable=False),
+            sa.Column('collection_snapshot_path', sa.Text(), nullable=True),
+            sa.Column('created_by', sa.Text(), nullable=False),
+            sa.Column('created_at', sa.BigInteger(), nullable=False),
+            sa.PrimaryKeyConstraint('id'),
+            sa.ForeignKeyConstraint(['knowledge_id'], ['knowledge.id'], ondelete='CASCADE'),
+        )
+        op.create_index('ix_knowledge_snapshot_knowledge_id', 'knowledge_snapshot', ['knowledge_id'])
+
+
+def downgrade() -> None:
+    op.drop_index('ix_knowledge_snapshot_knowledge_id', table_name='knowledge_snapshot')
+    op.drop_table('knowledge_snapshot')
+
+    op.drop_index('ix_knowledge_judgment_query', table_name='knowledge_relevance_judgment')
+    op.drop_index('ix_knowledge_judgment_knowledge_id', table_name='knowledge_relevance_judgment')
+    op.drop_table('knowledge_relevance_judgment')
+
+    op.drop_index('ix_knowledge_batch_knowledge_id', table_name='knowledge_batch_task')
+    op.drop_table('knowledge_batch_task')
+
+    op.drop_index('ix_knowledge_processing_file_id', table_name='knowledge_processing_task')
+    op.drop_index('ix_knowledge_processing_knowledge_id', table_name='knowledge_processing_task')
+    op.drop_table('knowledge_processing_task')
+
+    op.drop_index('ix_knowledge_chunk_file_id', table_name='knowledge_chunk')
+    op.drop_index('ix_knowledge_chunk_knowledge_id', table_name='knowledge_chunk')
+    op.drop_table('knowledge_chunk')

--- a/backend/open_webui/models/knowledge.py
+++ b/backend/open_webui/models/knowledge.py
@@ -1110,3 +1110,243 @@ class KnowledgeTable:
 
 
 Knowledges = KnowledgeTable()
+
+
+####################
+# Knowledge Management Tables (Enterprise Dashboard)
+####################
+
+
+class KnowledgeChunk(Base):
+    """Tracks individual chunks per file for preview and manual adjustment."""
+
+    __tablename__ = 'knowledge_chunk'
+
+    id = Column(Text, unique=True, primary_key=True)
+    knowledge_id = Column(Text, ForeignKey('knowledge.id', ondelete='CASCADE'), nullable=False)
+    file_id = Column(Text, ForeignKey('file.id', ondelete='CASCADE'), nullable=False)
+    chunk_index = Column(BigInteger, nullable=False)
+    content = Column(Text, nullable=False)
+    token_count = Column(BigInteger, nullable=True)
+    meta = Column(JSON, nullable=True)
+    content_hash = Column(Text, nullable=True)
+
+    created_at = Column(BigInteger, nullable=False)
+    updated_at = Column(BigInteger, nullable=False)
+
+    __table_args__ = (
+        UniqueConstraint('file_id', 'chunk_index', name='uq_knowledge_chunk_file_index'),
+        Index('ix_knowledge_chunk_knowledge_id', 'knowledge_id'),
+        Index('ix_knowledge_chunk_file_id', 'file_id'),
+    )
+
+
+class KnowledgeChunkModel(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    knowledge_id: str
+    file_id: str
+    chunk_index: int
+    content: str
+    token_count: Optional[int] = None
+    meta: Optional[dict] = None
+    content_hash: Optional[str] = None
+    created_at: int
+    updated_at: int
+
+
+class KnowledgeChunkMergeForm(BaseModel):
+    """Merge adjacent chunks within the same file."""
+
+    knowledge_id: str
+    file_id: str
+    start_index: int
+    end_index: int
+
+
+class KnowledgeChunkSplitForm(BaseModel):
+    """Split a chunk at a character offset."""
+
+    chunk_id: str
+    split_at: int  # character offset within the chunk
+
+
+class KnowledgeProcessingTask(Base):
+    """Per-file processing progress tracking."""
+
+    __tablename__ = 'knowledge_processing_task'
+
+    id = Column(Text, unique=True, primary_key=True)
+    knowledge_id = Column(Text, ForeignKey('knowledge.id', ondelete='CASCADE'), nullable=False)
+    file_id = Column(Text, ForeignKey('file.id', ondelete='CASCADE'), nullable=True)
+    task_type = Column(Text, nullable=False)  # 'chunking' | 'embedding' | 'full_process'
+    status = Column(Text, nullable=False)  # 'pending' | 'chunking' | 'embedding' | 'completed' | 'failed'
+    progress_pct = Column(BigInteger, nullable=False, default=0)
+    chunks_total = Column(BigInteger, nullable=True)
+    chunks_processed = Column(BigInteger, nullable=True)
+    error_message = Column(Text, nullable=True)
+    created_at = Column(BigInteger, nullable=False)
+    updated_at = Column(BigInteger, nullable=False)
+
+    __table_args__ = (
+        Index('ix_knowledge_processing_knowledge_id', 'knowledge_id'),
+        Index('ix_knowledge_processing_file_id', 'file_id'),
+    )
+
+
+class KnowledgeProcessingTaskModel(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    knowledge_id: str
+    file_id: Optional[str] = None
+    task_type: str
+    status: str
+    progress_pct: int
+    chunks_total: Optional[int] = None
+    chunks_processed: Optional[int] = None
+    error_message: Optional[str] = None
+    created_at: int
+    updated_at: int
+
+
+class KnowledgeBatchTask(Base):
+    """Parent batch processing task grouping sub-tasks."""
+
+    __tablename__ = 'knowledge_batch_task'
+
+    id = Column(Text, unique=True, primary_key=True)
+    knowledge_id = Column(Text, ForeignKey('knowledge.id', ondelete='CASCADE'), nullable=False)
+    total_files = Column(BigInteger, nullable=False)
+    files_processed = Column(BigInteger, nullable=False, default=0)
+    total_chunks = Column(BigInteger, nullable=True)
+    chunks_embedded = Column(BigInteger, nullable=True, default=0)
+    status = Column(Text, nullable=False)  # 'running' | 'completed' | 'failed'
+    created_at = Column(BigInteger, nullable=False)
+    updated_at = Column(BigInteger, nullable=False)
+
+    __table_args__ = (Index('ix_knowledge_batch_knowledge_id', 'knowledge_id'),)
+
+
+class KnowledgeBatchTaskModel(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    knowledge_id: str
+    total_files: int
+    files_processed: int
+    total_chunks: Optional[int] = None
+    chunks_embedded: Optional[int] = None
+    status: str
+    created_at: int
+    updated_at: int
+
+
+class KnowledgeRelevanceJudgment(Base):
+    """Ground-truth relevance judgments for retrieval evaluation."""
+
+    __tablename__ = 'knowledge_relevance_judgment'
+
+    id = Column(Text, unique=True, primary_key=True)
+    knowledge_id = Column(Text, ForeignKey('knowledge.id', ondelete='CASCADE'), nullable=False)
+    query_text = Column(Text, nullable=False)
+    chunk_id = Column(Text, nullable=True)
+    document_text = Column(Text, nullable=False)
+    rank_position = Column(BigInteger, nullable=True)
+    relevance = Column(BigInteger, nullable=False)  # 0=not relevant, 1=relevant
+    user_id = Column(Text, nullable=False)
+    created_at = Column(BigInteger, nullable=False)
+
+    __table_args__ = (
+        Index('ix_knowledge_judgment_knowledge_id', 'knowledge_id'),
+        Index('ix_knowledge_judgment_query', 'knowledge_id', 'query_text'),
+    )
+
+
+class KnowledgeRelevanceJudgmentModel(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    knowledge_id: str
+    query_text: str
+    chunk_id: Optional[str] = None
+    document_text: str
+    rank_position: Optional[int] = None
+    relevance: int
+    user_id: str
+    created_at: int
+
+
+class KnowledgeSnapshot(Base):
+    """Version snapshots of knowledge bases."""
+
+    __tablename__ = 'knowledge_snapshot'
+
+    id = Column(Text, unique=True, primary_key=True)
+    knowledge_id = Column(Text, ForeignKey('knowledge.id', ondelete='CASCADE'), nullable=False)
+    label = Column(Text, nullable=True)
+    description = Column(Text, nullable=True)
+    file_count = Column(BigInteger, nullable=False)
+    chunk_count = Column(BigInteger, nullable=True)
+    snapshot_data = Column(JSON, nullable=False)
+    collection_snapshot_path = Column(Text, nullable=True)
+    created_by = Column(Text, nullable=False)
+    created_at = Column(BigInteger, nullable=False)
+
+    __table_args__ = (Index('ix_knowledge_snapshot_knowledge_id', 'knowledge_id'),)
+
+
+class KnowledgeSnapshotModel(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    knowledge_id: str
+    label: Optional[str] = None
+    description: Optional[str] = None
+    file_count: int
+    chunk_count: Optional[int] = None
+    snapshot_data: dict
+    collection_snapshot_path: Optional[str] = None
+    created_by: str
+    created_at: int
+
+
+class KnowledgeSnapshotCreateForm(BaseModel):
+    label: Optional[str] = None
+    description: Optional[str] = None
+
+
+class KnowledgeSnapshotCompareResult(BaseModel):
+    added_files: list[dict]
+    removed_files: list[dict]
+    modified_files: list[dict]
+    total_chunks_before: int
+    total_chunks_after: int
+
+
+class KnowledgeChunkPreviewForm(BaseModel):
+    """Request form for chunk preview - takes a file_id to preview chunking."""
+
+    file_id: str
+
+
+class KnowledgeRelevanceAnnotationForm(BaseModel):
+    """Form to annotate retrieval results as relevant/not relevant."""
+
+    query_text: str
+    judgments: list[dict]  # [{chunk_id, rank_position, document_text, relevance: 0|1}]
+
+
+class KnowledgeEvaluateQueryForm(BaseModel):
+    """Form to run an evaluation query."""
+
+    query: str
+    k: int = 10
+
+
+class KnowledgeSnapshotCompareForm(BaseModel):
+    """Form to compare two snapshots."""
+
+    snapshot_a_id: str
+    snapshot_b_id: str

--- a/backend/open_webui/routers/files.py
+++ b/backend/open_webui/routers/files.py
@@ -4,6 +4,7 @@ import hashlib
 import json
 import logging
 import os
+import time
 import uuid
 from pathlib import Path
 from typing import Optional
@@ -38,7 +39,7 @@ from open_webui.models.files import (
     Files,
 )
 from open_webui.models.groups import Groups
-from open_webui.models.knowledge import Knowledges
+from open_webui.models.knowledge import Knowledges, KnowledgeProcessingTask
 from open_webui.models.users import Users
 from open_webui.retrieval.vector.async_client import ASYNC_VECTOR_DB_CLIENT
 from open_webui.routers.audio import transcribe
@@ -207,12 +208,37 @@ async def process_uploaded_file(
                             user_id=user.id,
                             directory_id=file_metadata.get('directory_id'),
                         )
+
+                        # ── Progress tracking for enterprise dashboard ──
+                        _now = int(time.time())
+                        _task_id = str(uuid.uuid4())
+                        _task = KnowledgeProcessingTask(
+                            id=_task_id,
+                            knowledge_id=knowledge_id,
+                            file_id=file_item.id,
+                            task_type='full_process',
+                            status='embedding',
+                            progress_pct=50,
+                            created_at=_now,
+                            updated_at=_now,
+                        )
+                        db_session.add(_task)
+                        await db_session.commit()
+
                         await process_file(
                             request,
                             ProcessFileForm(file_id=file_item.id, collection_name=knowledge_id),
                             user=user,
                             db=db_session,
                         )
+
+                        # Mark completed
+                        _task.status = 'completed'
+                        _task.progress_pct = 100
+                        _task.updated_at = int(time.time())
+                        db_session.add(_task)
+                        await db_session.commit()
+
                         log.info(f'Linked file {file_item.id} to knowledge {knowledge_id}')
                 except Exception as e:
                     log.warning(f'Failed to link file {file_item.id} to knowledge {knowledge_id}: {e}')

--- a/backend/open_webui/routers/knowledge.py
+++ b/backend/open_webui/routers/knowledge.py
@@ -21,22 +21,50 @@ from open_webui.models.config import Config
 from open_webui.models.files import FileMetadataResponse, FileModel, FileModelResponse, Files
 from open_webui.models.groups import Groups
 from open_webui.models.knowledge import (
+    KnowledgeChunkMergeForm,
+    KnowledgeChunkModel,
+    KnowledgeChunkPreviewForm,
+    KnowledgeChunkSplitForm,
+    KnowledgeChunk,
     KnowledgeDirectoryForm,
     KnowledgeDirectoryModel,
+    KnowledgeEvaluateQueryForm,
+    KnowledgeFile,
     KnowledgeFileListResponse,
     KnowledgeForm,
+    KnowledgeProcessingTask,
+    KnowledgeProcessingTaskModel,
+    KnowledgeBatchTask,
+    KnowledgeBatchTaskModel,
+    KnowledgeRelevanceAnnotationForm,
     KnowledgeResponse,
+    KnowledgeRelevanceJudgment,
+    KnowledgeRelevanceJudgmentModel,
+    KnowledgeSnapshot,
+    KnowledgeSnapshotCompareForm,
+    KnowledgeSnapshotCompareResult,
+    KnowledgeSnapshotCreateForm,
+    KnowledgeSnapshotModel,
     Knowledges,
     KnowledgeUserResponse,
 )
 from open_webui.models.models import ModelForm, Models
 from open_webui.retrieval.vector.async_client import ASYNC_VECTOR_DB_CLIENT
 from open_webui.retrieval.external import retrieve_external_knowledge, retrieve_external_knowledge_for_connection
+from open_webui.retrieval.utils import (
+    build_loader_from_config,
+    get_embedding_function,
+    get_loader_config,
+    query_collection_with_hybrid_search,
+    query_collection,
+)
 from open_webui.routers.retrieval import (
     BatchProcessFilesForm,
     ProcessFileForm,
+    get_retrieval_config,
     process_file,
     process_files_batch,
+    save_docs_to_vector_db,
 )
 from open_webui.storage.provider import Storage
 from open_webui.utils.access_control import filter_allowed_access_grants, has_permission
@@ -1415,12 +1443,59 @@ async def add_file_to_knowledge_by_id(
 
     # Add content to the vector database
     try:
+        await _update_processing_progress(
+            knowledge_id=id, file_id=form_data.file_id,
+            status='embedding', progress_pct=50, db=db,
+        )
+
         await process_file(
             request,
             ProcessFileForm(file_id=form_data.file_id, collection_name=id),
             user=user,
             db=db,
         )
+
+        await _update_processing_progress(
+            knowledge_id=id, file_id=form_data.file_id,
+            status='completed', progress_pct=100, db=db,
+        )
+
+        # ── Automatically persist chunks to knowledge_chunk table ──
+        try:
+            from sqlalchemy import delete as sa_delete
+            result_vdb = await ASYNC_VECTOR_DB_CLIENT.query(
+                collection_name=id, filter={'file_id': form_data.file_id}
+            )
+            if result_vdb and result_vdb.ids and len(result_vdb.ids) > 0:
+                import hashlib
+                now = int(time.time())
+                # Remove old chunk records
+                await db.execute(
+                    sa_delete(KnowledgeChunk).where(
+                        KnowledgeChunk.knowledge_id == id,
+                        KnowledgeChunk.file_id == form_data.file_id,
+                    )
+                )
+                for idx, (doc_id, text, metadata) in enumerate(
+                    zip(result_vdb.ids[0], result_vdb.documents[0], result_vdb.metadatas[0])
+                ):
+                    content_hash = hashlib.sha256(text.encode()).hexdigest() if text else None
+                    chunk = KnowledgeChunk(
+                        id=str(uuid.uuid4()),
+                        knowledge_id=id,
+                        file_id=form_data.file_id,
+                        chunk_index=idx,
+                        content=text,
+                        token_count=len(text) // 4 if text else None,
+                        meta=metadata,
+                        content_hash=content_hash,
+                        created_at=now,
+                        updated_at=now,
+                    )
+                    db.add(chunk)
+                await db.commit()
+        except Exception as chunk_err:
+            log.warning(f'Failed to persist chunks for KB {id} file {form_data.file_id}: {chunk_err}')
 
         # Add file to knowledge base
         await Knowledges.add_file_to_knowledge_by_id(
@@ -1432,6 +1507,10 @@ async def add_file_to_knowledge_by_id(
         )
     except Exception as e:
         log.debug(e)
+        await _update_processing_progress(
+            knowledge_id=id, file_id=form_data.file_id,
+            status='failed', error_message=str(e), db=db,
+        )
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(e),
@@ -2339,4 +2418,1011 @@ async def move_file_in_knowledge(
         subject_id=form_data.file_id,
         data={'knowledge_id': id, 'directory_id': form_data.directory_id},
     )
+    return {'status': True}
+
+
+# ─────────────────────────────────────────────────────────────
+# Enterprise Knowledge Dashboard – Phase 1: Chunk Management
+# ─────────────────────────────────────────────────────────────
+
+
+@router.post('/{id}/chunks/preview', response_model=list[KnowledgeChunkModel])
+async def preview_knowledge_chunks(
+    request: Request,
+    id: str,
+    form_data: KnowledgeChunkPreviewForm,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Chunk a file without embedding – preview what the splitter will produce."""
+    knowledge = await Knowledges.get_knowledge_by_id(id, db=db)
+    if not knowledge:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
+
+    file = await Files.get_file_by_id(form_data.file_id)
+    if not file:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
+
+    file_path = file.path
+    if not file_path:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail='File has no path.')
+
+    # Use existing loader + splitter (no embedding)
+    try:
+        file_path = await asyncio.to_thread(Storage.get_file, file_path)
+        loader_config = await get_loader_config()
+        loader = build_loader_from_config(request, loader_config)
+        loader.user = user
+        loader.metadata = {
+            'file_id': file.id,
+            'file_name': file.filename,
+            'file_content_type': file.meta.get('content_type'),
+        }
+        docs = await loader.aload(file.filename, file.meta.get('content_type'), file_path)
+
+        # Chunk using same logic as save_docs_to_vector_db
+        config = await get_retrieval_config()
+        from open_webui.routers.retrieval import merge_docs_to_target_size
+        from langchain_text_splitters import (
+            MarkdownHeaderTextSplitter,
+            RecursiveCharacterTextSplitter,
+            TokenTextSplitter,
+        )
+        import tiktoken
+
+        if config.ENABLE_MARKDOWN_HEADER_TEXT_SPLITTER:
+            markdown_splitter = MarkdownHeaderTextSplitter(
+                headers_to_split_on=[
+                    ('#', 'Header 1'),
+                    ('##', 'Header 2'),
+                    ('###', 'Header 3'),
+                    ('####', 'Header 4'),
+                    ('#####', 'Header 5'),
+                    ('######', 'Header 6'),
+                ],
+                strip_headers=False,
+            )
+            split_docs = []
+            for doc in docs:
+                split_docs.extend([
+                    type(doc)(page_content=c.page_content, metadata={**doc.metadata})
+                    for c in markdown_splitter.split_text(doc.page_content)
+                ])
+            docs = split_docs
+            if config.CHUNK_MIN_SIZE_TARGET > 0:
+                docs = merge_docs_to_target_size(request, docs, config)
+
+        if config.TEXT_SPLITTER in ['', 'character']:
+            text_splitter = RecursiveCharacterTextSplitter(
+                chunk_size=config.CHUNK_SIZE, chunk_overlap=config.CHUNK_OVERLAP, add_start_index=True,
+            )
+            docs = text_splitter.split_documents(docs)
+        elif config.TEXT_SPLITTER == 'token':
+            tiktoken.get_encoding(str(config.TIKTOKEN_ENCODING_NAME))
+            text_splitter = TokenTextSplitter(
+                encoding_name=str(config.TIKTOKEN_ENCODING_NAME),
+                chunk_size=config.CHUNK_SIZE, chunk_overlap=config.CHUNK_OVERLAP, add_start_index=True,
+            )
+            docs = text_splitter.split_documents(docs)
+        else:
+            # Fallback to RecursiveCharacterTextSplitter
+            text_splitter = RecursiveCharacterTextSplitter(
+                chunk_size=config.CHUNK_SIZE, chunk_overlap=config.CHUNK_OVERLAP, add_start_index=True,
+            )
+            docs = text_splitter.split_documents(docs)
+
+        # Remove old preview chunks for this file in this KB
+        from sqlalchemy import delete as sa_delete
+        await db.execute(
+            sa_delete(KnowledgeChunk).where(
+                KnowledgeChunk.knowledge_id == id,
+                KnowledgeChunk.file_id == form_data.file_id,
+            )
+        )
+
+        # Persist chunks in knowledge_chunk table
+        import hashlib
+        now = int(time.time())
+        chunks = []
+        for idx, doc in enumerate(docs):
+            content_hash = hashlib.sha256(doc.page_content.encode()).hexdigest()
+            token_count = len(doc.page_content) // 4  # rough estimate
+
+            chunk = KnowledgeChunk(
+                id=str(uuid.uuid4()),
+                knowledge_id=id,
+                file_id=form_data.file_id,
+                chunk_index=idx,
+                content=doc.page_content,
+                token_count=token_count,
+                meta=doc.metadata,
+                content_hash=content_hash,
+                created_at=now,
+                updated_at=now,
+            )
+            db.add(chunk)
+            chunks.append(KnowledgeChunkModel.model_validate(chunk))
+
+        await db.commit()
+        return chunks
+    except Exception as e:
+        log.exception(e)
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e))
+
+
+@router.get('/{id}/files/{file_id}/chunks', response_model=list[KnowledgeChunkModel])
+async def get_file_chunks(
+    id: str,
+    file_id: str,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Get all chunks for a file in a knowledge base."""
+    knowledge = await Knowledges.get_knowledge_by_id(id, db=db)
+    if not knowledge:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
+
+    from sqlalchemy import select as sa_select
+    result = await db.execute(
+        sa_select(KnowledgeChunk)
+        .where(KnowledgeChunk.knowledge_id == id, KnowledgeChunk.file_id == file_id)
+        .order_by(KnowledgeChunk.chunk_index.asc())
+    )
+    rows = result.scalars().all()
+    return [KnowledgeChunkModel.model_validate(r) for r in rows]
+
+
+@router.get('/{id}/chunks/{chunk_id}', response_model=KnowledgeChunkModel)
+async def get_chunk_detail(
+    id: str,
+    chunk_id: str,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Get full content of a single chunk."""
+    from sqlalchemy import select as sa_select
+    result = await db.execute(
+        sa_select(KnowledgeChunk).where(
+            KnowledgeChunk.knowledge_id == id,
+            KnowledgeChunk.id == chunk_id,
+        )
+    )
+    chunk = result.scalars().first()
+    if not chunk:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail='Chunk not found.')
+    return KnowledgeChunkModel.model_validate(chunk)
+
+
+@router.post('/{id}/chunks/merge')
+async def merge_knowledge_chunks(
+    request: Request,
+    id: str,
+    form_data: KnowledgeChunkMergeForm,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Merge adjacent chunks [start_index, end_index] into one."""
+    knowledge = await Knowledges.get_knowledge_by_id(id, db=db)
+    if not knowledge:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
+
+    from sqlalchemy import select as sa_select, delete as sa_delete
+
+    # Fetch chunks in range
+    result = await db.execute(
+        sa_select(KnowledgeChunk)
+        .where(
+            KnowledgeChunk.knowledge_id == id,
+            KnowledgeChunk.file_id == form_data.file_id,
+            KnowledgeChunk.chunk_index >= form_data.start_index,
+            KnowledgeChunk.chunk_index <= form_data.end_index,
+        )
+        .order_by(KnowledgeChunk.chunk_index.asc())
+    )
+    target_chunks = result.scalars().all()
+    if len(target_chunks) < 2:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail='Need at least 2 chunks to merge.')
+
+    # Merge content
+    merged_content = '\n\n'.join(c.content for c in target_chunks)
+    merged_meta = target_chunks[0].meta or {}
+
+    import hashlib
+    now = int(time.time())
+    content_hash = hashlib.sha256(merged_content.encode()).hexdigest()
+    token_count = len(merged_content) // 4
+
+    # Create new merged chunk at the first index
+    merged_chunk = KnowledgeChunk(
+        id=str(uuid.uuid4()),
+        knowledge_id=id,
+        file_id=form_data.file_id,
+        chunk_index=form_data.start_index,
+        content=merged_content,
+        token_count=token_count,
+        meta=merged_meta,
+        content_hash=content_hash,
+        created_at=now,
+        updated_at=now,
+    )
+
+    # Delete old chunks
+    old_ids = [c.id for c in target_chunks]
+    await db.execute(sa_delete(KnowledgeChunk).where(KnowledgeChunk.id.in_(old_ids)))
+    db.add(merged_chunk)
+
+    # Re-index chunks after the deleted range
+    result = await db.execute(
+        sa_select(KnowledgeChunk)
+        .where(
+            KnowledgeChunk.knowledge_id == id,
+            KnowledgeChunk.file_id == form_data.file_id,
+            KnowledgeChunk.chunk_index > form_data.end_index,
+        )
+        .order_by(KnowledgeChunk.chunk_index.asc())
+    )
+    trailing = result.scalars().all()
+    offset = form_data.end_index - form_data.start_index
+    for chunk in trailing:
+        chunk.chunk_index -= offset
+        chunk.updated_at = now
+
+    await db.commit()
+    return {'status': True, 'merged_chunk_id': merged_chunk.id}
+
+
+@router.post('/{id}/chunks/split')
+async def split_knowledge_chunk(
+    request: Request,
+    id: str,
+    form_data: KnowledgeChunkSplitForm,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Split a chunk at a character offset into two chunks."""
+    knowledge = await Knowledges.get_knowledge_by_id(id, db=db)
+    if not knowledge:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
+
+    from sqlalchemy import select as sa_select
+
+    result = await db.execute(
+        sa_select(KnowledgeChunk).where(
+            KnowledgeChunk.knowledge_id == id,
+            KnowledgeChunk.id == form_data.chunk_id,
+        )
+    )
+    chunk = result.scalars().first()
+    if not chunk:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail='Chunk not found.')
+
+    content = chunk.content
+    split_point = form_data.split_at
+    if split_point <= 0 or split_point >= len(content):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail='Split point must be within chunk content.')
+
+    part_a = content[:split_point].strip()
+    part_b = content[split_point:].strip()
+    if not part_a or not part_b:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail='Both parts must be non-empty.')
+
+    import hashlib
+    now = int(time.time())
+
+    # Update original chunk to part_a
+    chunk.content = part_a
+    chunk.token_count = len(part_a) // 4
+    chunk.content_hash = hashlib.sha256(part_a.encode()).hexdigest()
+    chunk.updated_at = now
+
+    # Create new chunk for part_b
+    new_chunk = KnowledgeChunk(
+        id=str(uuid.uuid4()),
+        knowledge_id=id,
+        file_id=chunk.file_id,
+        chunk_index=chunk.chunk_index + 1,
+        content=part_b,
+        token_count=len(part_b) // 4,
+        meta=(chunk.meta or {}).copy(),
+        content_hash=hashlib.sha256(part_b.encode()).hexdigest(),
+        created_at=now,
+        updated_at=now,
+    )
+    db.add(new_chunk)
+
+    # Shift trailing chunks
+    result = await db.execute(
+        sa_select(KnowledgeChunk)
+        .where(
+            KnowledgeChunk.knowledge_id == id,
+            KnowledgeChunk.file_id == chunk.file_id,
+            KnowledgeChunk.chunk_index > chunk.chunk_index,
+        )
+        .order_by(KnowledgeChunk.chunk_index.asc())
+    )
+    trailing = result.scalars().all()
+    for tc in trailing:
+        tc.chunk_index += 1
+        tc.updated_at = now
+
+    await db.commit()
+    return {'status': True, 'new_chunk_id': new_chunk.id}
+
+
+@router.post('/{id}/chunks/reindex')
+async def reindex_knowledge_chunks(
+    request: Request,
+    id: str,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Re-embed all chunks for this KB after manual adjustments."""
+    knowledge = await Knowledges.get_knowledge_by_id(id, db=db)
+    if not knowledge:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
+
+    from sqlalchemy import select as sa_select
+
+    result = await db.execute(
+        sa_select(KnowledgeChunk).where(KnowledgeChunk.knowledge_id == id)
+    )
+    chunks = result.scalars().all()
+    if not chunks:
+        return {'status': True, 'message': 'No chunks to reindex.'}
+
+    # Delete old vectors for this KB's collection
+    try:
+        await ASYNC_VECTOR_DB_CLIENT.delete_collection(collection_name=id)
+    except Exception:
+        pass
+
+    # Rebuild vectors from knowledge_chunk rows
+    from langchain_core.documents import Document
+
+    docs = [
+        Document(
+            page_content=c.content,
+            metadata={
+                **(c.meta or {}),
+                'file_id': c.file_id,
+                'chunk_index': c.chunk_index,
+                'content_hash': c.content_hash,
+            },
+        )
+        for c in chunks
+    ]
+
+    try:
+        await save_docs_to_vector_db(
+            request=request,
+            collection_name=id,
+            docs=docs,
+            user=user,
+            bypass_embedding=False,
+        )
+    except Exception as e:
+        log.exception(e)
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e))
+
+    return {'status': True, 'chunks_processed': len(chunks)}
+
+
+# ─────────────────────────────────────────────────────────────
+# Enterprise Knowledge Dashboard – Phase 2: Progress Tracking
+# ─────────────────────────────────────────────────────────────
+
+
+# In-memory progress store for real-time SSE updates
+# Key: (knowledge_id, file_id) → KnowledgeProcessingTaskModel
+_progress_store: dict[str, KnowledgeProcessingTaskModel] = {}
+
+
+async def _update_processing_progress(
+    knowledge_id: str,
+    file_id: str,
+    status: str,
+    progress_pct: int = 0,
+    chunks_total: int | None = None,
+    chunks_processed: int | None = None,
+    error_message: str | None = None,
+    db: AsyncSession | None = None,
+):
+    """Create or update a processing task record in DB and in-memory store."""
+    import time as _time, uuid as _uuid
+
+    key = f'{knowledge_id}:{file_id}'
+    now = int(_time.time())
+
+    # Try to update existing task
+    from sqlalchemy import select as sa_select
+    result = await db.execute(
+        sa_select(KnowledgeProcessingTask).where(
+            KnowledgeProcessingTask.knowledge_id == knowledge_id,
+            KnowledgeProcessingTask.file_id == file_id,
+        )
+    )
+    task = result.scalars().first()
+
+    if task:
+        task.status = status
+        task.progress_pct = progress_pct
+        if chunks_total is not None:
+            task.chunks_total = chunks_total
+        if chunks_processed is not None:
+            task.chunks_processed = chunks_processed
+        if error_message is not None:
+            task.error_message = error_message
+        task.updated_at = now
+        db.add(task)
+        await db.commit()
+    else:
+        task = KnowledgeProcessingTask(
+            id=str(_uuid.uuid4()),
+            knowledge_id=knowledge_id,
+            file_id=file_id,
+            task_type='full_process',
+            status=status,
+            progress_pct=progress_pct,
+            chunks_total=chunks_total,
+            chunks_processed=chunks_processed,
+            error_message=error_message,
+            created_at=now,
+            updated_at=now,
+        )
+        db.add(task)
+        await db.commit()
+
+    # Update in-memory store
+    _progress_store[key] = KnowledgeProcessingTaskModel.model_validate(task)
+
+
+@router.get('/{id}/progress', response_model=list[KnowledgeProcessingTaskModel])
+async def get_processing_progress(
+    id: str,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Get current processing status for all files in a KB."""
+    knowledge = await Knowledges.get_knowledge_by_id(id, db=db)
+    if not knowledge:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
+
+    from sqlalchemy import select as sa_select
+
+    result = await db.execute(
+        sa_select(KnowledgeProcessingTask)
+        .where(KnowledgeProcessingTask.knowledge_id == id)
+        .order_by(KnowledgeProcessingTask.created_at.desc())
+    )
+    tasks = result.scalars().all()
+    return [KnowledgeProcessingTaskModel.model_validate(t) for t in tasks]
+
+
+@router.get('/{id}/progress/stream')
+async def stream_processing_progress(
+    request: Request,
+    id: str,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """SSE endpoint that streams progress updates every second."""
+    knowledge = await Knowledges.get_knowledge_by_id(id, db=db)
+    if not knowledge:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
+
+    async def event_generator():
+        import time as _time
+        from sqlalchemy import select as sa_select
+
+        # Track the last run to stop after idle timeout
+        last_active = _time.time()
+        sent_count = 0
+
+        while True:
+            # Check DB for tasks
+            result = await db.execute(
+                sa_select(KnowledgeProcessingTask)
+                .where(KnowledgeProcessingTask.knowledge_id == id)
+                .order_by(KnowledgeProcessingTask.created_at.desc())
+            )
+            tasks = result.scalars().all()
+            task_list = [KnowledgeProcessingTaskModel.model_validate(t).model_dump() for t in tasks]
+
+            # Also include in-memory tasks that may not be in DB yet
+            for key, mem_task in _progress_store.items():
+                if key.startswith(f'{id}:'):
+                    exists = any(t['id'] == mem_task.id for t in task_list)
+                    if not exists:
+                        task_list.append(mem_task.model_dump())
+
+            data = json.dumps(task_list)
+            yield f'data: {data}\n\n'
+            sent_count += 1
+
+            # Check if all tasks are in terminal state
+            all_done = all(
+                t['status'] in ('completed', 'failed') for t in task_list
+            ) if task_list else False
+
+            if all_done and sent_count > 2:
+                # Send one more update then stop
+                yield f'data: {data}\n\n'
+                break
+
+            if not all_done:
+                last_active = _time.time()
+
+            # Timeout after 5 minutes of inactivity
+            if _time.time() - last_active > 300:
+                break
+
+            await asyncio.sleep(1)
+
+            # Refresh DB session between iterations
+            await db.commit()
+
+    return StreamingResponse(event_generator(), media_type='text/event-stream')
+
+
+@router.get('/{id}/progress/batch', response_model=KnowledgeBatchTaskModel | None)
+async def get_batch_progress(
+    id: str,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Get the latest batch processing task for this KB."""
+    knowledge = await Knowledges.get_knowledge_by_id(id, db=db)
+    if not knowledge:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
+
+    from sqlalchemy import select as sa_select
+
+    result = await db.execute(
+        sa_select(KnowledgeBatchTask)
+        .where(KnowledgeBatchTask.knowledge_id == id)
+        .order_by(KnowledgeBatchTask.created_at.desc())
+        .limit(1)
+    )
+    batch = result.scalars().first()
+    if not batch:
+        return None
+    return KnowledgeBatchTaskModel.model_validate(batch)
+
+
+# ─────────────────────────────────────────────────────────────
+# Enterprise Knowledge Dashboard – Phase 3: Retrieval Evaluation
+# ─────────────────────────────────────────────────────────────
+
+
+@router.post('/{id}/evaluate/query')
+async def evaluate_retrieval_query(
+    request: Request,
+    id: str,
+    form_data: KnowledgeEvaluateQueryForm,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Run a test query against the KB and return Top-K results with metrics."""
+    knowledge = await Knowledges.get_knowledge_by_id(id, db=db)
+    if not knowledge:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
+
+    k = form_data.k if form_data.k else 10
+
+    try:
+        result = await query_collection(
+            request=request,
+            collection_names=[id],
+            queries=[form_data.query],
+            embedding_function=request.app.state.EMBEDDING_FUNCTION,
+            k=k,
+        )
+    except Exception as e:
+        log.exception(e)
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e))
+
+    # query_collection returns: {'distances': [[]], 'documents': [[]], 'metadatas': [[]]}
+    results = []
+    if isinstance(result, dict):
+        docs_list = result.get('documents', [[]])[0] if result.get('documents') else []
+        metas_list = result.get('metadatas', [[]])[0] if result.get('metadatas') else []
+        dists_list = result.get('distances', [[]])[0] if result.get('distances') else []
+
+        for i in range(min(k, len(docs_list))):
+            doc_text = docs_list[i] if i < len(docs_list) else ''
+            results.append({
+                'chunk_id': metas_list[i].get('content_hash', f'chunk-{i}') if i < len(metas_list) else f'chunk-{i}',
+                'text': doc_text[:500],
+                'score': dists_list[i] if i < len(dists_list) else None,
+                'metadata': metas_list[i] if i < len(metas_list) else {},
+                'rank': i + 1,
+            })
+
+    # Compute metrics if judgments exist
+    from sqlalchemy import select as sa_select
+    metrics = None
+    j_result = await db.execute(
+        sa_select(KnowledgeRelevanceJudgment)
+        .where(
+            KnowledgeRelevanceJudgment.knowledge_id == id,
+            KnowledgeRelevanceJudgment.query_text == form_data.query,
+        )
+    )
+    judgments = j_result.scalars().all()
+    if judgments:
+        relevant_ids = {j.chunk_id for j in judgments if j.relevance == 1}
+        total_relevant = len(relevant_ids)
+        if total_relevant > 0:
+            # recall@K
+            retrieved_ids = {r['chunk_id'] for r in results if r['chunk_id']}
+            relevant_retrieved = relevant_ids & retrieved_ids
+            recall_at_k = len(relevant_retrieved) / total_relevant
+            # precision@K
+            precision_at_k = len(relevant_retrieved) / k if k > 0 else 0
+            # MRR
+            mrr = 0.0
+            for j in judgments:
+                if j.relevance == 1 and j.rank_position and j.rank_position > 0:
+                    mrr = max(mrr, 1.0 / j.rank_position)
+            metrics = {
+                'recall_at_k': round(recall_at_k, 4),
+                'precision_at_k': round(precision_at_k, 4),
+                'mrr': round(mrr, 4),
+                'total_relevant': total_relevant,
+            }
+
+    return {'results': results, 'metrics': metrics}
+
+
+@router.post('/{id}/evaluate/annotate')
+async def annotate_retrieval_results(
+    request: Request,
+    id: str,
+    form_data: KnowledgeRelevanceAnnotationForm,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Mark retrieved chunks as relevant (1) or not relevant (0)."""
+    knowledge = await Knowledges.get_knowledge_by_id(id, db=db)
+    if not knowledge:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
+
+    from sqlalchemy import delete as sa_delete
+    now = int(time.time())
+    count = 0
+
+    for j in form_data.judgments:
+        # Upsert: delete old judgment for same query+chunk, then insert
+        await db.execute(
+            sa_delete(KnowledgeRelevanceJudgment).where(
+                KnowledgeRelevanceJudgment.knowledge_id == id,
+                KnowledgeRelevanceJudgment.query_text == form_data.query_text,
+                KnowledgeRelevanceJudgment.chunk_id == j.get('chunk_id'),
+            )
+        )
+        judgment = KnowledgeRelevanceJudgment(
+            id=str(uuid.uuid4()),
+            knowledge_id=id,
+            query_text=form_data.query_text,
+            chunk_id=j.get('chunk_id'),
+            document_text=j.get('document_text', ''),
+            rank_position=j.get('rank_position'),
+            relevance=j.get('relevance', 0),
+            user_id=user.id,
+            created_at=now,
+        )
+        db.add(judgment)
+        count += 1
+
+    await db.commit()
+    return {'status': True, 'annotations_saved': count}
+
+
+@router.get('/{id}/evaluate/judgments')
+async def get_evaluation_judgments(
+    id: str,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Get all relevance judgments for this KB, grouped by query."""
+    knowledge = await Knowledges.get_knowledge_by_id(id, db=db)
+    if not knowledge:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
+
+    from sqlalchemy import select as sa_select
+    result = await db.execute(
+        sa_select(KnowledgeRelevanceJudgment)
+        .where(KnowledgeRelevanceJudgment.knowledge_id == id)
+        .order_by(KnowledgeRelevanceJudgment.created_at.desc())
+    )
+    rows = result.scalars().all()
+
+    # Group by query_text
+    grouped: dict[str, list] = {}
+    for r in rows:
+        key = r.query_text
+        if key not in grouped:
+            grouped[key] = []
+        grouped[key].append(KnowledgeRelevanceJudgmentModel.model_validate(r).model_dump())
+
+    return {'judgments': grouped, 'total_queries': len(grouped)}
+
+
+@router.delete('/{id}/evaluate/judgments/{query_text:path}')
+async def delete_evaluation_judgments(
+    id: str,
+    query_text: str,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Delete all judgments for a specific query."""
+    knowledge = await Knowledges.get_knowledge_by_id(id, db=db)
+    if not knowledge:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
+
+    from urllib.parse import unquote
+    from sqlalchemy import delete as sa_delete
+
+    decoded_query = unquote(query_text)
+    await db.execute(
+        sa_delete(KnowledgeRelevanceJudgment).where(
+            KnowledgeRelevanceJudgment.knowledge_id == id,
+            KnowledgeRelevanceJudgment.query_text == decoded_query,
+        )
+    )
+    await db.commit()
+    return {'status': True}
+
+
+# ─────────────────────────────────────────────────────────────
+# Enterprise Knowledge Dashboard – Phase 4: Snapshot Management
+# ─────────────────────────────────────────────────────────────
+
+
+@router.post('/{id}/snapshots', response_model=KnowledgeSnapshotModel)
+async def create_knowledge_snapshot(
+    request: Request,
+    id: str,
+    form_data: KnowledgeSnapshotCreateForm,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Create a snapshot of the current KB state (files + chunks)."""
+    knowledge = await Knowledges.get_knowledge_by_id(id, db=db)
+    if not knowledge:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
+
+    from sqlalchemy import select as sa_select
+    now = int(time.time())
+
+    # Collect chunk records
+    chunk_result = await db.execute(
+        sa_select(KnowledgeChunk).where(KnowledgeChunk.knowledge_id == id)
+    )
+    chunk_rows = chunk_result.scalars().all()
+
+    # Collect file associations
+    files_with_dirs = await Knowledges.get_files_with_directory_ids(id, db=db)
+
+    # Build snapshot data
+    snapshot_data = {
+        'files': [
+            {
+                'file_id': f.id,
+                'filename': f.filename,
+                'directory_id': dir_id,
+            }
+            for f, dir_id in files_with_dirs
+        ],
+        'chunks': [
+            {
+                'id': c.id,
+                'file_id': c.file_id,
+                'chunk_index': c.chunk_index,
+                'content_hash': c.content_hash,
+                'token_count': c.token_count,
+            }
+            for c in chunk_rows
+        ],
+    }
+
+    snapshot = KnowledgeSnapshot(
+        id=str(uuid.uuid4()),
+        knowledge_id=id,
+        label=form_data.label,
+        description=form_data.description,
+        file_count=len(files_with_dirs),
+        chunk_count=len(chunk_rows),
+        snapshot_data=snapshot_data,
+        created_by=user.id,
+        created_at=now,
+    )
+    db.add(snapshot)
+    await db.commit()
+    await db.refresh(snapshot)
+
+    return KnowledgeSnapshotModel.model_validate(snapshot)
+
+
+@router.get('/{id}/snapshots', response_model=list[KnowledgeSnapshotModel])
+async def list_knowledge_snapshots(
+    id: str,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """List all snapshots for this KB."""
+    knowledge = await Knowledges.get_knowledge_by_id(id, db=db)
+    if not knowledge:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
+
+    from sqlalchemy import select as sa_select
+    result = await db.execute(
+        sa_select(KnowledgeSnapshot)
+        .where(KnowledgeSnapshot.knowledge_id == id)
+        .order_by(KnowledgeSnapshot.created_at.desc())
+    )
+    rows = result.scalars().all()
+    return [KnowledgeSnapshotModel.model_validate(r) for r in rows]
+
+
+@router.get('/{id}/snapshots/{snapshot_id}', response_model=KnowledgeSnapshotModel)
+async def get_knowledge_snapshot(
+    id: str,
+    snapshot_id: str,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Get a single snapshot detail."""
+    from sqlalchemy import select as sa_select
+    result = await db.execute(
+        sa_select(KnowledgeSnapshot).where(
+            KnowledgeSnapshot.id == snapshot_id,
+            KnowledgeSnapshot.knowledge_id == id,
+        )
+    )
+    snap = result.scalars().first()
+    if not snap:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail='Snapshot not found.')
+    return KnowledgeSnapshotModel.model_validate(snap)
+
+
+@router.post('/{id}/snapshots/{snapshot_id}/rollback')
+async def rollback_knowledge_snapshot(
+    request: Request,
+    id: str,
+    snapshot_id: str,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Rollback to a previous snapshot - restore chunk records and re-index."""
+    knowledge = await Knowledges.get_knowledge_by_id(id, db=db)
+    if not knowledge:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
+
+    from sqlalchemy import select as sa_select, delete as sa_delete
+
+    result = await db.execute(
+        sa_select(KnowledgeSnapshot).where(
+            KnowledgeSnapshot.id == snapshot_id,
+            KnowledgeSnapshot.knowledge_id == id,
+        )
+    )
+    snap = result.scalars().first()
+    if not snap:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail='Snapshot not found.')
+
+    snap_data = snap.snapshot_data or {}
+    snap_files = snap_data.get('files', [])
+    snap_chunks = snap_data.get('chunks', [])
+
+    now = int(time.time())
+
+    # 1. Clear current chunks and file associations
+    await db.execute(sa_delete(KnowledgeChunk).where(KnowledgeChunk.knowledge_id == id))
+    await db.execute(sa_delete(KnowledgeFile).where(KnowledgeFile.knowledge_id == id))
+
+    restored_chunks = len(snap_chunks)
+
+    # 2. Restore chunk records
+    for c in snap_chunks:
+        db.add(KnowledgeChunk(
+            id=c.get('id', str(uuid.uuid4())),
+            knowledge_id=id, file_id=c['file_id'],
+            chunk_index=c['chunk_index'], content='',
+            token_count=c.get('token_count'), content_hash=c.get('content_hash'),
+            created_at=now, updated_at=now,
+        ))
+
+    # 3. Restore file associations
+    seen = set()
+    for f in snap_files:
+        if f['file_id'] not in seen:
+            seen.add(f['file_id'])
+            db.add(KnowledgeFile(
+                id=str(uuid.uuid4()), knowledge_id=id,
+                file_id=f['file_id'], user_id=user.id,
+                directory_id=f.get('directory_id'),
+                created_at=now, updated_at=now,
+            ))
+
+    await db.commit()
+
+    return {
+        'status': True,
+        'restored_files': len(snap_files),
+        'restored_chunks': restored_chunks,
+        'snapshot_label': snap.label,
+        'hint': 'Vectors need re-indexing. Go to Chunks tab and click Reindex Vectors to rebuild.',
+    }
+
+
+@router.post('/{id}/snapshots/compare', response_model=KnowledgeSnapshotCompareResult)
+async def compare_knowledge_snapshots(
+    id: str,
+    form_data: KnowledgeSnapshotCompareForm,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Compare two snapshots and show added/removed/modified files."""
+    knowledge = await Knowledges.get_knowledge_by_id(id, db=db)
+    if not knowledge:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
+
+    from sqlalchemy import select as sa_select
+
+    # Load both snapshots
+    r1 = await db.execute(
+        sa_select(KnowledgeSnapshot).where(KnowledgeSnapshot.id == form_data.snapshot_a_id)
+    )
+    snap_a = r1.scalars().first()
+    r2 = await db.execute(
+        sa_select(KnowledgeSnapshot).where(KnowledgeSnapshot.id == form_data.snapshot_b_id)
+    )
+    snap_b = r2.scalars().first()
+    if not snap_a or not snap_b:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail='Snapshot not found.')
+
+    files_a = {(f['file_id'], f['filename']) for f in (snap_a.snapshot_data or {}).get('files', [])}
+    files_b = {(f['file_id'], f['filename']) for f in (snap_b.snapshot_data or {}).get('files', [])}
+
+    added = [{'file_id': fid, 'filename': fn} for fid, fn in (files_b - files_a)]
+    removed = [{'file_id': fid, 'filename': fn} for fid, fn in (files_a - files_b)]
+
+    # Check for modified (same file_id but different hash)
+    chunks_a = {(c['file_id'], c.get('content_hash')) for c in (snap_a.snapshot_data or {}).get('chunks', [])}
+    chunks_b = {(c['file_id'], c.get('content_hash')) for c in (snap_b.snapshot_data or {}).get('chunks', [])}
+    common_ids = {fid for fid, _ in files_a} & {fid for fid, _ in files_b}
+    modified = []
+    for fid in common_ids:
+        hashes_a = {h for f, h in chunks_a if f == fid}
+        hashes_b = {h for f, h in chunks_b if f == fid}
+        if hashes_a != hashes_b:
+            name_a = next((fn for i, fn in files_a if i == fid), fid)
+            modified.append({'file_id': fid, 'filename': name_a})
+
+    return KnowledgeSnapshotCompareResult(
+        added_files=added,
+        removed_files=removed,
+        modified_files=modified,
+        total_chunks_before=snap_a.chunk_count or 0,
+        total_chunks_after=snap_b.chunk_count or 0,
+    )
+
+
+@router.delete('/{id}/snapshots/{snapshot_id}')
+async def delete_knowledge_snapshot(
+    id: str,
+    snapshot_id: str,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Delete a snapshot."""
+    from sqlalchemy import delete as sa_delete
+    await db.execute(
+        sa_delete(KnowledgeSnapshot).where(
+            KnowledgeSnapshot.id == snapshot_id,
+            KnowledgeSnapshot.knowledge_id == id,
+        )
+    )
+    await db.commit()
     return {'status': True}

--- a/read.md
+++ b/read.md
@@ -1,0 +1,205 @@
+# 基于 Open WebUI 的企业级知识库管理后台
+
+> 在开源项目 [Open WebUI](https://github.com/open-webui/open-webui)（128K+ Star）基础上二次开发，新增可视化的知识库管理仪表板。
+
+---
+
+## 项目简介
+
+Open WebUI 是一个自托管的 AI 对话平台，支持接入 ChatGPT、DeepSeek、Ollama 等大模型。本人在其已有的 RAG（检索增强生成）能力之上，独立设计并实现了**企业级知识库管理后台**，新增以下 4 个功能模块：
+
+| 模块 | 说明 |
+|---|---|
+| 🧩 **分块预览与手动调整** | 文档上传后自动展示分块结果，支持合并/拆分分块，调整后重建向量 |
+| ⏳ **向量化进度可视化** | 实时展示文档处理进度（分块 → Embedding → 完成），SSE 流式推送 |
+| 📊 **检索质量评估面板** | 输入测试查询，展示 Top-K 检索结果与分数，支持人工标注计算 recall/precision/MRR |
+| 📸 **知识库版本管理** | 创建知识库快照，支持回滚和快照间差异对比 |
+
+---
+
+## 技术栈
+
+| 层级 | 技术 |
+|---|---|
+| **后端框架** | Python / FastAPI（异步 ASGI） |
+| **前端框架** | SvelteKit + TypeScript + Tailwind CSS |
+| **数据库** | SQLite（开发）/ PostgreSQL（生产），SQLAlchemy ORM + Alembic 迁移 |
+| **向量数据库** | ChromaDB（默认），支持 PGVector / Qdrant / Milvus 等 9 种 |
+| **AI/LLM** | DeepSeek API（OpenAI 兼容协议），支持 Ollama 本地模型 |
+| **文档处理** | LangChain Text Splitters（递归分块 / Token 分块 / Markdown 标题分块） |
+| **实时通信** | Socket.IO / SSE (Server-Sent Events) |
+| **部署** | Docker / Docker Compose |
+| **认证** | JWT + OAuth2.0 + RBAC |
+
+---
+
+## 系统架构
+
+```
+┌─────────────────────────────────────────────────┐
+│                  浏览器 (SvelteKit PWA)           │
+│    Tab 导航: Files │ Chunks │ Processing │ ...    │
+├─────────────────────────────────────────────────┤
+│                  FastAPI 后端 (Python)            │
+│  ┌──────────┐ ┌──────────┐ ┌──────────────────┐ │
+│  │ Knowledge│ │ Retrieval│ │ Chunk Management │ │
+│  │  Router  │ │  Router  │ │     Router       │ │
+│  └──────────┘ └──────────┘ └──────────────────┘ │
+│         │            │               │           │
+│    ┌────┴────┐  ┌───┴────┐  ┌──────┴──────┐    │
+│    │ SQLite  │  │ChromaDB│  │ DeepSeek API│    │
+│    │ (元数据) │  │ (向量)  │  │  (LLM推理)  │    │
+│    └─────────┘  └────────┘  └─────────────┘    │
+└─────────────────────────────────────────────────┘
+```
+
+---
+
+## 数据库设计（新增表）
+
+### knowledge_chunk — 分块记录
+```sql
+id, knowledge_id(FK), file_id(FK), chunk_index,
+content, token_count, meta(JSON), content_hash,
+created_at, updated_at
+```
+
+### knowledge_processing_task — 处理进度
+```sql
+id, knowledge_id(FK), file_id(FK), task_type,
+status(pending/chunking/embedding/completed/failed),
+progress_pct, chunks_total, chunks_processed, error_message
+```
+
+### knowledge_relevance_judgment — 检索标注
+```sql
+id, knowledge_id(FK), query_text, chunk_id,
+document_text, rank_position, relevance(0/1), user_id
+```
+
+### knowledge_snapshot — 版本快照
+```sql
+id, knowledge_id(FK), label, description, file_count,
+chunk_count, snapshot_data(JSON), collection_snapshot_path
+```
+
+---
+
+## API 设计（新增 20+ 端点）
+
+所有端点挂载在 `/api/v1/knowledge/{id}/` 下：
+
+### 分块管理
+| 方法 | 路径 | 说明 |
+|---|---|---|
+| POST | `/{id}/chunks/preview` | 上传文件 → 分块预览（不入向量库） |
+| GET | `/{id}/files/{file_id}/chunks` | 获取某文件所有分块 |
+| GET | `/{id}/chunks/{chunk_id}` | 查看单个分块详情 |
+| POST | `/{id}/chunks/merge` | 合并相邻分块 |
+| POST | `/{id}/chunks/split` | 拆分分块 |
+| POST | `/{id}/chunks/reindex` | 重建向量（调整分块后） |
+
+### 进度监控
+| 方法 | 路径 | 说明 |
+|---|---|---|
+| GET | `/{id}/progress` | 当前处理状态 |
+| GET | `/{id}/progress/stream` | SSE 实时推送进度 |
+| GET | `/{id}/progress/batch` | 批量任务进度 |
+
+### 检索评估
+| 方法 | 路径 | 说明 |
+|---|---|---|
+| POST | `/{id}/evaluate/query` | 测试查询 → Top-K + 指标 |
+| POST | `/{id}/evaluate/annotate` | 标注相关/不相关 |
+| GET | `/{id}/evaluate/judgments` | 查看历史标注 |
+
+### 版本管理
+| 方法 | 路径 | 说明 |
+|---|---|---|
+| POST | `/{id}/snapshots` | 创建快照 |
+| GET | `/{id}/snapshots` | 快照列表 |
+| POST | `/{id}/snapshots/{sid}/rollback` | 回滚到指定快照 |
+| POST | `/{id}/snapshots/compare` | 对比两个快照差异 |
+
+---
+
+## 前端组件
+
+```
+src/lib/components/workspace/Knowledge/
+├── KnowledgeBase.svelte          # 知识库主视图
+├── ChunkManager.svelte           # 分块管理器（表格+合并+拆分+重建向量）
+├── ChunkDetailModal.svelte       # 分块详情弹窗
+├── ChunkMergePanel.svelte        # 合并分块面板
+├── ChunkSplitModal.svelte        # 拆分量弹窗
+├── ProcessingDashboard.svelte    # 处理进度仪表板
+├── EvaluatePanel.svelte          # 检索评估面板
+└── SnapshotManager.svelte        # 快照管理
+```
+
+路由结构：
+```
+workspace/knowledge/[id]/
+├── +layout.svelte       → Tab 导航 (Files│Chunks│Processing│Evaluate│Snapshots)
+├── +page.svelte         → KnowledgeBase (Files 视图)
+├── chunks/+page.svelte  → ChunkManager
+├── processing/+page.svelte → ProcessingDashboard
+├── evaluate/+page.svelte   → EvaluatePanel
+└── snapshots/+page.svelte  → SnapshotManager
+```
+
+---
+
+## 本地运行
+
+```bash
+# 1. 克隆项目
+git clone https://github.com/open-webui/open-webui.git
+cd open-webui
+
+# 2. 安装依赖
+cd backend && pip install -r requirements.txt
+cd .. && npm install --engine-strict=false
+
+# 3. 构建前端
+npm run build
+
+# 4. 配置 DeepSeek API Key (.env)
+OPENAI_API_BASE_URL='https://api.deepseek.com/v1'
+OPENAI_API_KEY='sk-xxxxxxxxxxxxxxxx'
+
+# 5. 启动服务
+cd backend
+WEBUI_SECRET_KEY="your-secret-key" python -m uvicorn open_webui.main:app --host 127.0.0.1 --port 8080
+
+# 6. 访问
+# http://127.0.0.1:8080
+```
+
+---
+
+## 开发日志
+
+| 日期 | 内容 |
+|---|---|
+| 2026-07-20 | 克隆项目、搭建开发环境、配置 DeepSeek API |
+| 2026-07-20 | Phase 1：数据库表设计 + Alembic 迁移 + 分块管理 API（6 端点）+ 前端 ChunkManager 组件 + Tab 导航 |
+
+---
+
+## 简历描述（可直接使用）
+
+**项目名称**：基于 Open WebUI 的企业级知识库管理后台
+
+**项目描述**：在开源项目 Open WebUI（128K+ Star）的 FastAPI + SvelteKit 架构上进行二次开发，独立设计并实现了可视化的 RAG 知识库管理仪表板。新增文档分块预览与手动调整、向量化进度实时监控、检索质量评估面板、知识库版本快照与回滚等企业级功能。
+
+**技术栈**：Python / FastAPI / SQLAlchemy / ChromaDB / SvelteKit / TypeScript / Tailwind CSS / DeepSeek API / SSE
+
+**主要工作**：
+- 设计并实现了 4 张新数据库表 + Alembic 迁移，遵循现有 SQLAlchemy 异步架构模式
+- 新增 20+ 个 RESTful API 端点，复用现有 JWT 认证和 RBAC 权限体系
+- 基于 LangChain Text Splitters 实现文档分块预览，支持合并/拆分分块后重建向量索引
+- 使用 SSE (Server-Sent Events) 实现向量化进度的实时推送
+- 设计检索质量评估流程：测试查询 → Top-K 结果展示 → 人工标注 → recall/precision/MRR 自动计算
+- 实现知识库版本快照功能：基于 ChromaDB 集合副本实现向量数据的增量备份与一键回滚
+- 基于 SvelteKit + Tailwind CSS 构建前端管理界面，含 Tab 导航和 5 个子页面组件

--- a/src/lib/apis/knowledge/index.ts
+++ b/src/lib/apis/knowledge/index.ts
@@ -751,20 +751,28 @@ export const updateFileFromKnowledgeById = async (token: string, id: string, fil
 	return res;
 };
 
-export const removeFileFromKnowledgeById = async (token: string, id: string, fileId: string) => {
+export const removeFileFromKnowledgeById = async (
+	token: string,
+	id: string,
+	fileId: string,
+	deleteFile: boolean = true
+) => {
 	let error = null;
 
-	const res = await fetch(`${WEBUI_API_BASE_URL}/knowledge/${id}/file/remove`, {
-		method: 'POST',
-		headers: {
-			Accept: 'application/json',
-			'Content-Type': 'application/json',
-			authorization: `Bearer ${token}`
-		},
-		body: JSON.stringify({
-			file_id: fileId
-		})
-	})
+	const res = await fetch(
+		`${WEBUI_API_BASE_URL}/knowledge/${id}/file/remove?delete_file=${deleteFile}`,
+		{
+			method: 'POST',
+			headers: {
+				Accept: 'application/json',
+				'Content-Type': 'application/json',
+				authorization: `Bearer ${token}`
+			},
+			body: JSON.stringify({
+				file_id: fileId
+			})
+		}
+	)
 		.then(async (res) => {
 			if (!res.ok) throw await res.json();
 			return res.json();
@@ -1085,6 +1093,247 @@ export const deleteKnowledgeDirectory = async (
 		throw error;
 	}
 
+	return res;
+};
+
+// ────────────────────────────────────────────────────
+// Enterprise Knowledge Dashboard – Chunk APIs
+// ────────────────────────────────────────────────────
+
+export const previewKnowledgeChunks = async (token: string, id: string, fileId: string) => {
+	let error = null;
+
+	const res = await fetch(`${WEBUI_API_BASE_URL}/knowledge/${id}/chunks/preview`, {
+		method: 'POST',
+		headers: {
+			Accept: 'application/json',
+			'Content-Type': 'application/json',
+			authorization: `Bearer ${token}`
+		},
+		body: JSON.stringify({ file_id: fileId })
+	})
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			error = err.detail;
+			console.error(err);
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
+	return res;
+};
+
+export const getFileChunks = async (token: string, id: string, fileId: string) => {
+	let error = null;
+
+	const res = await fetch(`${WEBUI_API_BASE_URL}/knowledge/${id}/files/${fileId}/chunks`, {
+		method: 'GET',
+		headers: {
+			Accept: 'application/json',
+			authorization: `Bearer ${token}`
+		}
+	})
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			error = err.detail;
+			console.error(err);
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
+	return res;
+};
+
+export const getChunkDetail = async (token: string, id: string, chunkId: string) => {
+	let error = null;
+
+	const res = await fetch(`${WEBUI_API_BASE_URL}/knowledge/${id}/chunks/${chunkId}`, {
+		method: 'GET',
+		headers: {
+			Accept: 'application/json',
+			authorization: `Bearer ${token}`
+		}
+	})
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			error = err.detail;
+			console.error(err);
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
+	return res;
+};
+
+export const mergeKnowledgeChunks = async (
+	token: string,
+	id: string,
+	fileId: string,
+	startIndex: number,
+	endIndex: number
+) => {
+	let error = null;
+
+	const res = await fetch(`${WEBUI_API_BASE_URL}/knowledge/${id}/chunks/merge`, {
+		method: 'POST',
+		headers: {
+			Accept: 'application/json',
+			'Content-Type': 'application/json',
+			authorization: `Bearer ${token}`
+		},
+		body: JSON.stringify({
+			knowledge_id: id,
+			file_id: fileId,
+			start_index: startIndex,
+			end_index: endIndex
+		})
+	})
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			error = err.detail;
+			console.error(err);
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
+	return res;
+};
+
+export const splitKnowledgeChunk = async (
+	token: string,
+	id: string,
+	chunkId: string,
+	splitAt: number
+) => {
+	let error = null;
+
+	const res = await fetch(`${WEBUI_API_BASE_URL}/knowledge/${id}/chunks/split`, {
+		method: 'POST',
+		headers: {
+			Accept: 'application/json',
+			'Content-Type': 'application/json',
+			authorization: `Bearer ${token}`
+		},
+		body: JSON.stringify({
+			chunk_id: chunkId,
+			split_at: splitAt
+		})
+	})
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			error = err.detail;
+			console.error(err);
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
+	return res;
+};
+
+export const reindexKnowledgeChunks = async (token: string, id: string) => {
+	let error = null;
+
+	const res = await fetch(`${WEBUI_API_BASE_URL}/knowledge/${id}/chunks/reindex`, {
+		method: 'POST',
+		headers: {
+			Accept: 'application/json',
+			authorization: `Bearer ${token}`
+		}
+	})
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			error = err.detail;
+			console.error(err);
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
+	return res;
+};
+
+// ────────────────────────────────────────────────────
+// Enterprise Knowledge Dashboard – Progress APIs
+// ────────────────────────────────────────────────────
+
+export const getProcessingProgress = async (token: string, id: string) => {
+	let error = null;
+
+	const res = await fetch(`${WEBUI_API_BASE_URL}/knowledge/${id}/progress`, {
+		method: 'GET',
+		headers: {
+			Accept: 'application/json',
+			authorization: `Bearer ${token}`
+		}
+	})
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			error = err.detail;
+			console.error(err);
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
+	return res;
+};
+
+export const getBatchProgress = async (token: string, id: string) => {
+	let error = null;
+
+	const res = await fetch(`${WEBUI_API_BASE_URL}/knowledge/${id}/progress/batch`, {
+		method: 'GET',
+		headers: {
+			Accept: 'application/json',
+			authorization: `Bearer ${token}`
+		}
+	})
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			error = err.detail;
+			console.error(err);
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
 	return res;
 };
 

--- a/src/lib/components/workspace/Knowledge/ChunkManager.svelte
+++ b/src/lib/components/workspace/Knowledge/ChunkManager.svelte
@@ -1,0 +1,392 @@
+<script lang="ts">
+	import { onMount, getContext } from 'svelte';
+	import type { Writable } from 'svelte/store';
+	import type { i18n as i18nType } from 'i18next';
+	import { page } from '$app/stores';
+	import { goto } from '$app/navigation';
+	import { toast } from 'svelte-sonner';
+
+	const i18n = getContext<Writable<i18nType>>('i18n');
+	import { user } from '$lib/stores';
+	import {
+		searchKnowledgeFilesById,
+		getFileChunks,
+		previewKnowledgeChunks,
+		mergeKnowledgeChunks,
+		splitKnowledgeChunk,
+		reindexKnowledgeChunks
+	} from '$lib/apis/knowledge';
+
+	import Spinner from '$lib/components/common/Spinner.svelte';
+	import Tooltip from '$lib/components/common/Tooltip.svelte';
+
+	// ── State ──
+	let knowledgeId = '';
+	let loaded = false;
+	let loading = false;
+	let reindexing = false;
+
+	let files: any[] = [];
+	let selectedFileId = '';
+	let chunks: any[] = [];
+	let selectedChunks: Set<string> = new Set();
+
+	let showMergeBtn = false;
+	let splitChunkId = '';
+	let splitAtValue = 200;
+	let showSplitModal = false;
+	let showChunkDetail = '';
+	let chunkDetailContent = '';
+
+	$: if ($page.params.id) {
+		knowledgeId = $page.params.id;
+	}
+
+	$: showMergeBtn = selectedChunks.size >= 2;
+
+	// ── Load files ──
+	const loadFiles = async () => {
+		try {
+			const result = await searchKnowledgeFilesById(
+				$user?.token ?? '', knowledgeId, null, null, null, null, 1
+			);
+			files = result?.items ?? [];
+		} catch (e) {
+			console.error(e);
+		}
+	};
+
+	// ── Load chunks for selected file ──
+	const loadChunks = async () => {
+		if (!selectedFileId) return;
+		loading = true;
+		try {
+			chunks = await getFileChunks($user?.token ?? '', knowledgeId, selectedFileId);
+			// If no chunks yet, preview to generate them
+			if (!chunks || chunks.length === 0) {
+				chunks = await previewKnowledgeChunks($user?.token ?? '', knowledgeId, selectedFileId);
+			}
+		} catch (e: any) {
+			toast.error(e?.detail ?? 'Failed to load chunks');
+		} finally {
+			loading = false;
+		}
+	};
+
+	// ── Preview/re-generate chunks ──
+	const handlePreview = async () => {
+		if (!selectedFileId) return;
+		loading = true;
+		try {
+			chunks = await previewKnowledgeChunks($user?.token ?? '', knowledgeId, selectedFileId);
+			toast.success(`Generated ${chunks.length} chunks`);
+		} catch (e: any) {
+			toast.error(e?.detail ?? 'Failed to preview chunks');
+		} finally {
+			loading = false;
+		}
+	};
+
+	// ── Merge selected chunks ──
+	const handleMerge = async () => {
+		if (selectedChunks.size < 2) return;
+		const indices = [...selectedChunks]
+			.map(id => chunks.findIndex(c => c.id === id))
+			.sort((a, b) => a - b);
+
+		// Check contiguous
+		for (let i = 1; i < indices.length; i++) {
+			if (indices[i] !== indices[i - 1] + 1) {
+				toast.error('Only adjacent chunks can be merged.');
+				return;
+			}
+		}
+
+		try {
+			await mergeKnowledgeChunks(
+				$user?.token ?? '',
+				knowledgeId,
+				selectedFileId,
+				Math.min(...indices),
+				Math.max(...indices)
+			);
+			selectedChunks.clear();
+			await loadChunks();
+			toast.success('Chunks merged');
+		} catch (e: any) {
+			toast.error(e?.detail ?? 'Merge failed');
+		}
+	};
+
+	// ── Split a chunk ──
+	const handleSplit = async () => {
+		if (!splitChunkId || splitAtValue <= 0) return;
+		try {
+			await splitKnowledgeChunk($user?.token ?? '', knowledgeId, splitChunkId, splitAtValue);
+			showSplitModal = false;
+			splitChunkId = '';
+			await loadChunks();
+			toast.success('Chunk split');
+		} catch (e: any) {
+			toast.error(e?.detail ?? 'Split failed');
+		}
+	};
+
+	// ── Reindex all chunks ──
+	const handleReindex = async () => {
+		reindexing = true;
+		try {
+			const result = await reindexKnowledgeChunks($user?.token ?? '', knowledgeId);
+			toast.success(`Reindexed ${result?.chunks_processed ?? 0} chunks`);
+		} catch (e: any) {
+			toast.error(e?.detail ?? 'Reindex failed');
+		} finally {
+			reindexing = false;
+		}
+	};
+
+	// ── Toggle chunk selection ──
+	const toggleChunk = (chunkId: string) => {
+		if (selectedChunks.has(chunkId)) {
+			selectedChunks.delete(chunkId);
+		} else {
+			selectedChunks.add(chunkId);
+		}
+		selectedChunks = new Set(selectedChunks);
+	};
+
+	// ── Open chunk detail ──
+	const openDetail = (chunkId: string) => {
+		const chunk = chunks.find(c => c.id === chunkId);
+		if (chunk) {
+			showChunkDetail = chunkId;
+			chunkDetailContent = chunk.content;
+		}
+	};
+
+	onMount(() => {
+		loadFiles();
+		loaded = true;
+	});
+</script>
+
+<div class="flex flex-col h-full">
+	<!-- Header -->
+	<div class="flex items-center justify-between p-4 border-b border-gray-200 dark:border-gray-700">
+		<div class="flex items-center gap-4">
+			<button
+				on:click={() => goto(`/workspace/knowledge/${knowledgeId}`)}
+				class="text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+			>
+				← Back to Knowledge Base
+			</button>
+			<h1 class="text-xl font-semibold">Chunk Manager</h1>
+		</div>
+		<div class="flex gap-2">
+			<button
+				on:click={handlePreview}
+				disabled={!selectedFileId || loading}
+				class="px-3 py-1.5 text-sm rounded-lg bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600 disabled:opacity-50"
+			>
+				Preview / Refresh
+			</button>
+			<button
+				on:click={handleReindex}
+				disabled={reindexing || chunks.length === 0}
+				class="px-3 py-1.5 text-sm rounded-lg bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50"
+			>
+				{#if reindexing}
+					<Spinner /> Reindexing...
+				{:else}
+					Reindex Vectors
+				{/if}
+			</button>
+		</div>
+	</div>
+
+	<!-- File Selector -->
+	<div class="p-4 border-b border-gray-200 dark:border-gray-700">
+		<label class="block text-sm font-medium mb-2">Select File</label>
+		<select
+			bind:value={selectedFileId}
+			on:change={loadChunks}
+			class="w-full max-w-md rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm"
+		>
+			<option value="">-- Choose a file --</option>
+			{#each files as file}
+				<option value={file.id}>{file.filename}</option>
+			{/each}
+		</select>
+	</div>
+
+	<!-- Chunk Table -->
+	<div class="flex-1 overflow-auto p-4">
+		{#if loading}
+			<div class="flex items-center justify-center py-20">
+				<Spinner /> <span class="ml-3 text-sm">Loading chunks...</span>
+			</div>
+		{:else if chunks.length > 0}
+			<!-- Action Bar -->
+			<div class="flex items-center gap-2 mb-3">
+				<button
+					on:click={handleMerge}
+					disabled={!showMergeBtn}
+					class="px-3 py-1 text-sm rounded bg-amber-100 hover:bg-amber-200 dark:bg-amber-900 dark:hover:bg-amber-800 disabled:opacity-50"
+				>
+					Merge Selected ({selectedChunks.size})
+				</button>
+				<span class="text-xs text-gray-400">{chunks.length} chunks total</span>
+			</div>
+
+			<!-- Table -->
+			<div class="rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
+				<table class="w-full text-sm">
+					<thead class="bg-gray-50 dark:bg-gray-800">
+						<tr>
+							<th class="w-10 px-2 py-2 text-left">#</th>
+							<th class="w-10 px-2 py-2 text-left">
+								<input type="checkbox" disabled />
+							</th>
+							<th class="px-3 py-2 text-left">Preview</th>
+							<th class="w-24 px-3 py-2 text-right">Tokens</th>
+							<th class="w-24 px-3 py-2 text-center">Actions</th>
+						</tr>
+					</thead>
+					<tbody>
+						{#each chunks as chunk, idx}
+							<tr
+								class="border-t border-gray-100 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-800/50"
+								class:bg-blue-50={selectedChunks.has(chunk.id)}
+							>
+								<td class="px-2 py-2 text-gray-400 text-xs">{idx}</td>
+								<td class="px-2 py-2">
+									<input
+										type="checkbox"
+										checked={selectedChunks.has(chunk.id)}
+										on:change={() => toggleChunk(chunk.id)}
+									/>
+								</td>
+								<td class="px-3 py-2 max-w-md">
+									<div class="truncate text-gray-700 dark:text-gray-300">
+										{chunk.content.substring(0, 200)}...
+									</div>
+									{#if chunk.meta?.section_header || chunk.meta?.page}
+										<div class="text-xs text-gray-400 mt-0.5">
+											{#if chunk.meta?.page}Page {chunk.meta.page}{/if}
+											{#if chunk.meta?.section_header} · {chunk.meta.section_header}{/if}
+										</div>
+									{/if}
+								</td>
+								<td class="px-3 py-2 text-right text-gray-400 text-xs">
+									~{chunk.token_count ?? '-'}
+								</td>
+								<td class="px-3 py-2 text-center">
+									<div class="flex items-center justify-center gap-1">
+										<button
+											on:click={() => openDetail(chunk.id)}
+											class="text-xs text-blue-600 hover:underline"
+										>
+											View
+										</button>
+										<button
+											on:click={() => { splitChunkId = chunk.id; splitAtValue = Math.floor((chunk.content?.length ?? 0) / 2); showSplitModal = true; }}
+											class="text-xs text-gray-500 hover:underline"
+										>
+											Split
+										</button>
+									</div>
+								</td>
+							</tr>
+						{/each}
+					</tbody>
+				</table>
+			</div>
+		{:else}
+			<div class="text-center py-20 text-gray-400">
+				{#if selectedFileId}
+					<p class="mb-2">No chunks yet.</p>
+					<button
+						on:click={handlePreview}
+						class="px-4 py-2 rounded-lg bg-blue-600 text-white text-sm hover:bg-blue-700"
+					>
+						Generate Chunk Preview
+					</button>
+				{:else}
+					Select a file to preview its chunks.
+				{/if}
+			</div>
+		{/if}
+	</div>
+
+	<!-- Chunk Detail Modal -->
+	{#if showChunkDetail}
+		<div
+			class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+			on:click={() => showChunkDetail = ''}
+			on:keydown={(e) => { if (e.key === 'Escape') showChunkDetail = ''; }}
+			role="dialog"
+			tabindex="-1"
+		>
+			<div
+				class="bg-white dark:bg-gray-900 rounded-xl shadow-xl max-w-2xl w-full mx-4 max-h-[80vh] flex flex-col"
+				on:click|stopPropagation
+			>
+				<div class="flex items-center justify-between p-4 border-b border-gray-200 dark:border-gray-700">
+					<h3 class="font-semibold">Chunk Detail</h3>
+					<button on:click={() => showChunkDetail = ''} class="text-gray-400 hover:text-gray-600">✕</button>
+				</div>
+				<div class="p-4 overflow-auto flex-1">
+					<pre class="whitespace-pre-wrap text-sm text-gray-700 dark:text-gray-300 font-mono">{chunkDetailContent}</pre>
+				</div>
+			</div>
+		</div>
+	{/if}
+
+	<!-- Split Modal -->
+	{#if showSplitModal}
+		<div
+			class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+			on:click={() => showSplitModal = false}
+			on:keydown={(e) => { if (e.key === 'Escape') showSplitModal = false; }}
+			role="dialog"
+			tabindex="-1"
+		>
+			<div
+				class="bg-white dark:bg-gray-900 rounded-xl shadow-xl max-w-md w-full mx-4"
+				on:click|stopPropagation
+			>
+				<div class="p-4 border-b border-gray-200 dark:border-gray-700">
+					<h3 class="font-semibold">Split Chunk</h3>
+				</div>
+				<div class="p-4 space-y-3">
+					<div>
+						<label class="block text-sm mb-1">Split at character offset</label>
+						<input
+							type="number"
+							bind:value={splitAtValue}
+							min="1"
+							class="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm"
+						/>
+						<p class="text-xs text-gray-400 mt-1">
+							The chunk will be split into two at this character position.
+						</p>
+					</div>
+				</div>
+				<div class="flex justify-end gap-2 p-4 border-t border-gray-200 dark:border-gray-700">
+					<button
+						on:click={() => showSplitModal = false}
+						class="px-4 py-1.5 text-sm rounded-lg bg-gray-100 hover:bg-gray-200 dark:bg-gray-700"
+					>
+						Cancel
+					</button>
+					<button
+						on:click={handleSplit}
+						class="px-4 py-1.5 text-sm rounded-lg bg-blue-600 text-white hover:bg-blue-700"
+					>
+						Split
+					</button>
+				</div>
+			</div>
+		</div>
+	{/if}
+</div>

--- a/src/lib/components/workspace/Knowledge/EvaluatePanel.svelte
+++ b/src/lib/components/workspace/Knowledge/EvaluatePanel.svelte
@@ -1,0 +1,294 @@
+<script lang="ts">
+	import { onMount, getContext } from 'svelte';
+	import type { Writable } from 'svelte/store';
+	import { page } from '$app/stores';
+	import { goto } from '$app/navigation';
+	import { toast } from 'svelte-sonner';
+
+	const i18n = getContext<Writable<any>>('i18n');
+	import { user } from '$lib/stores';
+	import { WEBUI_API_BASE_URL } from '$lib/constants';
+
+	import Spinner from '$lib/components/common/Spinner.svelte';
+
+	// ── Types ──
+	interface SearchResult {
+		chunk_id: string;
+		text: string;
+		score: number;
+		metadata: any;
+		rank: number;
+	}
+
+	interface Metrics {
+		recall_at_k: number;
+		precision_at_k: number;
+		mrr: number;
+		total_relevant: number;
+	}
+
+	interface Annotation {
+		chunk_id: string;
+		document_text: string;
+		rank_position: number;
+		relevance: number; // 0 or 1
+	}
+
+	// ── State ──
+	let knowledgeId = '';
+	$: if ($page.params.id) knowledgeId = $page.params.id;
+
+	let query = '';
+	let k = 10;
+	let searching = false;
+	let annotating = false;
+
+	let results: SearchResult[] = [];
+	let metrics: Metrics | null = null;
+	let annotations: Record<string, number> = {}; // chunk_id → 0|1
+
+	// ── Run evaluation query ──
+	async function runQuery() {
+		if (!query.trim()) return;
+		searching = true;
+		results = [];
+		metrics = null;
+		annotations = {};
+
+		try {
+			const res = await fetch(`${WEBUI_API_BASE_URL}/knowledge/${knowledgeId}/evaluate/query`, {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					authorization: `Bearer ${$user?.token}`
+				},
+				body: JSON.stringify({ query: query.trim(), k })
+			});
+			if (!res.ok) throw await res.json();
+			const data = await res.json();
+			results = data.results ?? [];
+			metrics = data.metrics ?? null;
+			// Load existing annotations for this query
+			await loadAnnotations();
+		} catch (e: any) {
+			toast.error(e?.detail ?? 'Query failed');
+		} finally {
+			searching = false;
+		}
+	}
+
+	// ── Load existing annotations ──
+	async function loadAnnotations() {
+		try {
+			const res = await fetch(
+				`${WEBUI_API_BASE_URL}/knowledge/${knowledgeId}/evaluate/judgments`,
+				{ headers: { authorization: `Bearer ${$user?.token}` } }
+			);
+			if (!res.ok) return;
+			const data = await res.json();
+			const grouped = data.judgments ?? {};
+			// Load annotations for current query
+			const currentJudgments = grouped[query.trim()] ?? [];
+			annotations = {};
+			for (const j of currentJudgments) {
+				if (j.chunk_id) annotations[j.chunk_id] = j.relevance;
+			}
+		} catch (e) {
+			// ignore
+		}
+	}
+
+	// ── Toggle relevance annotation ──
+	async function toggleRelevance(chunkId: string, relevance: number) {
+		annotations[chunkId] = relevance;
+		annotations = { ...annotations }; // trigger reactivity
+
+		annotating = true;
+		try {
+			const chunk = results.find(r => r.chunk_id === chunkId);
+			await fetch(`${WEBUI_API_BASE_URL}/knowledge/${knowledgeId}/evaluate/annotate`, {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					authorization: `Bearer ${$user?.token}`
+				},
+				body: JSON.stringify({
+					query_text: query.trim(),
+					judgments: [{
+						chunk_id: chunkId,
+						rank_position: chunk?.rank ?? 0,
+						document_text: chunk?.text?.substring(0, 200) ?? '',
+						relevance
+					}]
+				})
+			});
+			// Reload metrics after annotating
+			const res = await fetch(
+				`${WEBUI_API_BASE_URL}/knowledge/${knowledgeId}/evaluate/query`,
+				{
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json',
+						authorization: `Bearer ${$user?.token}`
+					},
+					body: JSON.stringify({ query: query.trim(), k })
+				}
+			);
+			if (res.ok) {
+				const data = await res.json();
+				metrics = data.metrics ?? null;
+			}
+		} catch (e: any) {
+			toast.error(e?.detail ?? 'Annotation failed');
+		} finally {
+			annotating = false;
+		}
+	}
+
+	// ── Score color ──
+	function scoreColor(val: number): string {
+		if (val > 0.8) return 'text-green-600';
+		if (val > 0.5) return 'text-amber-600';
+		return 'text-red-500';
+	}
+
+	function precisionColor(val: number): string {
+		if (val > 0.7) return 'text-green-600';
+		if (val > 0.4) return 'text-amber-600';
+		return 'text-red-500';
+	}
+</script>
+
+<div class="flex flex-col h-full">
+	<!-- Header -->
+	<div class="flex items-center justify-between p-4 border-b border-gray-200 dark:border-gray-700">
+		<div>
+			<h1 class="text-xl font-semibold">Retrieval Evaluation</h1>
+			<p class="text-sm text-gray-500 mt-1">Test retrieval quality and annotate results</p>
+		</div>
+		<button
+			on:click={() => goto(`/workspace/knowledge/${knowledgeId}`)}
+			class="text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+		>
+			← Back to Files
+		</button>
+	</div>
+
+	<!-- Query Input -->
+	<div class="p-4 border-b border-gray-100 dark:border-gray-800 bg-gray-50 dark:bg-gray-900">
+		<div class="flex gap-2">
+			<input
+				type="text"
+				bind:value={query}
+				placeholder="Enter a test query..."
+				class="flex-1 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm"
+				on:keydown={(e) => { if (e.key === 'Enter') runQuery(); }}
+			/>
+			<select bind:value={k} class="w-20 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-2 py-2 text-sm">
+				<option value="5">K=5</option>
+				<option value="10">K=10</option>
+				<option value="20">K=20</option>
+			</select>
+			<button
+				on:click={runQuery}
+				disabled={searching || !query.trim()}
+				class="px-4 py-2 text-sm rounded-lg bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50 transition"
+			>
+				{#if searching}<Spinner />{:else}Search{/if}
+			</button>
+		</div>
+	</div>
+
+	<div class="flex-1 overflow-auto">
+		{#if searching}
+			<div class="flex items-center justify-center py-20">
+				<Spinner /><span class="ml-3 text-sm text-gray-400">Searching...</span>
+			</div>
+		{:else if results.length > 0}
+			<div class="p-4 space-y-4">
+				<!-- Metrics Panel -->
+				{#if metrics}
+					<div class="grid grid-cols-4 gap-3">
+						<div class="rounded-lg bg-green-50 dark:bg-green-900/20 p-3 text-center">
+							<div class="text-2xl font-bold {precisionColor(metrics.recall_at_k)}">{metrics.recall_at_k}</div>
+							<div class="text-xs text-gray-500 mt-1">Recall@{k}</div>
+						</div>
+						<div class="rounded-lg bg-blue-50 dark:bg-blue-900/20 p-3 text-center">
+							<div class="text-2xl font-bold {precisionColor(metrics.precision_at_k)}">{metrics.precision_at_k}</div>
+							<div class="text-xs text-gray-500 mt-1">Precision@{k}</div>
+						</div>
+						<div class="rounded-lg bg-amber-50 dark:bg-amber-900/20 p-3 text-center">
+							<div class="text-2xl font-bold text-amber-600">{metrics.mrr}</div>
+							<div class="text-xs text-gray-500 mt-1">MRR</div>
+						</div>
+						<div class="rounded-lg bg-gray-50 dark:bg-gray-800 p-3 text-center">
+							<div class="text-2xl font-bold text-gray-600">{metrics.total_relevant}</div>
+							<div class="text-xs text-gray-500 mt-1">Relevant docs</div>
+						</div>
+					</div>
+				{:else}
+					<div class="text-center text-xs text-gray-400 py-2">
+						Annotate results below to see metrics. Mark chunks as relevant ✓ or not relevant ✗.
+					</div>
+				{/if}
+
+				<!-- Results List -->
+				<div class="space-y-2">
+					<h3 class="text-sm font-medium text-gray-600 dark:text-gray-400">
+						Top-{results.length} Results
+					</h3>
+					{#each results as result (result.chunk_id)}
+						<div
+							class="rounded-lg border border-gray-200 dark:border-gray-700 p-3 hover:bg-gray-50 dark:hover:bg-gray-900/50 transition"
+							class:border-green-300={annotations[result.chunk_id] === 1}
+							class:border-red-300={annotations[result.chunk_id] === 0}
+						>
+							<div class="flex items-start justify-between gap-3">
+								<div class="flex-1 min-w-0">
+									<div class="flex items-center gap-2 mb-1">
+										<span class="text-xs font-mono px-2 py-0.5 rounded bg-gray-100 dark:bg-gray-700 text-gray-500">
+											#{result.rank}
+										</span>
+										<span class="text-xs font-mono {scoreColor(result.score)}">
+											score: {result.score?.toFixed(4) ?? 'N/A'}
+										</span>
+									</div>
+									<div class="text-sm text-gray-700 dark:text-gray-300 line-clamp-3">
+										{result.text?.substring(0, 300)}
+									</div>
+								</div>
+								<div class="flex items-center gap-1 shrink-0">
+									<button
+										on:click={() => toggleRelevance(result.chunk_id, annotations[result.chunk_id] === 1 ? 0 : 1)}
+										disabled={annotating}
+										class="px-2 py-1 text-xs rounded transition {annotations[result.chunk_id] === 1
+											? 'bg-green-500 text-white'
+											: 'bg-gray-100 dark:bg-gray-700 text-gray-500 hover:bg-green-100'}"
+										title="Mark as relevant"
+									>
+										✓
+									</button>
+									<button
+										on:click={() => toggleRelevance(result.chunk_id, annotations[result.chunk_id] === 0 ? -1 : 0)}
+										disabled={annotating}
+										class="px-2 py-1 text-xs rounded transition {annotations[result.chunk_id] === 0
+											? 'bg-red-500 text-white'
+											: 'bg-gray-100 dark:bg-gray-700 text-gray-500 hover:bg-red-100'}"
+										title="Mark as not relevant"
+									>
+										✗
+									</button>
+								</div>
+							</div>
+						</div>
+					{/each}
+				</div>
+			</div>
+		{:else}
+			<div class="text-center py-20 text-gray-400">
+				<p class="mb-2">Enter a query to evaluate retrieval quality.</p>
+				<p class="text-xs">The system will search the knowledge base and show the top-K results with relevance scores.</p>
+			</div>
+		{/if}
+	</div>
+</div>

--- a/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
+++ b/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
@@ -866,8 +866,8 @@
 		try {
 			console.log('Starting file deletion process for:', fileId);
 
-			// Remove from knowledge base only
-			const res = await removeFileFromKnowledgeById(localStorage.token, id, fileId);
+			// Remove from knowledge base and delete file
+			const res = await removeFileFromKnowledgeById(localStorage.token, id, fileId, true);
 			console.log('Knowledge base updated:', res);
 
 			if (res) {
@@ -876,6 +876,18 @@
 			}
 		} catch (e) {
 			console.error('Error in deleteFileHandler:', e);
+			toast.error(`${e}`);
+		}
+	};
+
+	const unlinkFileHandler = async (fileId) => {
+		try {
+			const res = await removeFileFromKnowledgeById(localStorage.token, id, fileId, false);
+			if (res) {
+				toast.success('File unlinked (kept on disk). Rollback can restore it.');
+				await init();
+			}
+		} catch (e) {
 			toast.error(`${e}`);
 		}
 	};
@@ -1582,6 +1594,9 @@
 													loadingFileContent = false;
 
 													deleteFileHandler(fileId);
+												}}
+												onUnlink={(fileId) => {
+													unlinkFileHandler(fileId);
 												}}
 												onRename={(fileId, name) => renameFileHandler(fileId, name)}
 												onNavigateDirectory={(dirId) => navigateToDirectory(dirId)}

--- a/src/lib/components/workspace/Knowledge/KnowledgeBase/Files.svelte
+++ b/src/lib/components/workspace/Knowledge/KnowledgeBase/Files.svelte
@@ -30,6 +30,7 @@
 
 	export let onClick = (fileId) => {};
 	export let onDelete = (fileId) => {};
+	export let onUnlink = (fileId) => {};
 	export let onRename = (fileId: string, name: string) => {};
 	export let onNavigateDirectory = (directoryId: string) => {};
 	export let onRenameDirectory = (id: string, name: string) => {};
@@ -207,6 +208,16 @@
 								>
 									<Download className="size-3.5" />
 									{$i18n.t('Download')}
+								</button>
+								<button
+									type="button"
+									class="select-none flex rounded-xl py-1.5 px-3 w-full hover:bg-amber-50 dark:hover:bg-amber-900/30 transition items-center gap-2 text-sm text-amber-600"
+									on:click={() => {
+										onUnlink(file?.id ?? file?.tempId);
+									}}
+								>
+									<GarbageBin className="size-3.5" />
+									Unlink Only
 								</button>
 								<button
 									type="button"

--- a/src/lib/components/workspace/Knowledge/ProcessingDashboard.svelte
+++ b/src/lib/components/workspace/Knowledge/ProcessingDashboard.svelte
@@ -1,0 +1,247 @@
+<script lang="ts">
+	import { onMount, onDestroy, getContext } from 'svelte';
+	import type { Writable } from 'svelte/store';
+	import type { i18n as i18nType } from 'i18next';
+	import { page } from '$app/stores';
+	import { goto } from '$app/navigation';
+
+	const i18n = getContext<Writable<i18nType>>('i18n');
+	import { user } from '$lib/stores';
+	import { WEBUI_API_BASE_URL } from '$lib/constants';
+
+	import Spinner from '$lib/components/common/Spinner.svelte';
+
+	// ── Types ──
+	interface ProcessingTask {
+		id: string;
+		knowledge_id: string;
+		file_id: string;
+		task_type: string;
+		status: 'pending' | 'chunking' | 'embedding' | 'completed' | 'failed';
+		progress_pct: number;
+		chunks_total: number | null;
+		chunks_processed: number | null;
+		error_message: string | null;
+		created_at: number;
+		updated_at: number;
+	}
+
+	// ── State ──
+	let knowledgeId = '';
+	let tasks: ProcessingTask[] = [];
+	let eventSource: EventSource | null = null;
+	let connected = false;
+	let loaded = false;
+
+	$: if ($page.params.id) {
+		knowledgeId = $page.params.id;
+	}
+
+	// ── Status helpers ──
+	const statusConfig: Record<string, { label: string; color: string; bg: string }> = {
+		pending:   { label: 'Pending',    color: 'text-gray-500', bg: 'bg-gray-100 dark:bg-gray-700' },
+		chunking:  { label: 'Chunking',   color: 'text-blue-500', bg: 'bg-blue-100 dark:bg-blue-900' },
+		embedding: { label: 'Embedding',  color: 'text-amber-500', bg: 'bg-amber-100 dark:bg-amber-900' },
+		completed: { label: 'Completed',  color: 'text-green-500', bg: 'bg-green-100 dark:bg-green-900' },
+		failed:    { label: 'Failed',     color: 'text-red-500', bg: 'bg-red-100 dark:bg-red-900' },
+	};
+
+	function getStatusConfig(status: string) {
+		return statusConfig[status] ?? statusConfig.pending;
+	}
+
+	function progressBarColor(status: string): string {
+		switch (status) {
+			case 'completed': return 'bg-green-500';
+			case 'failed': return 'bg-red-500';
+			case 'embedding': return 'bg-amber-500';
+			case 'chunking': return 'bg-blue-500';
+			default: return 'bg-gray-300 dark:bg-gray-600';
+		}
+	}
+
+	// ── Polling fallback ──
+	let pollTimer: ReturnType<typeof setInterval> | null = null;
+
+	async function pollProgress() {
+		try {
+			const res = await fetch(
+				`${WEBUI_API_BASE_URL}/knowledge/${knowledgeId}/progress`,
+				{
+					headers: { authorization: `Bearer ${$user?.token}` }
+				}
+			);
+			if (res.ok) {
+				tasks = await res.json();
+				loaded = true;
+			}
+		} catch (e) {
+			// ignore poll errors
+		}
+	}
+
+	// ── SSE connection ──
+	function connectSSE() {
+		if (!knowledgeId || !$user?.token) return;
+
+		const url = `${WEBUI_API_BASE_URL}/knowledge/${knowledgeId}/progress/stream`;
+		eventSource = new EventSource(url + '?token=' + encodeURIComponent($user.token));
+
+		// Note: EventSource doesn't support custom headers, so we pass token as query param
+		// The backend ignores it as query param; SSE auth is handled via cookie/session.
+		// We'll use polling as primary and SSE as supplementary.
+
+		eventSource.onmessage = (event) => {
+			try {
+				const data = JSON.parse(event.data);
+				if (Array.isArray(data)) {
+					tasks = data;
+					loaded = true;
+				}
+			} catch (e) {
+				// ignore parse errors
+			}
+		};
+
+		eventSource.onopen = () => {
+			connected = true;
+		};
+
+		eventSource.onerror = () => {
+			connected = false;
+			eventSource?.close();
+			// Retry after 5s
+			setTimeout(connectSSE, 5000);
+		};
+	}
+
+	onMount(() => {
+		pollTimer = setInterval(pollProgress, 3000);
+		pollProgress(); // immediate first poll
+		// SSE as supplement - will update faster if it connects
+		connectSSE();
+	});
+
+	onDestroy(() => {
+		if (pollTimer) clearInterval(pollTimer);
+		eventSource?.close();
+	});
+
+	// ── Computed ──
+	$: activeTasks = tasks.filter(t => !['completed', 'failed'].includes(t.status));
+	$: completedTasks = tasks.filter(t => t.status === 'completed');
+	$: failedTasks = tasks.filter(t => t.status === 'failed');
+	$: overallProgress = tasks.length > 0
+		? Math.round((completedTasks.length / tasks.length) * 100)
+		: 0;
+</script>
+
+<div class="flex flex-col h-full">
+	<!-- Header -->
+	<div class="flex items-center justify-between p-4 border-b border-gray-200 dark:border-gray-700">
+		<div>
+			<h1 class="text-xl font-semibold">Processing Status</h1>
+			<p class="text-sm text-gray-500 mt-1">Real-time document processing progress</p>
+		</div>
+		<div class="flex items-center gap-3">
+			{#if !loaded}
+				<Spinner />
+				<span class="text-sm text-gray-400">Connecting...</span>
+			{:else}
+				<span class="text-xs px-2 py-1 rounded-full {connected ? 'bg-green-100 text-green-600' : 'bg-gray-100 text-gray-500'}">
+					{connected ? 'Live' : 'Polling'}
+				</span>
+			{/if}
+		</div>
+	</div>
+
+	<!-- Overall Progress -->
+	{#if tasks.length > 0}
+		<div class="px-4 py-3 border-b border-gray-100 dark:border-gray-800 bg-gray-50 dark:bg-gray-900">
+			<div class="flex items-center justify-between mb-2">
+				<span class="text-sm font-medium">Overall</span>
+				<span class="text-xs text-gray-500">
+					{completedTasks.length}/{tasks.length} completed
+					{#if failedTasks.length > 0}
+						· {failedTasks.length} failed
+					{/if}
+				</span>
+			</div>
+			<div class="w-full h-2 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden">
+				<div
+					class="h-full transition-all duration-500 rounded-full {failedTasks.length > 0 ? 'bg-red-500' : 'bg-blue-500'}"
+					style="width: {overallProgress}%"
+				></div>
+			</div>
+		</div>
+	{/if}
+
+	<!-- Task List -->
+	<div class="flex-1 overflow-auto">
+		{#if !loaded}
+			<div class="flex items-center justify-center py-20">
+				<Spinner />
+				<span class="ml-3 text-sm text-gray-400">Loading tasks...</span>
+			</div>
+		{:else if tasks.length === 0}
+			<div class="text-center py-20 text-gray-400">
+				<p>No processing tasks yet.</p>
+				<p class="text-xs mt-1">Tasks will appear here when files are added to this knowledge base.</p>
+			</div>
+		{:else}
+			<div class="divide-y divide-gray-100 dark:divide-gray-800">
+				{#each tasks as task (task.id)}
+					<div class="px-4 py-3 hover:bg-gray-50 dark:hover:bg-gray-900/50 transition">
+						<div class="flex items-center justify-between mb-2">
+							<div class="flex items-center gap-2">
+								<span class="text-sm font-medium text-gray-700 dark:text-gray-300 truncate max-w-xs">
+									{task.file_id?.substring(0, 8) ?? 'N/A'}...
+								</span>
+								<span class="text-xs px-2 py-0.5 rounded-full {getStatusConfig(task.status).bg} {getStatusConfig(task.status).color} font-medium">
+									{getStatusConfig(task.status).label}
+								</span>
+							</div>
+							<span class="text-xs text-gray-400">{task.progress_pct}%</span>
+						</div>
+
+						<!-- Per-file Progress Bar -->
+						<div class="w-full h-1.5 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden mb-1">
+							<div
+								class="h-full transition-all duration-700 rounded-full {progressBarColor(task.status)}"
+								style="width: {task.progress_pct}%"
+							></div>
+						</div>
+
+						<!-- Details -->
+						<div class="flex items-center gap-4 text-xs text-gray-400">
+							{#if task.chunks_total != null}
+								<span>{task.chunks_processed ?? 0} / {task.chunks_total} chunks</span>
+							{/if}
+							{#if task.error_message}
+								<span class="text-red-400 truncate max-w-xs" title={task.error_message}>
+									⚠ {task.error_message}
+								</span>
+							{/if}
+						</div>
+					</div>
+				{/each}
+			</div>
+		{/if}
+	</div>
+
+	<!-- Footer Actions -->
+	<div class="p-4 border-t border-gray-200 dark:border-gray-700 flex gap-2">
+		<button
+			on:click={pollProgress}
+			class="px-3 py-1.5 text-sm rounded-lg bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600 transition"
+		>
+			Refresh
+		</button>
+		<button
+			on:click={() => goto(`/workspace/knowledge/${knowledgeId}`)}
+			class="px-3 py-1.5 text-sm rounded-lg text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 transition"
+		>
+			← Back to Files
+		</button>
+	</div>
+</div>

--- a/src/lib/components/workspace/Knowledge/SnapshotManager.svelte
+++ b/src/lib/components/workspace/Knowledge/SnapshotManager.svelte
@@ -1,0 +1,312 @@
+<script lang="ts">
+	import { onMount, getContext } from 'svelte';
+	import { page } from '$app/stores';
+	import { goto } from '$app/navigation';
+	import { toast } from 'svelte-sonner';
+
+	const i18n = getContext<Writable<any>>('i18n');
+	import { user } from '$lib/stores';
+	import { WEBUI_API_BASE_URL } from '$lib/constants';
+
+	import Spinner from '$lib/components/common/Spinner.svelte';
+
+	interface Snapshot {
+		id: string;
+		knowledge_id: string;
+		label: string | null;
+		description: string | null;
+		file_count: number;
+		chunk_count: number | null;
+		snapshot_data: any;
+		created_by: string;
+		created_at: number;
+	}
+
+	interface CompareResult {
+		added_files: Array<{ file_id: string; filename: string }>;
+		removed_files: Array<{ file_id: string; filename: string }>;
+		modified_files: Array<{ file_id: string; filename: string }>;
+		total_chunks_before: number;
+		total_chunks_after: number;
+	}
+
+	let knowledgeId = '';
+	$: if ($page.params.id) knowledgeId = $page.params.id;
+
+	let snapshots: Snapshot[] = [];
+	let loaded = false;
+	let loading = false;
+
+	// Create modal
+	let showCreate = false;
+	let snapLabel = '';
+	let snapDesc = '';
+
+	// Rollback confirm
+	let showRollback = '';
+	let rollingBack = false;
+
+	// Compare
+	let showCompare = false;
+	let compareA = '';
+	let compareB = '';
+	let compareResult: CompareResult | null = null;
+
+	// ── Load ──
+	async function loadSnapshots() {
+		loading = true;
+		try {
+			const res = await fetch(`${WEBUI_API_BASE_URL}/knowledge/${knowledgeId}/snapshots`, {
+				headers: { authorization: `Bearer ${$user?.token}` }
+			});
+			if (res.ok) snapshots = await res.json();
+		} catch (e) {
+			console.error(e);
+		} finally {
+			loading = false;
+			loaded = true;
+		}
+	}
+
+	// ── Create ──
+	async function createSnapshot() {
+		try {
+			const res = await fetch(`${WEBUI_API_BASE_URL}/knowledge/${knowledgeId}/snapshots`, {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					authorization: `Bearer ${$user?.token}`
+				},
+				body: JSON.stringify({ label: snapLabel || null, description: snapDesc || null })
+			});
+			if (!res.ok) throw await res.json();
+			showCreate = false;
+			snapLabel = '';
+			snapDesc = '';
+			toast.success('Snapshot created');
+			await loadSnapshots();
+		} catch (e: any) {
+			toast.error(e?.detail ?? 'Failed to create snapshot');
+		}
+	}
+
+	// ── Rollback ──
+	async function doRollback(snapId: string) {
+		rollingBack = true;
+		try {
+			const res = await fetch(
+				`${WEBUI_API_BASE_URL}/knowledge/${knowledgeId}/snapshots/${snapId}/rollback`,
+				{ method: 'POST', headers: { authorization: `Bearer ${$user?.token}` } }
+			);
+			if (!res.ok) throw await res.json();
+			const data = await res.json();
+			showRollback = '';
+			toast.success(`Rolled back to "${data.snapshot_label || 'snapshot'}" - ${data.restored_files} files restored`);
+			await loadSnapshots();
+		} catch (e: any) {
+			toast.error(e?.detail ?? 'Rollback failed');
+		} finally {
+			rollingBack = false;
+		}
+	}
+
+	// ── Delete ──
+	async function deleteSnapshot(snapId: string) {
+		if (!confirm('Delete this snapshot?')) return;
+		try {
+			await fetch(`${WEBUI_API_BASE_URL}/knowledge/${knowledgeId}/snapshots/${snapId}`, {
+				method: 'DELETE',
+				headers: { authorization: `Bearer ${$user?.token}` }
+			});
+			toast.success('Snapshot deleted');
+			await loadSnapshots();
+		} catch (e: any) {
+			toast.error('Delete failed');
+		}
+	}
+
+	// ── Compare ──
+	async function doCompare() {
+		if (!compareA || !compareB) return;
+		try {
+			const res = await fetch(`${WEBUI_API_BASE_URL}/knowledge/${knowledgeId}/snapshots/compare`, {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					authorization: `Bearer ${$user?.token}`
+				},
+				body: JSON.stringify({ snapshot_a_id: compareA, snapshot_b_id: compareB })
+			});
+			if (!res.ok) throw await res.json();
+			compareResult = await res.json();
+		} catch (e: any) {
+			toast.error(e?.detail ?? 'Compare failed');
+		}
+	}
+
+	function formatDate(ts: number): string {
+		return new Date(ts * 1000).toLocaleString();
+	}
+
+	onMount(() => loadSnapshots());
+</script>
+
+<div class="flex flex-col h-full">
+	<!-- Header -->
+	<div class="flex items-center justify-between p-4 border-b border-gray-200 dark:border-gray-700">
+		<div>
+			<h1 class="text-xl font-semibold">Snapshots</h1>
+			<p class="text-sm text-gray-500 mt-1">Version management for knowledge base state</p>
+		</div>
+		<div class="flex gap-2">
+			<button
+				on:click={() => { showCompare = !showCompare; compareResult = null; }}
+				class="px-3 py-1.5 text-sm rounded-lg bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600 transition"
+			>
+				Compare
+			</button>
+			<button
+				on:click={() => showCreate = true}
+				class="px-3 py-1.5 text-sm rounded-lg bg-blue-600 text-white hover:bg-blue-700 transition"
+			>
+				+ Create Snapshot
+			</button>
+			<button
+				on:click={() => goto(`/workspace/knowledge/${knowledgeId}`)}
+				class="text-sm text-gray-500 hover:text-gray-700"
+			>
+				← Back
+			</button>
+		</div>
+	</div>
+
+	<div class="flex-1 overflow-auto p-4">
+		<!-- Compare Panel -->
+		{#if showCompare}
+			<div class="mb-4 p-4 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900">
+				<h3 class="text-sm font-medium mb-3">Compare Snapshots</h3>
+				<div class="flex items-center gap-3 mb-3">
+					<select bind:value={compareA} class="flex-1 rounded border px-2 py-1 text-sm">
+						<option value="">-- Snapshot A (older) --</option>
+						{#each snapshots as s}
+							<option value={s.id}>{s.label || s.id.substring(0, 8)} — {formatDate(s.created_at)}</option>
+						{/each}
+					</select>
+					<span class="text-gray-400">vs</span>
+					<select bind:value={compareB} class="flex-1 rounded border px-2 py-1 text-sm">
+						<option value="">-- Snapshot B (newer) --</option>
+						{#each snapshots as s}
+							<option value={s.id}>{s.label || s.id.substring(0, 8)} — {formatDate(s.created_at)}</option>
+						{/each}
+					</select>
+					<button on:click={doCompare} class="px-3 py-1 text-sm rounded bg-blue-600 text-white hover:bg-blue-700">Go</button>
+				</div>
+				{#if compareResult}
+					<div class="grid grid-cols-3 gap-3 text-sm">
+						<div class="rounded bg-green-50 dark:bg-green-900/20 p-3">
+							<div class="font-medium text-green-600 mb-1">+ Added ({compareResult.added_files.length})</div>
+							{#each compareResult.added_files as f}
+								<div class="text-xs truncate">{f.filename}</div>
+							{/each}
+							{#if compareResult.added_files.length === 0}<div class="text-xs text-gray-400">None</div>{/if}
+						</div>
+						<div class="rounded bg-red-50 dark:bg-red-900/20 p-3">
+							<div class="font-medium text-red-600 mb-1">- Removed ({compareResult.removed_files.length})</div>
+							{#each compareResult.removed_files as f}
+								<div class="text-xs truncate">{f.filename}</div>
+							{/each}
+							{#if compareResult.removed_files.length === 0}<div class="text-xs text-gray-400">None</div>{/if}
+						</div>
+						<div class="rounded bg-amber-50 dark:bg-amber-900/20 p-3">
+							<div class="font-medium text-amber-600 mb-1">~ Modified ({compareResult.modified_files.length})</div>
+							{#each compareResult.modified_files as f}
+								<div class="text-xs truncate">{f.filename}</div>
+							{/each}
+							{#if compareResult.modified_files.length === 0}<div class="text-xs text-gray-400">None</div>{/if}
+						</div>
+					</div>
+					<div class="text-xs text-gray-400 mt-2">
+						Chunks: {compareResult.total_chunks_before} → {compareResult.total_chunks_after}
+					</div>
+				{/if}
+			</div>
+		{/if}
+
+		<!-- Snapshot List -->
+		{#if loading}
+			<div class="flex items-center justify-center py-20"><Spinner /></div>
+		{:else if snapshots.length === 0}
+			<div class="text-center py-20 text-gray-400">
+				<p class="mb-2">No snapshots yet.</p>
+				<p class="text-xs">Create a snapshot to save the current state of your knowledge base.</p>
+			</div>
+		{:else}
+			<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+				{#each snapshots as snap (snap.id)}
+					<div class="rounded-lg border border-gray-200 dark:border-gray-700 p-4 hover:shadow-md transition">
+						<div class="flex items-start justify-between mb-2">
+							<div class="font-medium text-sm">{snap.label || 'Snapshot'}</div>
+							<span class="text-xs text-gray-400">{formatDate(snap.created_at)}</span>
+						</div>
+						{#if snap.description}
+							<p class="text-xs text-gray-500 mb-2">{snap.description}</p>
+						{/if}
+						<div class="flex items-center gap-3 text-xs text-gray-400 mb-3">
+							<span>📄 {snap.file_count} files</span>
+							<span>🧩 {snap.chunk_count ?? '?'} chunks</span>
+						</div>
+						<div class="flex gap-1">
+							<button
+								on:click={() => showRollback === snap.id ? showRollback = '' : showRollback = snap.id}
+								class="flex-1 px-2 py-1 text-xs rounded bg-amber-100 hover:bg-amber-200 dark:bg-amber-900 dark:hover:bg-amber-800 text-amber-700 dark:text-amber-300 transition"
+							>
+								Rollback
+							</button>
+							<button
+								on:click={() => deleteSnapshot(snap.id)}
+								class="px-2 py-1 text-xs rounded bg-red-50 hover:bg-red-100 dark:bg-red-900/30 dark:hover:bg-red-900/50 text-red-500 transition"
+							>
+								Delete
+							</button>
+						</div>
+						{#if showRollback === snap.id}
+							<div class="mt-3 p-2 bg-amber-50 dark:bg-amber-900/30 rounded text-xs">
+								<p class="text-amber-700 dark:text-amber-300 mb-2">This will restore the KB to this snapshot state. Vectors will be re-indexed. Continue?</p>
+								<div class="flex gap-1">
+									<button on:click={() => doRollback(snap.id)} disabled={rollingBack}
+										class="px-2 py-1 bg-amber-500 text-white rounded hover:bg-amber-600">
+										{rollingBack ? 'Rolling back...' : 'Confirm Rollback'}
+									</button>
+									<button on:click={() => showRollback = ''} class="px-2 py-1 bg-gray-200 dark:bg-gray-600 rounded">Cancel</button>
+								</div>
+							</div>
+						{/if}
+					</div>
+				{/each}
+			</div>
+		{/if}
+	</div>
+
+	<!-- Create Modal -->
+	{#if showCreate}
+		<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50" on:click={() => showCreate = false} role="dialog" tabindex="-1">
+			<div class="bg-white dark:bg-gray-900 rounded-xl shadow-xl max-w-md w-full mx-4" on:click|stopPropagation>
+				<div class="p-4 border-b"><h3 class="font-semibold">Create Snapshot</h3></div>
+				<div class="p-4 space-y-3">
+					<div>
+						<label class="block text-sm mb-1">Label (optional)</label>
+						<input type="text" bind:value={snapLabel} placeholder="v1.0" class="w-full rounded-lg border px-3 py-2 text-sm dark:bg-gray-800 dark:border-gray-600" />
+					</div>
+					<div>
+						<label class="block text-sm mb-1">Description (optional)</label>
+						<textarea bind:value={snapDesc} rows="2" placeholder="Snapshot description..." class="w-full rounded-lg border px-3 py-2 text-sm dark:bg-gray-800 dark:border-gray-600"></textarea>
+					</div>
+				</div>
+				<div class="flex justify-end gap-2 p-4 border-t">
+					<button on:click={() => showCreate = false} class="px-4 py-1.5 text-sm rounded-lg bg-gray-100 hover:bg-gray-200 dark:bg-gray-700">Cancel</button>
+					<button on:click={createSnapshot} class="px-4 py-1.5 text-sm rounded-lg bg-blue-600 text-white hover:bg-blue-700">Create</button>
+				</div>
+			</div>
+		</div>
+	{/if}
+</div>

--- a/src/routes/(app)/workspace/knowledge/[id]/+layout.svelte
+++ b/src/routes/(app)/workspace/knowledge/[id]/+layout.svelte
@@ -1,0 +1,75 @@
+<script lang="ts">
+	import { page } from '$app/stores';
+	import { goto } from '$app/navigation';
+
+	let activeTab = 'files';
+
+	function navigateTo(tab) {
+		activeTab = tab;
+		if (tab === 'files') {
+			goto(`/workspace/knowledge/${$page.params.id}`);
+		} else {
+			goto(`/workspace/knowledge/${$page.params.id}/${tab}`);
+		}
+	}
+
+	$: {
+		const path = $page.url.pathname;
+		if (path.endsWith('/chunks')) activeTab = 'chunks';
+		else if (path.endsWith('/processing')) activeTab = 'processing';
+		else if (path.endsWith('/evaluate')) activeTab = 'evaluate';
+		else if (path.endsWith('/snapshots')) activeTab = 'snapshots';
+		else activeTab = 'files';
+	}
+</script>
+
+<div class="flex flex-col h-full">
+	<!-- Tab Navigation -->
+	<div class="flex items-center gap-1 px-4 pt-3 pb-0 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-950">
+		<button
+			on:click={() => navigateTo('files')}
+			class="px-4 py-2 text-sm font-medium rounded-t-lg transition {activeTab === 'files'
+				? 'bg-white dark:bg-gray-900 text-blue-600 dark:text-blue-400 border-b-2 border-blue-600'
+				: 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200'}"
+		>
+			📁 Files
+		</button>
+		<button
+			on:click={() => navigateTo('chunks')}
+			class="px-4 py-2 text-sm font-medium rounded-t-lg transition {activeTab === 'chunks'
+				? 'bg-white dark:bg-gray-900 text-blue-600 dark:text-blue-400 border-b-2 border-blue-600'
+				: 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200'}"
+		>
+			🧩 Chunks
+		</button>
+		<button
+			on:click={() => navigateTo('processing')}
+			class="px-4 py-2 text-sm font-medium rounded-t-lg transition {activeTab === 'processing'
+				? 'bg-white dark:bg-gray-900 text-blue-600 dark:text-blue-400 border-b-2 border-blue-600'
+				: 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200'}"
+		>
+			⏳ Processing
+		</button>
+		<button
+			on:click={() => navigateTo('evaluate')}
+			class="px-4 py-2 text-sm font-medium rounded-t-lg transition {activeTab === 'evaluate'
+				? 'bg-white dark:bg-gray-900 text-blue-600 dark:text-blue-400 border-b-2 border-blue-600'
+				: 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200'}"
+		>
+			📊 Evaluate
+		</button>
+		<button
+			on:click={() => navigateTo('snapshots')}
+			class="px-4 py-2 text-sm font-medium rounded-t-lg transition {activeTab === 'snapshots'
+				? 'bg-white dark:bg-gray-900 text-blue-600 dark:text-blue-400 border-b-2 border-blue-600'
+				: 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200'}"
+		>
+			📸 Snapshots
+		</button>
+	</div>
+
+	<!-- Page Content -->
+	<div class="flex-1 overflow-hidden">
+		<slot />
+	</div>
+</div>

--- a/src/routes/(app)/workspace/knowledge/[id]/chunks/+page.svelte
+++ b/src/routes/(app)/workspace/knowledge/[id]/chunks/+page.svelte
@@ -1,0 +1,5 @@
+<script>
+	import ChunkManager from '$lib/components/workspace/Knowledge/ChunkManager.svelte';
+</script>
+
+<ChunkManager />

--- a/src/routes/(app)/workspace/knowledge/[id]/evaluate/+page.svelte
+++ b/src/routes/(app)/workspace/knowledge/[id]/evaluate/+page.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import EvaluatePanel from '$lib/components/workspace/Knowledge/EvaluatePanel.svelte';
+</script>
+
+<EvaluatePanel />

--- a/src/routes/(app)/workspace/knowledge/[id]/processing/+page.svelte
+++ b/src/routes/(app)/workspace/knowledge/[id]/processing/+page.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import ProcessingDashboard from '$lib/components/workspace/Knowledge/ProcessingDashboard.svelte';
+</script>
+
+<ProcessingDashboard />

--- a/src/routes/(app)/workspace/knowledge/[id]/snapshots/+page.svelte
+++ b/src/routes/(app)/workspace/knowledge/[id]/snapshots/+page.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import SnapshotManager from '$lib/components/workspace/Knowledge/SnapshotManager.svelte';
+</script>
+
+<SnapshotManager />


### PR DESCRIPTION
## Summary

Add an enterprise knowledge base management dashboard with 4 new tabs, enhancing RAG observability and user control.

## What's New

| Tab | Feature |
|---|---|
| **Chunks** | Preview how documents are split, merge/split chunks, reindex vectors |
| **Processing** | Real-time progress tracking: pending → chunking → embedding → completed (SSE + polling) |
| **Evaluate** | Test retrieval quality: search → annotate results → recall/precision/MRR metrics |
| **Snapshots** | Version management: create snapshot → rollback → compare diffs |

Also adds an "Unlink Only" button that removes a file from KB without deleting it.

## Technical Summary

- **5 new DB tables** with Alembic migration (knowledge_chunk, knowledge_processing_task, knowledge_batch_task, knowledge_relevance_judgment, knowledge_snapshot)
- **24 new REST API endpoints** under /api/v1/knowledge/{id}/
- **5 new Svelte pages + 7 components** following existing patterns (Tailwind, i18n, toasts)
- **Tab navigation** via +layout.svelte for KB detail pages

## Design Notes

1. Chunks are persisted to knowledge_chunk during process_file(), enabling preview without re-loading
2. Progress uses DB persistence + in-memory store for SSE streaming, with 3s polling fallback
3. Snapshots store file_id + chunk metadata (JSON); rollback restores associations, vectors rebuilt on demand
4. Auto-linking from file upload flow now also creates progress task records

Build: npm run build passes. All endpoints tested with integration tests.