### PR TITLE
ci: scope PR format checks to the files each PR changes

### DIFF
--- a/.github/workflows/backend.yaml
+++ b/.github/workflows/backend.yaml
@@ -28,6 +28,10 @@ jobs:
         python-version: ['3.11', '3.12']
     steps:
       - uses: actions/checkout@v5
+        with:
+          # On pull_request the checkout is the PR merge commit; depth 2 makes its
+          # first parent (the base branch tip) available for changed-file diffs
+          fetch-depth: 2
 
       - uses: actions/setup-python@v6
         with:
@@ -36,7 +40,17 @@ jobs:
       - name: Install formatter
         run: pip install "ruff>=0.15.5"
 
-      - name: Verify formatting
+      # PRs are judged on the files they touch, so a PR's check reflects the PR
+      # itself rather than the formatting state of the base branch
+      - name: Verify formatting (files changed by this PR)
+        if: github.event_name == 'pull_request'
+        run: |
+          git diff --name-only --diff-filter=d HEAD^1 HEAD -- 'backend/**/*.py' \
+            | xargs -r ruff format --check
+
+      # Pushes to dev/main keep the whole-repository signal
+      - name: Verify formatting (full tree)
+        if: github.event_name == 'push'
         run: ruff format --check . --exclude .venv --exclude venv
 
       - name: Detect logic errors

--- a/.github/workflows/frontend.yaml
+++ b/.github/workflows/frontend.yaml
@@ -24,6 +24,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v5
+        with:
+          # On pull_request the checkout is the PR merge commit; depth 2 makes its
+          # first parent (the base branch tip) available for changed-file diffs
+          fetch-depth: 2
 
       - uses: actions/setup-node@v5
         with:
@@ -32,13 +36,27 @@ jobs:
       - name: Install dependencies
         run: npm install --force
 
-      - name: Verify code formatting
+      # PRs are judged on the files they touch, so a PR's check reflects the PR
+      # itself rather than the formatting state of the base branch. The i18n
+      # catalog sync stays a push/release concern and is not required of PRs.
+      - name: Verify code formatting (files changed by this PR)
+        if: github.event_name == 'pull_request'
+        run: |
+          git diff --name-only --diff-filter=d HEAD^1 HEAD -- \
+            '*.js' '*.ts' '*.svelte' '*.css' '*.md' '*.html' '*.json' \
+            | xargs -r npx prettier --check
+
+      # Pushes to dev/main keep the whole-repository signal
+      - name: Verify code formatting (full tree)
+        if: github.event_name == 'push'
         run: npm run format
 
       - name: Verify i18n strings
+        if: github.event_name == 'push'
         run: npm run i18n:parse
 
       - name: Ensure working tree is clean
+        if: github.event_name == 'push'
         run: git diff --exit-code
 
       - name: Production build


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Relates to #27252 — proposal to scope CI format checks to PR changes so check results stay meaningful between releases.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **ci**: CI/CD workflow changes

# Changelog Entry

### Description

**Problem:** Between release-time formatting sweeps, the `Python CI` and `Frontend Build` checks fail on every pull request and push regardless of the change's content, because both verify the entire tree against formatters while `dev` is mid-cycle. A red X currently carries no information about the PR it is attached to (full analysis and discussion in #27252).

**Fix:** On `pull_request` events, both workflows now check only the files the PR actually changes, diffed against the PR's merge base (`HEAD^1` of the merge commit, available via `fetch-depth: 2`):

- **`backend.yaml`:** `ruff format --check` runs on the changed `backend/**/*.py` files only. The `ruff check --select=F` logic-error step is unchanged (it passes tree-wide today).
- **`frontend.yaml`:** `prettier --check` runs on the changed `js/ts/svelte/css/md/html/json` files only. The `i18n:parse` + clean-tree requirement no longer applies to PRs — the catalog sync stays a push/release concern, exactly as it is handled today.
- **`push` events keep the existing full-tree checks unchanged**, preserving the whole-repository signal on `dev`/`main`.

Behavioral consequences, stated explicitly:

1. A PR whose own files are correctly formatted gets a green check even while `dev` is mid-cycle — the goal of #27252.
2. A PR that touches a file that is *already* unformatted on `dev` must format that file to pass ("you touch it, you format it") — a mild, arguably healthy, boy-scout effect.
3. A PR changing no matching files (e.g. only binary assets) passes trivially (`xargs -r` skips the check).

Scope: 2 workflow files; no third-party actions introduced; `permissions` unchanged.

Key logic (identical shape in both workflows):

```yaml
- uses: actions/checkout@v5
  with:
    fetch-depth: 2   # makes the PR merge commit's first parent (base tip) available

- name: Verify formatting (files changed by this PR)
  if: github.event_name == 'pull_request'
  run: |
    git diff --name-only --diff-filter=d HEAD^1 HEAD -- 'backend/**/*.py' \
      | xargs -r ruff format --check

- name: Verify formatting (full tree)
  if: github.event_name == 'push'
  run: ruff format --check . --exclude .venv --exclude venv
```

### Changed

- CI format checks on pull requests now verify only the files each PR changes, so a PR's check status reflects the PR itself rather than the formatting state of the base branch. Full-tree checks on branch pushes are unchanged.

---

### Additional Information

- No third-party changed-files actions are used — plain `git diff` against the merge commit's first parent, which `actions/checkout` produces natively for `pull_request` events.
- `--diff-filter=d` excludes deleted files so the formatters are never invoked on paths that no longer exist.
- This PR was prepared with AI assistance (Claude Code). All verification below — the local simulations and the end-to-end fork test — was executed by the AI; the author reviewed the workflow diff and this description.

**Verification Performed**

Both workflow files parse cleanly, and the scoped-check pipeline was exercised locally against real simulated PR merge commits on the current `dev` (which has 11 ruff-dirty backend files, making it the exact scenario the change addresses):

1. PR adding a correctly formatted backend change while the base tree is dirty → scoped check **passes**; control run of the current full-tree check on the same commit still fails (demonstrating the before/after difference).
2. PR adding an unformatted backend change (double quotes, which the project's ruff config rejects) → scoped check **fails**, as it should.
3. PR adding a prettier-clean frontend change → scoped check **passes**.
4. PR adding a prettier-dirty frontend change → scoped check **fails**, as it should.
5. PR changing only non-matching files → scoped check **passes** via `xargs -r` (formatter never invoked).
6. **End-to-end on GitHub Actions** (fork test PR [silentoplayz#6](https://github.com/silentoplayz/open-webui/pull/6), running these exact workflow files): a commit with deliberately unformatted backend + frontend changes failed both workflows precisely at the new scoped steps ([Python CI](https://github.com/silentoplayz/open-webui/actions/runs/29793544365), [Frontend Build](https://github.com/silentoplayz/open-webui/actions/runs/29793544332)); after formatting only the touched files — with the base tree still containing 11 pre-existing ruff-dirty files — both workflows completed fully green, including the production build ([Python CI](https://github.com/silentoplayz/open-webui/actions/runs/29793624370), [Frontend Build](https://github.com/silentoplayz/open-webui/actions/runs/29793624367)).

### Screenshots or Videos

- N/A (CI workflow change)

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
