### PR TITLE
ci: auto-label bug reports created outside the issue form

### DIFF
--- a/.github/workflows/issue-label.yaml
+++ b/.github/workflows/issue-label.yaml
@@ -1,0 +1,43 @@
+name: Issue Labeler
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  label-bug-reports:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add "bug" label to unlabeled bug reports
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+
+            // Web-form submissions already carry the label from the issue template
+            if (issue.labels.some((label) => label.name === 'bug')) {
+              return;
+            }
+
+            const title = issue.title ?? '';
+            const body = issue.body ?? '';
+
+            // Freeform bug reports: "issue: ...", "bug: ...", "fix: ...", "[Bug] ...", "issue/UX: ..."
+            const bugLikeTitle = /^\s*\[?(bug|issue|fix)\]?\s*[:/\-]/i.test(title);
+
+            // API/CLI-created issues that reproduce the bug report form structure.
+            // Only headings distinctive to the bug form (both are required fields there) —
+            // generic headings like "Expected Behavior" also appear in freeform feature requests.
+            const bugFormBody = /###\s*(Installation Method|Open WebUI Version)/i.test(body);
+
+            if (bugLikeTitle || bugFormBody) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                labels: ['bug']
+              });
+            }


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Relates to #27246 — Discussion proposing automatic labeling of bug reports created outside the issue form.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **ci**: CI/CD workflow changes

# Changelog Entry

### Description

**Problem:** A meaningful share of new bug reports arrive in the Issues tab with no labels, so maintainers cannot spot them by the `bug` label alone. Sampling the ~40 most recent open issues, roughly a quarter of bug reports had zero labels (e.g. #27195, #27214, #27061, #27074).

**Root cause:** The bug report form template already declares `labels: ['bug', 'triage']`, but GitHub only applies template labels to issues submitted through the web form. Issues created via the REST API or `gh` CLI — increasingly common now that many reporters file issues through AI coding tools — skip template labels entirely, and reporters without triage permission cannot add labels themselves. (`blank_issues_enabled: false` only hides the blank option in the web chooser; it does not affect API-created issues.)

**Fix:** Adds a minimal `Issue Labeler` workflow (`.github/workflows/issue-label.yaml`) triggered on `issues: opened`. If the new issue does not already carry the `bug` label, it adds one when either:

- the title matches a bug-report pattern (`issue:`, `bug:`, `fix:`, `[Bug]`, case-insensitive), or
- the body contains headings distinctive to the bug report form (`### Installation Method`, `### Open WebUI Version` — both required fields there), which catches API-created issues that copied the form structure. Generic headings like `### Expected Behavior` are deliberately excluded because they also appear in freeform feature requests.

Form-submitted bug reports are a no-op (already labeled at creation). Feature requests use the `feat:` title prefix and a different body structure, so they never match. The scope of changes is one new file, ~40 lines.

Key logic:

```javascript
// Web-form submissions already carry the label from the issue template
if (issue.labels.some((label) => label.name === 'bug')) return;

const bugLikeTitle = /^\s*\[?(bug|issue|fix)\]?\s*[:/\-]/i.test(title);
const bugFormBody = /###\s*(Installation Method|Open WebUI Version)/i.test(body);

if (bugLikeTitle || bugFormBody) {
  await github.rest.issues.addLabels({ ..., labels: ['bug'] });
}
```

### Added

- CI workflow that automatically applies the `bug` label to bug reports created outside the web issue form (via REST API, `gh` CLI, or integrations), where GitHub does not apply the issue template's labels.

---

### Additional Information

- Security: `issues`-triggered workflows always run in the base-repository context (no fork code execution), so the `issues: write` permission carries no untrusted-code risk. No third-party actions are introduced; the logic is a short `actions/github-script` step.
- Activation: `issues`-triggered workflows run from the default branch, so this workflow takes effect once the change is promoted from `dev`.
- Related observation for maintainers (not addressed in this PR to keep it atomic): the `triage` label referenced by both issue templates does not exist in the repository's label list, so GitHub silently drops it on every form submission. It could either be created (requires repo admin) or removed from the templates in a follow-up.
- This PR was prepared with AI assistance (Claude Code). The workflow YAML and the matching logic were verified by the AI via the backtest described below; the author reviewed the workflow diff and this description.

**Verification Performed**

1. Workflow YAML validated (parses cleanly; `permissions: issues: write`, trigger `issues: opened` only).
2. Backtested the exact matching logic against the repository's 27 most recent real issues (2026-07-20): the 12 issues already carrying `bug` (web-form submissions) are skipped; all 9 unlabeled bug reports created outside the form would be labeled (including #27254, #27248, #27214, #27210, #27195); all 6 feature requests/questions are left untouched — zero false positives, zero false negatives on the sample.
3. The backtest surfaced and fixed two edge cases: `fix:`-titled bug reports (e.g. #27248) were initially missed, and one `feat:` request (#27185) containing a generic `### Expected Behavior` heading was initially a false positive — the final regexes address both.
4. End-to-end run not exercised pre-merge: `issues`-triggered workflows only execute from the default branch, and fork repositories have Issues disabled, so a live run is only possible after merge. The backtest in (2) covers the decision logic against real production data.

### Screenshots or Videos

- [Attach a screenshot of the fork's workflow run adding the label, if desired]

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
