### PR TITLE
perf: cut per-chunk and per-request DB waste in the filter pipeline

### DIFF
--- a/backend/open_webui/models/functions.py
+++ b/backend/open_webui/models/functions.py
@@ -7,7 +7,7 @@ import time
 
 # local imports
 from open_webui.internal.db import Base, JSONField, get_async_db_context
-from open_webui.models.users import UserResponse, Users
+from open_webui.models.users import User, UserResponse, Users, UserSettings
 from open_webui.utils.valves import decrypt_valves, encrypt_valves
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy import BigInteger, Boolean, Column, Index, String, Text, delete, select, update
@@ -275,6 +275,13 @@ class FunctionsTable:
             result = await db.execute(select(Function).filter_by(type='filter', is_active=True, is_global=True))
             return [FunctionModel.model_validate(function) for function in result.scalars().all()]
 
+    async def get_active_filter_ids(self, db: AsyncSession | None = None) -> list[tuple[str, bool]]:
+        """(id, is_global) of active filter functions, without fetching full rows
+        (each row carries the plugin's entire source in `content`)."""
+        async with get_async_db_context(db) as db:
+            result = await db.execute(select(Function.id, Function.is_global).filter_by(type='filter', is_active=True))
+            return [(row[0], bool(row[1])) for row in result.all()]
+
     async def get_global_action_functions(self, db: AsyncSession | None = None) -> list[FunctionModel]:
         async with get_async_db_context(db) as db:
             result = await db.execute(select(Function).filter_by(type='action', is_active=True, is_global=True))
@@ -283,8 +290,11 @@ class FunctionsTable:
     async def get_function_valves_by_id(self, id: str, db: AsyncSession | None = None) -> dict | None:
         async with get_async_db_context(db) as db:
             try:
-                function = await db.get(Function, id)
-                return decrypt_valves(function.valves if function else None)
+                # Select only the valves column — the full row carries the
+                # plugin's entire source, and this runs per streamed chunk.
+                result = await db.execute(select(Function.valves).filter_by(id=id))
+                row = result.first()
+                return decrypt_valves(row[0] if row else None)
             except Exception as e:
                 log.exception(f'Error getting function valves by id {id}: {e}')
                 return None
@@ -347,8 +357,12 @@ class FunctionsTable:
         self, id: str, user_id: str, db: AsyncSession | None = None
     ) -> dict | None:
         try:
-            user = await Users.get_user_by_id(user_id, db=db)
-            user_settings = user.settings.model_dump() if user.settings else {}
+            # Select only the settings column — the full user row (incl.
+            # profile image data) is fetched per streamed chunk otherwise.
+            async with get_async_db_context(db) as db:
+                result = await db.execute(select(User.settings).filter_by(id=user_id))
+                row = result.one()
+            user_settings = UserSettings(**row[0]).model_dump() if row[0] else {}
 
             # Check if user has "functions" and "valves" settings
             if 'functions' not in user_settings:

--- a/backend/open_webui/utils/filter.py
+++ b/backend/open_webui/utils/filter.py
@@ -1,5 +1,6 @@
 import inspect
 import logging
+import weakref
 
 from open_webui.env import ENABLE_PLUGINS
 from open_webui.models.functions import Functions
@@ -9,6 +10,31 @@ from open_webui.utils.plugin import (
 )
 
 log = logging.getLogger(__name__)
+
+# Handler introspection cache: inspect.signature is expensive and stream
+# handlers are introspected once per streamed chunk. Keyed weakly on the
+# underlying function object so reloaded plugins get fresh entries.
+_HANDLER_SPECS: weakref.WeakKeyDictionary = weakref.WeakKeyDictionary()
+
+
+def _get_handler_spec(handler) -> tuple[frozenset, bool]:
+    """(parameter names, is-coroutine) for a filter handler."""
+    key = getattr(handler, '__func__', handler)
+    try:
+        spec = _HANDLER_SPECS.get(key)
+    except TypeError:
+        key, spec = None, None
+    if spec is None:
+        spec = (
+            frozenset(inspect.signature(handler).parameters),
+            inspect.iscoroutinefunction(handler),
+        )
+        if key is not None:
+            try:
+                _HANDLER_SPECS[key] = spec
+            except TypeError:
+                pass
+    return spec
 
 
 async def get_function_module(request, function_id, load_from_db=True):
@@ -23,22 +49,15 @@ async def get_sorted_filter_ids(request, model: dict, enabled_filter_ids: list =
     if not ENABLE_PLUGINS:
         return []
 
-    async def get_priority(function_id):
-        try:
-            function_module = await get_function_module(request, function_id)
-            if function_module and hasattr(function_module, 'Valves'):
-                valves_db = await Functions.get_function_valves_by_id(function_id)
-                valves = function_module.Valves(**(valves_db if valves_db else {}))
-                return getattr(valves, 'priority', 0)
-        except Exception:
-            pass
-        return 0
+    # One narrow query serves both the global and the active-filter sets
+    # (global filters are by definition a subset of active filters).
+    active_filters = await Functions.get_active_filter_ids()
 
-    filter_ids = [function.id for function in await Functions.get_global_filter_functions()]
+    filter_ids = [fid for fid, is_global in active_filters if is_global]
     if 'info' in model and 'meta' in model['info']:
         filter_ids.extend(model['info']['meta'].get('filterIds', []))
         filter_ids = list(set(filter_ids))
-    active_filter_ids = {function.id for function in await Functions.get_functions_by_type('filter', active_only=True)}
+    active_filter_ids = {fid for fid, _ in active_filters}
 
     async def get_active_status(filter_id):
         function_module = await get_function_module(request, filter_id)
@@ -56,6 +75,20 @@ async def get_sorted_filter_ids(request, model: dict, enabled_filter_ids: list =
 
     filter_ids = [fid for fid in filter_ids if fid in active_filter_ids]
 
+    # Batch-fetch valves in one query instead of one query per filter.
+    valves_by_id = await Functions.get_function_valves_by_ids(filter_ids)
+
+    async def get_priority(function_id):
+        try:
+            function_module = await get_function_module(request, function_id)
+            if function_module and hasattr(function_module, 'Valves'):
+                valves_db = valves_by_id.get(function_id)
+                valves = function_module.Valves(**(valves_db if valves_db else {}))
+                return getattr(valves, 'priority', 0)
+        except Exception:
+            pass
+        return 0
+
     # Pre-compute priorities (async functions can't be used in sort keys)
     priorities = {}
     for fid in filter_ids:
@@ -72,6 +105,11 @@ async def process_filter_functions(request, filter_functions, filter_type, form_
         return form_data, {}
 
     skip_files = None
+
+    # Lazily batch-fetched on first use: one query for all filters instead of
+    # one per filter (per streamed chunk for stream-type calls), and none at
+    # all when no filter defines valves.
+    valves_by_id = None
 
     for function in filter_functions:
         filter = function
@@ -91,12 +129,14 @@ async def process_filter_functions(request, filter_functions, filter_type, form_
 
         # Apply valves to the function
         if hasattr(function_module, 'valves') and hasattr(function_module, 'Valves'):
-            valves = await Functions.get_function_valves_by_id(filter_id)
+            if valves_by_id is None:
+                valves_by_id = await Functions.get_function_valves_by_ids([f.id for f in filter_functions if f])
+            valves = valves_by_id.get(filter_id)
             function_module.valves = function_module.Valves(**(valves if valves else {}))
 
         try:
             # Prepare parameters
-            sig = inspect.signature(handler)
+            sig_params, is_coroutine = _get_handler_spec(handler)
 
             params = {'body': form_data}
             if filter_type == 'stream':
@@ -108,11 +148,11 @@ async def process_filter_functions(request, filter_functions, filter_type, form_
                     **extra_params,
                     '__id__': filter_id,
                 }.items()
-                if k in sig.parameters
+                if k in sig_params
             }
 
             # Handle user parameters
-            if '__user__' in sig.parameters:
+            if '__user__' in sig_params:
                 if hasattr(function_module, 'UserValves'):
                     try:
                         params['__user__']['valves'] = function_module.UserValves(
@@ -122,7 +162,7 @@ async def process_filter_functions(request, filter_functions, filter_type, form_
                         log.exception(f'Failed to get user values: {e}')
 
             # Execute handler
-            if inspect.iscoroutinefunction(handler):
+            if is_coroutine:
                 form_data = await handler(**params)
             else:
                 form_data = handler(**params)

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -3626,11 +3626,11 @@ async def streaming_chat_response_handler(response, ctx):
         '__model__': model,
     }
 
+    # Single batched query instead of one query per filter id.
     filter_functions = (
-        [
-            await Functions.get_function_by_id(filter_id)
-            for filter_id in await get_sorted_filter_ids(request, model, metadata.get('filter_ids', []))
-        ]
+        await Functions.get_functions_by_ids(
+            await get_sorted_filter_ids(request, model, metadata.get('filter_ids', []))
+        )
         if ENABLE_PLUGINS
         else []
     )


### PR DESCRIPTION
Stream filters run once per streamed chunk, and the pipeline around them repeated significant database work on that path:

- get_function_valves_by_id fetched the full function row — including the plugin's entire Python source in `content` — to read only the `valves` JSON column, once per streamed chunk for stream filters. Select just the valves column instead.
- get_user_valves_by_id_and_user_id fetched and validated the full user row (including the profile image) to read one nested settings key. Select just the settings column; validation of that column is unchanged, so results are identical.
- process_filter_functions issued one valves query per filter per invocation. Batch them with the existing get_function_valves_by_ids, lazily, so invocations where no filter defines valves issue no query at all (previously zero, now still zero).
- process_filter_functions recomputed inspect.signature() and iscoroutinefunction() for every handler on every invocation — per chunk for stream filters. Cache both per handler, weakly keyed on the underlying function object so reloaded plugins get fresh entries.
- get_sorted_filter_ids ran two full-row queries (global filters, active filters) and used only the ids; global filters are by definition a subset of active ones. One narrow (id, is_global) query now serves both sets, and per-filter priority valves lookups are batched (N+1 -> 1).
- The streaming response handler fetched filter functions one query per id; use the existing batched get_functions_by_ids (N -> 1).

Final filter ordering is unchanged (it is fully determined by the (priority, id) sort). Error semantics preserved: batch lookup misses behave exactly like the previous per-id fetch failures.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
