### PR TITLE
fix: knowledge_fs grep splits on literal backslash-n instead of newline

### DIFF
--- a/backend/open_webui/tools/knowledge_fs.py
+++ b/backend/open_webui/tools/knowledge_fs.py
@@ -686,7 +686,7 @@ async def _kb_grep(
 
     # Grep on piped input
     if piped_input is not None:
-        lines = piped_input.split('\\n')
+        lines = piped_input.split('\n')
         matched = []
         for i, line in enumerate(lines, 1):
             if _matches(line):
@@ -702,7 +702,7 @@ async def _kb_grep(
         elif 'error' in resolved:
             return resolved['error']
         else:
-            lines = resolved['content'].split('\\n')
+            lines = resolved['content'].split('\n')
             matched = []
             for i, line in enumerate(lines, 1):
                 if _matches(line):


### PR DESCRIPTION
Closes #26744

## What

Fix a bug in `knowledge_fs.py` where `grep` splits file content on the literal string `\n` (backslash + n) instead of the actual newline character.

## Root Cause

Two `split('\n')` calls should be `split('\n')` — the escaped backslash-n in Python source creates a literal two-character string rather than a newline character.

```diff
- lines = piped_input.split('\n')
+ lines = piped_input.split('\n')

- lines = resolved['content'].split('\n')
+ lines = resolved['content'].split('\n')
```

Lines 689 and 705 in `backend/open_webui/tools/knowledge_fs.py`.

## Impact

Before: grep would treat an entire file as one line, returning the whole file content when a match was found.
After: grep correctly splits on newlines and returns per-line matches with line numbers.

## Checklist

- [x] **Linked Issue/Discussion:** Closes #26744
- [x] **Target branch:** dev
- [x] **Description:** provided above
- [ ] **Changelog:** N/A (minor bug fix)
- [ ] **Documentation:** N/A
- [ ] **Dependencies:** none added
- [x] **Testing:** Manually verified split behavior
- [x] **No Unchecked AI Code:** Author reviewed the diff
- [x] **Self-Review:** done
- [x] **Architecture:** minimal 2-line fix
- [x] **Git Hygiene:** 1 commit, rebased on dev

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.