### PR TITLE
fix: make native date/time picker icons visible in dark mode

### DIFF
--- a/src/lib/components/admin/Analytics/Dashboard.svelte
+++ b/src/lib/components/admin/Analytics/Dashboard.svelte
@@ -251,14 +251,14 @@
 				type="date"
 				bind:value={customStart}
 				max={customEnd || undefined}
-				class="w-fit rounded-sm px-2 text-xs bg-transparent outline-none"
+				class="w-fit rounded-sm px-2 text-xs bg-transparent outline-none dark:scheme-dark"
 			/>
 			<span class="text-xs text-gray-400">–</span>
 			<input
 				type="date"
 				bind:value={customEnd}
 				min={customStart || undefined}
-				class="w-fit rounded-sm px-2 text-xs bg-transparent outline-none"
+				class="w-fit rounded-sm px-2 text-xs bg-transparent outline-none dark:scheme-dark"
 			/>
 		{/if}
 		<select

--- a/src/lib/components/automations/ScheduleDropdown.svelte
+++ b/src/lib/components/automations/ScheduleDropdown.svelte
@@ -230,7 +230,7 @@
 							type="date"
 							bind:value={onceDate}
 							min={new Date().toISOString().split('T')[0]}
-							class="bg-transparent outline-hidden text-xs dark:color-scheme-dark"
+							class="bg-transparent outline-hidden text-xs dark:scheme-dark"
 							on:click={(e) => e.stopPropagation()}
 							on:input={onChange}
 						/>
@@ -239,7 +239,7 @@
 						<input
 							type="time"
 							bind:value={onceTime}
-							class="bg-transparent outline-hidden text-xs dark:color-scheme-dark"
+							class="bg-transparent outline-hidden text-xs dark:scheme-dark"
 							on:click={(e) => e.stopPropagation()}
 							on:input={onChange}
 						/>
@@ -256,7 +256,7 @@
 								minute = m;
 								onChange();
 							}}
-							class="bg-transparent text-center outline-hidden text-xs dark:color-scheme-dark"
+							class="bg-transparent text-center outline-hidden text-xs dark:scheme-dark"
 							on:click={(e) => e.stopPropagation()}
 						/>
 					</div>

--- a/src/lib/components/calendar/CalendarEventModal.svelte
+++ b/src/lib/components/calendar/CalendarEventModal.svelte
@@ -214,11 +214,11 @@
 			<div>
 				<div class="mb-1 text-xs text-gray-500">{$i18n.t('When')}</div>
 				<div class="flex items-center gap-2 text-sm flex-wrap">
-					<input type="date" class="bg-transparent outline-hidden" bind:value={startDate} />
+					<input type="date" class="bg-transparent outline-hidden dark:scheme-dark" bind:value={startDate} />
 					{#if !allDay}
-						<input type="time" class="bg-transparent outline-hidden" bind:value={startTime} />
+						<input type="time" class="bg-transparent outline-hidden dark:scheme-dark" bind:value={startTime} />
 						<span class="text-gray-300 dark:text-gray-600">–</span>
-						<input type="time" class="bg-transparent outline-hidden" bind:value={endTime} />
+						<input type="time" class="bg-transparent outline-hidden dark:scheme-dark" bind:value={endTime} />
 					{/if}
 					<label class="flex items-center gap-1.5 cursor-pointer text-xs text-gray-400 ml-auto">
 						<input type="checkbox" class="accent-blue-500" bind:checked={allDay} />

--- a/src/lib/components/chat/MessageInput/InputVariablesModal.svelte
+++ b/src/lib/components/chat/MessageInput/InputVariablesModal.svelte
@@ -175,7 +175,7 @@
 												{:else if variables[variable]?.type === 'date'}
 													<input
 														type="date"
-														class="w-full rounded-lg py-2 px-4 text-sm dark:text-gray-300 dark:bg-gray-850 outline-hidden border border-gray-100/30 dark:border-gray-850/30"
+														class="w-full rounded-lg py-2 px-4 text-sm dark:text-gray-300 dark:bg-gray-850 outline-hidden border border-gray-100/30 dark:border-gray-850/30 dark:scheme-dark"
 														placeholder={variables[variable]?.placeholder ?? ''}
 														bind:value={variableValues[variable]}
 														autocomplete="off"
@@ -186,7 +186,7 @@
 												{:else if variables[variable]?.type === 'datetime-local'}
 													<input
 														type="datetime-local"
-														class="w-full rounded-lg py-2 px-4 text-sm dark:text-gray-300 dark:bg-gray-850 outline-hidden border border-gray-100/30 dark:border-gray-850/30"
+														class="w-full rounded-lg py-2 px-4 text-sm dark:text-gray-300 dark:bg-gray-850 outline-hidden border border-gray-100/30 dark:border-gray-850/30 dark:scheme-dark"
 														placeholder={variables[variable]?.placeholder ?? ''}
 														bind:value={variableValues[variable]}
 														autocomplete="off"
@@ -208,7 +208,7 @@
 												{:else if variables[variable]?.type === 'month'}
 													<input
 														type="month"
-														class="w-full rounded-lg py-2 px-4 text-sm dark:text-gray-300 dark:bg-gray-850 outline-hidden border border-gray-100/30 dark:border-gray-850/30"
+														class="w-full rounded-lg py-2 px-4 text-sm dark:text-gray-300 dark:bg-gray-850 outline-hidden border border-gray-100/30 dark:border-gray-850/30 dark:scheme-dark"
 														placeholder={variables[variable]?.placeholder ?? ''}
 														bind:value={variableValues[variable]}
 														autocomplete="off"
@@ -283,7 +283,7 @@
 												{:else if variables[variable]?.type === 'time'}
 													<input
 														type="time"
-														class="w-full rounded-lg py-2 px-4 text-sm dark:text-gray-300 dark:bg-gray-850 outline-hidden border border-gray-100/30 dark:border-gray-850/30"
+														class="w-full rounded-lg py-2 px-4 text-sm dark:text-gray-300 dark:bg-gray-850 outline-hidden border border-gray-100/30 dark:border-gray-850/30 dark:scheme-dark"
 														placeholder={variables[variable]?.placeholder ?? ''}
 														bind:value={variableValues[variable]}
 														autocomplete="off"

--- a/src/lib/components/chat/Settings/Account.svelte
+++ b/src/lib/components/chat/Settings/Account.svelte
@@ -197,7 +197,7 @@
 				description={$i18n.t('Set the birth date saved with your profile.')}
 			>
 				<input
-					class={inputClass}
+					class="{inputClass} dark:scheme-dark"
 					type="date"
 					aria-label={$i18n.t('Birth Date')}
 					bind:value={dateOfBirth}


### PR DESCRIPTION
 <!--
  ⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
  1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
  2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
  -->

  **Before submitting, make sure you've checked the following:**

  - [x] **Linked Issue/Discussion:** Closes #27274
  - [x] **Target branch:** The pull request targets the `dev` branch.
  - [x] **Description:** A concise description of the changes is provided below.
  - [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
  - [x] **Documentation:** N/A — no documented behavior changes (visual-only fix).
  - [x] **Dependencies:** N/A — no new or updated dependencies.
  - [x] **Testing:** Manually verified in dark mode across the affected screens. Screenshot included below.
  - [x] **No Unchecked AI Code:** Change has been human-reviewed and manually tested.
  - [x] **Self-Review:** A self-review of the code has been performed.
  - [x] **Architecture:** No new settings; uses the existing Tailwind dark-mode variant, consistent with the rest of the codebase.
  - [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
  - [x] **Title Prefix:** `fix:`

 # Changelog Entry

 ### Description
 - Native date/time inputs (`date`, `time`, `month`, `datetime-local`) rendered their picker icons in a dark color that was nearly invisible on the dark background in dark mode. Added `dark:scheme-dark` (`color-scheme: dark`) so the browser renders these native controls for a dark UI.

### Fixed
- Date/time picker icons are now visible in dark mode (calendar event modal, automation schedule, Settings → Account, Admin → Analytics, prompt input variables).


### Screenshots or Videos

<img width="959" height="828" alt="image" src="https://github.com/user-attachments/assets/8edf2065-a29c-47c2-b4cb-d88f86e04afc" />

<img width="1001" height="803" alt="image" src="https://github.com/user-attachments/assets/fa5de0f1-b9a2-4751-8205-183b05962281" />

<img width="1339" height="830" alt="image" src="https://github.com/user-attachments/assets/99adb7b8-05e1-4d9c-a463-77a0f2e66420" />

<img width="1308" height="821" alt="image" src="https://github.com/user-attachments/assets/f2b61542-0726-4fd5-8b36-c18b2a54f882" />

  ### Contributor License Agreement

  <!--
  🚨 DO NOT DELETE THE TEXT BELOW 🚨
  Keep the "Contributor License Agreement" confirmation text intact.
  -->

  - [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement
  (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

  > [!NOTE]
  > Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.