### PR TITLE
feat: add BaseRT provider support

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -889,7 +889,7 @@ async def unload_model(request: Request, form_data: ModelUnloadForm, user=Depend
     """
     Unified model unload endpoint.
     Resolves the provider that owns the model and calls its native unload mechanism.
-    Supports: Ollama (keep_alive=0) and llama.cpp (/models/unload).
+    Supports: Ollama (keep_alive=0), llama.cpp (/models/unload), and baseRT (/v1/models/unload).
     """
     model_id = form_data.model
 
@@ -962,8 +962,12 @@ async def unload_model(request: Request, form_data: ModelUnloadForm, user=Depend
         base_url = openai_base_urls[idx]
         key = openai_api_keys[idx] if idx < len(openai_api_keys) else ''
 
-        if provider == 'llama.cpp':
-            root_url = base_url.rstrip('/').removesuffix('/v1')
+        if provider in ('llama.cpp', 'basert'):
+            if provider == 'basert':
+                # baseRT serves /v1/models/unload under the configured base url
+                root_url = base_url.rstrip('/')
+            else:
+                root_url = base_url.rstrip('/').removesuffix('/v1')
             actual_model = strip_provider_model_prefix(model_id, api_config.get('prefix_id'))
             try:
                 timeout = aiohttp.ClientTimeout(total=30)
@@ -984,7 +988,7 @@ async def unload_model(request: Request, form_data: ModelUnloadForm, user=Depend
             except HTTPException:
                 raise
             except Exception as e:
-                log.exception(f'Failed to unload model via llama.cpp: {e}')
+                log.exception(f'Failed to unload model via {provider}: {e}')
                 raise HTTPException(status_code=500, detail=str(e))
         else:
             raise HTTPException(

--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -242,20 +242,27 @@ LLAMACPP_LOADED_STATES = {'loaded', 'sleeping'}
 LLAMACPP_UNLOADED_STATES = {'loading', 'unloaded'}
 
 
-def get_llamacpp_model_loaded_state(model: dict, provider: str, manual_model_ids: bool = False) -> bool | None:
-    if provider != 'llama.cpp':
+def get_local_model_loaded_state(model: dict, provider: str, manual_model_ids: bool = False) -> bool | None:
+    if provider == 'llama.cpp':
+        status = model.get('status')
+        if isinstance(status, dict):
+            value = status.get('value')
+            if value in LLAMACPP_LOADED_STATES:
+                return True
+            if value in LLAMACPP_UNLOADED_STATES:
+                return False
+
+        if not manual_model_ids and 'status' not in model:
+            return True
+
         return None
 
-    status = model.get('status')
-    if isinstance(status, dict):
-        value = status.get('value')
-        if value in LLAMACPP_LOADED_STATES:
-            return True
-        if value in LLAMACPP_UNLOADED_STATES:
-            return False
-
-    if not manual_model_ids and 'status' not in model:
-        return True
+    if provider == 'basert':
+        # baseRT reports a boolean `loaded` field on /v1/models
+        loaded = model.get('loaded')
+        if isinstance(loaded, bool):
+            return loaded
+        return None
 
     return None
 
@@ -701,7 +708,7 @@ async def get_all_models(request: Request, user: UserModel) -> dict[str, list]:
                             'urlIdx': idx,
                         }
 
-                        loaded = get_llamacpp_model_loaded_state(
+                        loaded = get_local_model_loaded_state(
                             model,
                             provider,
                             manual_model_ids=bool(api_config.get('model_ids')),

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2032,13 +2032,13 @@ def get_reasoning_format(model: dict) -> str | None:
 
     Returns:
         'think_tags': Ollama expects <think> tags in content.
-        'reasoning_content': llama.cpp supports reasoning_content as a top-level field.
+        'reasoning_content': llama.cpp and baseRT support reasoning_content as a top-level field.
         None: skip reasoning (safe default for strict providers).
     """
     provider = model.get('provider', '')
     if provider == 'ollama':
         return 'think_tags'
-    if provider == 'llama.cpp':
+    if provider in ('llama.cpp', 'basert'):
         return 'reasoning_content'
     return None
 

--- a/src/lib/components/AddConnectionModal.svelte
+++ b/src/lib/components/AddConnectionModal.svelte
@@ -496,10 +496,16 @@
 									<select
 										id="provider-select"
 										bind:value={provider}
+										on:change={() => {
+											if (provider === 'basert' && !edit) {
+												connectionType = 'local';
+											}
+										}}
 										class="text-xs text-gray-700 dark:text-gray-300 bg-transparent outline-hidden"
 									>
 										<option value="">{$i18n.t('Default')}</option>
 										<option value="azure">{$i18n.t('Azure OpenAI')}</option>
+										<option value="basert">{$i18n.t('BaseRT')}</option>
 										<option value="llama.cpp">{$i18n.t('llama.cpp')}</option>
 									</select>
 								</div>

--- a/src/lib/i18n/locales/ar-BH/translation.json
+++ b/src/lib/i18n/locales/ar-BH/translation.json
@@ -379,6 +379,7 @@
 	"Base Model is required.": "",
 	"Base Model List Cache speeds up access by fetching base models only at startup or on settings save—faster, but may not show recent base model changes.": "",
 	"Base URL": "",
+	"BaseRT": "",
 	"Bearer": "",
 	"before": "قبل",
 	"Being lazy": "كون كسول",

--- a/src/lib/i18n/locales/ar/translation.json
+++ b/src/lib/i18n/locales/ar/translation.json
@@ -379,6 +379,7 @@
 	"Base Model is required.": "",
 	"Base Model List Cache speeds up access by fetching base models only at startup or on settings save—faster, but may not show recent base model changes.": "",
 	"Base URL": "",
+	"BaseRT": "",
 	"Bearer": "",
 	"before": "قبل",
 	"Being lazy": "كونك كسولاً",

--- a/src/lib/i18n/locales/az-AZ/translation.json
+++ b/src/lib/i18n/locales/az-AZ/translation.json
@@ -351,6 +351,7 @@
 	"Base Model is required.": "",
 	"Base Model List Cache speeds up access by fetching base models only at startup or on settings save—faster, but may not show recent base model changes.": "Əsas model siyahısı keşlənməsi, modelləri yalnız sistem açılışında və ya ayarları yadda saxladıqda gətirərək girişi sürətləndirir — daha sürətlidir, lakin ən son model dəyişikliklərini dərhal göstərməyə bilər.",
 	"Base URL": "",
+	"BaseRT": "",
 	"Bearer": "Bearer (Daşıyıcı)",
 	"before": "əvvəl",
 	"Being lazy": "Tənbəllik edir",

--- a/src/lib/i18n/locales/bg-BG/translation.json
+++ b/src/lib/i18n/locales/bg-BG/translation.json
@@ -351,6 +351,7 @@
 	"Base Model is required.": "",
 	"Base Model List Cache speeds up access by fetching base models only at startup or on settings save—faster, but may not show recent base model changes.": "",
 	"Base URL": "",
+	"BaseRT": "",
 	"Bearer": "",
 	"before": "преди",
 	"Being lazy": "Мързелив е",

--- a/src/lib/i18n/locales/bn-BD/translation.json
+++ b/src/lib/i18n/locales/bn-BD/translation.json
@@ -351,6 +351,7 @@
 	"Base Model is required.": "",
 	"Base Model List Cache speeds up access by fetching base models only at startup or on settings save—faster, but may not show recent base model changes.": "",
 	"Base URL": "",
+	"BaseRT": "",
 	"Bearer": "",
 	"before": "পূর্ববর্তী",
 	"Being lazy": "অলস হওয়া",

--- a/src/lib/i18n/locales/bo-TB/translation.json
+++ b/src/lib/i18n/locales/bo-TB/translation.json
@@ -344,6 +344,7 @@
 	"Base Model is required.": "",
 	"Base Model List Cache speeds up access by fetching base models only at startup or on settings save—faster, but may not show recent base model changes.": "",
 	"Base URL": "",
+	"BaseRT": "",
 	"Bearer": "",
 	"before": "སྔོན།",
 	"Being lazy": "ལེ་ལོ་བྱེད་པ།",

--- a/src/lib/i18n/locales/bs-BA/translation.json
+++ b/src/lib/i18n/locales/bs-BA/translation.json
@@ -358,6 +358,7 @@
 	"Base Model is required.": "",
 	"Base Model List Cache speeds up access by fetching base models only at startup or on settings save—faster, but may not show recent base model changes.": "",
 	"Base URL": "",
+	"BaseRT": "",
 	"Bearer": "",
 	"before": "prije",
 	"Being lazy": "Biti lijen",

--- a/src/lib/i18n/locales/ca-ES/translation.json
+++ b/src/lib/i18n/locales/ca-ES/translation.json
@@ -358,6 +358,7 @@
 	"Base Model is required.": "Es requereix el model base.",
 	"Base Model List Cache speeds up access by fetching base models only at startup or on settings save—faster, but may not show recent base model changes.": "La memòria cau de la llista de models base accelera l'accés obtenint els models base només a l'inici o en desar la configuració; és més ràpid, però és possible que no mostri els canvis recents del model base.",
 	"Base URL": "",
+	"BaseRT": "",
 	"Bearer": "Bearer",
 	"before": "abans",
 	"Being lazy": "Essent mandrós",

--- a/src/lib/i18n/locales/ceb-PH/translation.json
+++ b/src/lib/i18n/locales/ceb-PH/translation.json
@@ -351,6 +351,7 @@
 	"Base Model is required.": "",
 	"Base Model List Cache speeds up access by fetching base models only at startup or on settings save—faster, but may not show recent base model changes.": "",
 	"Base URL": "",
+	"BaseRT": "",
 	"Bearer": "",
 	"before": "",
 	"Being lazy": "",

--- a/src/lib/i18n/locales/cs-CZ/translation.json
+++ b/src/lib/i18n/locales/cs-CZ/translation.json
@@ -365,6 +365,7 @@
 	"Base Model is required.": "",
 	"Base Model List Cache speeds up access by fetching base models only at startup or on settings save—faster, but may not show recent base model changes.": "Mezipaměť seznamu základních modelů zrychluje přístup načítáním základních modelů pouze při spuštění nebo při uložení nastavení – je to rychlejší, ale nemusí zobrazovat nedávné změny základních modelů.",
 	"Base URL": "",
+	"BaseRT": "",
 	"Bearer": "Bearer",
 	"before": "před",
 	"Being lazy": "Být líný",

--- a/src/lib/i18n/locales/da-DK/translation.json
+++ b/src/lib/i18n/locales/da-DK/translation.json
@@ -351,6 +351,7 @@
 	"Base Model is required.": "",
 	"Base Model List Cache speeds up access by fetching base models only at startup or on settings save—faster, but may not show recent base model changes.": "Base Model List Cache øger hastigheden ved kun at hente base modeller ved opstart eller når indstillinger gemmes, men viser muligvis ikke nylige ændringer i base modeller.",
 	"Base URL": "",
+	"BaseRT": "",
 	"Bearer": "Bearer",
 	"before": "før",
 	"Being lazy": "At være doven",

--- a/src/lib/i18n/locales/de-DE/translation.json
+++ b/src/lib/i18n/locales/de-DE/translation.json
@@ -351,6 +351,7 @@
 	"Base Model is required.": "Basis Modell ist notwendig.",
 	"Base Model List Cache speeds up access by fetching base models only at startup or on settings save—faster, but may not show recent base model changes.": "Der Cache für die Basismodell-Liste beschleunigt den Zugriff, indem Basismodelle nur beim Start oder Speichern abgerufen werden – schneller, zeigt aber evtl. keine aktuellen Änderungen an.",
 	"Base URL": "",
+	"BaseRT": "",
 	"Bearer": "Bearer",
 	"before": "zuvor",
 	"Being lazy": "Faulheit",

--- a/src/lib/i18n/locales/dg-DG/translation.json
+++ b/src/lib/i18n/locales/dg-DG/translation.json
@@ -351,6 +351,7 @@
 	"Base Model is required.": "",
 	"Base Model List Cache speeds up access by fetching base models only at startup or on settings save—faster, but may not show recent base model changes.": "",
 	"Base URL": "",
+	"BaseRT": "",
 	"Bearer": "",
 	"before": "",
 	"Being lazy": "",

--- a/src/lib/i18n/locales/el-GR/translation.json
+++ b/src/lib/i18n/locales/el-GR/translation.json
@@ -351,6 +351,7 @@
 	"Base Model is required.": "",
 	"Base Model List Cache speeds up access by fetching base models only at startup or on settings save—faster, but may not show recent base model changes.": "",
 	"Base URL": "",
+	"BaseRT": "",
 	"Bearer": "",
 	"before": "πριν",
 	"Being lazy": "Τρώλακας",

--- a/src/lib/i18n/locales/en-GB/translation.json
+++ b/src/lib/i18n/locales/en-GB/translation.json
@@ -351,6 +351,7 @@
 	"Base Model is required.": "",
 	"Base Model List Cache speeds up access by fetching base models only at startup or on settings save—faster, but may not show recent base model changes.": "",
 	"Base URL": "",
+	"BaseRT": "",
 	"Bearer": "",
 	"before": "",
 	"Being lazy": "",

--- a/src/lib/i18n/locales/en-US/translation.json
+++ b/src/lib/i18n/locales/en-US/translation.json
@@ -351,6 +351,7 @@
 	"Base Model is required.": "",
 	"Base Model List Cache speeds up access by fetching base models only at startup or on settings save—faster, but may not show recent base model changes.": "",
 	"Base URL": "",
+	"BaseRT": "",
 	"Bearer": "",
 	"before": "",
 	"Being lazy": "",

--- a/src/lib/i18n/locales/es-ES/translation.json
+++ b/src/lib/i18n/locales/es-ES/translation.json
@@ -358,6 +358,7 @@
 	"Base Model is required.": "",
 	"Base Model List Cache speeds up access by fetching base models only at startup or on settings save—faster, but may not show recent base model changes.": "La caché de la lista de modelos base acelera el acceso recuperando los modelos base sólo al inicio o en el autoguardado rápido de la configuración, si se activa hay que tener en cuenta que los cambios más recientes en las listas de modelos podrían no reflejarse de manera inmediata.",
 	"Base URL": "",
+	"BaseRT": "",
 	"Bearer": "Portador (Bearer)",
 	"before": "antes",
 	"Being lazy": "Vaguear",

--- a/src/lib/i18n/locales/et-EE/translation.json
+++ b/src/lib/i18n/locales/et-EE/translation.json
@@ -351,6 +351,7 @@
 	"Base Model is required.": "",
 	"Base Model List Cache speeds up access by fetching base models only at startup or on settings save—faster, but may not show recent base model changes.": "Baasmudelite nimekirja vahemälu kiirendab juurdepääsu, tuues baasmudelid ainult käivitamisel või seadete salvestamisel—kiirem, kuid ei pruugi näidata hiljutisi muudatusi.",
 	"Base URL": "",
+	"BaseRT": "",
 	"Bearer": "Bearer",
 	"before": "enne",
 	"Being lazy": "Laisklemine",

--- a/src/lib/i18n/locales/eu-ES/translation.json
+++ b/src/lib/i18n/locales/eu-ES/translation.json
@@ -351,6 +351,7 @@
 	"Base Model is required.": "",
 	"Base Model List Cache speeds up access by fetching base models only at startup or on settings save—faster, but may not show recent base model changes.": "",
 	"Base URL": "",
+	"BaseRT": "",
 	"Bearer": "",
 	"before": "aurretik",
 	"Being lazy": "Alferra izatea",

--- a/src/lib/i18n/locales/fa-IR/translation.json
+++ b/src/lib/i18n/locales/fa-IR/translation.json
@@ -351,6 +351,7 @@
 	"Base Model is required.": "",
 	"Base Model List Cache speeds up access by fetching base models only at startup or on settings save—faster, but may not show recent base model changes.": "کش لیست مدل پایه، با واکشی مدل\u200cهای پایه فقط در هنگام راه\u200cاندازی یا ذخیره تنظیمات، دسترسی را سرعت می\u200cبخشد – سریع\u200cتر است، اما ممکن است تغییرات اخیر مدل پایه را نشان ندهد.",
 	"Base URL": "",
+	"BaseRT": "",
 	"Bearer": "حامل",
 	"before": "قبل",
 	"Being lazy": "حالت سازنده",

--- a/src/lib/i18n/locales/fi-FI/translation.json
+++ b/src/lib/i18n/locales/fi-FI/translation.json
@@ -351,6 +351,7 @@
 	"Base Model is required.": "",
 	"Base Model List Cache speeds up access by fetching base models only at startup or on settings save—faster, but may not show recent base model changes.": "Malliluettelon välimuisti nopeuttaa käyttöä hakemalla mallit vain käynnistyksen yhteydessä, tai asetusten tallentamisen yhteydessä - nopeampaa, mutta ei välttämättä näytä viimeisimpiä malli muutoksia.",
 	"Base URL": "",
+	"BaseRT": "",
 	"Bearer": "Bearer",
 	"before": "ennen",
 	"Being lazy": "Oli laiska",

--- a/src/lib/i18n/locales/fil-PH/translation.json
+++ b/src/lib/i18n/locales/fil-PH/translation.json
@@ -352,6 +352,7 @@
 	"Base Model is required.": "",
 	"Base Model List Cache speeds up access by fetching base models only at startup or on settings save—faster, but may not show recent base model changes.": "",
 	"Base URL": "",
+	"BaseRT": "",
 	"Bearer": "",
 	"before": "",
 	"Being lazy": "",

--- a/src/lib/i18n/locales/fr-CA/translation.json
+++ b/src/lib/i18n/locales/fr-CA/translation.json
@@ -358,6 +358,7 @@
 	"Base Model is required.": "",
 	"Base Model List Cache speeds up access by fetching base models only at startup or on settings save—faster, but may not show recent base model changes.": "La mise en cache de la liste des modèles de base accélère l'accès en ne récupérant les modèles de base qu'au démarrage ou lors de la sauvegarde des réglages - plus rapide, mais peut ne pas afficher les modifications récentes des modèles de base.",
 	"Base URL": "",
+	"BaseRT": "",
 	"Bearer": "",
 	"before": "avant",
 	"Being lazy": "Être fainéant",

--- a/src/lib/i18n/locales/fr-FR/translation.json
+++ b/src/lib/i18n/locales/fr-FR/translation.json
@@ -358,6 +358,7 @@
 	"Base Model is required.": "",
 	"Base Model List Cache speeds up access by fetching base models only at startup or on settings save—faster, but may not show recent base model changes.": "La mise en cache de la liste des modèles de base accélère l'accès en ne récupérant les modèles de base qu'au démarrage ou lors de la sauvegarde des réglages - plus rapide, mais peut ne pas afficher les modifications récentes des modèles de base.",
 	"Base URL": "",
+	"BaseRT": "",
 	"Bearer": "Bearer",
 	"before": "avant",
 	"Being lazy": "Être fainéant",

--- a/src/lib/i18n/locales/gl-ES/translation.json
+++ b/src/lib/i18n/locales/gl-ES/translation.json
@@ -351,6 +351,7 @@
 	"Base Model is required.": "",
 	"Base Model List Cache speeds up access by fetching base models only at startup or on settings save—faster, but may not show recent base model changes.": "",
 	"Base URL": "",
+	"BaseRT": "",
 	"Bearer": "",
 	"before": "antes",
 	"Being lazy": "Ser pregizeiro",

--- a/src/lib/i18n/locales/he-IL/translation.json
+++ b/src/lib/i18n/locales/he-IL/translation.json
@@ -358,6 +358,7 @@
 	"Base Model is required.": "",
 	"Base Model List Cache speeds up access by fetching base models only at startup or on settings save—faster, but may not show recent base model changes.": "",
 	"Base URL": "",
+	"BaseRT": "",
 	"Bearer": "",
 	"before": "לפני",
 	"Being lazy": "להיות עצלן",

--- a/src/lib/i18n/locales/hi-IN/translation.json
+++ b/src/lib/i18n/locales/hi-IN/translation.json
@@ -351,6 +351,7 @@
 	"Base Model is required.": "",
 	"Base Model List Cache speeds up access by fetching base models only at startup or on settings save—faster, but may not show recent base model changes.": "",
 	"Base URL": "",
+	"BaseRT": "",
 	"Bearer": "",
 	"before": "पहले",
 	"Being lazy": "आलसी होना",

--- a/src/lib/i18n/locales/hr-HR/translation.json
+++ b/src/lib/i18n/locales/hr-HR/translation.json
@@ -358,6 +358,7 @@
 	"Base Model is required.": "",
 	"Base Model List Cache speeds up access by fetching base models only at startup or on settings save—faster, but may not show recent base model changes.": "",
 	"Base URL": "",
+	"BaseRT": "",
 	"Bearer": "",
 	"before": "prije",
 	"Being lazy": "Biti lijen",

--- a/src/lib/i18n/locales/hu-HU/translation.json
+++ b/src/lib/i18n/locales/hu-HU/translation.json
@@ -351,6 +351,7 @@
 	"Base Model is required.": "",
 	"Base Model List Cache speeds up access by fetching base models only at startup or on settings save—faster, but may not show recent base model changes.": "",
 	"Base URL": "",
+	"BaseRT": "",
 	"Bearer": "",
 	"before": "előtt",
 	"Being lazy": "Lustaság",

--- a/src/lib/i18n/locales/id-ID/translation.json
+++ b/src/lib/i18n/locales/id-ID/translation.json
@@ -344,6 +344,7 @@
 	"Base Model is required.": "",
 	"Base Model List Cache speeds up access by fetching base models only at startup or on settings save—faster, but may not show recent base model changes.": "",
 	"Base URL": "",
+	"BaseRT": "",
 	"Bearer": "",
 	"before": "sebelum",
 	"Being lazy": "Menjadi malas",

--- a/src/lib/i18n/locales/ie-GA/translation.json
+++ b/src/lib/i18n/locales/ie-GA/translation.json
@@ -351,6 +351,7 @@
 	"Base Model is required.": "",
 	"Base Model List Cache speeds up access by fetching base models only at startup or on settings save—faster, but may not show recent base model changes.": "Luasaíonn Taisce an Liosta Bunsamhail de rochtain trí bhunmhúnlaí a fháil ach amháin ag am tosaithe nó ar shocruithe a shábháil-níos tapúla, ach b'fhéidir nach dtaispeánfar athruithe bonnsamhail le déanaí.",
 	"Base URL": "",
+	"BaseRT": "",
 	"Bearer": "Iompróir",
 	"before": "roimh",
 	"Being lazy": "A bheith leisciúil",

--- a/src/lib/i18n/locales/it-IT/translation.json
+++ b/src/lib/i18n/locales/it-IT/translation.json
@@ -358,6 +358,7 @@
 	"Base Model is required.": "",
 	"Base Model List Cache speeds up access by fetching base models only at startup or on settings save—faster, but may not show recent base model changes.": "",
 	"Base URL": "",
+	"BaseRT": "",
 	"Bearer": "",
 	"before": "prima",
 	"Being lazy": "Faccio il pigro",

--- a/src/lib/i18n/locales/ja-JP/translation.json
+++ b/src/lib/i18n/locales/ja-JP/translation.json
@@ -344,6 +344,7 @@
 	"Base Model is required.": "ベースモデルが必要です",
 	"Base Model List Cache speeds up access by fetching base models only at startup or on settings save—faster, but may not show recent base model changes.": "ベースモデルリストキャッシュは、起動時または設定保存時にのみベースモデルを取得することでアクセスを高速化します。これにより高速になりますが、最近のベースモデルの変更が表示されない場合があります。",
 	"Base URL": "",
+	"BaseRT": "",
 	"Bearer": "Bearer",
 	"before": "以前",
 	"Being lazy": "怠惰な",

--- a/src/lib/i18n/locales/ka-GE/translation.json
+++ b/src/lib/i18n/locales/ka-GE/translation.json
@@ -351,6 +351,7 @@
 	"Base Model is required.": "",
 	"Base Model List Cache speeds up access by fetching base models only at startup or on settings save—faster, but may not show recent base model changes.": "",
 	"Base URL": "",
+	"BaseRT": "",
 	"Bearer": "Bearer",
 	"before": "მითითებულ დრომდე",
 	"Being lazy": "ზარმაცობა",

--- a/src/lib/i18n/locales/kab-DZ/translation.json
+++ b/src/lib/i18n/locales/kab-DZ/translation.json
@@ -351,6 +351,7 @@
 	"Base Model is required.": "",
 	"Base Model List Cache speeds up access by fetching base models only at startup or on settings save—faster, but may not show recent base model changes.": "Umuɣ n uzadur n tebdart Cache yessazzel anekcum s tmudmin tidusanin kan deg ubeddu neɣ deg yiɣewwaren i d-yettwasellken — amestir, maca yezmer lḥal ur d-yesskan ara ibeddilen ineggura n tmudemt azadur.",
 	"Base URL": "",
+	"BaseRT": "",
 	"Bearer": "",
 	"before": "send",
 	"Being lazy": "Ili-k d ameɛdaz",

--- a/src/lib/i18n/locales/ko-KR/translation.json
+++ b/src/lib/i18n/locales/ko-KR/translation.json
@@ -345,6 +345,7 @@
 	"Base Model is required.": "",
 	"Base Model List Cache speeds up access by fetching base models only at startup or on settings save—faster, but may not show recent base model changes.": "기본 모델 목록 캐시는 시작 시 또는 설정 저장 시에만 기본 모델을 불러와 접근 속도를 높여줍니다. 이는 더 빠르지만, 최근 기본 모델 변경 사항이 반영되지 않을 수 있습니다.",
 	"Base URL": "",
+	"BaseRT": "",
 	"Bearer": "보유자",
 	"before": "이전",
 	"Being lazy": "게으름 피우기",

--- a/src/lib/i18n/locales/lt-LT/translation.json
+++ b/src/lib/i18n/locales/lt-LT/translation.json
@@ -365,6 +365,7 @@
 	"Base Model is required.": "",
 	"Base Model List Cache speeds up access by fetching base models only at startup or on settings save—faster, but may not show recent base model changes.": "",
 	"Base URL": "",
+	"BaseRT": "",
 	"Bearer": "",
 	"before": "prieš",
 	"Being lazy": "Būvimas tingiu",

--- a/src/lib/i18n/locales/lv-LV/translation.json
+++ b/src/lib/i18n/locales/lv-LV/translation.json
@@ -358,6 +358,7 @@
 	"Base Model is required.": "",
 	"Base Model List Cache speeds up access by fetching base models only at startup or on settings save—faster, but may not show recent base model changes.": "Bāzes modeļu saraksta kešatmiņa paātrina piekļuvi, ielādējot bāzes modeļus tikai startējot vai saglabājot iestatījumus — ātrāk, bet var nerādīt nesenās bāzes modeļu izmaiņas.",
 	"Base URL": "",
+	"BaseRT": "",
 	"Bearer": "Bearer",
 	"before": "pirms",
 	"Being lazy": "Esmu slinks",

--- a/src/lib/i18n/locales/ms-MY/translation.json
+++ b/src/lib/i18n/locales/ms-MY/translation.json
@@ -344,6 +344,7 @@
 	"Base Model is required.": "",
 	"Base Model List Cache speeds up access by fetching base models only at startup or on settings save—faster, but may not show recent base model changes.": "Senarai Cache Model Asas mempercepatkan akses dengan mengambil model asas hanya pada permulaan atau penyimpanan tetapan—lebih pantas, tetapi mungkin tidak menunjukkan perubahan model asas terbaru.",
 	"Base URL": "",
+	"BaseRT": "",
 	"Bearer": "Bearer",
 	"before": "sebelum",
 	"Being lazy": "Menjadi Malas",

--- a/src/lib/i18n/locales/nb-NO/translation.json
+++ b/src/lib/i18n/locales/nb-NO/translation.json
@@ -351,6 +351,7 @@
 	"Base Model is required.": "",
 	"Base Model List Cache speeds up access by fetching base models only at startup or on settings save—faster, but may not show recent base model changes.": "",
 	"Base URL": "",
+	"BaseRT": "",
 	"Bearer": "",
 	"before": "før",
 	"Being lazy": "Er lat",

--- a/src/lib/i18n/locales/nl-NL/translation.json
+++ b/src/lib/i18n/locales/nl-NL/translation.json
@@ -351,6 +351,7 @@
 	"Base Model is required.": "",
 	"Base Model List Cache speeds up access by fetching base models only at startup or on settings save—faster, but may not show recent base model changes.": "Cache voor basismodellen versnelt de toegang door basismodellen alleen op te halen bij het opstarten of bij het opslaan van instellingen. Dit is sneller, maar toont mogelijk geen recente wijzigingen in basismodellen.",
 	"Base URL": "",
+	"BaseRT": "",
 	"Bearer": "Bearer",
 	"before": "voor",
 	"Being lazy": "Lui zijn",

--- a/src/lib/i18n/locales/pa-IN/translation.json
+++ b/src/lib/i18n/locales/pa-IN/translation.json
@@ -351,6 +351,7 @@
 	"Base Model is required.": "",
 	"Base Model List Cache speeds up access by fetching base models only at startup or on settings save—faster, but may not show recent base model changes.": "",
 	"Base URL": "",
+	"BaseRT": "",
 	"Bearer": "",
 	"before": "ਪਹਿਲਾਂ",
 	"Being lazy": "ਆਲਸੀ ਹੋਣਾ",

--- a/src/lib/i18n/locales/pl-PL/translation.json
+++ b/src/lib/i18n/locales/pl-PL/translation.json
@@ -365,6 +365,7 @@
 	"Base Model is required.": "",
 	"Base Model List Cache speeds up access by fetching base models only at startup or on settings save—faster, but may not show recent base model changes.": "Cache listy modeli bazowych przyspiesza dostęp, pobierając je tylko przy starcie lub zapisie ustawień – szybciej, ale może nie pokazać ostatnich zmian w modelach.",
 	"Base URL": "",
+	"BaseRT": "",
 	"Bearer": "Bearer",
 	"before": "przed",
 	"Being lazy": "Zbyt ogólnikowy",

--- a/src/lib/i18n/locales/pt-BR/translation.json
+++ b/src/lib/i18n/locales/pt-BR/translation.json
@@ -358,6 +358,7 @@
 	"Base Model is required.": "Modelo Base é obrigatório.",
 	"Base Model List Cache speeds up access by fetching base models only at startup or on settings save—faster, but may not show recent base model changes.": "O cache da lista de modelos base acelera o acesso buscando modelos base somente na inicialização ou ao salvar as configurações — mais rápido, mas pode não mostrar alterações recentes no modelo base.",
 	"Base URL": "",
+	"BaseRT": "",
 	"Bearer": "Bearer",
 	"before": "antes",
 	"Being lazy": "Sendo preguiçoso",

--- a/src/lib/i18n/locales/pt-PT/translation.json
+++ b/src/lib/i18n/locales/pt-PT/translation.json
@@ -358,6 +358,7 @@
 	"Base Model is required.": "",
 	"Base Model List Cache speeds up access by fetching base models only at startup or on settings save—faster, but may not show recent base model changes.": "O cache da lista de modelos base acelera o acesso ao buscar apenas os modelos base na inicialização ou ao salvar as configurações—mais rápido, mas pode não mostrar alterações recentes nos modelos base.",
 	"Base URL": "",
+	"BaseRT": "",
 	"Bearer": "Bearer",
 	"before": "antes",
 	"Being lazy": "Ser preguiçoso",

--- a/src/lib/i18n/locales/ro-RO/translation.json
+++ b/src/lib/i18n/locales/ro-RO/translation.json
@@ -358,6 +358,7 @@
 	"Base Model is required.": "",
 	"Base Model List Cache speeds up access by fetching base models only at startup or on settings save—faster, but may not show recent base model changes.": "",
 	"Base URL": "",
+	"BaseRT": "",
 	"Bearer": "",
 	"before": "înainte",
 	"Being lazy": "Fiind leneș",

--- a/src/lib/i18n/locales/ru-RU/translation.json
+++ b/src/lib/i18n/locales/ru-RU/translation.json
@@ -365,6 +365,7 @@
 	"Base Model is required.": "",
 	"Base Model List Cache speeds up access by fetching base models only at startup or on settings save—faster, but may not show recent base model changes.": "Кэш списка базовых моделей ускоряет доступ, загружая базовые модели только при запуске или сохранении настроек — быстрее, но может не показывать новые изменения в базовых моделях.",
 	"Base URL": "",
+	"BaseRT": "",
 	"Bearer": "Bearer",
 	"before": "до",
 	"Being lazy": "Лениво",

--- a/src/lib/i18n/locales/sk-SK/translation.json
+++ b/src/lib/i18n/locales/sk-SK/translation.json
@@ -365,6 +365,7 @@
 	"Base Model is required.": "",
 	"Base Model List Cache speeds up access by fetching base models only at startup or on settings save—faster, but may not show recent base model changes.": "",
 	"Base URL": "",
+	"BaseRT": "",
 	"Bearer": "",
 	"before": "pred",
 	"Being lazy": "",

--- a/src/lib/i18n/locales/sr-RS/translation.json
+++ b/src/lib/i18n/locales/sr-RS/translation.json
@@ -358,6 +358,7 @@
 	"Base Model is required.": "",
 	"Base Model List Cache speeds up access by fetching base models only at startup or on settings save—faster, but may not show recent base model changes.": "",
 	"Base URL": "",
+	"BaseRT": "",
 	"Bearer": "",
 	"before": "пре",
 	"Being lazy": "Бити лењ",

--- a/src/lib/i18n/locales/sv-SE/translation.json
+++ b/src/lib/i18n/locales/sv-SE/translation.json
@@ -351,6 +351,7 @@
 	"Base Model is required.": "",
 	"Base Model List Cache speeds up access by fetching base models only at startup or on settings save—faster, but may not show recent base model changes.": "Base Model List Cache påskyndar åtkomsten genom att hämta basmodeller endast vid start eller när inställningarna sparas snabbare, men visar kanske inte de senaste basmodelländringarna.",
 	"Base URL": "",
+	"BaseRT": "",
 	"Bearer": "Bearer",
 	"before": "före",
 	"Being lazy": "Är lat",

--- a/src/lib/i18n/locales/ta-IN/translation.json
+++ b/src/lib/i18n/locales/ta-IN/translation.json
@@ -351,6 +351,7 @@
 	"Base Model is required.": "",
 	"Base Model List Cache speeds up access by fetching base models only at startup or on settings save—faster, but may not show recent base model changes.": "அடிப்படை மாதிரி பட்டியல் கேச், தொடக்கத்தில் அல்லது சேமி அமைப்புகளில் மட்டுமே அடிப்படை மாதிரிகளைப் பெறுவதன் மூலம் அணுகலை விரைவுபடுத்துகிறது, ஆனால் சமீபத்திய அடிப்படை மாதிரி மாற்றங்களைக் காட்டாமல் போகலாம்.",
 	"Base URL": "",
+	"BaseRT": "",
 	"Bearer": "தாங்குபவர்",
 	"before": "முன்",
 	"Being lazy": "சோம்பேறியாக இருப்பது",

--- a/src/lib/i18n/locales/th-TH/translation.json
+++ b/src/lib/i18n/locales/th-TH/translation.json
@@ -344,6 +344,7 @@
 	"Base Model is required.": "ต้องระบุโมเดลพื้นฐาน",
 	"Base Model List Cache speeds up access by fetching base models only at startup or on settings save—faster, but may not show recent base model changes.": "การแคชรายการ Base Model ช่วยเร่งการเข้าถึงโดยดึงข้อมูลโมเดลเฉพาะตอนเริ่มต้นระบบหรือเมื่อบันทึกการตั้งค่า ซึ่งทำให้เร็วขึ้น แต่อาจไม่แสดงการเปลี่ยนแปลงโมเดลล่าสุด",
 	"Base URL": "",
+	"BaseRT": "",
 	"Bearer": "Bearer",
 	"before": "ก่อน",
 	"Being lazy": "ขี้เกียจ",

--- a/src/lib/i18n/locales/tk-TM/translation.json
+++ b/src/lib/i18n/locales/tk-TM/translation.json
@@ -351,6 +351,7 @@
 	"Base Model is required.": "",
 	"Base Model List Cache speeds up access by fetching base models only at startup or on settings save—faster, but may not show recent base model changes.": "",
 	"Base URL": "",
+	"BaseRT": "",
 	"Bearer": "",
 	"before": "öň",
 	"Being lazy": "Ýaltalyk",

--- a/src/lib/i18n/locales/tr-TR/translation.json
+++ b/src/lib/i18n/locales/tr-TR/translation.json
@@ -351,6 +351,7 @@
 	"Base Model is required.": "",
 	"Base Model List Cache speeds up access by fetching base models only at startup or on settings save—faster, but may not show recent base model changes.": "Temel Model Listesi Önbelleği, temel modelleri yalnızca başlangıçta veya ayarlar kaydedilirken getirerek erişimi hızlandırır—daha hızlıdır, ancak son temel model değişikliklerini göstermeyebilir.",
 	"Base URL": "",
+	"BaseRT": "",
 	"Bearer": "Bearer",
 	"before": "önce",
 	"Being lazy": "Tembelleşiyor",

--- a/src/lib/i18n/locales/ug-CN/translation.json
+++ b/src/lib/i18n/locales/ug-CN/translation.json
@@ -351,6 +351,7 @@
 	"Base Model is required.": "",
 	"Base Model List Cache speeds up access by fetching base models only at startup or on settings save—faster, but may not show recent base model changes.": "",
 	"Base URL": "",
+	"BaseRT": "",
 	"Bearer": "",
 	"before": "بۇرۇن",
 	"Being lazy": "ھورۇن بۇلۇش",

--- a/src/lib/i18n/locales/uk-UA/translation.json
+++ b/src/lib/i18n/locales/uk-UA/translation.json
@@ -365,6 +365,7 @@
 	"Base Model is required.": "",
 	"Base Model List Cache speeds up access by fetching base models only at startup or on settings save—faster, but may not show recent base model changes.": "",
 	"Base URL": "",
+	"BaseRT": "",
 	"Bearer": "",
 	"before": "до того, як",
 	"Being lazy": "Не поспішати",

--- a/src/lib/i18n/locales/ur-PK/translation.json
+++ b/src/lib/i18n/locales/ur-PK/translation.json
@@ -351,6 +351,7 @@
 	"Base Model is required.": "",
 	"Base Model List Cache speeds up access by fetching base models only at startup or on settings save—faster, but may not show recent base model changes.": "",
 	"Base URL": "",
+	"BaseRT": "",
 	"Bearer": "",
 	"before": "پہلے",
 	"Being lazy": "سستی کر رہا ہے",

--- a/src/lib/i18n/locales/uz-Cyrl-UZ/translation.json
+++ b/src/lib/i18n/locales/uz-Cyrl-UZ/translation.json
@@ -351,6 +351,7 @@
 	"Base Model is required.": "",
 	"Base Model List Cache speeds up access by fetching base models only at startup or on settings save—faster, but may not show recent base model changes.": "",
 	"Base URL": "",
+	"BaseRT": "",
 	"Bearer": "",
 	"before": "олдин",
 	"Being lazy": "Дангаса бўлиш",

--- a/src/lib/i18n/locales/uz-Latn-Uz/translation.json
+++ b/src/lib/i18n/locales/uz-Latn-Uz/translation.json
@@ -351,6 +351,7 @@
 	"Base Model is required.": "",
 	"Base Model List Cache speeds up access by fetching base models only at startup or on settings save—faster, but may not show recent base model changes.": "",
 	"Base URL": "",
+	"BaseRT": "",
 	"Bearer": "",
 	"before": "oldin",
 	"Being lazy": "Dangasa bo'lish",

--- a/src/lib/i18n/locales/vi-VN/translation.json
+++ b/src/lib/i18n/locales/vi-VN/translation.json
@@ -344,6 +344,7 @@
 	"Base Model is required.": "",
 	"Base Model List Cache speeds up access by fetching base models only at startup or on settings save—faster, but may not show recent base model changes.": "",
 	"Base URL": "",
+	"BaseRT": "",
 	"Bearer": "",
 	"before": "trước",
 	"Being lazy": "Lười biếng",

--- a/src/lib/i18n/locales/zh-CN/translation.json
+++ b/src/lib/i18n/locales/zh-CN/translation.json
@@ -344,6 +344,7 @@
 	"Base Model is required.": "",
 	"Base Model List Cache speeds up access by fetching base models only at startup or on settings save—faster, but may not show recent base model changes.": "仅在启动或保存设置时获取基础模型列表以提升访问速度，但显示的模型列表可能不是最新的。",
 	"Base URL": "",
+	"BaseRT": "",
 	"Bearer": "密钥（Bearer）",
 	"before": "之前",
 	"Being lazy": "回答不完整或敷衍了事",

--- a/src/lib/i18n/locales/zh-TW/translation.json
+++ b/src/lib/i18n/locales/zh-TW/translation.json
@@ -344,6 +344,7 @@
 	"Base Model is required.": "",
 	"Base Model List Cache speeds up access by fetching base models only at startup or on settings save—faster, but may not show recent base model changes.": "基礎模型清單快取只會在啟動或儲存設定時才取得基礎模型，以加快存取速度，但可能不會顯示最近的基礎模型變更。",
 	"Base URL": "",
+	"BaseRT": "",
 	"Bearer": "Bearer",
 	"before": "之前",
 	"Being lazy": "懶惰模式",


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Relates to #27265 <!-- TODO: open a discussion/issue and link it here -->
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** No new or updated dependencies — this change reuses the existing OpenAI-compatible connection path.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes: **feat**

# Changelog Entry

### Description

Adds first-class support for [BaseRT](https://github.com/basecompute/baseRT), a local LLM inference runtime for Apple Silicon written directly against Apple's Metal API (no MLX/PyTorch/CoreML dependency), which serves an OpenAI-compatible API for chat, completions, embeddings, transcription, and tool calls.

**Motivation.** BaseRT gives macOS users a notably fast local backend for Open WebUI. In published benchmarks ([arXiv:2607.00501](https://arxiv.org/abs/2607.00501)), it reports the highest LLM inference throughput measured on Apple Silicon, ahead of both llama.cpp and MLX; on M5 hardware ([M5 technical report](https://www.basecompute.co/BaseRT_M5.pdf)), Metal 4 tensor-core kernels extend that to up to 6.4× prompt-processing throughput over llama.cpp and up to 3.9× over MLX across fifteen model configurations (Qwen3/3.5/3.6, Llama 3.2, Gemma 4), with decode gains of up to 1.75× over llama.cpp. Faster prefill translates directly into lower time-to-first-token for the long-prompt and agentic workloads Open WebUI users run against local models.

Because BaseRT's wire protocol is OpenAI-compatible (including `reasoning_content` deltas, OpenAI-schema tool calls, and streaming usage chunks — all verified against a live `basert serve` instance), this PR deliberately does **not** add a new provider stack. It follows the existing `llama.cpp`/`azure` provider-hook precedent on the OpenAI connection path, keeping the diff small and maintenance cost near zero.

### Added

- **BaseRT** option in the connection provider dropdown (`AddConnectionModal.svelte`); selecting it defaults the connection type to **Local**, making BaseRT models eligible as the local task model
- Loaded-state badge for BaseRT models in the model selector, read from the boolean `loaded` field BaseRT reports on `GET /v1/models`
- Model unload (admin Eject button) for BaseRT connections: `/api/models/unload` dispatches `provider == 'basert'` to `POST {base_url}/models/unload`
- Reasoning replay support: `get_reasoning_format` returns `'reasoning_content'` for BaseRT (as for llama.cpp), so reasoning content is round-tripped in multi-turn history instead of dropped
- `"BaseRT"` i18n key across all locales

### Changed

- Renamed `get_llamacpp_model_loaded_state` → `get_local_model_loaded_state` in `routers/openai.py`, generalizing it to handle per-provider loaded-state reporting (llama.cpp `status.value`, BaseRT boolean `loaded`)

### Deprecated

- None

### Removed

- None

### Fixed

- None

### Security

- None

### Breaking Changes

- None

---

### Additional Information

- Verified end-to-end against a live `basert serve` instance: model discovery, non-streaming and SSE chat (`data: [DONE]` termination), usage chunks via `stream_options`, `reasoning_content` streaming deltas, tool calls (`finish_reason: "tool_calls"`), `/v1/embeddings`, unload request shape, and OpenAI-style error objects
- Test/lint status: vitest 2/2 passed; svelte-check, ruff (lint + format), eslint, and prettier all show zero new findings versus the `dev` baseline
- Out of scope (follow-ups): a model pull/delete management tab (pending an HTTP management surface in BaseRT; would follow the `ManageModelsModal` tab-strip pattern) and provider branding assets
- How to test:
  ```sh
  basert serve Qwen/Qwen3-4B --api-key "$(uuidgen)" --port 8081
  ```
  Admin Settings → Connections → OpenAI → add `http://127.0.0.1:8081/v1` with the key, Provider = **BaseRT**. The served model appears in the selector with a loaded indicator; chat (including reasoning and tool calls), embeddings, and admin Eject work against the local runtime.

### Screenshots or Videos

- 
<img width="894" height="960" alt="basert_provider_dropdown" src="https://github.com/user-attachments/assets/7f9192ed-3bee-46bf-8aac-639b98c518e7" />
<img width="760" height="500" alt="basert_loaded_badge" src="https://github.com/user-attachments/assets/48c57976-f4c3-422c-9047-24f4be476c06" />


### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.