### PR TITLE
perf: halve function-table queries in get_all_models

### DIFF
--- a/backend/open_webui/utils/models.py
+++ b/backend/open_webui/utils/models.py
@@ -68,6 +68,7 @@ async def get_all_models(request, refresh: bool = False, user: UserModel = None)
         'models.base_models_cache',
         'evaluation.arena.enable',
         'evaluation.arena.models',
+        'models.default_metadata',
     )
     if (
         request.app.state.MODELS
@@ -125,23 +126,21 @@ async def get_all_models(request, refresh: bool = False, user: UserModel = None)
             ]
         models = models + arena_models
 
-    global_action_ids = (
-        {function.id for function in await Functions.get_global_action_functions()} if ENABLE_PLUGINS else set()
-    )
-    enabled_action_ids = (
-        {function.id for function in await Functions.get_functions_by_type('action', active_only=True)}
-        if ENABLE_PLUGINS
-        else set()
-    )
+    # One query per type: the global sets are subsets of the active sets, so
+    # deriving them from the same rows halves the function-table queries.
+    if ENABLE_PLUGINS:
+        active_actions = await Functions.get_functions_by_type('action', active_only=True)
+        global_action_ids = {function.id for function in active_actions if function.is_global}
+        enabled_action_ids = {function.id for function in active_actions}
 
-    global_filter_ids = (
-        {function.id for function in await Functions.get_global_filter_functions()} if ENABLE_PLUGINS else set()
-    )
-    enabled_filter_ids = (
-        {function.id for function in await Functions.get_functions_by_type('filter', active_only=True)}
-        if ENABLE_PLUGINS
-        else set()
-    )
+        active_filters = await Functions.get_functions_by_type('filter', active_only=True)
+        global_filter_ids = {function.id for function in active_filters if function.is_global}
+        enabled_filter_ids = {function.id for function in active_filters}
+    else:
+        global_action_ids = set()
+        enabled_action_ids = set()
+        global_filter_ids = set()
+        enabled_filter_ids = set()
 
     custom_models = await Models.get_all_models()
 
@@ -305,7 +304,7 @@ async def get_all_models(request, refresh: bool = False, user: UserModel = None)
 
     # Apply global model defaults to all models
     # Per-model overrides take precedence over global defaults
-    default_metadata = await Config.get('models.default_metadata', {}) or {}
+    default_metadata = config.get('models.default_metadata') or {}
 
     if default_metadata:
         for model in models:


### PR DESCRIPTION
get_all_models ran four function-table queries: global actions, active actions, global filters, active filters. Global functions are by definition (type, is_active=True, is_global=True) — a subset of the active set — so the global id sets can be derived from the active-rows queries' is_global flag. Four queries become two, and each dropped query returned full rows including every plugin's source code.

Also folds the mid-function 'models.default_metadata' read into the Config.get_many already issued at the top of the function (one fewer round trip; the existing `or {}` default handling is preserved).

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
