### PR TITLE
perf: cache the per-request enable_api_keys config read

### DIFF
--- a/backend/open_webui/models/config.py
+++ b/backend/open_webui/models/config.py
@@ -106,6 +106,9 @@ class Config(Base):
     DEFAULTS: ClassVar[dict[str, Any]] = {}
     PERSISTENT_ENABLED: ClassVar[bool] = True
     OAUTH_PERSISTENT_ENABLED: ClassVar[bool] = False
+    # Bumped on every write so read-side caches (e.g. AuthTokenMiddleware's
+    # enable_api_keys snapshot) can invalidate same-process without a DB read.
+    GENERATION: ClassVar[int] = 0
 
     # ── Class methods ────────────────────────────────────────
 
@@ -202,6 +205,7 @@ class Config(Base):
                 Config.DEFAULTS[key] = value
 
         if not persistent_updates:
+            Config.GENERATION += 1
             return
 
         async with get_async_db() as db:
@@ -214,6 +218,7 @@ class Config(Base):
                 else:
                     db.add(Config(key=key, value=value, updated_at=now))
             await db.commit()
+        Config.GENERATION += 1
 
     @staticmethod
     async def delete(key: str) -> bool:
@@ -223,6 +228,7 @@ class Config(Base):
             if row:
                 await db.delete(row)
                 await db.commit()
+                Config.GENERATION += 1
                 return True
             return False
 
@@ -232,6 +238,7 @@ class Config(Base):
         async with get_async_db() as db:
             await db.execute(delete(Config))
             await db.commit()
+        Config.GENERATION += 1
 
     @staticmethod
     async def seed_defaults(defaults: dict) -> None:

--- a/backend/open_webui/utils/asgi_middleware.py
+++ b/backend/open_webui/utils/asgi_middleware.py
@@ -141,11 +141,35 @@ class AuthTokenMiddleware:
     Also exposes `request.state.enable_api_keys` (snapshotted at request
     entry from runtime config) and stamps an `X-Process-Time` response
     header.
+
+    The enable_api_keys flag is cached with bounded staleness instead of
+    hitting the DB on every request: config writes in this process
+    invalidate immediately via `Config.GENERATION`; writes from other
+    instances become visible within `CONFIG_CACHE_TTL` seconds.
     """
+
+    CONFIG_CACHE_TTL = 15.0
 
     def __init__(self, app: ASGIApp, *, fastapi_app) -> None:
         self.app = app
         self._fastapi_app = fastapi_app
+        self._api_keys_value = None
+        self._api_keys_expires = 0.0
+        self._api_keys_generation = -1
+
+    async def _get_enable_api_keys(self):
+        now = time.monotonic()
+        if now < self._api_keys_expires and self._api_keys_generation == Config.GENERATION:
+            return self._api_keys_value
+        # Capture the generation before the fetch: a write that lands mid-read
+        # bumps it, so the next request refetches rather than trusting a value
+        # that may predate the write.
+        generation = Config.GENERATION
+        value = await Config.get('auth.enable_api_keys')
+        self._api_keys_value = value
+        self._api_keys_expires = now + self.CONFIG_CACHE_TTL
+        self._api_keys_generation = generation
+        return value
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope['type'] != 'http':
@@ -166,7 +190,7 @@ class AuthTokenMiddleware:
                 token = HTTPAuthorizationCredentials(scheme='Bearer', credentials=api_key)
 
         request.state.token = token
-        request.state.enable_api_keys = await Config.get('auth.enable_api_keys')
+        request.state.enable_api_keys = await self._get_enable_api_keys()
 
         async def send_with_timing(message: Message) -> None:
             if message['type'] == 'http.response.start':


### PR DESCRIPTION
AuthTokenMiddleware ran an uncached Config.get('auth.enable_api_keys') on every HTTP request — one DB round-trip per request, fleet-wide. (The pre-refactor code read the in-memory app.state.config attribute; the per-key config refactor traded that for an always-fresh DB read.)

Cache the flag per process with bounded staleness: a 15s TTL, plus a Config.GENERATION counter bumped by upsert/delete/clear so config writes in the same process invalidate on the very next request. Writes from other instances become visible within the TTL — a middle ground between the old process-lifetime staleness and the current per-request read. The generation is captured before the awaited fetch, so a write landing mid-read forces a refetch on the next request rather than caching a value that may predate the write. Fetch errors propagate per request and are never cached.

Per-credential security checks are unaffected: API key lookup, user permissions, and endpoint restrictions all remain live per-request reads; only the global enable toggle carries the bounded staleness.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
