### PR TITLE
feat: forward user info headers to Mistral OCR API

### DIFF
--- a/backend/open_webui/retrieval/loaders/main.py
+++ b/backend/open_webui/retrieval/loaders/main.py
@@ -554,6 +554,7 @@ class Loader:
                 api_key=self.kwargs.get('MISTRAL_OCR_API_KEY'),
                 file_path=file_path,
                 use_base64=self.kwargs.get('MISTRAL_OCR_USE_BASE64', False),
+                user=self.user,
             )
         elif self.engine == 'paddleocr_vl' and self.kwargs.get('PADDLEOCR_VL_TOKEN') != '':
             loader = PaddleOCRVLLoader(

--- a/backend/open_webui/retrieval/loaders/mistral.py
+++ b/backend/open_webui/retrieval/loaders/mistral.py
@@ -5,12 +5,13 @@ import os
 import sys
 import time
 from contextlib import asynccontextmanager
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import aiohttp
 import requests
 from langchain_core.documents import Document
-from open_webui.env import AIOHTTP_CLIENT_SESSION_SSL, GLOBAL_LOG_LEVEL
+from open_webui.env import AIOHTTP_CLIENT_SESSION_SSL, ENABLE_FORWARD_USER_INFO_HEADERS, GLOBAL_LOG_LEVEL
+from open_webui.utils.headers import include_user_info_headers
 
 logging.basicConfig(stream=sys.stdout, level=GLOBAL_LOG_LEVEL)
 log = logging.getLogger(__name__)
@@ -39,6 +40,7 @@ class MistralLoader:
         max_retries: int = 3,
         enable_debug_logging: bool = False,
         use_base64: bool = False,
+        user: Optional[Any] = None,
     ):
         """
         Initializes the loader with enhanced features.
@@ -50,6 +52,8 @@ class MistralLoader:
             max_retries: Maximum number of retry attempts.
             enable_debug_logging: Enable detailed debug logs.
             use_base64: Send the document as a data URL instead of uploading it first.
+            user: The requesting user, forwarded to Mistral via user-info headers
+                when ENABLE_FORWARD_USER_INFO_HEADERS is enabled.
         """
         if not api_key:
             raise ValueError('API key cannot be empty.')
@@ -63,6 +67,7 @@ class MistralLoader:
         self.max_retries = max_retries
         self.debug = enable_debug_logging
         self.use_base64 = use_base64
+        self.user = user
 
         # PERFORMANCE OPTIMIZATION: Differentiated timeouts for different operations
         # This prevents long-running OCR operations from affecting quick operations
@@ -82,6 +87,8 @@ class MistralLoader:
             'Authorization': f'Bearer {self.api_key}',
             'User-Agent': 'OpenWebUI-MistralLoader/2.0',  # Helps API provider track usage
         }
+        if self.user is not None and ENABLE_FORWARD_USER_INFO_HEADERS:
+            self.headers = include_user_info_headers(self.headers, self.user)
 
     def _debug_log(self, message: str, *args) -> None:
         """


### PR DESCRIPTION
**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing Issue - Closes [#27250](https://github.com/open-webui/open-webui/issues/27250).
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following Keep a Changelog format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the Open WebUI Docs Repository.
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes: `feat`

# Changelog Entry

### Description

`ENABLE_FORWARD_USER_INFO_HEADERS` forwards the requesting user's identity (signed JWT, or `X-OpenWebUI-User-*` headers) to external backends called on the user's behalf — already implemented for the TTS/STT integrations in `routers/audio.py` and for `ExternalDocumentLoader`. The Mistral OCR loader (`retrieval/loaders/mistral.py`), used when the RAG content extraction engine is set to `mistral_ocr`, was missing this behavior entirely, so a Mistral-compatible gateway/proxy in front of the OCR API couldn't attribute OCR requests to the requesting user.

This PR applies the same `include_user_info_headers()` pattern already used elsewhere in the codebase to `MistralLoader`, so it behaves consistently with the other outbound integrations.

### Added

- `MistralLoader` now forwards user info headers (signed JWT or `X-OpenWebUI-User-*`) on every request — upload, signed URL, OCR, and delete — when `ENABLE_FORWARD_USER_INFO_HEADERS` is enabled.

### Changed

- `MistralLoader.__init__` accepts an optional `user` parameter.
- `Loader._get_loader()` passes `user=self.user` when constructing `MistralLoader`, matching how it's already passed to `ExternalDocumentLoader`.

### Deprecated

- None

### Removed

- None

### Fixed

- Inconsistent user-header forwarding: the Mistral OCR path silently ignored `ENABLE_FORWARD_USER_INFO_HEADERS` while every other outbound integration honored it.

### Security

- None

### Breaking Changes

- None

---

### Additional Information

- Related prior art in this codebase: `routers/audio.py` (`_tts_openai`, `_transcribe_openai`) and `retrieval/loaders/external_document.py` both use the same `include_user_info_headers()` helper from `backend/open_webui/utils/headers.py`.
- Closes #27250

### Screenshots or Videos

- N/A — backend-only change, no UI impact.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
