### PR TITLE
fix: only admins may switch the global Automatic1111 checkpoint from image generation

### DIFF
--- a/backend/open_webui/routers/images.py
+++ b/backend/open_webui/routers/images.py
@@ -785,7 +785,11 @@ async def image_generations(
                 images.append({'url': url})
             return images
         elif image_config.IMAGE_GENERATION_ENGINE == 'automatic1111' or image_config.IMAGE_GENERATION_ENGINE == '':
-            if form_data.model:
+            # Automatic1111 holds one checkpoint instance-wide, so set_image_model
+            # persists the global default and switches the shared backend. Only an
+            # admin may do that; a non-admin generates on the currently configured
+            # checkpoint. The model field is not a per-user selection on this backend.
+            if form_data.model and user.role == 'admin':
                 await set_image_model(request, form_data.model)
 
             data = {


### PR DESCRIPTION
The Automatic1111 branch of the image generation route called set_image_model whenever the request carried a model field. On this backend set_image_model is not request-scoped: it persists image_generation.model to the global configuration and posts the new sd_model_checkpoint to the shared server, because Automatic1111 holds a single checkpoint instance-wide. A non-admin holding features.image_generation could therefore change the instance-wide image model and the shared backend checkpoint for every user by sending a model on an ordinary generation request, even though the setting is otherwise managed only through the admin-only image configuration route and the frontend never sends this field.

Gate the switch on an admin caller. A non-admin now generates on the currently configured checkpoint and the model field no longer mutates global state; admins retain per-request model switching here and through the image configuration route. Image editing is unaffected, as it selects its model per request without writing global configuration.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
