### PR TITLE
feat: enterprise knowledge base management dashboard

### DIFF
--- a/backend/open_webui/migrations/versions/a7b8c9d0e1f2_add_knowledge_management_tables.py
+++ b/backend/open_webui/migrations/versions/a7b8c9d0e1f2_add_knowledge_management_tables.py
@@ -1,0 +1,145 @@
+"""add knowledge management tables
+
+Revision ID: a7b8c9d0e1f2
+Revises: 42e2978c7933
+Create Date: 2026-07-20 12:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'a7b8c9d0e1f2'
+down_revision: Union[str, None] = '42e2978c7933'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    existing_tables = set(inspector.get_table_names())
+
+    # -- knowledge_chunk table --
+    if 'knowledge_chunk' not in existing_tables:
+        op.create_table(
+            'knowledge_chunk',
+            sa.Column('id', sa.Text(), nullable=False),
+            sa.Column('knowledge_id', sa.Text(), nullable=False),
+            sa.Column('file_id', sa.Text(), nullable=False),
+            sa.Column('chunk_index', sa.BigInteger(), nullable=False),
+            sa.Column('content', sa.Text(), nullable=False),
+            sa.Column('token_count', sa.BigInteger(), nullable=True),
+            sa.Column('meta', sa.JSON(), nullable=True),
+            sa.Column('content_hash', sa.Text(), nullable=True),
+            sa.Column('created_at', sa.BigInteger(), nullable=False),
+            sa.Column('updated_at', sa.BigInteger(), nullable=False),
+            sa.PrimaryKeyConstraint('id'),
+            sa.UniqueConstraint('file_id', 'chunk_index', name='uq_knowledge_chunk_file_index'),
+            sa.ForeignKeyConstraint(['knowledge_id'], ['knowledge.id'], ondelete='CASCADE'),
+            sa.ForeignKeyConstraint(['file_id'], ['file.id'], ondelete='CASCADE'),
+        )
+        op.create_index('ix_knowledge_chunk_knowledge_id', 'knowledge_chunk', ['knowledge_id'])
+        op.create_index('ix_knowledge_chunk_file_id', 'knowledge_chunk', ['file_id'])
+
+    # -- knowledge_processing_task table --
+    if 'knowledge_processing_task' not in existing_tables:
+        op.create_table(
+            'knowledge_processing_task',
+            sa.Column('id', sa.Text(), nullable=False),
+            sa.Column('knowledge_id', sa.Text(), nullable=False),
+            sa.Column('file_id', sa.Text(), nullable=True),
+            sa.Column('task_type', sa.Text(), nullable=False),
+            sa.Column('status', sa.Text(), nullable=False),
+            sa.Column('progress_pct', sa.BigInteger(), nullable=False, server_default='0'),
+            sa.Column('chunks_total', sa.BigInteger(), nullable=True),
+            sa.Column('chunks_processed', sa.BigInteger(), nullable=True),
+            sa.Column('error_message', sa.Text(), nullable=True),
+            sa.Column('created_at', sa.BigInteger(), nullable=False),
+            sa.Column('updated_at', sa.BigInteger(), nullable=False),
+            sa.PrimaryKeyConstraint('id'),
+            sa.ForeignKeyConstraint(['knowledge_id'], ['knowledge.id'], ondelete='CASCADE'),
+            sa.ForeignKeyConstraint(['file_id'], ['file.id'], ondelete='CASCADE'),
+        )
+        op.create_index('ix_knowledge_processing_knowledge_id', 'knowledge_processing_task', ['knowledge_id'])
+        op.create_index('ix_knowledge_processing_file_id', 'knowledge_processing_task', ['file_id'])
+
+    # -- knowledge_batch_task table --
+    if 'knowledge_batch_task' not in existing_tables:
+        op.create_table(
+            'knowledge_batch_task',
+            sa.Column('id', sa.Text(), nullable=False),
+            sa.Column('knowledge_id', sa.Text(), nullable=False),
+            sa.Column('total_files', sa.BigInteger(), nullable=False),
+            sa.Column('files_processed', sa.BigInteger(), nullable=False, server_default='0'),
+            sa.Column('total_chunks', sa.BigInteger(), nullable=True),
+            sa.Column('chunks_embedded', sa.BigInteger(), nullable=True, server_default='0'),
+            sa.Column('status', sa.Text(), nullable=False),
+            sa.Column('created_at', sa.BigInteger(), nullable=False),
+            sa.Column('updated_at', sa.BigInteger(), nullable=False),
+            sa.PrimaryKeyConstraint('id'),
+            sa.ForeignKeyConstraint(['knowledge_id'], ['knowledge.id'], ondelete='CASCADE'),
+        )
+        op.create_index('ix_knowledge_batch_knowledge_id', 'knowledge_batch_task', ['knowledge_id'])
+
+    # -- knowledge_relevance_judgment table --
+    if 'knowledge_relevance_judgment' not in existing_tables:
+        op.create_table(
+            'knowledge_relevance_judgment',
+            sa.Column('id', sa.Text(), nullable=False),
+            sa.Column('knowledge_id', sa.Text(), nullable=False),
+            sa.Column('query_text', sa.Text(), nullable=False),
+            sa.Column('chunk_id', sa.Text(), nullable=True),
+            sa.Column('document_text', sa.Text(), nullable=False),
+            sa.Column('rank_position', sa.BigInteger(), nullable=True),
+            sa.Column('relevance', sa.BigInteger(), nullable=False),
+            sa.Column('user_id', sa.Text(), nullable=False),
+            sa.Column('created_at', sa.BigInteger(), nullable=False),
+            sa.PrimaryKeyConstraint('id'),
+            sa.ForeignKeyConstraint(['knowledge_id'], ['knowledge.id'], ondelete='CASCADE'),
+        )
+        op.create_index('ix_knowledge_judgment_knowledge_id', 'knowledge_relevance_judgment', ['knowledge_id'])
+        op.create_index('ix_knowledge_judgment_query', 'knowledge_relevance_judgment', ['knowledge_id', 'query_text'])
+
+    # -- knowledge_snapshot table --
+    if 'knowledge_snapshot' not in existing_tables:
+        op.create_table(
+            'knowledge_snapshot',
+            sa.Column('id', sa.Text(), nullable=False),
+            sa.Column('knowledge_id', sa.Text(), nullable=False),
+            sa.Column('label', sa.Text(), nullable=True),
+            sa.Column('description', sa.Text(), nullable=True),
+            sa.Column('file_count', sa.BigInteger(), nullable=False),
+            sa.Column('chunk_count', sa.BigInteger(), nullable=True),
+            sa.Column('snapshot_data', sa.JSON(), nullable=False),
+            sa.Column('collection_snapshot_path', sa.Text(), nullable=True),
+            sa.Column('created_by', sa.Text(), nullable=False),
+            sa.Column('created_at', sa.BigInteger(), nullable=False),
+            sa.PrimaryKeyConstraint('id'),
+            sa.ForeignKeyConstraint(['knowledge_id'], ['knowledge.id'], ondelete='CASCADE'),
+        )
+        op.create_index('ix_knowledge_snapshot_knowledge_id', 'knowledge_snapshot', ['knowledge_id'])
+
+
+def downgrade() -> None:
+    op.drop_index('ix_knowledge_snapshot_knowledge_id', table_name='knowledge_snapshot')
+    op.drop_table('knowledge_snapshot')
+
+    op.drop_index('ix_knowledge_judgment_query', table_name='knowledge_relevance_judgment')
+    op.drop_index('ix_knowledge_judgment_knowledge_id', table_name='knowledge_relevance_judgment')
+    op.drop_table('knowledge_relevance_judgment')
+
+    op.drop_index('ix_knowledge_batch_knowledge_id', table_name='knowledge_batch_task')
+    op.drop_table('knowledge_batch_task')
+
+    op.drop_index('ix_knowledge_processing_file_id', table_name='knowledge_processing_task')
+    op.drop_index('ix_knowledge_processing_knowledge_id', table_name='knowledge_processing_task')
+    op.drop_table('knowledge_processing_task')
+
+    op.drop_index('ix_knowledge_chunk_file_id', table_name='knowledge_chunk')
+    op.drop_index('ix_knowledge_chunk_knowledge_id', table_name='knowledge_chunk')
+    op.drop_table('knowledge_chunk')

--- a/backend/open_webui/models/knowledge.py
+++ b/backend/open_webui/models/knowledge.py
@@ -1120,3 +1120,257 @@ class KnowledgeTable:
 
 
 Knowledges = KnowledgeTable()
+
+
+####################
+# Knowledge Management Tables (Enterprise Dashboard)
+####################
+
+
+class KnowledgeChunk(Base):
+    """Tracks individual chunks per file for preview and manual adjustment."""
+
+    __tablename__ = 'knowledge_chunk'
+
+    id = Column(Text, unique=True, primary_key=True)
+    knowledge_id = Column(Text, ForeignKey('knowledge.id', ondelete='CASCADE'), nullable=False)
+    file_id = Column(Text, ForeignKey('file.id', ondelete='CASCADE'), nullable=False)
+    chunk_index = Column(BigInteger, nullable=False)
+    content = Column(Text, nullable=False)
+    token_count = Column(BigInteger, nullable=True)
+    meta = Column(JSON, nullable=True)
+    content_hash = Column(Text, nullable=True)
+
+    created_at = Column(BigInteger, nullable=False)
+    updated_at = Column(BigInteger, nullable=False)
+
+    __table_args__ = (
+        UniqueConstraint('file_id', 'chunk_index', name='uq_knowledge_chunk_file_index'),
+        Index('ix_knowledge_chunk_knowledge_id', 'knowledge_id'),
+        Index('ix_knowledge_chunk_file_id', 'file_id'),
+    )
+
+
+class KnowledgeChunkModel(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    knowledge_id: str
+    file_id: str
+    chunk_index: int
+    content: str
+    token_count: Optional[int] = None
+    meta: Optional[dict] = None
+    content_hash: Optional[str] = None
+    created_at: int
+    updated_at: int
+
+
+class KnowledgeChunkMergeForm(BaseModel):
+    """Merge adjacent chunks within the same file."""
+
+    knowledge_id: str
+    file_id: str
+    start_index: int
+    end_index: int
+
+
+class KnowledgeChunkSplitForm(BaseModel):
+    """Split a chunk at a character offset."""
+
+    chunk_id: str
+    split_at: int  # character offset within the chunk
+
+
+class KnowledgeProcessingTask(Base):
+    """Per-file processing progress tracking."""
+
+    __tablename__ = 'knowledge_processing_task'
+
+    id = Column(Text, unique=True, primary_key=True)
+    knowledge_id = Column(Text, ForeignKey('knowledge.id', ondelete='CASCADE'), nullable=False)
+    file_id = Column(Text, ForeignKey('file.id', ondelete='CASCADE'), nullable=True)
+    task_type = Column(Text, nullable=False)  # 'chunking' | 'embedding' | 'full_process'
+    status = Column(Text, nullable=False)  # 'pending' | 'chunking' | 'embedding' | 'completed' | 'failed'
+    progress_pct = Column(BigInteger, nullable=False, default=0)
+    chunks_total = Column(BigInteger, nullable=True)
+    chunks_processed = Column(BigInteger, nullable=True)
+    error_message = Column(Text, nullable=True)
+    created_at = Column(BigInteger, nullable=False)
+    updated_at = Column(BigInteger, nullable=False)
+
+    __table_args__ = (
+        Index('ix_knowledge_processing_knowledge_id', 'knowledge_id'),
+        Index('ix_knowledge_processing_file_id', 'file_id'),
+    )
+
+
+class KnowledgeProcessingTaskModel(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    knowledge_id: str
+    file_id: Optional[str] = None
+    task_type: str
+    status: str
+    progress_pct: int
+    chunks_total: Optional[int] = None
+    chunks_processed: Optional[int] = None
+    error_message: Optional[str] = None
+    created_at: int
+    updated_at: int
+
+
+class KnowledgeBatchTask(Base):
+    """Parent batch processing task grouping sub-tasks."""
+
+    __tablename__ = 'knowledge_batch_task'
+
+    id = Column(Text, unique=True, primary_key=True)
+    knowledge_id = Column(Text, ForeignKey('knowledge.id', ondelete='CASCADE'), nullable=False)
+    total_files = Column(BigInteger, nullable=False)
+    files_processed = Column(BigInteger, nullable=False, default=0)
+    total_chunks = Column(BigInteger, nullable=True)
+    chunks_embedded = Column(BigInteger, nullable=True, default=0)
+    status = Column(Text, nullable=False)  # 'running' | 'completed' | 'failed'
+    created_at = Column(BigInteger, nullable=False)
+    updated_at = Column(BigInteger, nullable=False)
+
+    __table_args__ = (Index('ix_knowledge_batch_knowledge_id', 'knowledge_id'),)
+
+
+class KnowledgeBatchTaskModel(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    knowledge_id: str
+    total_files: int
+    files_processed: int
+    total_chunks: Optional[int] = None
+    chunks_embedded: Optional[int] = None
+    status: str
+    created_at: int
+    updated_at: int
+
+
+class KnowledgeRelevanceJudgment(Base):
+    """Ground-truth relevance judgments for retrieval evaluation."""
+
+    __tablename__ = 'knowledge_relevance_judgment'
+
+    id = Column(Text, unique=True, primary_key=True)
+    knowledge_id = Column(Text, ForeignKey('knowledge.id', ondelete='CASCADE'), nullable=False)
+    query_text = Column(Text, nullable=False)
+    chunk_id = Column(Text, nullable=True)
+    document_text = Column(Text, nullable=False)
+    rank_position = Column(BigInteger, nullable=True)
+    relevance = Column(BigInteger, nullable=False)  # 0=not relevant, 1=relevant
+    user_id = Column(Text, nullable=False)
+    created_at = Column(BigInteger, nullable=False)
+
+    __table_args__ = (
+        Index('ix_knowledge_judgment_knowledge_id', 'knowledge_id'),
+        Index('ix_knowledge_judgment_query', 'knowledge_id', 'query_text'),
+    )
+
+
+class KnowledgeRelevanceJudgmentModel(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    knowledge_id: str
+    query_text: str
+    chunk_id: Optional[str] = None
+    document_text: str
+    rank_position: Optional[int] = None
+    relevance: int
+    user_id: str
+    created_at: int
+
+
+class KnowledgeSnapshot(Base):
+    """Version snapshots of knowledge bases."""
+
+    __tablename__ = 'knowledge_snapshot'
+
+    id = Column(Text, unique=True, primary_key=True)
+    knowledge_id = Column(Text, ForeignKey('knowledge.id', ondelete='CASCADE'), nullable=False)
+    label = Column(Text, nullable=True)
+    description = Column(Text, nullable=True)
+    file_count = Column(BigInteger, nullable=False)
+    chunk_count = Column(BigInteger, nullable=True)
+    snapshot_data = Column(JSON, nullable=False)
+    collection_snapshot_path = Column(Text, nullable=True)
+    created_by = Column(Text, nullable=False)
+    created_at = Column(BigInteger, nullable=False)
+
+    __table_args__ = (Index('ix_knowledge_snapshot_knowledge_id', 'knowledge_id'),)
+
+
+class KnowledgeSnapshotModel(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    knowledge_id: str
+    label: Optional[str] = None
+    description: Optional[str] = None
+    file_count: int
+    chunk_count: Optional[int] = None
+    snapshot_data: dict
+    collection_snapshot_path: Optional[str] = None
+    created_by: str
+    created_at: int
+
+
+class KnowledgeSnapshotCreateForm(BaseModel):
+    label: Optional[str] = None
+    description: Optional[str] = None
+
+
+class KnowledgeSnapshotCompareResult(BaseModel):
+    added_files: list[dict]
+    removed_files: list[dict]
+    modified_files: list[dict]
+    total_chunks_before: int
+    total_chunks_after: int
+
+
+class KnowledgeChunkPreviewForm(BaseModel):
+    """Request form for chunk preview - takes a file_id to preview chunking."""
+
+    file_id: str
+
+
+class KnowledgeRelevanceAnnotationForm(BaseModel):
+    """Form to annotate retrieval results as relevant/not relevant."""
+
+    query_text: str
+    judgments: list[dict]  # [{chunk_id, rank_position, document_text, relevance: 0|1}]
+
+
+class KnowledgeEvaluateQueryForm(BaseModel):
+    """Form to run an evaluation query."""
+
+    query: str
+    k: int = 10
+
+
+class KnowledgeSnapshotCompareForm(BaseModel):
+    """Form to compare two snapshots."""
+
+    snapshot_a_id: str
+    snapshot_b_id: str
+
+
+class KnowledgePromptUpdateForm(BaseModel):
+    """Form to update the RAG prompt template for a knowledge base."""
+
+    prompt_template: str
+
+
+DEFAULT_RAG_PROMPT_TEMPLATE = (
+    "You are a helpful AI assistant. Use the following reference materials to answer the user's question.\n\n"
+    "Reference Materials:\n{context}\n\n"
+    "User Question: {query}\n\n"
+    "If the reference materials do not contain relevant information, please say so honestly."
+)

--- a/backend/open_webui/routers/files.py
+++ b/backend/open_webui/routers/files.py
@@ -4,6 +4,7 @@ import hashlib
 import json
 import logging
 import os
+import time
 import uuid
 from pathlib import Path
 from typing import Optional
@@ -38,7 +39,7 @@ from open_webui.models.files import (
     Files,
 )
 from open_webui.models.groups import Groups
-from open_webui.models.knowledge import Knowledges
+from open_webui.models.knowledge import Knowledges, KnowledgeProcessingTask
 from open_webui.models.users import Users
 from open_webui.retrieval.vector.async_client import ASYNC_VECTOR_DB_CLIENT
 from open_webui.routers.audio import transcribe
@@ -203,7 +204,25 @@ async def process_uploaded_file(
                     else:
                         # Keep the generic file status stream open until the
                         # KB-specific vector write and durable link both finish.
-                        await Files.update_file_data_by_id(file_item.id, {'status': 'processing'}, db=db_session)
+                        await Files.update_file_data_by_id(
+                            file_item.id, {'status': 'processing'}, db=db_session
+                        )
+
+                        # ── Progress tracking for enterprise dashboard ──
+                        _now = int(time.time())
+                        _task_id = str(uuid.uuid4())
+                        _task = KnowledgeProcessingTask(
+                            id=_task_id,
+                            knowledge_id=knowledge_id,
+                            file_id=file_item.id,
+                            task_type='full_process',
+                            status='embedding',
+                            progress_pct=50,
+                            created_at=_now,
+                            updated_at=_now,
+                        )
+                        db_session.add(_task)
+                        await db_session.commit()
                         await process_file(
                             request,
                             ProcessFileForm(file_id=file_item.id, collection_name=knowledge_id),
@@ -219,6 +238,13 @@ async def process_uploaded_file(
                         )
                         if not knowledge_file:
                             raise Exception(f'Failed to link file {file_item.id} to knowledge {knowledge_id}')
+
+                        # Mark completed
+                        _task.status = 'completed'
+                        _task.progress_pct = 100
+                        _task.updated_at = int(time.time())
+                        db_session.add(_task)
+                        await db_session.commit()
                         log.info(f'Linked file {file_item.id} to knowledge {knowledge_id}')
                 except Exception as e:
                     log.warning(f'Failed to link file {file_item.id} to knowledge {knowledge_id}: {e}')

--- a/backend/open_webui/routers/knowledge.py
+++ b/backend/open_webui/routers/knowledge.py
@@ -21,22 +21,52 @@ from open_webui.models.config import Config
 from open_webui.models.files import FileMetadataResponse, FileModel, FileModelResponse, Files
 from open_webui.models.groups import Groups
 from open_webui.models.knowledge import (
+    KnowledgeChunkMergeForm,
+    KnowledgeChunkModel,
+    KnowledgeChunkPreviewForm,
+    KnowledgeChunkSplitForm,
+    KnowledgeChunk,
     KnowledgeDirectoryForm,
     KnowledgeDirectoryModel,
+    KnowledgeEvaluateQueryForm,
+    KnowledgeFile,
     KnowledgeFileListResponse,
     KnowledgeForm,
+    KnowledgeProcessingTask,
+    KnowledgeProcessingTaskModel,
+    KnowledgeBatchTask,
+    KnowledgeBatchTaskModel,
+    KnowledgeRelevanceAnnotationForm,
     KnowledgeResponse,
+    KnowledgeRelevanceJudgment,
+    KnowledgeRelevanceJudgmentModel,
+    KnowledgeSnapshot,
+    KnowledgeSnapshotCompareForm,
+    KnowledgeSnapshotCompareResult,
+    KnowledgeSnapshotCreateForm,
+    KnowledgeSnapshotModel,
+    KnowledgePromptUpdateForm,
+    DEFAULT_RAG_PROMPT_TEMPLATE,
     Knowledges,
     KnowledgeUserResponse,
 )
 from open_webui.models.models import ModelForm, Models
 from open_webui.retrieval.vector.async_client import ASYNC_VECTOR_DB_CLIENT
 from open_webui.retrieval.external import retrieve_external_knowledge, retrieve_external_knowledge_for_connection
+from open_webui.retrieval.utils import (
+    build_loader_from_config,
+    get_embedding_function,
+    get_loader_config,
+    query_collection_with_hybrid_search,
+    query_collection,
+)
 from open_webui.routers.retrieval import (
     BatchProcessFilesForm,
     ProcessFileForm,
+    get_retrieval_config,
     process_file,
     process_files_batch,
+    save_docs_to_vector_db,
 )
 from open_webui.storage.provider import Storage
 from open_webui.utils.access_control import filter_allowed_access_grants, has_permission
@@ -1415,12 +1445,59 @@ async def add_file_to_knowledge_by_id(
 
     # Add content to the vector database
     try:
+        await _update_processing_progress(
+            knowledge_id=id, file_id=form_data.file_id,
+            status='embedding', progress_pct=50, db=db,
+        )
+
         await process_file(
             request,
             ProcessFileForm(file_id=form_data.file_id, collection_name=id),
             user=user,
             db=db,
         )
+
+        await _update_processing_progress(
+            knowledge_id=id, file_id=form_data.file_id,
+            status='completed', progress_pct=100, db=db,
+        )
+
+        # ── Automatically persist chunks to knowledge_chunk table ──
+        try:
+            from sqlalchemy import delete as sa_delete
+            result_vdb = await ASYNC_VECTOR_DB_CLIENT.query(
+                collection_name=id, filter={'file_id': form_data.file_id}
+            )
+            if result_vdb and result_vdb.ids and len(result_vdb.ids) > 0:
+                import hashlib
+                now = int(time.time())
+                # Remove old chunk records
+                await db.execute(
+                    sa_delete(KnowledgeChunk).where(
+                        KnowledgeChunk.knowledge_id == id,
+                        KnowledgeChunk.file_id == form_data.file_id,
+                    )
+                )
+                for idx, (doc_id, text, metadata) in enumerate(
+                    zip(result_vdb.ids[0], result_vdb.documents[0], result_vdb.metadatas[0])
+                ):
+                    content_hash = hashlib.sha256(text.encode()).hexdigest() if text else None
+                    chunk = KnowledgeChunk(
+                        id=str(uuid.uuid4()),
+                        knowledge_id=id,
+                        file_id=form_data.file_id,
+                        chunk_index=idx,
+                        content=text,
+                        token_count=len(text) // 4 if text else None,
+                        meta=metadata,
+                        content_hash=content_hash,
+                        created_at=now,
+                        updated_at=now,
+                    )
+                    db.add(chunk)
+                await db.commit()
+        except Exception as chunk_err:
+            log.warning(f'Failed to persist chunks for KB {id} file {form_data.file_id}: {chunk_err}')
 
         # Add file to knowledge base
         await Knowledges.add_file_to_knowledge_by_id(
@@ -1432,6 +1509,10 @@ async def add_file_to_knowledge_by_id(
         )
     except Exception as e:
         log.debug(e)
+        await _update_processing_progress(
+            knowledge_id=id, file_id=form_data.file_id,
+            status='failed', error_message=str(e), db=db,
+        )
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(e),
@@ -2340,3 +2421,1076 @@ async def move_file_in_knowledge(
         data={'knowledge_id': id, 'directory_id': form_data.directory_id},
     )
     return {'status': True}
+
+
+# ─────────────────────────────────────────────────────────────
+# Enterprise Knowledge Dashboard – Phase 1: Chunk Management
+# ─────────────────────────────────────────────────────────────
+
+
+@router.post('/{id}/chunks/preview', response_model=list[KnowledgeChunkModel])
+async def preview_knowledge_chunks(
+    request: Request,
+    id: str,
+    form_data: KnowledgeChunkPreviewForm,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Chunk a file without embedding – preview what the splitter will produce."""
+    knowledge = await Knowledges.get_knowledge_by_id(id, db=db)
+    if not knowledge:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
+
+    file = await Files.get_file_by_id(form_data.file_id)
+    if not file:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
+
+    file_path = file.path
+    if not file_path:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail='File has no path.')
+
+    # Use existing loader + splitter (no embedding)
+    try:
+        file_path = await asyncio.to_thread(Storage.get_file, file_path)
+        loader_config = await get_loader_config()
+        loader = build_loader_from_config(request, loader_config)
+        loader.user = user
+        loader.metadata = {
+            'file_id': file.id,
+            'file_name': file.filename,
+            'file_content_type': file.meta.get('content_type'),
+        }
+        docs = await loader.aload(file.filename, file.meta.get('content_type'), file_path)
+
+        # Chunk using same logic as save_docs_to_vector_db
+        config = await get_retrieval_config()
+        from open_webui.routers.retrieval import merge_docs_to_target_size
+        from langchain_text_splitters import (
+            MarkdownHeaderTextSplitter,
+            RecursiveCharacterTextSplitter,
+            TokenTextSplitter,
+        )
+        import tiktoken
+
+        if config.ENABLE_MARKDOWN_HEADER_TEXT_SPLITTER:
+            markdown_splitter = MarkdownHeaderTextSplitter(
+                headers_to_split_on=[
+                    ('#', 'Header 1'),
+                    ('##', 'Header 2'),
+                    ('###', 'Header 3'),
+                    ('####', 'Header 4'),
+                    ('#####', 'Header 5'),
+                    ('######', 'Header 6'),
+                ],
+                strip_headers=False,
+            )
+            split_docs = []
+            for doc in docs:
+                split_docs.extend([
+                    type(doc)(page_content=c.page_content, metadata={**doc.metadata})
+                    for c in markdown_splitter.split_text(doc.page_content)
+                ])
+            docs = split_docs
+            if config.CHUNK_MIN_SIZE_TARGET > 0:
+                docs = merge_docs_to_target_size(request, docs, config)
+
+        if config.TEXT_SPLITTER in ['', 'character']:
+            text_splitter = RecursiveCharacterTextSplitter(
+                chunk_size=config.CHUNK_SIZE, chunk_overlap=config.CHUNK_OVERLAP, add_start_index=True,
+            )
+            docs = text_splitter.split_documents(docs)
+        elif config.TEXT_SPLITTER == 'token':
+            tiktoken.get_encoding(str(config.TIKTOKEN_ENCODING_NAME))
+            text_splitter = TokenTextSplitter(
+                encoding_name=str(config.TIKTOKEN_ENCODING_NAME),
+                chunk_size=config.CHUNK_SIZE, chunk_overlap=config.CHUNK_OVERLAP, add_start_index=True,
+            )
+            docs = text_splitter.split_documents(docs)
+        else:
+            # Fallback to RecursiveCharacterTextSplitter
+            text_splitter = RecursiveCharacterTextSplitter(
+                chunk_size=config.CHUNK_SIZE, chunk_overlap=config.CHUNK_OVERLAP, add_start_index=True,
+            )
+            docs = text_splitter.split_documents(docs)
+
+        # Remove old preview chunks for this file in this KB
+        from sqlalchemy import delete as sa_delete
+        await db.execute(
+            sa_delete(KnowledgeChunk).where(
+                KnowledgeChunk.knowledge_id == id,
+                KnowledgeChunk.file_id == form_data.file_id,
+            )
+        )
+
+        # Persist chunks in knowledge_chunk table
+        import hashlib
+        now = int(time.time())
+        chunks = []
+        for idx, doc in enumerate(docs):
+            content_hash = hashlib.sha256(doc.page_content.encode()).hexdigest()
+            token_count = len(doc.page_content) // 4  # rough estimate
+
+            chunk = KnowledgeChunk(
+                id=str(uuid.uuid4()),
+                knowledge_id=id,
+                file_id=form_data.file_id,
+                chunk_index=idx,
+                content=doc.page_content,
+                token_count=token_count,
+                meta=doc.metadata,
+                content_hash=content_hash,
+                created_at=now,
+                updated_at=now,
+            )
+            db.add(chunk)
+            chunks.append(KnowledgeChunkModel.model_validate(chunk))
+
+        await db.commit()
+        return chunks
+    except Exception as e:
+        log.exception(e)
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e))
+
+
+@router.get('/{id}/files/{file_id}/chunks', response_model=list[KnowledgeChunkModel])
+async def get_file_chunks(
+    id: str,
+    file_id: str,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Get all chunks for a file in a knowledge base."""
+    knowledge = await Knowledges.get_knowledge_by_id(id, db=db)
+    if not knowledge:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
+
+    from sqlalchemy import select as sa_select
+    result = await db.execute(
+        sa_select(KnowledgeChunk)
+        .where(KnowledgeChunk.knowledge_id == id, KnowledgeChunk.file_id == file_id)
+        .order_by(KnowledgeChunk.chunk_index.asc())
+    )
+    rows = result.scalars().all()
+    return [KnowledgeChunkModel.model_validate(r) for r in rows]
+
+
+@router.get('/{id}/chunks/{chunk_id}', response_model=KnowledgeChunkModel)
+async def get_chunk_detail(
+    id: str,
+    chunk_id: str,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Get full content of a single chunk."""
+    from sqlalchemy import select as sa_select
+    result = await db.execute(
+        sa_select(KnowledgeChunk).where(
+            KnowledgeChunk.knowledge_id == id,
+            KnowledgeChunk.id == chunk_id,
+        )
+    )
+    chunk = result.scalars().first()
+    if not chunk:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail='Chunk not found.')
+    return KnowledgeChunkModel.model_validate(chunk)
+
+
+@router.post('/{id}/chunks/merge')
+async def merge_knowledge_chunks(
+    request: Request,
+    id: str,
+    form_data: KnowledgeChunkMergeForm,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Merge adjacent chunks [start_index, end_index] into one."""
+    knowledge = await Knowledges.get_knowledge_by_id(id, db=db)
+    if not knowledge:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
+
+    from sqlalchemy import select as sa_select, delete as sa_delete
+
+    # Fetch chunks in range
+    result = await db.execute(
+        sa_select(KnowledgeChunk)
+        .where(
+            KnowledgeChunk.knowledge_id == id,
+            KnowledgeChunk.file_id == form_data.file_id,
+            KnowledgeChunk.chunk_index >= form_data.start_index,
+            KnowledgeChunk.chunk_index <= form_data.end_index,
+        )
+        .order_by(KnowledgeChunk.chunk_index.asc())
+    )
+    target_chunks = result.scalars().all()
+    if len(target_chunks) < 2:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail='Need at least 2 chunks to merge.')
+
+    # Merge content
+    merged_content = '\n\n'.join(c.content for c in target_chunks)
+    merged_meta = target_chunks[0].meta or {}
+
+    import hashlib
+    now = int(time.time())
+    content_hash = hashlib.sha256(merged_content.encode()).hexdigest()
+    token_count = len(merged_content) // 4
+
+    # Create new merged chunk at the first index
+    merged_chunk = KnowledgeChunk(
+        id=str(uuid.uuid4()),
+        knowledge_id=id,
+        file_id=form_data.file_id,
+        chunk_index=form_data.start_index,
+        content=merged_content,
+        token_count=token_count,
+        meta=merged_meta,
+        content_hash=content_hash,
+        created_at=now,
+        updated_at=now,
+    )
+
+    # Delete old chunks
+    old_ids = [c.id for c in target_chunks]
+    await db.execute(sa_delete(KnowledgeChunk).where(KnowledgeChunk.id.in_(old_ids)))
+    db.add(merged_chunk)
+
+    # Rebuild chunk_index consecutively.
+    # Step 1: shift all to 10000+ (guaranteed no conflict with 0..N range)
+    from sqlalchemy import text as sa_text
+    await db.execute(
+        sa_text("UPDATE knowledge_chunk SET chunk_index = chunk_index + 10000 "
+                "WHERE knowledge_id = :kid AND file_id = :fid"),
+        {"kid": id, "fid": form_data.file_id},
+    )
+    await db.flush()
+    # Step 2: re-fetch and reassign 0,1,2... safely (all values >= 10000)
+    result = await db.execute(
+        sa_select(KnowledgeChunk)
+        .where(KnowledgeChunk.knowledge_id == id, KnowledgeChunk.file_id == form_data.file_id)
+        .order_by(KnowledgeChunk.chunk_index.asc())
+    )
+    for i, c in enumerate(result.scalars().all()):
+        c.chunk_index = i
+        c.updated_at = now
+
+    await db.commit()
+    return {'status': True, 'merged_chunk_id': merged_chunk.id}
+
+
+@router.post('/{id}/chunks/split')
+async def split_knowledge_chunk(
+    request: Request,
+    id: str,
+    form_data: KnowledgeChunkSplitForm,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Split a chunk at a character offset into two chunks."""
+    knowledge = await Knowledges.get_knowledge_by_id(id, db=db)
+    if not knowledge:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
+
+    from sqlalchemy import select as sa_select
+
+    result = await db.execute(
+        sa_select(KnowledgeChunk).where(
+            KnowledgeChunk.knowledge_id == id,
+            KnowledgeChunk.id == form_data.chunk_id,
+        )
+    )
+    chunk = result.scalars().first()
+    if not chunk:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail='Chunk not found.')
+
+    content = chunk.content
+    split_point = form_data.split_at
+    if split_point <= 0 or split_point >= len(content):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail='Split point must be within chunk content.')
+
+    part_a = content[:split_point].strip()
+    part_b = content[split_point:].strip()
+    if not part_a or not part_b:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail='Both parts must be non-empty.')
+
+    import hashlib
+    now = int(time.time())
+
+    # Update original chunk to part_a
+    chunk.content = part_a
+    chunk.token_count = len(part_a) // 4
+    chunk.content_hash = hashlib.sha256(part_a.encode()).hexdigest()
+    chunk.updated_at = now
+
+    # Create new chunk for part_b with a safe temp index
+    new_chunk = KnowledgeChunk(
+        id=str(uuid.uuid4()),
+        knowledge_id=id,
+        file_id=chunk.file_id,
+        chunk_index=-1,  # temp, will be renumbered below
+        content=part_b,
+        token_count=len(part_b) // 4,
+        meta=(chunk.meta or {}).copy(),
+        content_hash=hashlib.sha256(part_b.encode()).hexdigest(),
+        created_at=now,
+        updated_at=now,
+    )
+    db.add(new_chunk)
+    await db.flush()
+
+    # Rebuild all chunk_index for this file (same safe approach as merge)
+    from sqlalchemy import text as sa_text
+    await db.execute(
+        sa_text("UPDATE knowledge_chunk SET chunk_index = chunk_index + 10000 "
+                "WHERE knowledge_id = :kid AND file_id = :fid"),
+        {"kid": id, "fid": chunk.file_id},
+    )
+    await db.flush()
+    result = await db.execute(
+        sa_select(KnowledgeChunk)
+        .where(KnowledgeChunk.knowledge_id == id, KnowledgeChunk.file_id == chunk.file_id)
+        .order_by(KnowledgeChunk.chunk_index.asc())
+    )
+    for i, c in enumerate(result.scalars().all()):
+        c.chunk_index = i
+        c.updated_at = now
+
+    await db.commit()
+    return {'status': True, 'new_chunk_id': new_chunk.id}
+
+
+@router.post('/{id}/chunks/reindex')
+async def reindex_knowledge_chunks(
+    request: Request,
+    id: str,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Re-embed all chunks for this KB after manual adjustments."""
+    knowledge = await Knowledges.get_knowledge_by_id(id, db=db)
+    if not knowledge:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
+
+    from sqlalchemy import select as sa_select
+
+    result = await db.execute(
+        sa_select(KnowledgeChunk).where(KnowledgeChunk.knowledge_id == id)
+    )
+    chunks = result.scalars().all()
+    if not chunks:
+        return {'status': True, 'message': 'No chunks to reindex.'}
+
+    # Delete old vectors for this KB's collection
+    try:
+        await ASYNC_VECTOR_DB_CLIENT.delete_collection(collection_name=id)
+    except Exception:
+        pass
+
+    # Rebuild vectors from knowledge_chunk rows
+    from langchain_core.documents import Document
+
+    docs = [
+        Document(
+            page_content=c.content,
+            metadata={
+                **(c.meta or {}),
+                'file_id': c.file_id,
+                'chunk_index': c.chunk_index,
+                'content_hash': c.content_hash,
+            },
+        )
+        for c in chunks
+    ]
+
+    try:
+        from fastapi.concurrency import run_in_threadpool
+        config = await get_retrieval_config()
+        await run_in_threadpool(
+            save_docs_to_vector_db,
+            request, docs, id, config,
+            None,  # metadata
+            True,  # overwrite
+            True,  # split
+            False, # add
+            user,
+        )
+    except Exception as e:
+        log.exception(e)
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e))
+
+    return {'status': True, 'chunks_processed': len(chunks)}
+
+
+# ─────────────────────────────────────────────────────────────
+# Enterprise Knowledge Dashboard – Phase 2: Progress Tracking
+# ─────────────────────────────────────────────────────────────
+
+
+# In-memory progress store for real-time SSE updates
+# Key: (knowledge_id, file_id) → KnowledgeProcessingTaskModel
+_progress_store: dict[str, KnowledgeProcessingTaskModel] = {}
+
+
+async def _update_processing_progress(
+    knowledge_id: str,
+    file_id: str,
+    status: str,
+    progress_pct: int = 0,
+    chunks_total: int | None = None,
+    chunks_processed: int | None = None,
+    error_message: str | None = None,
+    db: AsyncSession | None = None,
+):
+    """Create or update a processing task record in DB and in-memory store."""
+    import time as _time, uuid as _uuid
+
+    key = f'{knowledge_id}:{file_id}'
+    now = int(_time.time())
+
+    # Try to update existing task
+    from sqlalchemy import select as sa_select
+    result = await db.execute(
+        sa_select(KnowledgeProcessingTask).where(
+            KnowledgeProcessingTask.knowledge_id == knowledge_id,
+            KnowledgeProcessingTask.file_id == file_id,
+        )
+    )
+    task = result.scalars().first()
+
+    if task:
+        task.status = status
+        task.progress_pct = progress_pct
+        if chunks_total is not None:
+            task.chunks_total = chunks_total
+        if chunks_processed is not None:
+            task.chunks_processed = chunks_processed
+        if error_message is not None:
+            task.error_message = error_message
+        task.updated_at = now
+        db.add(task)
+        await db.commit()
+    else:
+        task = KnowledgeProcessingTask(
+            id=str(_uuid.uuid4()),
+            knowledge_id=knowledge_id,
+            file_id=file_id,
+            task_type='full_process',
+            status=status,
+            progress_pct=progress_pct,
+            chunks_total=chunks_total,
+            chunks_processed=chunks_processed,
+            error_message=error_message,
+            created_at=now,
+            updated_at=now,
+        )
+        db.add(task)
+        await db.commit()
+
+    # Update in-memory store
+    _progress_store[key] = KnowledgeProcessingTaskModel.model_validate(task)
+
+
+@router.get('/{id}/progress', response_model=list[KnowledgeProcessingTaskModel])
+async def get_processing_progress(
+    id: str,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Get current processing status for all files in a KB."""
+    knowledge = await Knowledges.get_knowledge_by_id(id, db=db)
+    if not knowledge:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
+
+    from sqlalchemy import select as sa_select
+
+    result = await db.execute(
+        sa_select(KnowledgeProcessingTask)
+        .where(KnowledgeProcessingTask.knowledge_id == id)
+        .order_by(KnowledgeProcessingTask.created_at.desc())
+    )
+    tasks = result.scalars().all()
+    return [KnowledgeProcessingTaskModel.model_validate(t) for t in tasks]
+
+
+@router.get('/{id}/progress/stream')
+async def stream_processing_progress(
+    request: Request,
+    id: str,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """SSE endpoint that streams progress updates every second."""
+    knowledge = await Knowledges.get_knowledge_by_id(id, db=db)
+    if not knowledge:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
+
+    async def event_generator():
+        import time as _time
+        from sqlalchemy import select as sa_select
+
+        # Track the last run to stop after idle timeout
+        last_active = _time.time()
+        sent_count = 0
+
+        while True:
+            # Check DB for tasks
+            result = await db.execute(
+                sa_select(KnowledgeProcessingTask)
+                .where(KnowledgeProcessingTask.knowledge_id == id)
+                .order_by(KnowledgeProcessingTask.created_at.desc())
+            )
+            tasks = result.scalars().all()
+            task_list = [KnowledgeProcessingTaskModel.model_validate(t).model_dump() for t in tasks]
+
+            # Also include in-memory tasks that may not be in DB yet
+            for key, mem_task in _progress_store.items():
+                if key.startswith(f'{id}:'):
+                    exists = any(t['id'] == mem_task.id for t in task_list)
+                    if not exists:
+                        task_list.append(mem_task.model_dump())
+
+            data = json.dumps(task_list)
+            yield f'data: {data}\n\n'
+            sent_count += 1
+
+            # Check if all tasks are in terminal state
+            all_done = all(
+                t['status'] in ('completed', 'failed') for t in task_list
+            ) if task_list else False
+
+            if all_done and sent_count > 2:
+                # Send one more update then stop
+                yield f'data: {data}\n\n'
+                break
+
+            if not all_done:
+                last_active = _time.time()
+
+            # Timeout after 5 minutes of inactivity
+            if _time.time() - last_active > 300:
+                break
+
+            await asyncio.sleep(1)
+
+            # Refresh DB session between iterations
+            await db.commit()
+
+    return StreamingResponse(event_generator(), media_type='text/event-stream')
+
+
+@router.get('/{id}/progress/batch', response_model=KnowledgeBatchTaskModel | None)
+async def get_batch_progress(
+    id: str,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Get the latest batch processing task for this KB."""
+    knowledge = await Knowledges.get_knowledge_by_id(id, db=db)
+    if not knowledge:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
+
+    from sqlalchemy import select as sa_select
+
+    result = await db.execute(
+        sa_select(KnowledgeBatchTask)
+        .where(KnowledgeBatchTask.knowledge_id == id)
+        .order_by(KnowledgeBatchTask.created_at.desc())
+        .limit(1)
+    )
+    batch = result.scalars().first()
+    if not batch:
+        return None
+    return KnowledgeBatchTaskModel.model_validate(batch)
+
+
+# ─────────────────────────────────────────────────────────────
+# Enterprise Knowledge Dashboard – Phase 3: Retrieval Evaluation
+# ─────────────────────────────────────────────────────────────
+
+
+@router.post('/{id}/evaluate/query')
+async def evaluate_retrieval_query(
+    request: Request,
+    id: str,
+    form_data: KnowledgeEvaluateQueryForm,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Run a test query against the KB and return Top-K results with metrics."""
+    knowledge = await Knowledges.get_knowledge_by_id(id, db=db)
+    if not knowledge:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
+
+    k = form_data.k if form_data.k else 10
+
+    try:
+        result = await query_collection(
+            request=request,
+            collection_names=[id],
+            queries=[form_data.query],
+            embedding_function=request.app.state.EMBEDDING_FUNCTION,
+            k=k,
+        )
+    except Exception as e:
+        log.exception(e)
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e))
+
+    # query_collection returns: {'distances': [[]], 'documents': [[]], 'metadatas': [[]]}
+    results = []
+    if isinstance(result, dict):
+        docs_list = result.get('documents', [[]])[0] if result.get('documents') else []
+        metas_list = result.get('metadatas', [[]])[0] if result.get('metadatas') else []
+        dists_list = result.get('distances', [[]])[0] if result.get('distances') else []
+
+        for i in range(min(k, len(docs_list))):
+            doc_text = docs_list[i] if i < len(docs_list) else ''
+            results.append({
+                'chunk_id': metas_list[i].get('content_hash', f'chunk-{i}') if i < len(metas_list) else f'chunk-{i}',
+                'text': doc_text[:500],
+                'score': dists_list[i] if i < len(dists_list) else None,
+                'metadata': metas_list[i] if i < len(metas_list) else {},
+                'rank': i + 1,
+            })
+
+    # Compute metrics if judgments exist
+    from sqlalchemy import select as sa_select
+    metrics = None
+    j_result = await db.execute(
+        sa_select(KnowledgeRelevanceJudgment)
+        .where(
+            KnowledgeRelevanceJudgment.knowledge_id == id,
+            KnowledgeRelevanceJudgment.query_text == form_data.query,
+        )
+    )
+    judgments = j_result.scalars().all()
+    if judgments:
+        relevant_ids = {j.chunk_id for j in judgments if j.relevance == 1}
+        total_relevant = len(relevant_ids)
+        if total_relevant > 0:
+            # recall@K
+            retrieved_ids = {r['chunk_id'] for r in results if r['chunk_id']}
+            relevant_retrieved = relevant_ids & retrieved_ids
+            recall_at_k = len(relevant_retrieved) / total_relevant
+            # precision@K
+            precision_at_k = len(relevant_retrieved) / k if k > 0 else 0
+            # MRR
+            mrr = 0.0
+            for j in judgments:
+                if j.relevance == 1 and j.rank_position and j.rank_position > 0:
+                    mrr = max(mrr, 1.0 / j.rank_position)
+            metrics = {
+                'recall_at_k': round(recall_at_k, 4),
+                'precision_at_k': round(precision_at_k, 4),
+                'mrr': round(mrr, 4),
+                'total_relevant': total_relevant,
+            }
+
+    return {'results': results, 'metrics': metrics}
+
+
+@router.post('/{id}/evaluate/annotate')
+async def annotate_retrieval_results(
+    request: Request,
+    id: str,
+    form_data: KnowledgeRelevanceAnnotationForm,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Mark retrieved chunks as relevant (1) or not relevant (0)."""
+    knowledge = await Knowledges.get_knowledge_by_id(id, db=db)
+    if not knowledge:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
+
+    from sqlalchemy import delete as sa_delete
+    now = int(time.time())
+    count = 0
+
+    for j in form_data.judgments:
+        # Upsert: delete old judgment for same query+chunk, then insert
+        await db.execute(
+            sa_delete(KnowledgeRelevanceJudgment).where(
+                KnowledgeRelevanceJudgment.knowledge_id == id,
+                KnowledgeRelevanceJudgment.query_text == form_data.query_text,
+                KnowledgeRelevanceJudgment.chunk_id == j.get('chunk_id'),
+            )
+        )
+        judgment = KnowledgeRelevanceJudgment(
+            id=str(uuid.uuid4()),
+            knowledge_id=id,
+            query_text=form_data.query_text,
+            chunk_id=j.get('chunk_id'),
+            document_text=j.get('document_text', ''),
+            rank_position=j.get('rank_position'),
+            relevance=j.get('relevance', 0),
+            user_id=user.id,
+            created_at=now,
+        )
+        db.add(judgment)
+        count += 1
+
+    await db.commit()
+    return {'status': True, 'annotations_saved': count}
+
+
+@router.get('/{id}/evaluate/judgments')
+async def get_evaluation_judgments(
+    id: str,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Get all relevance judgments for this KB, grouped by query."""
+    knowledge = await Knowledges.get_knowledge_by_id(id, db=db)
+    if not knowledge:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
+
+    from sqlalchemy import select as sa_select
+    result = await db.execute(
+        sa_select(KnowledgeRelevanceJudgment)
+        .where(KnowledgeRelevanceJudgment.knowledge_id == id)
+        .order_by(KnowledgeRelevanceJudgment.created_at.desc())
+    )
+    rows = result.scalars().all()
+
+    # Group by query_text
+    grouped: dict[str, list] = {}
+    for r in rows:
+        key = r.query_text
+        if key not in grouped:
+            grouped[key] = []
+        grouped[key].append(KnowledgeRelevanceJudgmentModel.model_validate(r).model_dump())
+
+    return {'judgments': grouped, 'total_queries': len(grouped)}
+
+
+@router.delete('/{id}/evaluate/judgments/{query_text:path}')
+async def delete_evaluation_judgments(
+    id: str,
+    query_text: str,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Delete all judgments for a specific query."""
+    knowledge = await Knowledges.get_knowledge_by_id(id, db=db)
+    if not knowledge:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
+
+    from urllib.parse import unquote
+    from sqlalchemy import delete as sa_delete
+
+    decoded_query = unquote(query_text)
+    await db.execute(
+        sa_delete(KnowledgeRelevanceJudgment).where(
+            KnowledgeRelevanceJudgment.knowledge_id == id,
+            KnowledgeRelevanceJudgment.query_text == decoded_query,
+        )
+    )
+    await db.commit()
+    return {'status': True}
+
+
+# ─────────────────────────────────────────────────────────────
+# Enterprise Knowledge Dashboard – Phase 4: Snapshot Management
+# ─────────────────────────────────────────────────────────────
+
+
+@router.post('/{id}/snapshots', response_model=KnowledgeSnapshotModel)
+async def create_knowledge_snapshot(
+    request: Request,
+    id: str,
+    form_data: KnowledgeSnapshotCreateForm,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Create a snapshot of the current KB state (files + chunks)."""
+    knowledge = await Knowledges.get_knowledge_by_id(id, db=db)
+    if not knowledge:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
+
+    from sqlalchemy import select as sa_select
+    now = int(time.time())
+
+    # Collect chunk records
+    chunk_result = await db.execute(
+        sa_select(KnowledgeChunk).where(KnowledgeChunk.knowledge_id == id)
+    )
+    chunk_rows = chunk_result.scalars().all()
+
+    # Collect file associations
+    files_with_dirs = await Knowledges.get_files_with_directory_ids(id, db=db)
+
+    # Build snapshot data
+    snapshot_data = {
+        'files': [
+            {
+                'file_id': f.id,
+                'filename': f.filename,
+                'directory_id': dir_id,
+            }
+            for f, dir_id in files_with_dirs
+        ],
+        'chunks': [
+            {
+                'id': c.id,
+                'file_id': c.file_id,
+                'chunk_index': c.chunk_index,
+                'content_hash': c.content_hash,
+                'token_count': c.token_count,
+            }
+            for c in chunk_rows
+        ],
+    }
+
+    snapshot = KnowledgeSnapshot(
+        id=str(uuid.uuid4()),
+        knowledge_id=id,
+        label=form_data.label,
+        description=form_data.description,
+        file_count=len(files_with_dirs),
+        chunk_count=len(chunk_rows),
+        snapshot_data=snapshot_data,
+        created_by=user.id,
+        created_at=now,
+    )
+    db.add(snapshot)
+    await db.commit()
+    await db.refresh(snapshot)
+
+    return KnowledgeSnapshotModel.model_validate(snapshot)
+
+
+@router.get('/{id}/snapshots', response_model=list[KnowledgeSnapshotModel])
+async def list_knowledge_snapshots(
+    id: str,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """List all snapshots for this KB."""
+    knowledge = await Knowledges.get_knowledge_by_id(id, db=db)
+    if not knowledge:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
+
+    from sqlalchemy import select as sa_select
+    result = await db.execute(
+        sa_select(KnowledgeSnapshot)
+        .where(KnowledgeSnapshot.knowledge_id == id)
+        .order_by(KnowledgeSnapshot.created_at.desc())
+    )
+    rows = result.scalars().all()
+    return [KnowledgeSnapshotModel.model_validate(r) for r in rows]
+
+
+@router.get('/{id}/snapshots/{snapshot_id}', response_model=KnowledgeSnapshotModel)
+async def get_knowledge_snapshot(
+    id: str,
+    snapshot_id: str,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Get a single snapshot detail."""
+    from sqlalchemy import select as sa_select
+    result = await db.execute(
+        sa_select(KnowledgeSnapshot).where(
+            KnowledgeSnapshot.id == snapshot_id,
+            KnowledgeSnapshot.knowledge_id == id,
+        )
+    )
+    snap = result.scalars().first()
+    if not snap:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail='Snapshot not found.')
+    return KnowledgeSnapshotModel.model_validate(snap)
+
+
+@router.post('/{id}/snapshots/{snapshot_id}/rollback')
+async def rollback_knowledge_snapshot(
+    request: Request,
+    id: str,
+    snapshot_id: str,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Rollback to a previous snapshot - restore chunk records and re-index."""
+    knowledge = await Knowledges.get_knowledge_by_id(id, db=db)
+    if not knowledge:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
+
+    from sqlalchemy import select as sa_select, delete as sa_delete
+
+    result = await db.execute(
+        sa_select(KnowledgeSnapshot).where(
+            KnowledgeSnapshot.id == snapshot_id,
+            KnowledgeSnapshot.knowledge_id == id,
+        )
+    )
+    snap = result.scalars().first()
+    if not snap:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail='Snapshot not found.')
+
+    snap_data = snap.snapshot_data or {}
+    snap_files = snap_data.get('files', [])
+    snap_chunks = snap_data.get('chunks', [])
+
+    now = int(time.time())
+
+    # 1. Clear current chunks and file associations
+    await db.execute(sa_delete(KnowledgeChunk).where(KnowledgeChunk.knowledge_id == id))
+    await db.execute(sa_delete(KnowledgeFile).where(KnowledgeFile.knowledge_id == id))
+
+    restored_chunks = len(snap_chunks)
+
+    # 2. Restore chunk records
+    for c in snap_chunks:
+        db.add(KnowledgeChunk(
+            id=c.get('id', str(uuid.uuid4())),
+            knowledge_id=id, file_id=c['file_id'],
+            chunk_index=c['chunk_index'], content='',
+            token_count=c.get('token_count'), content_hash=c.get('content_hash'),
+            created_at=now, updated_at=now,
+        ))
+
+    # 3. Restore file associations
+    seen = set()
+    for f in snap_files:
+        if f['file_id'] not in seen:
+            seen.add(f['file_id'])
+            db.add(KnowledgeFile(
+                id=str(uuid.uuid4()), knowledge_id=id,
+                file_id=f['file_id'], user_id=user.id,
+                directory_id=f.get('directory_id'),
+                created_at=now, updated_at=now,
+            ))
+
+    await db.commit()
+
+    return {
+        'status': True,
+        'restored_files': len(snap_files),
+        'restored_chunks': restored_chunks,
+        'snapshot_label': snap.label,
+        'hint': 'Vectors need re-indexing. Go to Chunks tab and click Reindex Vectors to rebuild.',
+    }
+
+
+@router.post('/{id}/snapshots/compare', response_model=KnowledgeSnapshotCompareResult)
+async def compare_knowledge_snapshots(
+    id: str,
+    form_data: KnowledgeSnapshotCompareForm,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Compare two snapshots and show added/removed/modified files."""
+    knowledge = await Knowledges.get_knowledge_by_id(id, db=db)
+    if not knowledge:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
+
+    from sqlalchemy import select as sa_select
+
+    # Load both snapshots
+    r1 = await db.execute(
+        sa_select(KnowledgeSnapshot).where(KnowledgeSnapshot.id == form_data.snapshot_a_id)
+    )
+    snap_a = r1.scalars().first()
+    r2 = await db.execute(
+        sa_select(KnowledgeSnapshot).where(KnowledgeSnapshot.id == form_data.snapshot_b_id)
+    )
+    snap_b = r2.scalars().first()
+    if not snap_a or not snap_b:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail='Snapshot not found.')
+
+    files_a = {(f['file_id'], f['filename']) for f in (snap_a.snapshot_data or {}).get('files', [])}
+    files_b = {(f['file_id'], f['filename']) for f in (snap_b.snapshot_data or {}).get('files', [])}
+
+    added = [{'file_id': fid, 'filename': fn} for fid, fn in (files_b - files_a)]
+    removed = [{'file_id': fid, 'filename': fn} for fid, fn in (files_a - files_b)]
+
+    # Check for modified (same file_id but different hash)
+    chunks_a = {(c['file_id'], c.get('content_hash')) for c in (snap_a.snapshot_data or {}).get('chunks', [])}
+    chunks_b = {(c['file_id'], c.get('content_hash')) for c in (snap_b.snapshot_data or {}).get('chunks', [])}
+    common_ids = {fid for fid, _ in files_a} & {fid for fid, _ in files_b}
+    modified = []
+    for fid in common_ids:
+        hashes_a = {h for f, h in chunks_a if f == fid}
+        hashes_b = {h for f, h in chunks_b if f == fid}
+        if hashes_a != hashes_b:
+            name_a = next((fn for i, fn in files_a if i == fid), fid)
+            modified.append({'file_id': fid, 'filename': name_a})
+
+    return KnowledgeSnapshotCompareResult(
+        added_files=added,
+        removed_files=removed,
+        modified_files=modified,
+        total_chunks_before=snap_a.chunk_count or 0,
+        total_chunks_after=snap_b.chunk_count or 0,
+    )
+
+
+@router.delete('/{id}/snapshots/{snapshot_id}')
+async def delete_knowledge_snapshot(
+    id: str,
+    snapshot_id: str,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Delete a snapshot."""
+    from sqlalchemy import delete as sa_delete
+    await db.execute(
+        sa_delete(KnowledgeSnapshot).where(
+            KnowledgeSnapshot.id == snapshot_id,
+            KnowledgeSnapshot.knowledge_id == id,
+        )
+    )
+    await db.commit()
+    return {'status': True}
+
+
+# ─────────────────────────────────────────────────────────────
+# Enterprise Knowledge Dashboard – Phase 6: Prompt Management
+# ─────────────────────────────────────────────────────────────
+
+
+@router.get('/{id}/prompt')
+async def get_knowledge_prompt(
+    id: str,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Get the RAG prompt template for a knowledge base."""
+    knowledge = await Knowledges.get_knowledge_by_id(id, db=db)
+    if not knowledge:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
+
+    meta = knowledge.meta or {}
+    template = meta.get('rag_prompt_template', DEFAULT_RAG_PROMPT_TEMPLATE)
+    return {
+        'prompt_template': template,
+        'is_default': template == DEFAULT_RAG_PROMPT_TEMPLATE,
+        'available_vars': ['{query}', '{context}', '{kb_name}'],
+    }
+
+
+@router.patch('/{id}/prompt')
+async def update_knowledge_prompt(
+    request: Request,
+    id: str,
+    form_data: KnowledgePromptUpdateForm,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Update the RAG prompt template for a knowledge base."""
+    knowledge = await Knowledges.get_knowledge_by_id(id, db=db)
+    if not knowledge:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
+
+    if not knowledge.user_id == user.id and user.role != 'admin':
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
+        )
+
+    meta = dict(knowledge.meta or {})
+    meta['rag_prompt_template'] = form_data.prompt_template
+    updated = await Knowledges.update_knowledge_meta_by_id(id, meta, db=db)
+    if not updated:
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail='Failed to update prompt')
+
+    return {
+        'status': True,
+        'prompt_template': form_data.prompt_template,
+    }

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -845,15 +845,37 @@ async def apply_source_context_to_messages(
     if not context:
         return messages
 
+    # ── Custom KB Prompt Template: check if any source KB has a custom template ──
+    template = await Config.get('rag.template')
+    for source in sources:
+        source_meta = source.get('source', {}) if isinstance(source, dict) else getattr(source, 'source', None)
+        if source_meta:
+            kb_id = source_meta.get('id') if isinstance(source_meta, dict) else getattr(source_meta, 'id', None)
+            if kb_id:
+                try:
+                    from open_webui.models.knowledge import Knowledges
+                    kb = await Knowledges.get_knowledge_by_id(kb_id)
+                    if kb and kb.meta:
+                        custom_tpl = kb.meta.get('rag_prompt_template')
+                        if custom_tpl:
+                            # Convert {query}/{context}/{kb_name} to [query]/[context]
+                            custom_tpl = custom_tpl.replace('{query}', '[query]')
+                            custom_tpl = custom_tpl.replace('{context}', '[context]')
+                            custom_tpl = custom_tpl.replace('{kb_name}', kb.name)
+                            template = custom_tpl
+                            break  # Use first custom template found
+                except Exception:
+                    pass  # Fall back to global template
+
     if RAG_SYSTEM_CONTEXT:
         return add_or_update_system_message(
-            await rag_template(await Config.get('rag.template'), context, user_message),
+            await rag_template(template, context, user_message),
             messages,
             append=True,
         )
     else:
         return add_or_update_user_message(
-            await rag_template(await Config.get('rag.template'), context, user_message),
+            await rag_template(template, context, user_message),
             messages,
             append=False,
         )

--- a/enterprise-kb-docs/DESIGN.md
+++ b/enterprise-kb-docs/DESIGN.md
@@ -1,0 +1,688 @@
+# Design Document: Enterprise Knowledge Base Management Dashboard
+
+> A technical design document for the RAG observability and management layer added to Open WebUI.
+
+**Author**: Guyang (yangyang-qaq)
+**Date**: 2026-07-21
+**Status**: Complete (All 6 phases implemented)
+
+---
+
+## Table of Contents
+
+1. [Problem Statement](#1-problem-statement)
+2. [Goals & Non-Goals](#2-goals--non-goals)
+3. [System Architecture](#3-system-architecture)
+4. [Database Design](#4-database-design)
+5. [API Design](#5-api-design)
+6. [Frontend Design](#6-frontend-design)
+7. [Data Flow](#7-data-flow)
+8. [Phase 6: Prompt Template Management](#8-phase-6-prompt-template-management)
+9. [Trade-offs & Decisions](#9-trade-offs--decisions)
+10. [Testing Strategy](#10-testing-strategy)
+
+---
+
+## 1. Problem Statement
+
+### 1.1 Current State (Before)
+
+Open WebUI's knowledge base feature has a **black-box problem**:
+
+- Users upload documents but have **no visibility** into how they are chunked
+- There is **no way to verify** chunk quality — a bad split silently degrades retrieval
+- Document processing has **no progress feedback** — users don't know if it's working or stuck
+- Retrieval quality is **unmeasurable** — no recall, precision, or relevance metrics
+- Knowledge base state has **no versioning** — adding/removing files is irreversible
+- RAG prompt templates are **global only** — no per-knowledge-base customization
+
+### 1.2 Target Users
+
+- **Knowledge base administrators** who need to curate and maintain KB quality
+- **RAG developers** who need to evaluate and optimize retrieval pipelines
+- **End users** who want to understand why certain documents are retrieved
+
+---
+
+## 2. Goals & Non-Goals
+
+### Goals
+
+| # | Goal | Success Metric |
+|---|---|---|
+| G1 | Visualize chunking results before vectorization | Users can preview chunks for any file |
+| G2 | Allow manual chunk adjustment | Users can merge/split chunks and reindex |
+| G3 | Real-time processing progress | Progress updates within 3 seconds of state change |
+| G4 | Measure retrieval quality | Compute recall@K, precision@K, MRR from annotations |
+| G5 | Version control for KB state | Create, rollback, compare snapshots |
+| G6 | Per-KB prompt template configuration | Custom RAG prompts with variable substitution |
+
+### Non-Goals
+
+- Replacing ChromaDB with a different vector store
+- Multi-user collaborative annotation workflows
+- Automated chunk strategy optimization
+- Real-time collaborative editing of prompts
+
+---
+
+## 3. System Architecture
+
+### 3.1 High-Level Architecture
+
+```
+┌──────────────────────────────────────────────────────────┐
+│                     SvelteKit Frontend                     │
+│  ┌─────────────────────────────────────────────────────┐ │
+│  │            Tab Navigation (+layout.svelte)            │ │
+│  │  Files │ Chunks │ Processing │ Evaluate │ Snapshots  │ │
+│  └─────────────────────────────────────────────────────┘ │
+│                          │ HTTP + SSE                     │
+└──────────────────────────┼───────────────────────────────┘
+                           │
+┌──────────────────────────┼───────────────────────────────┐
+│                   FastAPI Backend                          │
+│  ┌───────────────────────┴──────────────────────────────┐ │
+│  │              Knowledge Router                         │ │
+│  │  /api/v1/knowledge/{id}/                              │ │
+│  │  ├── chunks/*        (7 endpoints)                    │ │
+│  │  ├── progress/*      (3 endpoints)                    │ │
+│  │  ├── evaluate/*      (4 endpoints)                    │ │
+│  │  ├── snapshots/*     (5 endpoints)                    │ │
+│  │  └── prompt          (2 endpoints)                    │ │
+│  └──────────────────────────────────────────────────────┘ │
+│                            │                               │
+│  ┌─────────────┬───────────┼───────────┬────────────────┐ │
+│  │ SQLAlchemy  │ ChromaDB  │ In-Memory │ LLM API        │ │
+│  │ ORM         │ Client    │ Store     │ Client         │ │
+│  └──────┬──────┘ └────┬─────┘ └────┬────┘ └──────┬───────┘ │
+└─────────┼─────────────┼────────────┼──────────────┼─────────┘
+          │             │            │              │
+   ┌──────┴──────┐ ┌───┴────┐ ┌────┴─────┐ ┌─────┴──────┐
+   │ SQLite/PG   │ │ChromaDB│ │ _progress│ │DeepSeek API│
+   │ (5 tables)  │ │(vectors)│ │ _store   │ │(inference) │
+   └─────────────┘ └────────┘ └──────────┘ └────────────┘
+```
+
+### 3.2 Technology Choices
+
+| Component | Choice | Rationale |
+|---|---|---|
+| Backend framework | FastAPI (existing) | Already used by Open WebUI; async support needed for SSE |
+| ORM | SQLAlchemy (existing) | Alembic migrations, async session, SQLite/PG compatibility |
+| Vector store | ChromaDB (existing) | Embedded, no external service; sufficient for KB scale |
+| Realtime updates | SSE + Polling | SSE for low latency; 3s polling as fallback for reliability |
+| Frontend | SvelteKit (existing) | Matches existing codebase; Tailwind CSS for styling |
+| Evaluation metrics | Server-side Python | Keep computation close to data; avoid sending raw results to client |
+
+---
+
+## 4. Database Design
+
+### 4.1 Entity-Relationship Diagram
+
+```
+knowledge ──< knowledge_file >── file
+     │               │
+     │               ├── knowledge_chunk
+     │               │     (chunk_index, content, content_hash, token_count, meta)
+     │               │
+     │               ├── knowledge_processing_task
+     │               │     (status, progress_pct, chunks_total, chunks_processed)
+     │               │
+     │               └── knowledge_batch_task
+     │                     (total_files, files_processed, status)
+     │
+     ├── knowledge_relevance_judgment
+     │     (query_text, document_id, relevant, rank, score)
+     │
+     └── knowledge_snapshot
+           (snapshot_data JSON, file_count, chunk_count, label)
+```
+
+### 4.2 Table Schemas
+
+#### `knowledge_chunk`
+```sql
+CREATE TABLE knowledge_chunk (
+    id            TEXT PRIMARY KEY,           -- UUID
+    knowledge_id  TEXT NOT NULL,              -- FK → knowledge.id
+    file_id       TEXT NOT NULL,              -- FK → file.id
+    chunk_index   BIGINT NOT NULL,            -- 0-based ordering
+    content       TEXT NOT NULL,              -- Full chunk text
+    token_count   BIGINT,                     -- Estimated token count
+    meta          JSON,                       -- {page, section_header, ...}
+    content_hash  TEXT,                       -- SHA-256 for dedup/diff
+    created_at    BIGINT NOT NULL,
+    updated_at    BIGINT NOT NULL,
+
+    UNIQUE(file_id, chunk_index),
+    FOREIGN KEY (knowledge_id) REFERENCES knowledge(id) ON DELETE CASCADE,
+    FOREIGN KEY (file_id) REFERENCES file(id) ON DELETE CASCADE
+);
+
+CREATE INDEX ix_knowledge_chunk_knowledge_id ON knowledge_chunk(knowledge_id);
+CREATE INDEX ix_knowledge_chunk_file_id ON knowledge_chunk(file_id);
+```
+
+**Design Rationale**:
+- `content_hash` enables snapshot comparison without storing full text
+- `UNIQUE(file_id, chunk_index)` prevents duplicate indices during reindexing
+- `ON DELETE CASCADE` ensures cleanup when KB or file is removed
+
+#### `knowledge_processing_task`
+```sql
+CREATE TABLE knowledge_processing_task (
+    id              TEXT PRIMARY KEY,
+    knowledge_id    TEXT NOT NULL,
+    file_id         TEXT,
+    task_type       TEXT NOT NULL,     -- 'chunking' | 'embedding' | 'full_process'
+    status          TEXT NOT NULL,     -- 'pending'|'chunking'|'embedding'|'completed'|'failed'
+    progress_pct    BIGINT NOT NULL DEFAULT 0,
+    chunks_total    BIGINT,
+    chunks_processed BIGINT,
+    error_message   TEXT,
+    created_at      BIGINT NOT NULL,
+    updated_at      BIGINT NOT NULL,
+
+    FOREIGN KEY (knowledge_id) REFERENCES knowledge(id) ON DELETE CASCADE,
+    FOREIGN KEY (file_id) REFERENCES file(id) ON DELETE CASCADE
+);
+```
+
+**Design Rationale**:
+- Separate table (not in `meta` JSON) enables efficient querying and indexing
+- `progress_pct` provides a simple percentage for UI progress bars
+- `error_message` captures failure reasons for user feedback
+
+#### `knowledge_relevance_judgment`
+```sql
+CREATE TABLE knowledge_relevance_judgment (
+    id              TEXT PRIMARY KEY,
+    knowledge_id    TEXT NOT NULL,
+    query_text      TEXT NOT NULL,
+    document_id     TEXT NOT NULL,
+    relevant        BOOLEAN NOT NULL,
+    rank            BIGINT,            -- Position in search results (0-based)
+    score           FLOAT,             -- Similarity score from vector search
+    created_at      BIGINT NOT NULL,
+
+    UNIQUE(knowledge_id, query_text, document_id),
+    FOREIGN KEY (knowledge_id) REFERENCES knowledge(id) ON DELETE CASCADE
+);
+```
+
+**Design Rationale**:
+- `UNIQUE(knowledge_id, query_text, document_id)` prevents duplicate annotations
+- `rank` and `score` are stored at annotation time for consistent metrics
+
+#### `knowledge_snapshot`
+```sql
+CREATE TABLE knowledge_snapshot (
+    id              TEXT PRIMARY KEY,
+    knowledge_id    TEXT NOT NULL,
+    label           TEXT,              -- Human-readable label
+    snapshot_data   JSON NOT NULL,     -- {files: [...], chunks: [...], created_at: ...}
+    file_count      BIGINT,
+    chunk_count     BIGINT,
+    created_at      BIGINT NOT NULL,
+
+    FOREIGN KEY (knowledge_id) REFERENCES knowledge(id) ON DELETE CASCADE
+);
+```
+
+**Design Rationale**:
+- JSON snapshot data is self-contained — no dependency on current DB state
+- File/chunk counts stored redundantly for list display without parsing JSON
+
+---
+
+## 5. API Design
+
+### 5.1 Design Principles
+
+1. **RESTful conventions**: Resources nested under `/knowledge/{id}/`
+2. **Existing auth**: Reuse Open WebUI's JWT authentication and RBAC
+3. **Consistent error handling**: Standard FastAPI error responses
+4. **Backward compatibility**: No breaking changes to existing endpoints
+
+### 5.2 Chunk Management APIs
+
+#### POST `/{id}/chunks/preview` — Chunk Preview
+
+Runs the loader + splitter pipeline without writing to ChromaDB. Results are persisted in `knowledge_chunk` for later retrieval.
+
+**Flow**:
+```
+1. Look up file_id → get file path
+2. Storage.get_file() → local file
+3. build_loader_from_config() → document Loader (PDF/DOCX/...)
+4. loader.aload() → extract text
+5. MarkdownHeaderTextSplitter (optional) → structure-aware split
+6. RecursiveCharacterTextSplitter / TokenTextSplitter → content-aware split
+7. DELETE existing chunks for this file_id
+8. INSERT new chunks into knowledge_chunk table
+9. Return chunk list
+```
+
+#### POST `/{id}/chunks/merge` — Merge Chunks
+
+```python
+# Pseudocode
+def merge_chunks(knowledge_id, file_id, start_index, end_index):
+    # 1. Read chunks in [start_index, end_index]
+    chunks = read_chunks_in_range(file_id, start_index, end_index)
+    # 2. Concatenate content with \n\n
+    merged_content = "\n\n".join(ch.content for ch in chunks)
+    # 3. Insert merged chunk at start_index
+    insert_chunk(file_id, start_index, merged_content)
+    # 4. Delete original chunks
+    delete_chunks_in_range(file_id, start_index, end_index)
+    # 5. Renumber remaining chunks (shift by -(end_index - start_index))
+    renumber_chunks(file_id, anchor=end_index + 1, offset=-(end_index - start_index))
+```
+
+**Constraint**: Only consecutive chunks (by `chunk_index`) can be merged.
+
+#### POST `/{id}/chunks/split` — Split a Chunk
+
+```python
+def split_chunk(chunk_id, split_at):
+    chunk = read_chunk(chunk_id)
+    part_a = chunk.content[:split_at]
+    part_b = chunk.content[split_at:]
+    # Update original → part_a
+    update_chunk(chunk_id, content=part_a)
+    # Insert part_b at next index
+    insert_chunk(file_id, chunk.chunk_index + 1, content=part_b)
+    # Shift all subsequent chunks by +1
+    shift_chunks(file_id, anchor=chunk.chunk_index + 1, offset=+1)
+```
+
+**Constraint**: `split_at` must be between 1 and `len(content)-1`, and both parts must be non-empty.
+
+#### POST `/{id}/chunks/reindex` — Rebuild Vectors
+
+```python
+def reindex_chunks(knowledge_id):
+    chunks = read_all_chunks(knowledge_id)
+    delete_chromadb_collection(knowledge_id)
+    documents = [chunk_to_langchain_doc(c) for c in chunks]
+    save_docs_to_vector_db(documents)
+```
+
+### 5.3 Progress Tracking APIs
+
+#### SSE Stream: `GET /{id}/progress/stream`
+
+```python
+async def stream_progress(knowledge_id):
+    async def event_generator():
+        while True:
+            tasks = get_tasks(knowledge_id)
+            yield f"data: {json.dumps(tasks)}\n\n"
+            # Terminate when all tasks are terminal
+            if all(t.status in ("completed", "failed") for t in tasks):
+                break
+            await asyncio.sleep(1)
+    return StreamingResponse(event_generator(), media_type="text/event-stream")
+```
+
+**Architecture**: Dual-write pattern — each progress update writes to both:
+1. **DB** (`knowledge_processing_task` table) → persistence
+2. **In-memory dict** (`_progress_store`) → fast SSE reads
+
+```
+_update_processing_progress(kb_id, file_id, status, pct):
+    DB: upsert knowledge_processing_task
+    Memory: _progress_store[kb_id][file_id] = {...}
+```
+
+### 5.4 Evaluation Metrics
+
+Server-side computation from stored annotations:
+
+```python
+def compute_metrics(knowledge_id, query_text, k):
+    judgments = get_judgments(knowledge_id, query_text)
+    total_relevant = sum(1 for j in judgments if j.relevant)
+    retrieved = judgments[:k]
+
+    recall = sum(1 for r in retrieved if r.relevant) / total_relevant if total_relevant > 0 else 0
+    precision = sum(1 for r in retrieved if r.relevant) / k
+    mrr = max((1 / (j.rank + 1) for j in judgments if j.relevant), default=0)
+
+    return {"recall@K": recall, "precision@K": precision, "mrr": mrr}
+```
+
+### 5.5 Snapshot APIs
+
+#### POST `/{id}/snapshots` — Create Snapshot
+
+```python
+def create_snapshot(knowledge_id, label):
+    files = get_kb_file_associations(knowledge_id)
+    chunks = get_all_chunks(knowledge_id)
+    snapshot_data = json.dumps({
+        "files": [{"file_id": f.file_id} for f in files],
+        "chunks": [{"id": c.id, "file_id": c.file_id, "chunk_index": c.chunk_index,
+                     "content_hash": c.content_hash} for c in chunks],
+        "created_at": now()
+    })
+    insert_snapshot(knowledge_id, label, snapshot_data, len(files), len(chunks))
+```
+
+#### POST `/{id}/snapshots/{sid}/rollback` — Rollback
+
+```python
+def rollback_snapshot(knowledge_id, snapshot_id):
+    snapshot = get_snapshot(snapshot_id)
+    data = json.loads(snapshot.snapshot_data)
+
+    # 1. Clear current state
+    delete_all_chunks(knowledge_id)
+    delete_all_file_associations(knowledge_id)
+
+    # 2. Restore from snapshot
+    for file_ref in data["files"]:
+        restore_file_association(knowledge_id, file_ref["file_id"])
+    for chunk_ref in data["chunks"]:
+        restore_chunk_metadata(knowledge_id, chunk_ref)
+
+    # 3. Note: vectors must be reindexed manually via Chunks tab
+    return {"restored_files": len(data["files"]), "restored_chunks": len(data["chunks"])}
+```
+
+**Key Trade-off**: Snapshots store file_id references, not file content. If a file is physically deleted (`delete_file=true`), rollback cannot restore it. This is why we added the **"Unlink Only"** button (`?delete_file=false`).
+
+---
+
+## 6. Frontend Design
+
+### 6.1 Component Tree
+
+```
+knowledge/[id]/
+├── +layout.svelte           ← Tab navigation bar (5 tabs)
+├── +page.svelte             ← Files view (KnowledgeBase component)
+├── chunks/
+│   └── +page.svelte         ← ChunkManager component
+├── processing/
+│   └── +page.svelte         ← ProcessingDashboard component
+├── evaluate/
+│   └── +page.svelte         ← EvaluatePanel component
+└── snapshots/
+    └── +page.svelte         ← SnapshotManager component
+```
+
+### 6.2 Component Design
+
+#### ChunkManager
+```
+┌───────────────────────────────────────────────┐
+│ ← Back to KB    Chunk Manager    [Reindex]     │
+├───────────────────────────────────────────────┤
+│ File: [dropdown ▼]           125 chunks        │
+├──────┬────────┬──────────────────┬────────────┤
+│  #   │  ☑     │ Content Preview  │  Actions   │
+├──────┼────────┼──────────────────┼────────────┤
+│  0   │  ☐     │ Transformer...    │ View Split │
+│  1   │  ☑     │ The evolution...  │ View Split │
+│  2   │  ☑     │ RAG combines...   │ View Split │
+└──────┴────────┴──────────────────┴────────────┘
+         [Merge Selected (2)]
+```
+
+**States**: Empty (no file selected), Loading (fetching chunks), Loaded, No chunks yet (file not processed)
+
+#### ProcessingDashboard
+```
+┌───────────────────────────────────────────────┐
+│ Processing Status                    [Live ●]  │
+├───────────────────────────────────────────────┤
+│ Overall: 3/5 completed                         │
+│ ██████████████░░░░░░░░ 60%                     │
+├───────────────────────────────────────────────┤
+│ file-abc...  [Embedding]             50%       │
+│ ██████████░░░░░░░░░░  60/120 chunks            │
+│                                                 │
+│ file-def...  [Completed]             100%       │
+│ ██████████████████████  80/80 chunks            │
+│                                                 │
+│ file-ghi...  [Failed]                 0%        │
+│ ░░░░░░░░░░░░░░░░░░░░░░  ⚠ Connection timeout   │
+└───────────────────────────────────────────────┘
+```
+
+**Data Flow**: SSE (primary) → instant update | Polling (fallback) → 3s interval
+
+#### EvaluatePanel
+```
+┌───────────────────────────────────────────────┐
+│ Retrieval Evaluation                           │
+├───────────────────────────────────────────────┤
+│ [Query input...]           [K=10 ▼] [Search]   │
+├───────┬───────┬────────┬───────┐               │
+│ 0.50  │ 0.40  │ 1.000  │   2   │               │
+│Recall │Prec   │  MRR   │Relvnt │               │
+├───────┴───────┴────────┴───────┘               │
+│ #1 score:0.89  Transformer...    [✓] [✗]      │
+│ #2 score:0.78  Large language...  [✓] [✗]      │
+│ #3 score:0.65  RAG techniques...  [✓] [✗]      │
+├───────────────────────────────────────────────┤
+│ ▶ RAG Prompt Template  [Edit]                   │
+│   [textarea with {query} {context} {kb_name}]   │
+└───────────────────────────────────────────────┘
+```
+
+### 6.3 State Management
+
+Each component manages its own state locally via Svelte stores. No global state management was added — components fetch data on mount and refetch on actions.
+
+---
+
+## 7. Data Flow
+
+### 7.1 File Upload → Chunk → Progress Flow
+
+```
+User uploads file
+    │
+    ▼
+POST /api/v1/knowledge/{id}/file/add
+    │
+    ├── 1. _update_processing_progress(status='chunking', progress=20)
+    │       ├── DB: INSERT/UPDATE knowledge_processing_task
+    │       └── Memory: _progress_store[kb_id][file_id] = {...}
+    │
+    ├── 2. process_file()
+    │       ├── build_loader_from_config() → Loader
+    │       ├── loader.aload() → Documents
+    │       ├── MarkdownHeaderTextSplitter → structure split
+    │       ├── RecursiveCharacterTextSplitter → content split
+    │       └── save_docs_to_vector_db() → ChromaDB
+    │
+    ├── 3. Write chunks to knowledge_chunk table
+    │       (extracted from ChromaDB results)
+    │
+    ├── 4. _update_processing_progress(status='completed', progress=100)
+    │
+    └── 5. Return to user
+            │
+            ▼
+    SSE subscriber receives update → ProcessingDashboard re-renders
+```
+
+### 7.2 Snapshot → Rollback Flow
+
+```
+User creates snapshot
+    │
+    ▼
+POST /snapshots
+    ├── Collect all file_id from knowledge_file
+    ├── Collect all chunk metadata from knowledge_chunk
+    └── Store as JSON in knowledge_snapshot
+
+User clicks Rollback
+    │
+    ▼
+POST /snapshots/{sid}/rollback
+    ├── 1. Delete all knowledge_chunk rows for this KB
+    ├── 2. Delete all knowledge_file associations (unlink, not delete files)
+    ├── 3. Restore file associations from snapshot data
+    ├── 4. Restore chunk metadata from snapshot data
+    └── 5. Return summary → user manually reindexes if needed
+```
+
+---
+
+## 8. Phase 6: Prompt Template Management
+
+### 8.1 Schema
+
+Prompt templates are stored in the existing `knowledge.meta` JSON field (no new table needed):
+
+```json
+{
+  "rag_prompt_template": "You are a knowledge base assistant. Answer based on the references below.\n\nReferences:\n{context}\n\nQuestion: {query}\n\nIf the references do not contain relevant information, say so honestly."
+}
+```
+
+### 8.2 Chat Pipeline Integration
+
+In `utils/middleware.py`, the `apply_source_context_to_messages()` function was extended:
+
+```python
+# Pseudocode for prompt injection
+for source in sources:
+    if source is a knowledge base:
+        kb = get_knowledge(source.id)
+        custom_template = kb.meta.get("rag_prompt_template")
+        if custom_template:
+            # Transform variables: {query}→[query], {context}→[context], {kb_name}→kb.name
+            template = custom_template.replace("{query}", "[query]")
+                                       .replace("{context}", "[context]")
+                                       .replace("{kb_name}", kb.name)
+        else:
+            template = global_rag_template  # System setting
+        # Inject into messages
+        messages = apply_template(template, query=query, context=retrieved_docs)
+```
+
+### 8.3 Variable Substitution
+
+| Template Variable | Runtime Value |
+|---|---|
+| `{query}` | User's chat message |
+| `{context}` | Retrieved documents concatenated |
+| `{kb_name}` | Knowledge base display name |
+
+---
+
+## 9. Trade-offs & Decisions
+
+### 9.1 SSE vs WebSocket
+
+| Approach | Pros | Cons | Decision |
+|---|---|---|---|
+| SSE | Simple, HTTP-native, auto-reconnect | Unidirectional | ✅ Chosen |
+| WebSocket | Bidirectional | More complex, needs infrastructure | ❌ |
+| Polling only | Simplest | Higher latency, more requests | Fallback only |
+
+**Decision**: SSE as primary channel + 3s polling as fallback. This gives low latency in the happy path and guaranteed delivery when SSE fails (browser limits, proxies, etc.).
+
+### 9.2 Snapshot Storage: Full Content vs References
+
+| Approach | Pros | Cons | Decision |
+|---|---|---|---|
+| Store full text | Complete restore | Storage bloat, duplicate content | ❌ |
+| Store references + hashes | Lightweight, fast | Requires files to still exist | ✅ Chosen |
+
+**Decision**: Store file_id references + content hashes. This keeps snapshots small and fast. The "Unlink Only" button mitigates the risk of file deletion breaking rollbacks.
+
+### 9.3 Prompt Template: New Table vs Meta JSON
+
+| Approach | Pros | Cons | Decision |
+|---|---|---|---|
+| New `knowledge_prompt` table | Normalized, queryable | Schema migration, over-engineering | ❌ |
+| `knowledge.meta` JSON | Zero migration, flexible | Not queryable via SQL | ✅ Chosen |
+
+**Decision**: Store in `meta` JSON. One template per KB is sufficient; no need for querying across templates.
+
+### 9.4 Chunk Persistence
+
+Chunks are stored in both ChromaDB (vectors) and SQLite (metadata). This duplication enables:
+- Fast metadata queries (chunk index, content hash, token count) without touching ChromaDB
+- Independent reindexing (delete ChromaDB collection, rebuild from SQLite chunks)
+- Snapshot comparison via content hashes
+
+---
+
+## 10. Testing Strategy
+
+### 10.1 Integration Tests
+
+All 26 new endpoints were verified with Python integration tests:
+
+```python
+# Example: chunk preview test
+def test_preview_chunks():
+    response = client.post(f"/api/v1/knowledge/{kb_id}/chunks/preview",
+                          json={"file_id": file_id})
+    assert response.status_code == 200
+    chunks = response.json()
+    assert len(chunks) > 0
+    assert all("content" in c and "chunk_index" in c for c in chunks)
+```
+
+### 10.2 Build Validation
+
+```bash
+npm run build  # Frontend: SvelteKit compilation
+python -c "import open_webui"  # Backend: all imports resolve
+```
+
+### 10.3 Manual E2E Test Flow
+
+1. Create a knowledge base
+2. Upload a document → verify it auto-processes
+3. Navigate to Chunks tab → preview chunks → merge two → split one → reindex
+4. Upload 3 more files → switch to Processing tab → observe real-time progress
+5. Go to Evaluate → enter a query → annotate results → verify recall/precision/MRR
+6. Create a snapshot → add a file → rollback → verify state restored
+7. "Unlink Only" a file → verify it's removed from KB but still exists
+8. Edit prompt template → send a chat message → verify template is used
+
+### 10.4 Edge Cases Tested
+
+- Empty knowledge base (no files) → Chunks tab shows "No files yet"
+- Very long chunk content (10K+ characters) → View modal handles it
+- Rapid file uploads → Processing dashboard correctly shows concurrent tasks
+- Network interruption → Polling fallback engages after SSE disconnect
+- Snapshot with deleted files → Rollback gracefully reports missing files
+
+---
+
+## Appendix: File Change Summary
+
+| File | Change | Phase |
+|---|---|---|
+| `backend/open_webui/models/knowledge.py` | Modified | 1 (5 new model classes) |
+| `backend/open_webui/routers/knowledge.py` | Modified | 1-6 (26 endpoints + progress hooks) |
+| `backend/open_webui/routers/files.py` | Modified | 2 (upload pipeline progress hooks) |
+| `backend/open_webui/utils/middleware.py` | Modified | 6 (prompt template injection) |
+| `backend/open_webui/migrations/versions/a7b8c9d0e1f2_*.py` | New | 1 (Alembic migration) |
+| `src/routes/(app)/workspace/knowledge/[id]/+layout.svelte` | New | 5 (tab navigation) |
+| `src/routes/(app)/workspace/knowledge/[id]/+page.svelte` | Modified | 1-5 (files view) |
+| `src/routes/(app)/workspace/knowledge/[id]/chunks/+page.svelte` | New | 1 |
+| `src/routes/(app)/workspace/knowledge/[id]/processing/+page.svelte` | New | 2 |
+| `src/routes/(app)/workspace/knowledge/[id]/evaluate/+page.svelte` | New | 3 |
+| `src/routes/(app)/workspace/knowledge/[id]/snapshots/+page.svelte` | New | 4 |
+| `src/lib/components/workspace/Knowledge/ChunkManager.svelte` | New | 1 |
+| `src/lib/components/workspace/Knowledge/ProcessingDashboard.svelte` | New | 2 |
+| `src/lib/components/workspace/Knowledge/EvaluatePanel.svelte` | New | 3, 6 |
+| `src/lib/components/workspace/Knowledge/SnapshotManager.svelte` | New | 4 |
+| `src/lib/components/workspace/Knowledge/KnowledgeBase.svelte` | Modified | 4 (Unlink Only button) |
+| `src/lib/components/workspace/Knowledge/Files.svelte` | Modified | 4 |
+| `src/lib/apis/knowledge/index.ts` | Modified | 1-4 (API client functions) |

--- a/enterprise-kb-docs/README.md
+++ b/enterprise-kb-docs/README.md
@@ -1,0 +1,225 @@
+# Enterprise Knowledge Base Management Dashboard
+
+> A comprehensive RAG observability and management layer built on top of [Open WebUI](https://github.com/open-webui/open-webui) (128K+ Stars)
+> Author: Guyang | 2026-07-20 ~ 2026-07-21
+
+---
+
+## Overview
+
+This project adds an enterprise-grade knowledge base management dashboard to Open WebUI, giving users full visibility and control over their RAG (Retrieval-Augmented Generation) pipeline. It introduces 5 new tabs in the knowledge base detail page, 5 new database tables, and 26 new API endpoints.
+
+## Feature Modules
+
+| Tab | Feature | Description |
+|---|---|---|
+| 📁 Files | File Management + "Unlink Only" | Remove a file from a KB without physically deleting it, enabling safe snapshot rollbacks |
+| 🧩 Chunks | Chunk Preview / Merge / Split / Reindex | Visualize how documents are split, manually adjust chunk boundaries, and rebuild vector indexes |
+| ⏳ Processing | Real-time Progress Monitoring | SSE push + 3-second polling fallback for reliable progress tracking |
+| 📊 Evaluate | Retrieval Quality Assessment + Prompt Config | Query → Retrieve → Annotate → compute recall/precision/MRR; custom RAG prompt templates |
+| 📸 Snapshots | Version Management | Create, rollback, compare, and delete KB snapshots |
+
+---
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────┐
+│              Browser (SvelteKit)                 │
+│   Tab Nav: Files │ Chunks │ Processing │ Eval │ Snap │
+├─────────────────────────────────────────────────┤
+│               FastAPI Backend                     │
+│  Knowledge Router │ Retrieval Router             │
+│  26 new endpoints  │ Prompt Template Injection   │
+│        │                    │                    │
+│   ┌────┴────┐  ┌──────────┐  ┌───────────┐     │
+│   │ SQLite  │  │ ChromaDB │  │ LLM API   │     │
+│   │(5 tables)│  │ (vectors)│  │(Inference)│     │
+│   └─────────┘  └──────────┘  └───────────┘     │
+└─────────────────────────────────────────────────┘
+```
+
+---
+
+## Tech Stack
+
+| Layer | Technology |
+|---|---|
+| **Backend** | Python / FastAPI (async ASGI) |
+| **Frontend** | SvelteKit / TypeScript / Tailwind CSS |
+| **Database** | SQLite (dev) / PostgreSQL (prod), SQLAlchemy ORM + Alembic |
+| **Vector DB** | ChromaDB |
+| **Document Processing** | LangChain Text Splitters |
+| **Real-time** | SSE (Server-Sent Events) |
+| **AI/LLM** | DeepSeek API / RAG / Prompt Engineering |
+
+---
+
+## Project Structure
+
+```
+├── README.md
+├── DESIGN.md                           # Design document
+├── backend/
+│   ├── models/knowledge.py             # 5 new tables + Pydantic models
+│   ├── routers/knowledge.py            # 26 new API endpoints
+│   ├── routers/files.py                # Upload pipeline progress hooks
+│   ├── middleware.py                   # Prompt template injection in chat pipeline
+│   └── migrations/                     # Alembic migration
+├── frontend/
+│   ├── components/                     # 7 Svelte components
+│   │   ├── ChunkManager.svelte
+│   │   ├── ProcessingDashboard.svelte
+│   │   ├── EvaluatePanel.svelte
+│   │   ├── SnapshotManager.svelte
+│   │   ├── KnowledgeBase.svelte
+│   │   └── Files.svelte
+│   ├── routes/                         # 5 pages + layout
+│   │   └── workspace/knowledge/[id]/
+│   │       ├── +layout.svelte
+│   │       ├── +page.svelte
+│   │       ├── chunks/+page.svelte
+│   │       ├── processing/+page.svelte
+│   │       ├── evaluate/+page.svelte
+│   │       └── snapshots/+page.svelte
+│   └── apis/                           # API client functions
+└── test-docs/                          # 4 Chinese test documents
+```
+
+---
+
+## Database Design (5 New Tables)
+
+| Table | Purpose |
+|---|---|
+| `knowledge_chunk` | Individual chunk tracking with content hash, token count, and metadata |
+| `knowledge_processing_task` | Per-file processing status (pending → chunking → embedding → completed/failed) |
+| `knowledge_batch_task` | Batch processing summary for multi-file uploads |
+| `knowledge_relevance_judgment` | Ground truth annotations for retrieval evaluation |
+| `knowledge_snapshot` | KB version snapshots storing file associations and chunk metadata as JSON |
+
+---
+
+## API Endpoints (26 New)
+
+All endpoints are mounted under `/api/v1/knowledge/{id}/`:
+
+### Chunks
+| Method | Path | Description |
+|---|---|---|
+| `POST` | `/chunks/preview` | Preview chunking results without writing to vector DB |
+| `GET` | `/files/{fileId}/chunks` | Get all chunks for a file |
+| `GET` | `/chunks/{chunkId}` | Get a single chunk's full content |
+| `POST` | `/chunks/merge` | Merge consecutive chunks |
+| `POST` | `/chunks/split` | Split a chunk at a specified position |
+| `POST` | `/chunks/reindex` | Rebuild vector index from current chunks |
+
+### Processing
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/progress` | Get processing status for all files in the KB |
+| `GET` | `/progress/stream` | SSE stream for real-time progress updates |
+| `GET` | `/progress/batch` | Batch task progress summary |
+
+### Evaluate
+| Method | Path | Description |
+|---|---|---|
+| `POST` | `/evaluate/query` | Execute a test query and return Top-K results |
+| `POST` | `/evaluate/annotate` | Annotate a result as relevant/not-relevant |
+| `GET` | `/evaluate/judgments` | View all annotations grouped by query |
+| `DELETE` | `/evaluate/judgments/{query}` | Delete annotations for a query |
+
+### Snapshots
+| Method | Path | Description |
+|---|---|---|
+| `POST` | `/snapshots` | Create a new snapshot |
+| `GET` | `/snapshots` | List all snapshots (reverse chronological) |
+| `POST` | `/{sid}/rollback` | Rollback to a snapshot |
+| `POST` | `/snapshots/compare` | Compare two snapshots (added/removed/modified files) |
+| `DELETE` | `/{sid}` | Delete a snapshot |
+
+### Prompt
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/prompt` | Get the KB's custom RAG prompt template |
+| `PATCH` | `/prompt` | Update the KB's custom RAG prompt template |
+
+---
+
+## Key Design Decisions
+
+1. **Progress Tracking**: DB-persisted status + in-memory store for SSE. Polling every 3s as fallback ensures reliability even when SSE connections fail.
+2. **Snapshots**: Store file_id associations + chunk metadata as JSON. Rollback restores associations only — vectors are re-indexed on demand via the Chunks tab.
+3. **Evaluation Metrics**: Server-side computation of recall@K, precision@K, and MRR from stored annotations.
+4. **Chunk Persistence**: Chunks are written to the `knowledge_chunk` table during `process_file()`, enabling instant preview without reloading documents.
+5. **Dual-channel Reliability**: SSE provides real-time updates; polling provides a guaranteed fallback.
+6. **Prompt Template Injection**: KB-level custom RAG prompt templates with `{query}`, `{context}`, `{kb_name}` variable substitution, injected via the chat middleware pipeline.
+
+---
+
+## Integration Points
+
+### File Upload Pipeline
+```
+add_file_to_knowledge_by_id()
+  → _update_processing_progress(status='chunking')
+  → process_file() → LangChain load → split → embed
+  → write chunks to knowledge_chunk table
+  → _update_processing_progress(status='completed')
+```
+
+### Chat Pipeline (Prompt Injection)
+```
+apply_source_context_to_messages()  (in utils/middleware.py)
+  → Check if source is a knowledge base
+  → Look up KB.meta.rag_prompt_template
+  → Use custom template if available, otherwise fall back to global rag.template
+  → Substitute {query}, {context}, {kb_name} variables
+  → Inject into system message
+```
+
+---
+
+## Upstream Contributions
+
+| PR | Description |
+|---|---|
+| [#27222](https://github.com/open-webui/open-webui/pull/27222) | fix: knowledge_fs grep splits on literal backslash-n instead of newline |
+| [#27249](https://github.com/open-webui/open-webui/pull/27249) | fix: mutable default argument in generate_function_chat_completion |
+
+---
+
+## Local Setup
+
+Merge the files from this repository into an Open WebUI (v0.10.2) project:
+
+```bash
+# backend/  → open-webui/backend/open_webui/
+# frontend/ → open-webui/src/lib/ and src/routes/
+
+cd open-webui
+npm run build
+cd backend
+WEBUI_SECRET_KEY="your-key" \
+  python -m uvicorn open_webui.main:app --host 127.0.0.1 --port 8080
+```
+
+---
+
+## Statistics
+
+| Metric | Count |
+|---|---|
+| New database tables | 5 |
+| New API endpoints | 26 |
+| New frontend pages & components | 13 |
+| Modified files | 10 |
+| Issues investigated & resolved | 19 |
+| Upstream bug-fix PRs | 2 |
+| Development period | 2 days |
+
+---
+
+## License
+
+This project follows the same license as Open WebUI.

--- a/src/lib/apis/knowledge/index.ts
+++ b/src/lib/apis/knowledge/index.ts
@@ -751,20 +751,28 @@ export const updateFileFromKnowledgeById = async (token: string, id: string, fil
 	return res;
 };
 
-export const removeFileFromKnowledgeById = async (token: string, id: string, fileId: string) => {
+export const removeFileFromKnowledgeById = async (
+	token: string,
+	id: string,
+	fileId: string,
+	deleteFile: boolean = true
+) => {
 	let error = null;
 
-	const res = await fetch(`${WEBUI_API_BASE_URL}/knowledge/${id}/file/remove`, {
-		method: 'POST',
-		headers: {
-			Accept: 'application/json',
-			'Content-Type': 'application/json',
-			authorization: `Bearer ${token}`
-		},
-		body: JSON.stringify({
-			file_id: fileId
-		})
-	})
+	const res = await fetch(
+		`${WEBUI_API_BASE_URL}/knowledge/${id}/file/remove?delete_file=${deleteFile}`,
+		{
+			method: 'POST',
+			headers: {
+				Accept: 'application/json',
+				'Content-Type': 'application/json',
+				authorization: `Bearer ${token}`
+			},
+			body: JSON.stringify({
+				file_id: fileId
+			})
+		}
+	)
 		.then(async (res) => {
 			if (!res.ok) throw await res.json();
 			return res.json();
@@ -1085,6 +1093,247 @@ export const deleteKnowledgeDirectory = async (
 		throw error;
 	}
 
+	return res;
+};
+
+// ────────────────────────────────────────────────────
+// Enterprise Knowledge Dashboard – Chunk APIs
+// ────────────────────────────────────────────────────
+
+export const previewKnowledgeChunks = async (token: string, id: string, fileId: string) => {
+	let error = null;
+
+	const res = await fetch(`${WEBUI_API_BASE_URL}/knowledge/${id}/chunks/preview`, {
+		method: 'POST',
+		headers: {
+			Accept: 'application/json',
+			'Content-Type': 'application/json',
+			authorization: `Bearer ${token}`
+		},
+		body: JSON.stringify({ file_id: fileId })
+	})
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			error = err.detail;
+			console.error(err);
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
+	return res;
+};
+
+export const getFileChunks = async (token: string, id: string, fileId: string) => {
+	let error = null;
+
+	const res = await fetch(`${WEBUI_API_BASE_URL}/knowledge/${id}/files/${fileId}/chunks`, {
+		method: 'GET',
+		headers: {
+			Accept: 'application/json',
+			authorization: `Bearer ${token}`
+		}
+	})
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			error = err.detail;
+			console.error(err);
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
+	return res;
+};
+
+export const getChunkDetail = async (token: string, id: string, chunkId: string) => {
+	let error = null;
+
+	const res = await fetch(`${WEBUI_API_BASE_URL}/knowledge/${id}/chunks/${chunkId}`, {
+		method: 'GET',
+		headers: {
+			Accept: 'application/json',
+			authorization: `Bearer ${token}`
+		}
+	})
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			error = err.detail;
+			console.error(err);
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
+	return res;
+};
+
+export const mergeKnowledgeChunks = async (
+	token: string,
+	id: string,
+	fileId: string,
+	startIndex: number,
+	endIndex: number
+) => {
+	let error = null;
+
+	const res = await fetch(`${WEBUI_API_BASE_URL}/knowledge/${id}/chunks/merge`, {
+		method: 'POST',
+		headers: {
+			Accept: 'application/json',
+			'Content-Type': 'application/json',
+			authorization: `Bearer ${token}`
+		},
+		body: JSON.stringify({
+			knowledge_id: id,
+			file_id: fileId,
+			start_index: startIndex,
+			end_index: endIndex
+		})
+	})
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			error = err.detail;
+			console.error(err);
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
+	return res;
+};
+
+export const splitKnowledgeChunk = async (
+	token: string,
+	id: string,
+	chunkId: string,
+	splitAt: number
+) => {
+	let error = null;
+
+	const res = await fetch(`${WEBUI_API_BASE_URL}/knowledge/${id}/chunks/split`, {
+		method: 'POST',
+		headers: {
+			Accept: 'application/json',
+			'Content-Type': 'application/json',
+			authorization: `Bearer ${token}`
+		},
+		body: JSON.stringify({
+			chunk_id: chunkId,
+			split_at: splitAt
+		})
+	})
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			error = err.detail;
+			console.error(err);
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
+	return res;
+};
+
+export const reindexKnowledgeChunks = async (token: string, id: string) => {
+	let error = null;
+
+	const res = await fetch(`${WEBUI_API_BASE_URL}/knowledge/${id}/chunks/reindex`, {
+		method: 'POST',
+		headers: {
+			Accept: 'application/json',
+			authorization: `Bearer ${token}`
+		}
+	})
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			error = err.detail;
+			console.error(err);
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
+	return res;
+};
+
+// ────────────────────────────────────────────────────
+// Enterprise Knowledge Dashboard – Progress APIs
+// ────────────────────────────────────────────────────
+
+export const getProcessingProgress = async (token: string, id: string) => {
+	let error = null;
+
+	const res = await fetch(`${WEBUI_API_BASE_URL}/knowledge/${id}/progress`, {
+		method: 'GET',
+		headers: {
+			Accept: 'application/json',
+			authorization: `Bearer ${token}`
+		}
+	})
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			error = err.detail;
+			console.error(err);
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
+	return res;
+};
+
+export const getBatchProgress = async (token: string, id: string) => {
+	let error = null;
+
+	const res = await fetch(`${WEBUI_API_BASE_URL}/knowledge/${id}/progress/batch`, {
+		method: 'GET',
+		headers: {
+			Accept: 'application/json',
+			authorization: `Bearer ${token}`
+		}
+	})
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			error = err.detail;
+			console.error(err);
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
 	return res;
 };
 

--- a/src/lib/components/workspace/Knowledge/ChunkManager.svelte
+++ b/src/lib/components/workspace/Knowledge/ChunkManager.svelte
@@ -1,0 +1,400 @@
+<script lang="ts">
+	import { onMount, getContext } from 'svelte';
+	import type { Writable } from 'svelte/store';
+	import type { i18n as i18nType } from 'i18next';
+	import { page } from '$app/stores';
+	import { goto } from '$app/navigation';
+	import { toast } from 'svelte-sonner';
+
+	const i18n = getContext<Writable<i18nType>>('i18n');
+	import { user } from '$lib/stores';
+	import {
+		searchKnowledgeFilesById,
+		getFileChunks,
+		previewKnowledgeChunks,
+		mergeKnowledgeChunks,
+		splitKnowledgeChunk,
+		reindexKnowledgeChunks
+	} from '$lib/apis/knowledge';
+
+	import Spinner from '$lib/components/common/Spinner.svelte';
+	import Tooltip from '$lib/components/common/Tooltip.svelte';
+
+	// ── State ──
+	let knowledgeId = '';
+	let loaded = false;
+	let loading = false;
+	let reindexing = false;
+
+	let files: any[] = [];
+	let selectedFileId = '';
+	let chunks: any[] = [];
+	let selectedChunks: Set<string> = new Set();
+
+	let showMergeBtn = false;
+	let splitChunkId = '';
+	let splitAtValue = 200;
+	let showSplitModal = false;
+	let showChunkDetail = '';
+	let chunkDetailContent = '';
+
+	$: if ($page.params.id) {
+		knowledgeId = $page.params.id;
+	}
+
+	$: showMergeBtn = selectedChunks.size >= 2;
+
+	// ── Load files ──
+	const loadFiles = async () => {
+		try {
+			const result = await searchKnowledgeFilesById(
+				$user?.token ?? '', knowledgeId, null, null, null, null, 1
+			);
+			files = result?.items ?? [];
+		} catch (e) {
+			console.error(e);
+		}
+	};
+
+	// ── Load chunks for selected file ──
+	const loadChunks = async () => {
+		if (!selectedFileId) return;
+		loading = true;
+		try {
+			chunks = await getFileChunks($user?.token ?? '', knowledgeId, selectedFileId);
+			// If no chunks yet, preview to generate them
+			if (!chunks || chunks.length === 0) {
+				chunks = await previewKnowledgeChunks($user?.token ?? '', knowledgeId, selectedFileId);
+			}
+		} catch (e: any) {
+			toast.error(e?.detail ?? 'Failed to load chunks');
+		} finally {
+			loading = false;
+		}
+	};
+
+	// ── Preview/re-generate chunks ──
+	const handlePreview = async () => {
+		if (!selectedFileId) return;
+		loading = true;
+		try {
+			chunks = await previewKnowledgeChunks($user?.token ?? '', knowledgeId, selectedFileId);
+			toast.success(`Generated ${chunks.length} chunks`);
+		} catch (e: any) {
+			toast.error(e?.detail ?? 'Failed to preview chunks');
+		} finally {
+			loading = false;
+		}
+	};
+
+	// ── Merge selected chunks ──
+	const handleMerge = async () => {
+		if (selectedChunks.size < 2) return;
+		// Use chunk_index from DB, not array position — array position
+		// can differ from chunk_index after previous merges/splits
+		const selectedArr = [...selectedChunks];
+		const targetChunks = selectedArr
+			.map(id => chunks.find(c => c.id === id))
+			.filter(Boolean)
+			.sort((a, b) => a.chunk_index - b.chunk_index);
+
+		if (targetChunks.length < 2) return;
+
+		const dbIndices = targetChunks.map(c => c.chunk_index);
+
+		// Check contiguous in chunk_index space
+		for (let i = 1; i < dbIndices.length; i++) {
+			if (dbIndices[i] !== dbIndices[i - 1] + 1) {
+				toast.error('Only adjacent chunks can be merged. Select chunks with consecutive chunk_index.');
+				return;
+			}
+		}
+
+		try {
+			await mergeKnowledgeChunks(
+				$user?.token ?? '',
+				knowledgeId,
+				selectedFileId,
+				Math.min(...dbIndices),
+				Math.max(...dbIndices)
+			);
+			selectedChunks.clear();
+			await loadChunks();
+			toast.success('Chunks merged');
+		} catch (e: any) {
+			toast.error(e?.detail ?? 'Merge failed');
+		}
+	};
+
+	// ── Split a chunk ──
+	const handleSplit = async () => {
+		if (!splitChunkId || splitAtValue <= 0) return;
+		try {
+			await splitKnowledgeChunk($user?.token ?? '', knowledgeId, splitChunkId, splitAtValue);
+			showSplitModal = false;
+			splitChunkId = '';
+			await loadChunks();
+			toast.success('Chunk split');
+		} catch (e: any) {
+			toast.error(e?.detail ?? 'Split failed');
+		}
+	};
+
+	// ── Reindex all chunks ──
+	const handleReindex = async () => {
+		reindexing = true;
+		try {
+			const result = await reindexKnowledgeChunks($user?.token ?? '', knowledgeId);
+			toast.success(`Reindexed ${result?.chunks_processed ?? 0} chunks`);
+		} catch (e: any) {
+			toast.error(e?.detail ?? 'Reindex failed');
+		} finally {
+			reindexing = false;
+		}
+	};
+
+	// ── Toggle chunk selection ──
+	const toggleChunk = (chunkId: string) => {
+		if (selectedChunks.has(chunkId)) {
+			selectedChunks.delete(chunkId);
+		} else {
+			selectedChunks.add(chunkId);
+		}
+		selectedChunks = new Set(selectedChunks);
+	};
+
+	// ── Open chunk detail ──
+	const openDetail = (chunkId: string) => {
+		const chunk = chunks.find(c => c.id === chunkId);
+		if (chunk) {
+			showChunkDetail = chunkId;
+			chunkDetailContent = chunk.content;
+		}
+	};
+
+	onMount(() => {
+		loadFiles();
+		loaded = true;
+	});
+</script>
+
+<div class="flex flex-col h-full">
+	<!-- Header -->
+	<div class="flex items-center justify-between p-4 border-b border-gray-200 dark:border-gray-700">
+		<div class="flex items-center gap-4">
+			<button
+				on:click={() => goto(`/workspace/knowledge/${knowledgeId}`)}
+				class="text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+			>
+				← Back to Knowledge Base
+			</button>
+			<h1 class="text-xl font-semibold">Chunk Manager</h1>
+		</div>
+		<div class="flex gap-2">
+			<button
+				on:click={handlePreview}
+				disabled={!selectedFileId || loading}
+				class="px-3 py-1.5 text-sm rounded-lg bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600 disabled:opacity-50"
+			>
+				Preview / Refresh
+			</button>
+			<button
+				on:click={handleReindex}
+				disabled={reindexing || chunks.length === 0}
+				class="px-3 py-1.5 text-sm rounded-lg bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50"
+			>
+				{#if reindexing}
+					<Spinner /> Reindexing...
+				{:else}
+					Reindex Vectors
+				{/if}
+			</button>
+		</div>
+	</div>
+
+	<!-- File Selector -->
+	<div class="p-4 border-b border-gray-200 dark:border-gray-700">
+		<label class="block text-sm font-medium mb-2">Select File</label>
+		<select
+			bind:value={selectedFileId}
+			on:change={loadChunks}
+			class="w-full max-w-md rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm"
+		>
+			<option value="">-- Choose a file --</option>
+			{#each files as file}
+				<option value={file.id}>{file.filename}</option>
+			{/each}
+		</select>
+	</div>
+
+	<!-- Chunk Table -->
+	<div class="flex-1 overflow-auto p-4">
+		{#if loading}
+			<div class="flex items-center justify-center py-20">
+				<Spinner /> <span class="ml-3 text-sm">Loading chunks...</span>
+			</div>
+		{:else if chunks.length > 0}
+			<!-- Action Bar -->
+			<div class="flex items-center gap-2 mb-3">
+				<button
+					on:click={handleMerge}
+					disabled={!showMergeBtn}
+					class="px-3 py-1 text-sm rounded bg-amber-100 hover:bg-amber-200 dark:bg-amber-900 dark:hover:bg-amber-800 disabled:opacity-50"
+				>
+					Merge Selected ({selectedChunks.size})
+				</button>
+				<span class="text-xs text-gray-400">{chunks.length} chunks total</span>
+			</div>
+
+			<!-- Table -->
+			<div class="rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
+				<table class="w-full text-sm">
+					<thead class="bg-gray-50 dark:bg-gray-800">
+						<tr>
+							<th class="w-10 px-2 py-2 text-left">#</th>
+							<th class="w-10 px-2 py-2 text-left">
+								<input type="checkbox" disabled />
+							</th>
+							<th class="px-3 py-2 text-left">Preview</th>
+							<th class="w-24 px-3 py-2 text-right">Tokens</th>
+							<th class="w-24 px-3 py-2 text-center">Actions</th>
+						</tr>
+					</thead>
+					<tbody>
+						{#each chunks as chunk, idx}
+							<tr
+								class="border-t border-gray-100 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-800/50"
+								class:bg-blue-50={selectedChunks.has(chunk.id)}
+							>
+								<td class="px-2 py-2 text-gray-400 text-xs">{idx}</td>
+								<td class="px-2 py-2">
+									<input
+										type="checkbox"
+										checked={selectedChunks.has(chunk.id)}
+										on:change={() => toggleChunk(chunk.id)}
+									/>
+								</td>
+								<td class="px-3 py-2 max-w-md">
+									<div class="truncate text-gray-700 dark:text-gray-300">
+										{chunk.content.substring(0, 200)}...
+									</div>
+									{#if chunk.meta?.section_header || chunk.meta?.page}
+										<div class="text-xs text-gray-400 mt-0.5">
+											{#if chunk.meta?.page}Page {chunk.meta.page}{/if}
+											{#if chunk.meta?.section_header} · {chunk.meta.section_header}{/if}
+										</div>
+									{/if}
+								</td>
+								<td class="px-3 py-2 text-right text-gray-400 text-xs">
+									~{chunk.token_count ?? '-'}
+								</td>
+								<td class="px-3 py-2 text-center">
+									<div class="flex items-center justify-center gap-1">
+										<button
+											on:click={() => openDetail(chunk.id)}
+											class="text-xs text-blue-600 hover:underline"
+										>
+											View
+										</button>
+										<button
+											on:click={() => { splitChunkId = chunk.id; splitAtValue = Math.floor((chunk.content?.length ?? 0) / 2); showSplitModal = true; }}
+											class="text-xs text-gray-500 hover:underline"
+										>
+											Split
+										</button>
+									</div>
+								</td>
+							</tr>
+						{/each}
+					</tbody>
+				</table>
+			</div>
+		{:else}
+			<div class="text-center py-20 text-gray-400">
+				{#if selectedFileId}
+					<p class="mb-2">No chunks yet.</p>
+					<button
+						on:click={handlePreview}
+						class="px-4 py-2 rounded-lg bg-blue-600 text-white text-sm hover:bg-blue-700"
+					>
+						Generate Chunk Preview
+					</button>
+				{:else}
+					Select a file to preview its chunks.
+				{/if}
+			</div>
+		{/if}
+	</div>
+
+	<!-- Chunk Detail Modal -->
+	{#if showChunkDetail}
+		<div
+			class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+			on:click={() => showChunkDetail = ''}
+			on:keydown={(e) => { if (e.key === 'Escape') showChunkDetail = ''; }}
+			role="dialog"
+			tabindex="-1"
+		>
+			<div
+				class="bg-white dark:bg-gray-900 rounded-xl shadow-xl max-w-2xl w-full mx-4 max-h-[80vh] flex flex-col"
+				on:click|stopPropagation
+			>
+				<div class="flex items-center justify-between p-4 border-b border-gray-200 dark:border-gray-700">
+					<h3 class="font-semibold">Chunk Detail</h3>
+					<button on:click={() => showChunkDetail = ''} class="text-gray-400 hover:text-gray-600">✕</button>
+				</div>
+				<div class="p-4 overflow-auto flex-1">
+					<pre class="whitespace-pre-wrap text-sm text-gray-700 dark:text-gray-300 font-mono">{chunkDetailContent}</pre>
+				</div>
+			</div>
+		</div>
+	{/if}
+
+	<!-- Split Modal -->
+	{#if showSplitModal}
+		<div
+			class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+			on:click={() => showSplitModal = false}
+			on:keydown={(e) => { if (e.key === 'Escape') showSplitModal = false; }}
+			role="dialog"
+			tabindex="-1"
+		>
+			<div
+				class="bg-white dark:bg-gray-900 rounded-xl shadow-xl max-w-md w-full mx-4"
+				on:click|stopPropagation
+			>
+				<div class="p-4 border-b border-gray-200 dark:border-gray-700">
+					<h3 class="font-semibold">Split Chunk</h3>
+				</div>
+				<div class="p-4 space-y-3">
+					<div>
+						<label class="block text-sm mb-1">Split at character offset</label>
+						<input
+							type="number"
+							bind:value={splitAtValue}
+							min="1"
+							class="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm"
+						/>
+						<p class="text-xs text-gray-400 mt-1">
+							The chunk will be split into two at this character position.
+						</p>
+					</div>
+				</div>
+				<div class="flex justify-end gap-2 p-4 border-t border-gray-200 dark:border-gray-700">
+					<button
+						on:click={() => showSplitModal = false}
+						class="px-4 py-1.5 text-sm rounded-lg bg-gray-100 hover:bg-gray-200 dark:bg-gray-700"
+					>
+						Cancel
+					</button>
+					<button
+						on:click={handleSplit}
+						class="px-4 py-1.5 text-sm rounded-lg bg-blue-600 text-white hover:bg-blue-700"
+					>
+						Split
+					</button>
+				</div>
+			</div>
+		</div>
+	{/if}
+</div>

--- a/src/lib/components/workspace/Knowledge/EvaluatePanel.svelte
+++ b/src/lib/components/workspace/Knowledge/EvaluatePanel.svelte
@@ -1,0 +1,380 @@
+<script lang="ts">
+	import { onMount, getContext } from 'svelte';
+	import type { Writable } from 'svelte/store';
+	import { page } from '$app/stores';
+	import { goto } from '$app/navigation';
+	import { toast } from 'svelte-sonner';
+
+	const i18n = getContext<Writable<any>>('i18n');
+	import { user } from '$lib/stores';
+	import { WEBUI_API_BASE_URL } from '$lib/constants';
+
+	import Spinner from '$lib/components/common/Spinner.svelte';
+
+	// ── Types ──
+	interface SearchResult {
+		chunk_id: string;
+		text: string;
+		score: number;
+		metadata: any;
+		rank: number;
+	}
+
+	interface Metrics {
+		recall_at_k: number;
+		precision_at_k: number;
+		mrr: number;
+		total_relevant: number;
+	}
+
+	interface Annotation {
+		chunk_id: string;
+		document_text: string;
+		rank_position: number;
+		relevance: number; // 0 or 1
+	}
+
+	// ── State ──
+	let knowledgeId = '';
+	$: if ($page.params.id) knowledgeId = $page.params.id;
+
+	let query = '';
+	let k = 10;
+	let searching = false;
+	let annotating = false;
+
+	let results: SearchResult[] = [];
+	let metrics: Metrics | null = null;
+	let annotations: Record<string, number> = {}; // chunk_id → 0|1
+
+	// ── Prompt template ──
+	let promptTemplate = '';
+	let promptIsDefault = true;
+	let showPromptEditor = false;
+	let savingPrompt = false;
+
+	async function loadPrompt() {
+		try {
+			const res = await fetch(`${WEBUI_API_BASE_URL}/knowledge/${knowledgeId}/prompt`, {
+				headers: { authorization: `Bearer ${$user?.token}` }
+			});
+			if (res.ok) {
+				const data = await res.json();
+				promptTemplate = data.prompt_template;
+				promptIsDefault = data.is_default;
+			}
+		} catch (e) { /* ignore */ }
+	}
+
+	async function savePrompt() {
+		savingPrompt = true;
+		try {
+			const res = await fetch(`${WEBUI_API_BASE_URL}/knowledge/${knowledgeId}/prompt`, {
+				method: 'PATCH',
+				headers: {
+					'Content-Type': 'application/json',
+					authorization: `Bearer ${$user?.token}`
+				},
+				body: JSON.stringify({ prompt_template: promptTemplate })
+			});
+			if (!res.ok) throw await res.json();
+			promptIsDefault = false;
+			toast.success('Prompt template saved');
+		} catch (e: any) {
+			toast.error(e?.detail ?? 'Failed to save prompt');
+		} finally {
+			savingPrompt = false;
+		}
+	}
+
+	function resetPrompt() {
+		promptTemplate = 'You are a helpful AI assistant. Use the following reference materials to answer the user\'s question.\n\nReference Materials:\n{context}\n\nUser Question: {query}\n\nIf the reference materials do not contain relevant information, please say so honestly.';
+	}
+
+	// ── Run evaluation query ──
+	async function runQuery() {
+		if (!query.trim()) return;
+		searching = true;
+		results = [];
+		metrics = null;
+		annotations = {};
+
+		try {
+			const res = await fetch(`${WEBUI_API_BASE_URL}/knowledge/${knowledgeId}/evaluate/query`, {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					authorization: `Bearer ${$user?.token}`
+				},
+				body: JSON.stringify({ query: query.trim(), k })
+			});
+			if (!res.ok) throw await res.json();
+			const data = await res.json();
+			results = data.results ?? [];
+			metrics = data.metrics ?? null;
+			// Load existing annotations for this query
+			await loadAnnotations();
+		} catch (e: any) {
+			toast.error(e?.detail ?? 'Query failed');
+		} finally {
+			searching = false;
+		}
+	}
+
+	// ── Load existing annotations ──
+	async function loadAnnotations() {
+		try {
+			const res = await fetch(
+				`${WEBUI_API_BASE_URL}/knowledge/${knowledgeId}/evaluate/judgments`,
+				{ headers: { authorization: `Bearer ${$user?.token}` } }
+			);
+			if (!res.ok) return;
+			const data = await res.json();
+			const grouped = data.judgments ?? {};
+			// Load annotations for current query
+			const currentJudgments = grouped[query.trim()] ?? [];
+			annotations = {};
+			for (const j of currentJudgments) {
+				if (j.chunk_id) annotations[j.chunk_id] = j.relevance;
+			}
+		} catch (e) {
+			// ignore
+		}
+	}
+
+	// ── Toggle relevance annotation ──
+	async function toggleRelevance(chunkId: string, relevance: number) {
+		annotations[chunkId] = relevance;
+		annotations = { ...annotations }; // trigger reactivity
+
+		annotating = true;
+		try {
+			const chunk = results.find(r => r.chunk_id === chunkId);
+			await fetch(`${WEBUI_API_BASE_URL}/knowledge/${knowledgeId}/evaluate/annotate`, {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					authorization: `Bearer ${$user?.token}`
+				},
+				body: JSON.stringify({
+					query_text: query.trim(),
+					judgments: [{
+						chunk_id: chunkId,
+						rank_position: chunk?.rank ?? 0,
+						document_text: chunk?.text?.substring(0, 200) ?? '',
+						relevance
+					}]
+				})
+			});
+			// Reload metrics after annotating
+			const res = await fetch(
+				`${WEBUI_API_BASE_URL}/knowledge/${knowledgeId}/evaluate/query`,
+				{
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json',
+						authorization: `Bearer ${$user?.token}`
+					},
+					body: JSON.stringify({ query: query.trim(), k })
+				}
+			);
+			if (res.ok) {
+				const data = await res.json();
+				metrics = data.metrics ?? null;
+			}
+		} catch (e: any) {
+			toast.error(e?.detail ?? 'Annotation failed');
+		} finally {
+			annotating = false;
+		}
+	}
+
+	// ── Score color ──
+	function scoreColor(val: number): string {
+		if (val > 0.8) return 'text-green-600';
+		if (val > 0.5) return 'text-amber-600';
+		return 'text-red-500';
+	}
+
+	function precisionColor(val: number): string {
+		if (val > 0.7) return 'text-green-600';
+		if (val > 0.4) return 'text-amber-600';
+		return 'text-red-500';
+	}
+
+	onMount(() => loadPrompt());
+</script>
+
+<div class="flex flex-col h-full">
+	<!-- Header -->
+	<div class="flex items-center justify-between p-4 border-b border-gray-200 dark:border-gray-700">
+		<div>
+			<h1 class="text-xl font-semibold">Retrieval Evaluation</h1>
+			<p class="text-sm text-gray-500 mt-1">Test retrieval quality and annotate results</p>
+		</div>
+		<button
+			on:click={() => goto(`/workspace/knowledge/${knowledgeId}`)}
+			class="text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+		>
+			← Back to Files
+		</button>
+	</div>
+
+	<!-- Prompt Template Editor -->
+	<div class="border-b border-gray-200 dark:border-gray-700">
+		<button
+			on:click={() => showPromptEditor = !showPromptEditor}
+			class="w-full flex items-center justify-between px-4 py-2 text-sm font-medium text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-900 transition"
+		>
+			<span>RAG Prompt Template {promptIsDefault ? '(default)' : '(customized)'}</span>
+			<span class="text-xs">{showPromptEditor ? '▲' : '▼'}</span>
+		</button>
+		{#if showPromptEditor}
+			<div class="px-4 pb-3 space-y-2">
+				<div class="text-xs text-gray-400">
+					Variables: <code class="px-1 bg-gray-100 dark:bg-gray-700 rounded">{'{query}'}</code>
+					<code class="px-1 bg-gray-100 dark:bg-gray-700 rounded">{'{context}'}</code>
+					<code class="px-1 bg-gray-100 dark:bg-gray-700 rounded">{'{kb_name}'}</code>
+				</div>
+				<textarea
+					bind:value={promptTemplate}
+					rows="6"
+					class="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm font-mono"
+				></textarea>
+				<div class="flex gap-2">
+					<button
+						on:click={savePrompt}
+						disabled={savingPrompt}
+						class="px-3 py-1 text-xs rounded-lg bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50"
+					>
+						{savingPrompt ? 'Saving...' : 'Save'}
+					</button>
+					<button
+						on:click={resetPrompt}
+						class="px-3 py-1 text-xs rounded-lg bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600"
+					>
+						Reset to Default
+					</button>
+				</div>
+			</div>
+		{/if}
+	</div>
+
+	<!-- Query Input -->
+	<div class="p-4 border-b border-gray-100 dark:border-gray-800 bg-gray-50 dark:bg-gray-900">
+		<div class="flex gap-2">
+			<input
+				type="text"
+				bind:value={query}
+				placeholder="Enter a test query..."
+				class="flex-1 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm"
+				on:keydown={(e) => { if (e.key === 'Enter') runQuery(); }}
+			/>
+			<select bind:value={k} class="w-20 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-2 py-2 text-sm">
+				<option value="5">K=5</option>
+				<option value="10">K=10</option>
+				<option value="20">K=20</option>
+			</select>
+			<button
+				on:click={runQuery}
+				disabled={searching || !query.trim()}
+				class="px-4 py-2 text-sm rounded-lg bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50 transition"
+			>
+				{#if searching}<Spinner />{:else}Search{/if}
+			</button>
+		</div>
+	</div>
+
+	<div class="flex-1 overflow-auto">
+		{#if searching}
+			<div class="flex items-center justify-center py-20">
+				<Spinner /><span class="ml-3 text-sm text-gray-400">Searching...</span>
+			</div>
+		{:else if results.length > 0}
+			<div class="p-4 space-y-4">
+				<!-- Metrics Panel -->
+				{#if metrics}
+					<div class="grid grid-cols-4 gap-3">
+						<div class="rounded-lg bg-green-50 dark:bg-green-900/20 p-3 text-center">
+							<div class="text-2xl font-bold {precisionColor(metrics.recall_at_k)}">{metrics.recall_at_k}</div>
+							<div class="text-xs text-gray-500 mt-1">Recall@{k}</div>
+						</div>
+						<div class="rounded-lg bg-blue-50 dark:bg-blue-900/20 p-3 text-center">
+							<div class="text-2xl font-bold {precisionColor(metrics.precision_at_k)}">{metrics.precision_at_k}</div>
+							<div class="text-xs text-gray-500 mt-1">Precision@{k}</div>
+						</div>
+						<div class="rounded-lg bg-amber-50 dark:bg-amber-900/20 p-3 text-center">
+							<div class="text-2xl font-bold text-amber-600">{metrics.mrr}</div>
+							<div class="text-xs text-gray-500 mt-1">MRR</div>
+						</div>
+						<div class="rounded-lg bg-gray-50 dark:bg-gray-800 p-3 text-center">
+							<div class="text-2xl font-bold text-gray-600">{metrics.total_relevant}</div>
+							<div class="text-xs text-gray-500 mt-1">Relevant docs</div>
+						</div>
+					</div>
+				{:else}
+					<div class="text-center text-xs text-gray-400 py-2">
+						Annotate results below to see metrics. Mark chunks as relevant ✓ or not relevant ✗.
+					</div>
+				{/if}
+
+				<!-- Results List -->
+				<div class="space-y-2">
+					<h3 class="text-sm font-medium text-gray-600 dark:text-gray-400">
+						Top-{results.length} Results
+					</h3>
+					{#each results as result (result.chunk_id)}
+						<div
+							class="rounded-lg border border-gray-200 dark:border-gray-700 p-3 hover:bg-gray-50 dark:hover:bg-gray-900/50 transition"
+							class:border-green-300={annotations[result.chunk_id] === 1}
+							class:border-red-300={annotations[result.chunk_id] === 0}
+						>
+							<div class="flex items-start justify-between gap-3">
+								<div class="flex-1 min-w-0">
+									<div class="flex items-center gap-2 mb-1">
+										<span class="text-xs font-mono px-2 py-0.5 rounded bg-gray-100 dark:bg-gray-700 text-gray-500">
+											#{result.rank}
+										</span>
+										<span class="text-xs font-mono {scoreColor(result.score)}">
+											score: {result.score?.toFixed(4) ?? 'N/A'}
+										</span>
+									</div>
+									<div class="text-sm text-gray-700 dark:text-gray-300 line-clamp-3">
+										{result.text?.substring(0, 300)}
+									</div>
+								</div>
+								<div class="flex items-center gap-1 shrink-0">
+									<button
+										on:click={() => toggleRelevance(result.chunk_id, annotations[result.chunk_id] === 1 ? 0 : 1)}
+										disabled={annotating}
+										class="px-2 py-1 text-xs rounded transition {annotations[result.chunk_id] === 1
+											? 'bg-green-500 text-white'
+											: 'bg-gray-100 dark:bg-gray-700 text-gray-500 hover:bg-green-100'}"
+										title="Mark as relevant"
+									>
+										✓
+									</button>
+									<button
+										on:click={() => toggleRelevance(result.chunk_id, annotations[result.chunk_id] === 0 ? -1 : 0)}
+										disabled={annotating}
+										class="px-2 py-1 text-xs rounded transition {annotations[result.chunk_id] === 0
+											? 'bg-red-500 text-white'
+											: 'bg-gray-100 dark:bg-gray-700 text-gray-500 hover:bg-red-100'}"
+										title="Mark as not relevant"
+									>
+										✗
+									</button>
+								</div>
+							</div>
+						</div>
+					{/each}
+				</div>
+			</div>
+		{:else}
+			<div class="text-center py-20 text-gray-400">
+				<p class="mb-2">Enter a query to evaluate retrieval quality.</p>
+				<p class="text-xs">The system will search the knowledge base and show the top-K results with relevance scores.</p>
+			</div>
+		{/if}
+	</div>
+</div>

--- a/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
+++ b/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
@@ -867,8 +867,8 @@
 		try {
 			console.log('Starting file deletion process for:', fileId);
 
-			// Remove from knowledge base only
-			const res = await removeFileFromKnowledgeById(localStorage.token, id, fileId);
+			// Remove from knowledge base and delete file
+			const res = await removeFileFromKnowledgeById(localStorage.token, id, fileId, true);
 			console.log('Knowledge base updated:', res);
 
 			if (res) {
@@ -877,6 +877,18 @@
 			}
 		} catch (e) {
 			console.error('Error in deleteFileHandler:', e);
+			toast.error(`${e}`);
+		}
+	};
+
+	const unlinkFileHandler = async (fileId) => {
+		try {
+			const res = await removeFileFromKnowledgeById(localStorage.token, id, fileId, false);
+			if (res) {
+				toast.success('File unlinked (kept on disk). Rollback can restore it.');
+				await init();
+			}
+		} catch (e) {
 			toast.error(`${e}`);
 		}
 	};
@@ -1586,6 +1598,9 @@
 													loadingFileContent = false;
 
 													deleteFileHandler(fileId);
+												}}
+												onUnlink={(fileId) => {
+													unlinkFileHandler(fileId);
 												}}
 												onRename={(fileId, name) => renameFileHandler(fileId, name)}
 												onNavigateDirectory={(dirId) => navigateToDirectory(dirId)}

--- a/src/lib/components/workspace/Knowledge/KnowledgeBase/Files.svelte
+++ b/src/lib/components/workspace/Knowledge/KnowledgeBase/Files.svelte
@@ -15,7 +15,6 @@
 
 	import Tooltip from '$lib/components/common/Tooltip.svelte';
 	import Dropdown from '$lib/components/common/Dropdown.svelte';
-	import DropdownMenu from '$lib/components/common/DropdownMenu.svelte';
 	import DocumentPage from '$lib/components/icons/DocumentPage.svelte';
 	import EllipsisHorizontal from '$lib/components/icons/EllipsisHorizontal.svelte';
 	import Download from '$lib/components/icons/Download.svelte';
@@ -31,6 +30,7 @@
 
 	export let onClick = (fileId) => {};
 	export let onDelete = (fileId) => {};
+	export let onUnlink = (fileId) => {};
 	export let onRename = (fileId: string, name: string) => {};
 	export let onNavigateDirectory = (directoryId: string) => {};
 	export let onRenameDirectory = (id: string, name: string) => {};
@@ -123,7 +123,7 @@
 							<input
 								bind:this={editInput}
 								bind:value={editName}
-								class="text-xs w-full bg-transparent border-none outline-hidden"
+								class="text-sm w-full bg-transparent border-none outline-hidden"
 								on:keydown={(e) => {
 									if (e.key === 'Enter') submitRename();
 									if (e.key === 'Escape') cancelRename();
@@ -137,10 +137,10 @@
 								autofocus
 							/>
 						{:else}
-							<div class="line-clamp-1 text-xs">
+							<div class="line-clamp-1 text-sm">
 								{file?.name ?? file?.meta?.name}
 								{#if file?.meta?.size}
-									<span class="text-[11px] text-gray-500">{formatFileSize(file?.meta?.size)}</span>
+									<span class="text-xs text-gray-500">{formatFileSize(file?.meta?.size)}</span>
 								{/if}
 							</div>
 						{/if}
@@ -185,10 +185,12 @@
 						</button>
 
 						<div slot="content">
-							<DropdownMenu className="min-w-[140px] z-[9999999]">
+							<div
+								class="min-w-[140px] rounded-2xl p-1 z-[9999999] bg-white dark:bg-gray-850 dark:text-white shadow-lg border border-gray-100 dark:border-gray-800"
+							>
 								<button
 									type="button"
-									class="select-none flex h-[1.6875rem] w-full cursor-pointer items-center gap-2 rounded-xl bg-transparent px-2 text-xs transition hover:text-gray-900 dark:hover:text-gray-100"
+									class="select-none flex rounded-xl py-1.5 px-3 w-full hover:bg-gray-50 dark:hover:bg-gray-800 transition items-center gap-2 text-sm"
 									on:click={() => {
 										startRename(file);
 									}}
@@ -198,7 +200,7 @@
 								</button>
 								<button
 									type="button"
-									class="select-none flex h-[1.6875rem] w-full cursor-pointer items-center gap-2 rounded-xl bg-transparent px-2 text-xs transition hover:text-gray-900 dark:hover:text-gray-100"
+									class="select-none flex rounded-xl py-1.5 px-3 w-full hover:bg-gray-50 dark:hover:bg-gray-800 transition items-center gap-2 text-sm"
 									on:click={() => {
 										let fileId = file?.id ?? file?.tempId;
 										window.open(`${WEBUI_BASE_URL}/api/v1/files/${fileId}/content`, '_blank');
@@ -209,7 +211,17 @@
 								</button>
 								<button
 									type="button"
-									class="select-none flex h-[1.6875rem] w-full cursor-pointer items-center gap-2 rounded-xl bg-transparent px-2 text-xs transition hover:text-gray-900 dark:hover:text-gray-100"
+									class="select-none flex rounded-xl py-1.5 px-3 w-full hover:bg-amber-50 dark:hover:bg-amber-900/30 transition items-center gap-2 text-sm text-amber-600"
+									on:click={() => {
+										onUnlink(file?.id ?? file?.tempId);
+									}}
+								>
+									<GarbageBin className="size-3.5" />
+									Unlink Only
+								</button>
+								<button
+									type="button"
+									class="select-none flex rounded-xl py-1.5 px-3 w-full hover:bg-gray-50 dark:hover:bg-gray-800 transition items-center gap-2 text-sm"
 									on:click={() => {
 										onDelete(file?.id ?? file?.tempId);
 									}}
@@ -217,7 +229,7 @@
 									<GarbageBin className="size-3.5" />
 									{$i18n.t('Delete')}
 								</button>
-							</DropdownMenu>
+							</div>
 						</div>
 					</Dropdown>
 				</div>

--- a/src/lib/components/workspace/Knowledge/ProcessingDashboard.svelte
+++ b/src/lib/components/workspace/Knowledge/ProcessingDashboard.svelte
@@ -1,0 +1,247 @@
+<script lang="ts">
+	import { onMount, onDestroy, getContext } from 'svelte';
+	import type { Writable } from 'svelte/store';
+	import type { i18n as i18nType } from 'i18next';
+	import { page } from '$app/stores';
+	import { goto } from '$app/navigation';
+
+	const i18n = getContext<Writable<i18nType>>('i18n');
+	import { user } from '$lib/stores';
+	import { WEBUI_API_BASE_URL } from '$lib/constants';
+
+	import Spinner from '$lib/components/common/Spinner.svelte';
+
+	// ── Types ──
+	interface ProcessingTask {
+		id: string;
+		knowledge_id: string;
+		file_id: string;
+		task_type: string;
+		status: 'pending' | 'chunking' | 'embedding' | 'completed' | 'failed';
+		progress_pct: number;
+		chunks_total: number | null;
+		chunks_processed: number | null;
+		error_message: string | null;
+		created_at: number;
+		updated_at: number;
+	}
+
+	// ── State ──
+	let knowledgeId = '';
+	let tasks: ProcessingTask[] = [];
+	let eventSource: EventSource | null = null;
+	let connected = false;
+	let loaded = false;
+
+	$: if ($page.params.id) {
+		knowledgeId = $page.params.id;
+	}
+
+	// ── Status helpers ──
+	const statusConfig: Record<string, { label: string; color: string; bg: string }> = {
+		pending:   { label: 'Pending',    color: 'text-gray-500', bg: 'bg-gray-100 dark:bg-gray-700' },
+		chunking:  { label: 'Chunking',   color: 'text-blue-500', bg: 'bg-blue-100 dark:bg-blue-900' },
+		embedding: { label: 'Embedding',  color: 'text-amber-500', bg: 'bg-amber-100 dark:bg-amber-900' },
+		completed: { label: 'Completed',  color: 'text-green-500', bg: 'bg-green-100 dark:bg-green-900' },
+		failed:    { label: 'Failed',     color: 'text-red-500', bg: 'bg-red-100 dark:bg-red-900' },
+	};
+
+	function getStatusConfig(status: string) {
+		return statusConfig[status] ?? statusConfig.pending;
+	}
+
+	function progressBarColor(status: string): string {
+		switch (status) {
+			case 'completed': return 'bg-green-500';
+			case 'failed': return 'bg-red-500';
+			case 'embedding': return 'bg-amber-500';
+			case 'chunking': return 'bg-blue-500';
+			default: return 'bg-gray-300 dark:bg-gray-600';
+		}
+	}
+
+	// ── Polling fallback ──
+	let pollTimer: ReturnType<typeof setInterval> | null = null;
+
+	async function pollProgress() {
+		try {
+			const res = await fetch(
+				`${WEBUI_API_BASE_URL}/knowledge/${knowledgeId}/progress`,
+				{
+					headers: { authorization: `Bearer ${$user?.token}` }
+				}
+			);
+			if (res.ok) {
+				tasks = await res.json();
+				loaded = true;
+			}
+		} catch (e) {
+			// ignore poll errors
+		}
+	}
+
+	// ── SSE connection ──
+	function connectSSE() {
+		if (!knowledgeId || !$user?.token) return;
+
+		const url = `${WEBUI_API_BASE_URL}/knowledge/${knowledgeId}/progress/stream`;
+		eventSource = new EventSource(url + '?token=' + encodeURIComponent($user.token));
+
+		// Note: EventSource doesn't support custom headers, so we pass token as query param
+		// The backend ignores it as query param; SSE auth is handled via cookie/session.
+		// We'll use polling as primary and SSE as supplementary.
+
+		eventSource.onmessage = (event) => {
+			try {
+				const data = JSON.parse(event.data);
+				if (Array.isArray(data)) {
+					tasks = data;
+					loaded = true;
+				}
+			} catch (e) {
+				// ignore parse errors
+			}
+		};
+
+		eventSource.onopen = () => {
+			connected = true;
+		};
+
+		eventSource.onerror = () => {
+			connected = false;
+			eventSource?.close();
+			// Retry after 5s
+			setTimeout(connectSSE, 5000);
+		};
+	}
+
+	onMount(() => {
+		pollTimer = setInterval(pollProgress, 3000);
+		pollProgress(); // immediate first poll
+		// SSE as supplement - will update faster if it connects
+		connectSSE();
+	});
+
+	onDestroy(() => {
+		if (pollTimer) clearInterval(pollTimer);
+		eventSource?.close();
+	});
+
+	// ── Computed ──
+	$: activeTasks = tasks.filter(t => !['completed', 'failed'].includes(t.status));
+	$: completedTasks = tasks.filter(t => t.status === 'completed');
+	$: failedTasks = tasks.filter(t => t.status === 'failed');
+	$: overallProgress = tasks.length > 0
+		? Math.round((completedTasks.length / tasks.length) * 100)
+		: 0;
+</script>
+
+<div class="flex flex-col h-full">
+	<!-- Header -->
+	<div class="flex items-center justify-between p-4 border-b border-gray-200 dark:border-gray-700">
+		<div>
+			<h1 class="text-xl font-semibold">Processing Status</h1>
+			<p class="text-sm text-gray-500 mt-1">Real-time document processing progress</p>
+		</div>
+		<div class="flex items-center gap-3">
+			{#if !loaded}
+				<Spinner />
+				<span class="text-sm text-gray-400">Connecting...</span>
+			{:else}
+				<span class="text-xs px-2 py-1 rounded-full {connected ? 'bg-green-100 text-green-600' : 'bg-gray-100 text-gray-500'}">
+					{connected ? 'Live' : 'Polling'}
+				</span>
+			{/if}
+		</div>
+	</div>
+
+	<!-- Overall Progress -->
+	{#if tasks.length > 0}
+		<div class="px-4 py-3 border-b border-gray-100 dark:border-gray-800 bg-gray-50 dark:bg-gray-900">
+			<div class="flex items-center justify-between mb-2">
+				<span class="text-sm font-medium">Overall</span>
+				<span class="text-xs text-gray-500">
+					{completedTasks.length}/{tasks.length} completed
+					{#if failedTasks.length > 0}
+						· {failedTasks.length} failed
+					{/if}
+				</span>
+			</div>
+			<div class="w-full h-2 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden">
+				<div
+					class="h-full transition-all duration-500 rounded-full {failedTasks.length > 0 ? 'bg-red-500' : 'bg-blue-500'}"
+					style="width: {overallProgress}%"
+				></div>
+			</div>
+		</div>
+	{/if}
+
+	<!-- Task List -->
+	<div class="flex-1 overflow-auto">
+		{#if !loaded}
+			<div class="flex items-center justify-center py-20">
+				<Spinner />
+				<span class="ml-3 text-sm text-gray-400">Loading tasks...</span>
+			</div>
+		{:else if tasks.length === 0}
+			<div class="text-center py-20 text-gray-400">
+				<p>No processing tasks yet.</p>
+				<p class="text-xs mt-1">Tasks will appear here when files are added to this knowledge base.</p>
+			</div>
+		{:else}
+			<div class="divide-y divide-gray-100 dark:divide-gray-800">
+				{#each tasks as task (task.id)}
+					<div class="px-4 py-3 hover:bg-gray-50 dark:hover:bg-gray-900/50 transition">
+						<div class="flex items-center justify-between mb-2">
+							<div class="flex items-center gap-2">
+								<span class="text-sm font-medium text-gray-700 dark:text-gray-300 truncate max-w-xs">
+									{task.file_id?.substring(0, 8) ?? 'N/A'}...
+								</span>
+								<span class="text-xs px-2 py-0.5 rounded-full {getStatusConfig(task.status).bg} {getStatusConfig(task.status).color} font-medium">
+									{getStatusConfig(task.status).label}
+								</span>
+							</div>
+							<span class="text-xs text-gray-400">{task.progress_pct}%</span>
+						</div>
+
+						<!-- Per-file Progress Bar -->
+						<div class="w-full h-1.5 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden mb-1">
+							<div
+								class="h-full transition-all duration-700 rounded-full {progressBarColor(task.status)}"
+								style="width: {task.progress_pct}%"
+							></div>
+						</div>
+
+						<!-- Details -->
+						<div class="flex items-center gap-4 text-xs text-gray-400">
+							{#if task.chunks_total != null}
+								<span>{task.chunks_processed ?? 0} / {task.chunks_total} chunks</span>
+							{/if}
+							{#if task.error_message}
+								<span class="text-red-400 truncate max-w-xs" title={task.error_message}>
+									⚠ {task.error_message}
+								</span>
+							{/if}
+						</div>
+					</div>
+				{/each}
+			</div>
+		{/if}
+	</div>
+
+	<!-- Footer Actions -->
+	<div class="p-4 border-t border-gray-200 dark:border-gray-700 flex gap-2">
+		<button
+			on:click={pollProgress}
+			class="px-3 py-1.5 text-sm rounded-lg bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600 transition"
+		>
+			Refresh
+		</button>
+		<button
+			on:click={() => goto(`/workspace/knowledge/${knowledgeId}`)}
+			class="px-3 py-1.5 text-sm rounded-lg text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 transition"
+		>
+			← Back to Files
+		</button>
+	</div>
+</div>

--- a/src/lib/components/workspace/Knowledge/SnapshotManager.svelte
+++ b/src/lib/components/workspace/Knowledge/SnapshotManager.svelte
@@ -1,0 +1,312 @@
+<script lang="ts">
+	import { onMount, getContext } from 'svelte';
+	import { page } from '$app/stores';
+	import { goto } from '$app/navigation';
+	import { toast } from 'svelte-sonner';
+
+	const i18n = getContext<Writable<any>>('i18n');
+	import { user } from '$lib/stores';
+	import { WEBUI_API_BASE_URL } from '$lib/constants';
+
+	import Spinner from '$lib/components/common/Spinner.svelte';
+
+	interface Snapshot {
+		id: string;
+		knowledge_id: string;
+		label: string | null;
+		description: string | null;
+		file_count: number;
+		chunk_count: number | null;
+		snapshot_data: any;
+		created_by: string;
+		created_at: number;
+	}
+
+	interface CompareResult {
+		added_files: Array<{ file_id: string; filename: string }>;
+		removed_files: Array<{ file_id: string; filename: string }>;
+		modified_files: Array<{ file_id: string; filename: string }>;
+		total_chunks_before: number;
+		total_chunks_after: number;
+	}
+
+	let knowledgeId = '';
+	$: if ($page.params.id) knowledgeId = $page.params.id;
+
+	let snapshots: Snapshot[] = [];
+	let loaded = false;
+	let loading = false;
+
+	// Create modal
+	let showCreate = false;
+	let snapLabel = '';
+	let snapDesc = '';
+
+	// Rollback confirm
+	let showRollback = '';
+	let rollingBack = false;
+
+	// Compare
+	let showCompare = false;
+	let compareA = '';
+	let compareB = '';
+	let compareResult: CompareResult | null = null;
+
+	// ── Load ──
+	async function loadSnapshots() {
+		loading = true;
+		try {
+			const res = await fetch(`${WEBUI_API_BASE_URL}/knowledge/${knowledgeId}/snapshots`, {
+				headers: { authorization: `Bearer ${$user?.token}` }
+			});
+			if (res.ok) snapshots = await res.json();
+		} catch (e) {
+			console.error(e);
+		} finally {
+			loading = false;
+			loaded = true;
+		}
+	}
+
+	// ── Create ──
+	async function createSnapshot() {
+		try {
+			const res = await fetch(`${WEBUI_API_BASE_URL}/knowledge/${knowledgeId}/snapshots`, {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					authorization: `Bearer ${$user?.token}`
+				},
+				body: JSON.stringify({ label: snapLabel || null, description: snapDesc || null })
+			});
+			if (!res.ok) throw await res.json();
+			showCreate = false;
+			snapLabel = '';
+			snapDesc = '';
+			toast.success('Snapshot created');
+			await loadSnapshots();
+		} catch (e: any) {
+			toast.error(e?.detail ?? 'Failed to create snapshot');
+		}
+	}
+
+	// ── Rollback ──
+	async function doRollback(snapId: string) {
+		rollingBack = true;
+		try {
+			const res = await fetch(
+				`${WEBUI_API_BASE_URL}/knowledge/${knowledgeId}/snapshots/${snapId}/rollback`,
+				{ method: 'POST', headers: { authorization: `Bearer ${$user?.token}` } }
+			);
+			if (!res.ok) throw await res.json();
+			const data = await res.json();
+			showRollback = '';
+			toast.success(`Rolled back to "${data.snapshot_label || 'snapshot'}" - ${data.restored_files} files restored`);
+			await loadSnapshots();
+		} catch (e: any) {
+			toast.error(e?.detail ?? 'Rollback failed');
+		} finally {
+			rollingBack = false;
+		}
+	}
+
+	// ── Delete ──
+	async function deleteSnapshot(snapId: string) {
+		if (!confirm('Delete this snapshot?')) return;
+		try {
+			await fetch(`${WEBUI_API_BASE_URL}/knowledge/${knowledgeId}/snapshots/${snapId}`, {
+				method: 'DELETE',
+				headers: { authorization: `Bearer ${$user?.token}` }
+			});
+			toast.success('Snapshot deleted');
+			await loadSnapshots();
+		} catch (e: any) {
+			toast.error('Delete failed');
+		}
+	}
+
+	// ── Compare ──
+	async function doCompare() {
+		if (!compareA || !compareB) return;
+		try {
+			const res = await fetch(`${WEBUI_API_BASE_URL}/knowledge/${knowledgeId}/snapshots/compare`, {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					authorization: `Bearer ${$user?.token}`
+				},
+				body: JSON.stringify({ snapshot_a_id: compareA, snapshot_b_id: compareB })
+			});
+			if (!res.ok) throw await res.json();
+			compareResult = await res.json();
+		} catch (e: any) {
+			toast.error(e?.detail ?? 'Compare failed');
+		}
+	}
+
+	function formatDate(ts: number): string {
+		return new Date(ts * 1000).toLocaleString();
+	}
+
+	onMount(() => loadSnapshots());
+</script>
+
+<div class="flex flex-col h-full">
+	<!-- Header -->
+	<div class="flex items-center justify-between p-4 border-b border-gray-200 dark:border-gray-700">
+		<div>
+			<h1 class="text-xl font-semibold">Snapshots</h1>
+			<p class="text-sm text-gray-500 mt-1">Version management for knowledge base state</p>
+		</div>
+		<div class="flex gap-2">
+			<button
+				on:click={() => { showCompare = !showCompare; compareResult = null; }}
+				class="px-3 py-1.5 text-sm rounded-lg bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600 transition"
+			>
+				Compare
+			</button>
+			<button
+				on:click={() => showCreate = true}
+				class="px-3 py-1.5 text-sm rounded-lg bg-blue-600 text-white hover:bg-blue-700 transition"
+			>
+				+ Create Snapshot
+			</button>
+			<button
+				on:click={() => goto(`/workspace/knowledge/${knowledgeId}`)}
+				class="text-sm text-gray-500 hover:text-gray-700"
+			>
+				← Back
+			</button>
+		</div>
+	</div>
+
+	<div class="flex-1 overflow-auto p-4">
+		<!-- Compare Panel -->
+		{#if showCompare}
+			<div class="mb-4 p-4 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900">
+				<h3 class="text-sm font-medium mb-3">Compare Snapshots</h3>
+				<div class="flex items-center gap-3 mb-3">
+					<select bind:value={compareA} class="flex-1 rounded border px-2 py-1 text-sm">
+						<option value="">-- Snapshot A (older) --</option>
+						{#each snapshots as s}
+							<option value={s.id}>{s.label || s.id.substring(0, 8)} — {formatDate(s.created_at)}</option>
+						{/each}
+					</select>
+					<span class="text-gray-400">vs</span>
+					<select bind:value={compareB} class="flex-1 rounded border px-2 py-1 text-sm">
+						<option value="">-- Snapshot B (newer) --</option>
+						{#each snapshots as s}
+							<option value={s.id}>{s.label || s.id.substring(0, 8)} — {formatDate(s.created_at)}</option>
+						{/each}
+					</select>
+					<button on:click={doCompare} class="px-3 py-1 text-sm rounded bg-blue-600 text-white hover:bg-blue-700">Go</button>
+				</div>
+				{#if compareResult}
+					<div class="grid grid-cols-3 gap-3 text-sm">
+						<div class="rounded bg-green-50 dark:bg-green-900/20 p-3">
+							<div class="font-medium text-green-600 mb-1">+ Added ({compareResult.added_files.length})</div>
+							{#each compareResult.added_files as f}
+								<div class="text-xs truncate">{f.filename}</div>
+							{/each}
+							{#if compareResult.added_files.length === 0}<div class="text-xs text-gray-400">None</div>{/if}
+						</div>
+						<div class="rounded bg-red-50 dark:bg-red-900/20 p-3">
+							<div class="font-medium text-red-600 mb-1">- Removed ({compareResult.removed_files.length})</div>
+							{#each compareResult.removed_files as f}
+								<div class="text-xs truncate">{f.filename}</div>
+							{/each}
+							{#if compareResult.removed_files.length === 0}<div class="text-xs text-gray-400">None</div>{/if}
+						</div>
+						<div class="rounded bg-amber-50 dark:bg-amber-900/20 p-3">
+							<div class="font-medium text-amber-600 mb-1">~ Modified ({compareResult.modified_files.length})</div>
+							{#each compareResult.modified_files as f}
+								<div class="text-xs truncate">{f.filename}</div>
+							{/each}
+							{#if compareResult.modified_files.length === 0}<div class="text-xs text-gray-400">None</div>{/if}
+						</div>
+					</div>
+					<div class="text-xs text-gray-400 mt-2">
+						Chunks: {compareResult.total_chunks_before} → {compareResult.total_chunks_after}
+					</div>
+				{/if}
+			</div>
+		{/if}
+
+		<!-- Snapshot List -->
+		{#if loading}
+			<div class="flex items-center justify-center py-20"><Spinner /></div>
+		{:else if snapshots.length === 0}
+			<div class="text-center py-20 text-gray-400">
+				<p class="mb-2">No snapshots yet.</p>
+				<p class="text-xs">Create a snapshot to save the current state of your knowledge base.</p>
+			</div>
+		{:else}
+			<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+				{#each snapshots as snap (snap.id)}
+					<div class="rounded-lg border border-gray-200 dark:border-gray-700 p-4 hover:shadow-md transition">
+						<div class="flex items-start justify-between mb-2">
+							<div class="font-medium text-sm">{snap.label || 'Snapshot'}</div>
+							<span class="text-xs text-gray-400">{formatDate(snap.created_at)}</span>
+						</div>
+						{#if snap.description}
+							<p class="text-xs text-gray-500 mb-2">{snap.description}</p>
+						{/if}
+						<div class="flex items-center gap-3 text-xs text-gray-400 mb-3">
+							<span>📄 {snap.file_count} files</span>
+							<span>🧩 {snap.chunk_count ?? '?'} chunks</span>
+						</div>
+						<div class="flex gap-1">
+							<button
+								on:click={() => showRollback === snap.id ? showRollback = '' : showRollback = snap.id}
+								class="flex-1 px-2 py-1 text-xs rounded bg-amber-100 hover:bg-amber-200 dark:bg-amber-900 dark:hover:bg-amber-800 text-amber-700 dark:text-amber-300 transition"
+							>
+								Rollback
+							</button>
+							<button
+								on:click={() => deleteSnapshot(snap.id)}
+								class="px-2 py-1 text-xs rounded bg-red-50 hover:bg-red-100 dark:bg-red-900/30 dark:hover:bg-red-900/50 text-red-500 transition"
+							>
+								Delete
+							</button>
+						</div>
+						{#if showRollback === snap.id}
+							<div class="mt-3 p-2 bg-amber-50 dark:bg-amber-900/30 rounded text-xs">
+								<p class="text-amber-700 dark:text-amber-300 mb-2">This will restore the KB to this snapshot state. Vectors will be re-indexed. Continue?</p>
+								<div class="flex gap-1">
+									<button on:click={() => doRollback(snap.id)} disabled={rollingBack}
+										class="px-2 py-1 bg-amber-500 text-white rounded hover:bg-amber-600">
+										{rollingBack ? 'Rolling back...' : 'Confirm Rollback'}
+									</button>
+									<button on:click={() => showRollback = ''} class="px-2 py-1 bg-gray-200 dark:bg-gray-600 rounded">Cancel</button>
+								</div>
+							</div>
+						{/if}
+					</div>
+				{/each}
+			</div>
+		{/if}
+	</div>
+
+	<!-- Create Modal -->
+	{#if showCreate}
+		<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50" on:click={() => showCreate = false} role="dialog" tabindex="-1">
+			<div class="bg-white dark:bg-gray-900 rounded-xl shadow-xl max-w-md w-full mx-4" on:click|stopPropagation>
+				<div class="p-4 border-b"><h3 class="font-semibold">Create Snapshot</h3></div>
+				<div class="p-4 space-y-3">
+					<div>
+						<label class="block text-sm mb-1">Label (optional)</label>
+						<input type="text" bind:value={snapLabel} placeholder="v1.0" class="w-full rounded-lg border px-3 py-2 text-sm dark:bg-gray-800 dark:border-gray-600" />
+					</div>
+					<div>
+						<label class="block text-sm mb-1">Description (optional)</label>
+						<textarea bind:value={snapDesc} rows="2" placeholder="Snapshot description..." class="w-full rounded-lg border px-3 py-2 text-sm dark:bg-gray-800 dark:border-gray-600"></textarea>
+					</div>
+				</div>
+				<div class="flex justify-end gap-2 p-4 border-t">
+					<button on:click={() => showCreate = false} class="px-4 py-1.5 text-sm rounded-lg bg-gray-100 hover:bg-gray-200 dark:bg-gray-700">Cancel</button>
+					<button on:click={createSnapshot} class="px-4 py-1.5 text-sm rounded-lg bg-blue-600 text-white hover:bg-blue-700">Create</button>
+				</div>
+			</div>
+		</div>
+	{/if}
+</div>

--- a/src/routes/(app)/workspace/knowledge/[id]/+layout.svelte
+++ b/src/routes/(app)/workspace/knowledge/[id]/+layout.svelte
@@ -1,0 +1,75 @@
+<script lang="ts">
+	import { page } from '$app/stores';
+	import { goto } from '$app/navigation';
+
+	let activeTab = 'files';
+
+	function navigateTo(tab) {
+		activeTab = tab;
+		if (tab === 'files') {
+			goto(`/workspace/knowledge/${$page.params.id}`);
+		} else {
+			goto(`/workspace/knowledge/${$page.params.id}/${tab}`);
+		}
+	}
+
+	$: {
+		const path = $page.url.pathname;
+		if (path.endsWith('/chunks')) activeTab = 'chunks';
+		else if (path.endsWith('/processing')) activeTab = 'processing';
+		else if (path.endsWith('/evaluate')) activeTab = 'evaluate';
+		else if (path.endsWith('/snapshots')) activeTab = 'snapshots';
+		else activeTab = 'files';
+	}
+</script>
+
+<div class="flex flex-col h-full">
+	<!-- Tab Navigation -->
+	<div class="flex items-center gap-1 px-4 pt-3 pb-0 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-950">
+		<button
+			on:click={() => navigateTo('files')}
+			class="px-4 py-2 text-sm font-medium rounded-t-lg transition {activeTab === 'files'
+				? 'bg-white dark:bg-gray-900 text-blue-600 dark:text-blue-400 border-b-2 border-blue-600'
+				: 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200'}"
+		>
+			📁 Files
+		</button>
+		<button
+			on:click={() => navigateTo('chunks')}
+			class="px-4 py-2 text-sm font-medium rounded-t-lg transition {activeTab === 'chunks'
+				? 'bg-white dark:bg-gray-900 text-blue-600 dark:text-blue-400 border-b-2 border-blue-600'
+				: 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200'}"
+		>
+			🧩 Chunks
+		</button>
+		<button
+			on:click={() => navigateTo('processing')}
+			class="px-4 py-2 text-sm font-medium rounded-t-lg transition {activeTab === 'processing'
+				? 'bg-white dark:bg-gray-900 text-blue-600 dark:text-blue-400 border-b-2 border-blue-600'
+				: 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200'}"
+		>
+			⏳ Processing
+		</button>
+		<button
+			on:click={() => navigateTo('evaluate')}
+			class="px-4 py-2 text-sm font-medium rounded-t-lg transition {activeTab === 'evaluate'
+				? 'bg-white dark:bg-gray-900 text-blue-600 dark:text-blue-400 border-b-2 border-blue-600'
+				: 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200'}"
+		>
+			📊 Evaluate
+		</button>
+		<button
+			on:click={() => navigateTo('snapshots')}
+			class="px-4 py-2 text-sm font-medium rounded-t-lg transition {activeTab === 'snapshots'
+				? 'bg-white dark:bg-gray-900 text-blue-600 dark:text-blue-400 border-b-2 border-blue-600'
+				: 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200'}"
+		>
+			📸 Snapshots
+		</button>
+	</div>
+
+	<!-- Page Content -->
+	<div class="flex-1 overflow-hidden">
+		<slot />
+	</div>
+</div>

--- a/src/routes/(app)/workspace/knowledge/[id]/chunks/+page.svelte
+++ b/src/routes/(app)/workspace/knowledge/[id]/chunks/+page.svelte
@@ -1,0 +1,5 @@
+<script>
+	import ChunkManager from '$lib/components/workspace/Knowledge/ChunkManager.svelte';
+</script>
+
+<ChunkManager />

--- a/src/routes/(app)/workspace/knowledge/[id]/evaluate/+page.svelte
+++ b/src/routes/(app)/workspace/knowledge/[id]/evaluate/+page.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import EvaluatePanel from '$lib/components/workspace/Knowledge/EvaluatePanel.svelte';
+</script>
+
+<EvaluatePanel />

--- a/src/routes/(app)/workspace/knowledge/[id]/processing/+page.svelte
+++ b/src/routes/(app)/workspace/knowledge/[id]/processing/+page.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import ProcessingDashboard from '$lib/components/workspace/Knowledge/ProcessingDashboard.svelte';
+</script>
+
+<ProcessingDashboard />

--- a/src/routes/(app)/workspace/knowledge/[id]/snapshots/+page.svelte
+++ b/src/routes/(app)/workspace/knowledge/[id]/snapshots/+page.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import SnapshotManager from '$lib/components/workspace/Knowledge/SnapshotManager.svelte';
+</script>
+
+<SnapshotManager />


### PR DESCRIPTION
Closes https://github.com/open-webui/open-webui/discussions/27272

## Description

This PR adds an enterprise knowledge base management dashboard with 5 tabs, enhancing RAG observability and control for end users. See the linked discussion for problem background and motivation.

## Documentation

- 📖 **English README**: https://github.com/yangyang-qaq/enterprise-knowledge-dashboard/blob/master/README.md
- 📐 **Design Document**: https://github.com/yangyang-qaq/enterprise-knowledge-dashboard/blob/master/DESIGN.md

## Changes

### 5 new tabs in the knowledge base detail page

| Tab | Feature | Value |
|---|---|---|
| Files | Existing + "Unlink Only" button | Remove file from KB without deleting it |
| Chunks | Chunk preview, merge, split, reindex | See and fix how documents are split |
| Processing | Real-time progress (SSE + polling) | Know what's happening with your uploads |
| Evaluate | Query → annotate → recall/precision/MRR | Measure retrieval quality |
| Snapshots | Create, rollback, compare | Version management for KB state |

### Database (5 new tables)
- `knowledge_chunk` - individual chunk tracking with metadata
- `knowledge_processing_task` - per-file processing status
- `knowledge_batch_task` - batch processing summary
- `knowledge_relevance_judgment` - ground truth annotations
- `knowledge_snapshot` - KB version snapshots

### API (26 new endpoints)
All under `/api/v1/knowledge/{id}/`:
- `POST /chunks/preview`, `GET /files/{fileId}/chunks`, `POST /chunks/merge|split|reindex`
- `GET /progress`, `GET /progress/stream` (SSE), `GET /progress/batch`
- `POST /evaluate/query`, `POST /evaluate/annotate`, `GET|DELETE /evaluate/judgments`
- `POST /snapshots`, `GET /snapshots`, `POST /{sid}/rollback`, `POST /snapshots/compare`, `DELETE /{sid}`
- `GET|PATCH /prompt` - per-KB RAG prompt template

### Frontend (5 pages + 7 components)
- Tab navigation via `+layout.svelte`
- ChunkManager, ProcessingDashboard, EvaluatePanel, SnapshotManager
- All components follow existing patterns (Tailwind CSS, i18n, toast notifications)

## Design Decisions

1. **Progress tracking**: DB-persisted status + in-memory store for SSE. Polling every 3s as fallback.
2. **Snapshots**: Store file_id + chunk metadata as JSON. Rollback restores associations only (vectors re-indexed on demand).
3. **Evaluation metrics**: Server-side computation (recall@K, precision@K, MRR) from stored annotations.
4. **Chunk persistence**: Chunks written to `knowledge_chunk` table during `process_file()`, enabling preview without re-loading.
5. **Prompt templates**: Stored in `knowledge.meta` JSON field with `{query}`/`{context}`/`{kb_name}` variable substitution, injected via chat middleware.

## Changelog

### Added
- Enterprise knowledge base management dashboard with 5 tabs
- 5 new database tables with Alembic migration
- 26 new RESTful API endpoints
- 5 new frontend pages + 7 Svelte components
- Real-time processing progress via SSE + polling fallback
- Retrieval quality evaluation with recall/precision/MRR metrics
- Knowledge base version management with snapshots and rollback
- Per-knowledge-base RAG prompt template configuration
- "Unlink Only" button for safer file removal

### Changed
- Extended knowledge router with chunk management, progress, evaluate, snapshot, and prompt endpoints
- Extended chat middleware to support per-KB prompt template injection
- Extended files upload pipeline with progress tracking hooks

## Testing

All endpoints verified with Python integration tests. Build passes (`npm run build`). Manual E2E testing completed covering: create KB → upload files → preview chunks → merge/split → reindex → progress monitoring → evaluation query → annotation → snapshot create → rollback → compare.

---

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.