### PR TITLE
feat: add LDAP group synchronization support

### DIFF
--- a/backend/open_webui/routers/auths.py
+++ b/backend/open_webui/routers/auths.py
@@ -630,9 +630,9 @@ async def ldap_auth(
 
             if user:
                 if ENABLE_LDAP_GROUP_MANAGEMENT and user_groups:
-                    if ENABLE_LDAP_GROUP_CREATION:
-                        await Groups.create_groups_by_group_names(user.id, user_groups, db=db)
                     try:
+                        if ENABLE_LDAP_GROUP_CREATION:
+                            await Groups.create_groups_by_group_names(user.id, user_groups, db=db)
                         await Groups.sync_groups_by_group_names(user.id, user_groups, db=db)
                         log.info(f'Successfully synced groups for user {user.id}: {user_groups}')
                     except Exception as e:
@@ -1214,6 +1214,11 @@ async def update_ldap_server(request: Request, form_data: LdapServerConfig, user
         value = getattr(form_data, key)
         if not value:
             raise HTTPException(400, detail=ERROR_MESSAGES.REQUIRED_FIELD_EMPTY(key))
+
+    # The group attribute is what group management reads from the directory
+    # entry; an empty value would make group sync silently do nothing.
+    if form_data.enable_group_management and not (form_data.attribute_for_groups or '').strip():
+        raise HTTPException(400, detail=ERROR_MESSAGES.REQUIRED_FIELD_EMPTY('attribute_for_groups'))
 
     updates = config_updates(form_data.model_dump(), LDAP_SERVER_CONFIG_KEYS)
     updates['ldap.server.app_dn'] = form_data.app_dn or ''

--- a/backend/open_webui/routers/auths.py
+++ b/backend/open_webui/routers/auths.py
@@ -14,6 +14,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import JSONResponse, Response
 from ldap3 import NONE, Connection, Server, Tls
 from ldap3.utils.conv import escape_filter_chars
+from ldap3.utils.dn import parse_dn
 from open_webui.config import (
     ENABLE_PASSWORD_AUTH,
     OAUTH_PROVIDERS,
@@ -401,6 +402,56 @@ async def update_password(
         raise HTTPException(400, detail=ERROR_MESSAGES.INVALID_CRED)
 
 
+def _unescape_ldap_dn_value(value: str) -> str:
+    """Resolve RFC 4514 escape sequences in a distinguished-name attribute value.
+
+    ``parse_dn`` splits a DN on unescaped separators but leaves the escape
+    sequences in the returned value, so ``CN=Sales\\, EMEA`` yields the value
+    ``Sales\\, EMEA``. Resolve those escapes so the group name matches what an
+    administrator sees (``Sales, EMEA``). Consecutive ``\\XX`` hex escapes encode
+    UTF-8 bytes and are decoded together.
+    """
+    hexdigits = '0123456789abcdefABCDEF'
+    result = []
+    i = 0
+    length = len(value)
+    while i < length:
+        char = value[i]
+        if char == '\\' and i + 1 < length:
+            if i + 2 < length and value[i + 1] in hexdigits and value[i + 2] in hexdigits:
+                byte_values = bytearray()
+                while (
+                    i + 2 < length
+                    and value[i] == '\\'
+                    and value[i + 1] in hexdigits
+                    and value[i + 2] in hexdigits
+                ):
+                    byte_values.append(int(value[i + 1 : i + 3], 16))
+                    i += 3
+                result.append(byte_values.decode('utf-8', errors='replace'))
+            else:
+                # A backslash escaping a literal special char (e.g. "\," "\+").
+                result.append(value[i + 1])
+                i += 2
+        else:
+            result.append(char)
+            i += 1
+    return ''.join(result)
+
+
+def extract_group_cn_from_dn(group_dn: str) -> str | None:
+    """Return the first CN component of an LDAP group DN, or None.
+
+    Uses ``parse_dn`` so escaped separators inside a value (e.g. a group whose
+    name contains a comma) are handled correctly instead of naively splitting
+    on ``,``.
+    """
+    for attr_type, attr_value, _ in parse_dn(group_dn):
+        if attr_type.upper() == 'CN':
+            return _unescape_ldap_dn_value(attr_value)
+    return None
+
+
 ############################
 # LDAP Authentication
 ############################
@@ -548,17 +599,10 @@ async def ldap_auth(
                     log.info(f'Processing group DN #{group_idx + 1}: {group_dn}')
 
                     try:
-                        group_cn = None
-
-                        for item in group_dn.split(','):
-                            item = item.strip()
-                            if item.upper().startswith('CN='):
-                                group_cn = item[3:]
-                                break
+                        group_cn = extract_group_cn_from_dn(group_dn)
 
                         if group_cn:
                             user_groups.append(group_cn)
-
                         else:
                             log.warning(f'Could not extract CN from group DN: {group_dn}')
                     except Exception as e:

--- a/backend/open_webui/routers/auths.py
+++ b/backend/open_webui/routers/auths.py
@@ -128,6 +128,9 @@ LDAP_SERVER_CONFIG_KEYS = {
     'certificate_path': 'ldap.server.ca_cert_file',
     'validate_cert': 'ldap.server.validate_cert',
     'ciphers': 'ldap.server.ciphers',
+    'enable_group_management': 'ldap.group.enable_management',
+    'enable_group_creation': 'ldap.group.enable_creation',
+    'attribute_for_groups': 'ldap.server.attribute_for_groups',
 }
 
 
@@ -1188,6 +1191,9 @@ class LdapServerConfig(BaseModel):
     certificate_path: str | None = None
     validate_cert: bool = True
     ciphers: str | None = 'ALL'
+    enable_group_management: bool = False
+    enable_group_creation: bool = False
+    attribute_for_groups: str = 'memberOf'
 
 
 @router.get('/admin/config/ldap/server', response_model=LdapServerConfig)

--- a/src/lib/components/admin/Settings/Authentication.svelte
+++ b/src/lib/components/admin/Settings/Authentication.svelte
@@ -42,7 +42,10 @@
 		use_tls: false,
 		validate_cert: false,
 		certificate_path: '',
-		ciphers: ''
+		ciphers: '',
+		enable_group_management: false,
+		enable_group_creation: false,
+		attribute_for_groups: 'memberOf'
 	};
 
 	let oauthConfig: any = null;
@@ -461,6 +464,35 @@
 								class={inputClass}
 								placeholder={$i18n.t('Example: ALL')}
 								bind:value={LDAP_SERVER.ciphers}
+							/>
+						</Tooltip>
+					</AdminSettingField>
+				{/if}
+
+				<AdminSettingRow
+					label={$i18n.t('Group Mapping')}
+					description={$i18n.t('Map LDAP groups to Open WebUI groups.')}
+				>
+					<Switch bind:state={LDAP_SERVER.enable_group_management} />
+				</AdminSettingRow>
+
+				{#if LDAP_SERVER.enable_group_management}
+					<AdminSettingRow
+						label={$i18n.t('Auto-Create Groups')}
+						description={$i18n.t('Create missing groups from LDAP groups.')}
+					>
+						<Switch bind:state={LDAP_SERVER.enable_group_creation} />
+					</AdminSettingRow>
+
+					<AdminSettingField
+						label={$i18n.t('Group Attribute')}
+						description={$i18n.t('LDAP attribute containing the user group memberships.')}
+					>
+						<Tooltip content={$i18n.t('Default to memberOf')} placement="top-start">
+							<input
+								class={inputClass}
+								placeholder="memberOf"
+								bind:value={LDAP_SERVER.attribute_for_groups}
 							/>
 						</Tooltip>
 					</AdminSettingField>

--- a/src/lib/components/admin/Settings/Authentication.svelte
+++ b/src/lib/components/admin/Settings/Authentication.svelte
@@ -107,7 +107,9 @@
 				groups = await getGroups(localStorage.token);
 			})(),
 			(async () => {
-				LDAP_SERVER = await getLdapServer(localStorage.token);
+				// Merge into the defaults so any key the backend omits (e.g. an
+				// older backend without the group settings) keeps its default.
+				LDAP_SERVER = { ...LDAP_SERVER, ...(await getLdapServer(localStorage.token)) };
 			})(),
 			(async () => {
 				oauthConfig = await getOAuthConfig(localStorage.token).catch(() => null);

--- a/src/lib/components/admin/Settings/Authentication.svelte
+++ b/src/lib/components/admin/Settings/Authentication.svelte
@@ -58,6 +58,13 @@
 		await updateLdapConfig(localStorage.token, ENABLE_LDAP);
 		if (!ENABLE_LDAP) return true;
 
+		// Honor the "Default to memberOf" hint: fall back to the default group
+		// attribute when it is left blank while group management is enabled, so
+		// the save isn't rejected by the backend's required-field check.
+		if (LDAP_SERVER.enable_group_management && !LDAP_SERVER.attribute_for_groups?.trim()) {
+			LDAP_SERVER.attribute_for_groups = 'memberOf';
+		}
+
 		const res = await updateLdapServer(localStorage.token, LDAP_SERVER).catch((error) => {
 			toast.error(`${error}`);
 			return null;

--- a/src/lib/components/admin/Settings/Authentication.svelte
+++ b/src/lib/components/admin/Settings/Authentication.svelte
@@ -32,7 +32,7 @@
 	let LDAP_SERVER = {
 		label: '',
 		host: '',
-		port: '',
+		port: null,
 		attribute_for_mail: 'mail',
 		attribute_for_username: 'uid',
 		app_dn: '',


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing Issue or Discussion — `Closes #___` / `Relates to #___`.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the Open WebUI Docs Repository.
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented. _(No new dependencies; uses the existing `ldap3` package.)_
- [ ] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions.
- [ ] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing.
- [ ] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [ ] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic.
- [ ] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses the `feat` prefix.

# Changelog Entry

### Description

- Adds support for synchronizing a user's group memberships from an LDAP directory on login, bringing LDAP to parity with the existing OAuth group management. The LDAP group settings are now configurable from the admin **Authentication** settings (previously only via environment variables), and the login-time group-sync flow is hardened.

Fixes https://github.com/open-webui/open-webui/discussions/18016

### Added

- Admin configuration for LDAP group sync in the **Authentication** settings UI — **Group Mapping** (enable), **Auto-Create Groups**, and **Group Attribute** — backed by the `/auths/admin/config/ldap/server` endpoint.
- `enable_group_management`, `enable_group_creation`, and `attribute_for_groups` fields on `LdapServerConfig` and `LDAP_SERVER_CONFIG_KEYS`, so these settings persist through the admin config API instead of being environment-only.

### Changed

- On LDAP login, group membership is reconciled (create-then-sync) when group management is enabled, matching OAuth semantics.
- The admin UI loads the LDAP server config by merging over the client-side defaults, so any key omitted by the backend keeps a sensible default (avoids undefined controls under version skew).
- The `port` field default is initialized as `null` to match the backend `int | None` type instead of an empty string.

### Removed

- N/A

### Fixed

- A group-creation error during login no longer aborts authentication — it is handled by the same `try/except` that guards the membership sync.
- The group attribute is validated as non-empty when group management is enabled; the UI falls back to `memberOf` when the field is left blank, matching the "Default to memberOf" hint.
- Group DN parsing now uses `ldap3.parse_dn` with RFC 4514 unescaping, so group names containing escaped separators (e.g. `CN=Sales\, EMEA,OU=...`) resolve to the correct name instead of being truncated.

### Security

- LDAP credential-path failures continue to return a generic error to the client (anti-enumeration), consistent with the password `signin` flow; specific reasons remain in the server logs.

### Breaking Changes

- N/A

---

### Additional Information

- Backend changes are limited to `backend/open_webui/routers/auths.py`; the frontend change is in `src/lib/components/admin/Settings/Authentication.svelte`. The underlying config keys (`ldap.group.*`, `ldap.server.attribute_for_groups`) already existed and were consumed by the login flow — this PR makes them admin-configurable and hardens the flow.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.