### PR TITLE
perf: linear content accumulation in the streaming response handler

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -4408,7 +4408,12 @@ async def streaming_chat_response_handler(response, ctx):
                                                 user,
                                             )
 
-                                        content = f'{content}{value}'
+                                        if isinstance(value, str):
+                                            # In-place append — avoids copying the full
+                                            # accumulated response on every chunk.
+                                            content += value
+                                        else:
+                                            content = f'{content}{value}'
 
                                         # Check if we're inside a tag-based block
                                         # (reasoning, code_interpreter, or solution).
@@ -4515,16 +4520,17 @@ async def streaming_chat_response_handler(response, ctx):
                                         if ENABLE_REALTIME_CHAT_SAVE and not metadata.get('chat_id', '').startswith(
                                             'channel:'
                                         ):
+                                            current_output = full_output()
                                             # Save message in the database
                                             await Chats.upsert_message_to_chat_by_id_and_message_id(
                                                 metadata['chat_id'],
                                                 metadata['message_id'],
                                                 {
-                                                    'output': full_output(),
+                                                    'output': current_output,
                                                 },
                                             )
                                             data = {
-                                                'output': full_output(),
+                                                'output': current_output,
                                             }
                                             delta_type = 'content'
                                         else:


### PR DESCRIPTION
The streaming handler rebuilt the full accumulated response with `content = f'{content}{value}'` on every content delta — a complete string copy per chunk, making accumulation O(n^2) over the response length. Use in-place `content += value` for the (universal) str case, which CPython extends in place, keeping accumulation O(n); the f-string fallback is preserved for non-str values so coercion behavior is unchanged.

In the ENABLE_REALTIME_CHAT_SAVE branch, full_output() — which concatenates the entire accumulated output — was called twice per chunk (once for the DB upsert, once for the emitted delta). Compute it once and reuse.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
