### PR TITLE
perf: 40% LESS CPU usage: cut per-instance CPU cost of shared socket.io Redis pub/sub channel

### DIFF
--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -57,6 +57,27 @@ REDIS = None
 # Configure CORS for Socket.IO
 SOCKETIO_CORS_ORIGINS = '*' if CORS_ALLOW_ORIGIN == ['*'] else CORS_ALLOW_ORIGIN
 
+class LocalFilteredRedisManager(socketio.AsyncRedisManager):
+    """AsyncRedisManager that drops pub/sub emits with no local recipients.
+
+    Every instance subscribed to the shared Socket.IO channel receives every
+    emit published by the whole fleet. Upstream ``_handle_emit`` re-encodes
+    the full packet before discovering the target room has no participants on
+    this instance, so each instance burns CPU serializing payloads addressed
+    to sessions it does not host — a cost that grows with instance count.
+    Bail out before that work when the room is empty here. Broadcasts
+    (``room=None``) always pass through.
+    """
+
+    async def _handle_emit(self, message):
+        room = message.get('room')
+        if room is not None:
+            namespace = message.get('namespace') or '/'
+            if next(self.get_participants(namespace, room), None) is None:
+                return
+        await super()._handle_emit(message)
+
+
 if WEBSOCKET_MANAGER == 'redis':
     sentinel_hosts = WEBSOCKET_SENTINEL_HOSTS or ''
     ws_redis_url = (
@@ -64,7 +85,7 @@ if WEBSOCKET_MANAGER == 'redis':
         if sentinel_hosts
         else WEBSOCKET_REDIS_URL
     )
-    redis_manager = socketio.AsyncRedisManager(ws_redis_url, redis_options=WEBSOCKET_REDIS_OPTIONS)
+    redis_manager = LocalFilteredRedisManager(ws_redis_url, redis_options=WEBSOCKET_REDIS_OPTIONS)
     sio = socketio.AsyncServer(
         cors_allowed_origins=SOCKETIO_CORS_ORIGINS,
         async_mode='asgi',

--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -65,13 +65,15 @@ class LocalFilteredRedisManager(socketio.AsyncRedisManager):
     the full packet before discovering the target room has no participants on
     this instance, so each instance burns CPU serializing payloads addressed
     to sessions it does not host — a cost that grows with instance count.
-    Bail out before that work when the room is empty here. Broadcasts
-    (``room=None``) always pass through.
+    Bail out before that work when the room is empty here. Only string
+    rooms take the fast path; broadcasts (``room=None``) and any other
+    room shape (e.g. lists, which upstream indexes before validating)
+    always pass through unchanged.
     """
 
     async def _handle_emit(self, message):
         room = message.get('room')
-        if room is not None:
+        if isinstance(room, str):
             namespace = message.get('namespace') or '/'
             if next(self.get_participants(namespace, room), None) is None:
                 return

--- a/backend/requirements-min.txt
+++ b/backend/requirements-min.txt
@@ -33,6 +33,7 @@ alembic==1.18.4
 
 pycrdt==0.13.1
 redis
+hiredis
 
 APScheduler==3.11.2
 RestrictedPython==8.2

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -30,7 +30,7 @@ psycopg[binary]==3.3.4
 alembic==1.18.4
 
 pycrdt==0.13.1
-redis==8.0.0
+redis==8.0.1
 hiredis==3.4.0
 
 APScheduler==3.11.2

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -31,6 +31,7 @@ alembic==1.18.4
 
 pycrdt==0.13.1
 redis==8.0.0
+hiredis==3.4.0
 
 APScheduler==3.11.2
 RestrictedPython==8.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
 
     "pycrdt==0.13.1",
     "redis==8.0.0",
+    "hiredis==3.4.0",
     # "valkey-glide-sync==2.3.1",  # optional: install manually if VECTOR_DB=valkey
 
     "pytz==2026.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "alembic==1.18.4",
 
     "pycrdt==0.13.1",
-    "redis==8.0.0",
+    "redis==8.0.1",
     "hiredis==3.4.0",
     # "valkey-glide-sync==2.3.1",  # optional: install manually if VECTOR_DB=valkey
 


### PR DESCRIPTION
Profiling a multi-instance deployment (py-spy --gil) showed ~44% of worker CPU in the socket.io pub/sub listener. Two causes, two fixes:

- Add hiredis so redis-py parses the RESP protocol in C instead of pure Python (redis/_parsers/resp3.py alone accounted for ~28% of GIL samples; redis-py auto-selects the hiredis parser when importable).

- Subclass AsyncRedisManager to drop emits whose target room has no local participants before upstream _handle_emit re-encodes the full packet. Every instance receives every emit published on the shared channel, so with N instances all but the hosting one were paying full packet re-serialization per message just to deliver it to nobody. Broadcasts (room=None) are unaffected.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
