### PR TITLE
fix: Log upstream provider rejections at warn/error level

### DIFF
--- a/backend/open_webui/events.py
+++ b/backend/open_webui/events.py
@@ -1150,6 +1150,20 @@ async def publish_model_provider_request_failed(
         else 'upstream_error'
     )
 
+    # Server-log only; the upstream error body is otherwise invisible to admins
+    # (event sinks require an event function or webhook to be configured).
+    log.log(
+        logging.ERROR if status >= 500 else logging.WARNING,
+        'Upstream %s request failed: HTTP %d (%s) url=%s model=%s code=%s message=%s',
+        provider,
+        status,
+        error_type,
+        base_url,
+        requested_model or '-',
+        error_code or '-',
+        error_text[:MAX_STRING_LENGTH] or '-',
+    )
+
     data = {
         'error_type': error_type,
         'status': status,


### PR DESCRIPTION
When an upstream provider rejects a request (e.g. a 400 for a max_tokens value above the model's ceiling), the actionable error message was only published to event sinks, which are invisible unless an event function or webhook is configured. Admins had to query the provider's API directly to diagnose failures (open-webui#27237).

Add a single log line in publish_model_provider_request_failed — the chokepoint every upstream failure path (OpenAI-compatible chat, embeddings, responses, token counting, and Ollama) already routes through — recording status, provider, url, model, error code, and the upstream message truncated to 1000 chars. 4xx logs at WARNING, 5xx at ERROR. Client-facing responses are unchanged, so no additional error detail is exposed in the chat.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
