### PR TITLE
fix: enforce action availability and model access on the chat action route

### DIFF
--- a/backend/open_webui/utils/actions.py
+++ b/backend/open_webui/utils/actions.py
@@ -9,7 +9,7 @@ from open_webui.models.functions import Functions
 from open_webui.models.users import UserModel
 from open_webui.socket.main import get_event_call, get_event_emitter
 from open_webui.utils.middleware import process_tool_result
-from open_webui.utils.models import get_all_models
+from open_webui.utils.models import check_model_access, get_all_models
 from open_webui.utils.plugin import get_function_module_from_cache
 
 logging.basicConfig(stream=sys.stdout, level=GLOBAL_LOG_LEVEL)
@@ -45,6 +45,23 @@ async def chat_action(request: Request, action_id: str, form_data: dict, user: A
     if model_id not in models:
         raise Exception('Model not found')
     model = models[model_id]
+
+    # Availability gate — keep this route consistent with the actions a model
+    # actually surfaces to the client. Executing admin-authored Function code is
+    # intended; this only stops a disabled, unassigned, or access-restricted
+    # action from being reached by calling the route with a raw action_id.
+    if action.type != 'action' or not action.is_active:
+        raise Exception(f'Action not available: {action_id}')
+
+    # Direct connections carry a client-supplied model the caller already owns,
+    # so scope the model-bound checks to server-resolved models.
+    if not getattr(request.state, 'direct', False) and user.role != 'admin':
+        await check_model_access(user, model)
+        # model['actions'] entries are '<function_id>' or '<function_id>.<sub_id>';
+        # the function id is always the prefix.
+        surfaced_action_ids = {item.get('id', '').split('.', 1)[0] for item in model.get('actions', [])}
+        if action_id not in surfaced_action_ids:
+            raise Exception(f'Action not available: {action_id}')
 
     __event_emitter__ = await get_event_emitter(
         {


### PR DESCRIPTION
The chat action route loaded a Function by its raw action_id and executed its action callable after only checking that the id and the requested model existed. The model list that the client renders actions from resolves each model's actions to the active action-type Functions that are global or assigned to that model, and the action route did not mirror that resolution, so a disabled, unassigned, or wrong-type Function, or an action on a model the caller cannot access, could be reached by calling the route directly.

Gate the route on the same rules the model resolution applies: the Function must be an active action, and for server-resolved models the caller must have model access and the action must be one the model actually surfaces (matched by function id, the prefix of each model actions entry, so single and sub-actions both resolve). Direct connections carry a client-supplied model the caller already owns, so the model-bound checks are scoped to non-direct calls; the active-action check always applies. Executing admin-authored Function code remains intended behaviour — this only keeps the route consistent with which actions each model exposes.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
