### PR TITLE
perf: column-only selects for user activity and webhook lookups

### DIFF
--- a/backend/open_webui/models/users.py
+++ b/backend/open_webui/models/users.py
@@ -568,9 +568,10 @@ class UsersTable:
 
     async def get_user_webhook_url_by_id(self, id: str, db: AsyncSession | None = None) -> str | None:
         async with get_async_db_context(db) as session:
-            user = await session.get(User, id)
-            if user and user.settings:
-                return user.settings.get('ui', {}).get('notifications', {}).get('webhook_url', None)
+            # Column-only select — the full row includes the profile image.
+            row = (await session.execute(select(User.settings).where(User.id == id))).first()
+            if row and row[0]:
+                return row[0].get('ui', {}).get('notifications', {}).get('webhook_url', None)
             return None
 
     async def get_num_users_active_today(self, db: AsyncSession | None = None) -> int | None:
@@ -762,11 +763,12 @@ class UsersTable:
 
     async def is_user_active(self, user_id: str, db: AsyncSession | None = None) -> bool:
         async with get_async_db_context(db) as session:
-            user = await session.get(User, user_id)
-            if user and user.last_active_at:
+            # Column-only select — the full row includes the profile image.
+            row = (await session.execute(select(User.last_active_at).where(User.id == user_id))).first()
+            if row and row[0]:
                 # Consider user active if last_active_at within the last 3 minutes
                 three_minutes_ago = int(time.time()) - 180
-                return user.last_active_at >= three_minutes_ago
+                return row[0] >= three_minutes_ago
             return False
 
 


### PR DESCRIPTION
is_user_active and get_user_webhook_url_by_id each fetched the full User row to read a single value, and they run back-to-back on the post-completion webhook-notification path for every finished chat. The full row includes profile_image_url, which is frequently a base64 data URI — potentially hundreds of KB per fetch.

Select only last_active_at / settings respectively. Truthiness and missing-user semantics are preserved exactly (absent row -> False / None, NULL column -> False / None).

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
