### PR TITLE
fix: fetch the terminal system prompt per request

### DIFF
--- a/backend/open_webui/utils/tools.py
+++ b/backend/open_webui/utils/tools.py
@@ -8,6 +8,7 @@ import json
 import logging
 import os
 import re
+import time
 from functools import partial, update_wrapper
 from typing import (
     Any,
@@ -1093,7 +1094,8 @@ async def get_terminal_system_prompt(
     base = base_url.rstrip('/')
     try:
         async with aiohttp.ClientSession(
-            timeout=aiohttp.ClientTimeout(total=3),
+            # 30s: orchestrator instances may cold-start before answering
+            timeout=aiohttp.ClientTimeout(total=30),
             trust_env=True,
         ) as session:
             # 1. Check feature flag
@@ -1116,6 +1118,39 @@ async def get_terminal_system_prompt(
     except Exception as e:
         log.debug(f'Failed to fetch terminal system prompt: {e}')
     return None
+
+
+_TERMINAL_SYSTEM_PROMPT_TTL = 300  # seconds
+_TERMINAL_SYSTEM_PROMPT_ERROR_TTL = 60  # seconds
+_terminal_system_prompt_cache: dict[tuple[str, str], tuple[float, str | None]] = {}
+
+
+async def get_cached_terminal_system_prompt(
+    base_url: str,
+    headers: dict,
+    cookies: dict | None = None,
+) -> str | None:
+    """Return a terminal server's system prompt, cached per (URL, user).
+
+    Each user may resolve to a different orchestrator instance. Failures
+    are cached briefly so an unreachable instance doesn't stall every
+    request.
+    """
+    key = (base_url, headers.get('X-User-Id', ''))
+    now = time.monotonic()
+
+    cached = _terminal_system_prompt_cache.get(key)
+    if cached and cached[0] > now:
+        return cached[1]
+
+    prompt = await get_terminal_system_prompt(base_url, headers, cookies)
+
+    if len(_terminal_system_prompt_cache) > 4096:
+        for stale_key in [k for k, (expiry, _) in _terminal_system_prompt_cache.items() if expiry <= now]:
+            _terminal_system_prompt_cache.pop(stale_key, None)
+    ttl = _TERMINAL_SYSTEM_PROMPT_TTL if prompt else _TERMINAL_SYSTEM_PROMPT_ERROR_TTL
+    _terminal_system_prompt_cache[key] = (now + ttl, prompt)
+    return prompt
 
 
 async def set_terminal_servers(request: Request):
@@ -1245,15 +1280,20 @@ async def get_terminal_tools(
             headers.update(bearer_auth_header(oauth_token.get('access_token', '')))
     # auth_type == "none": no Authorization header
 
-    system_prompt = server_data.get('system_prompt')
-
     # Use chat_id as the per-session key for cwd tracking
     metadata = extra_params.get('__metadata__', {})
     session_id = metadata.get('chat_id')
     if session_id:
         headers['X-Session-Id'] = session_id
 
-    terminal_cwd = await get_terminal_cwd(server_data['url'], headers, cookies)
+    # Live fetch with the user's credentials; the set_terminal_servers
+    # snapshot is the fallback.
+    terminal_cwd, system_prompt = await asyncio.gather(
+        get_terminal_cwd(server_data['url'], headers, cookies),
+        get_cached_terminal_system_prompt(server_data['url'], headers, cookies),
+    )
+    if not system_prompt:
+        system_prompt = server_data.get('system_prompt')
 
     tools_dict = {}
     for spec in specs:

--- a/backend/open_webui/utils/tools.py
+++ b/backend/open_webui/utils/tools.py
@@ -8,7 +8,6 @@ import json
 import logging
 import os
 import re
-import time
 from functools import partial, update_wrapper
 from typing import (
     Any,
@@ -1094,8 +1093,7 @@ async def get_terminal_system_prompt(
     base = base_url.rstrip('/')
     try:
         async with aiohttp.ClientSession(
-            # 30s: orchestrator instances may cold-start before answering
-            timeout=aiohttp.ClientTimeout(total=30),
+            timeout=aiohttp.ClientTimeout(total=3),
             trust_env=True,
         ) as session:
             # 1. Check feature flag
@@ -1118,39 +1116,6 @@ async def get_terminal_system_prompt(
     except Exception as e:
         log.debug(f'Failed to fetch terminal system prompt: {e}')
     return None
-
-
-_TERMINAL_SYSTEM_PROMPT_TTL = 300  # seconds
-_TERMINAL_SYSTEM_PROMPT_ERROR_TTL = 60  # seconds
-_terminal_system_prompt_cache: dict[tuple[str, str], tuple[float, str | None]] = {}
-
-
-async def get_cached_terminal_system_prompt(
-    base_url: str,
-    headers: dict,
-    cookies: dict | None = None,
-) -> str | None:
-    """Return a terminal server's system prompt, cached per (URL, user).
-
-    Each user may resolve to a different orchestrator instance. Failures
-    are cached briefly so an unreachable instance doesn't stall every
-    request.
-    """
-    key = (base_url, headers.get('X-User-Id', ''))
-    now = time.monotonic()
-
-    cached = _terminal_system_prompt_cache.get(key)
-    if cached and cached[0] > now:
-        return cached[1]
-
-    prompt = await get_terminal_system_prompt(base_url, headers, cookies)
-
-    if len(_terminal_system_prompt_cache) > 4096:
-        for stale_key in [k for k, (expiry, _) in _terminal_system_prompt_cache.items() if expiry <= now]:
-            _terminal_system_prompt_cache.pop(stale_key, None)
-    ttl = _TERMINAL_SYSTEM_PROMPT_TTL if prompt else _TERMINAL_SYSTEM_PROMPT_ERROR_TTL
-    _terminal_system_prompt_cache[key] = (now + ttl, prompt)
-    return prompt
 
 
 async def set_terminal_servers(request: Request):
@@ -1286,11 +1251,10 @@ async def get_terminal_tools(
     if session_id:
         headers['X-Session-Id'] = session_id
 
-    # Live fetch with the user's credentials; the set_terminal_servers
-    # snapshot is the fallback.
+    # Fetch live with the user's credentials so prompt changes apply without a restart
     terminal_cwd, system_prompt = await asyncio.gather(
         get_terminal_cwd(server_data['url'], headers, cookies),
-        get_cached_terminal_system_prompt(server_data['url'], headers, cookies),
+        get_terminal_system_prompt(server_data['url'], headers, cookies),
     )
     if not system_prompt:
         system_prompt = server_data.get('system_prompt')


### PR DESCRIPTION
The terminal system prompt was read from `server_data['system_prompt']`, which is the value captured when the connection was configured. A prompt changed on the terminal server after that point never reached the model, so picking up a change meant re-saving the connection or restarting.

`get_terminal_tools` now fetches the prompt for each request using the caller's own credentials, gathered concurrently with the existing working-directory fetch so it adds no extra round trip. If the live fetch returns nothing, the stored value is used, so a terminal server that does not expose the endpoint behaves exactly as before.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
