### PR TITLE
fix: strip knowledge file content from /api/models payload

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -817,6 +817,46 @@ if audit_level != AuditLevel.NONE:
 ##################################
 
 
+def _strip_knowledge_content(model: dict) -> dict:
+    """Return a copy of `model` with attached knowledge file bodies removed.
+
+    A model with an attached knowledge base stores each file's fully-extracted
+    text in ``info.meta.knowledge``: knowledge files selected from a base keep
+    it under ``item["data"]["content"]``, while files uploaded through the model
+    editor keep it under ``item["file"]["data"]["content"]``. The model list
+    only needs each item's identity (id/name/collection) to render, and
+    retrieval re-fetches file content by id at query time, so inlining these
+    bodies is pure overhead — a single model with a large knowledge base can add
+    tens of MB to the ``/api/models`` response.
+
+    Nested dicts are copied rather than mutated so the shared
+    ``request.app.state.MODELS`` cache (reused for chat retrieval) keeps its
+    content intact.
+    """
+    meta = (model.get('info') or {}).get('meta') or {}
+    knowledge = meta.get('knowledge')
+    if not knowledge:
+        return model
+
+    def _drop_content(obj: dict) -> dict:
+        data = obj.get('data')
+        if not (isinstance(data, dict) and 'content' in data):
+            return obj
+        return {**obj, 'data': {k: v for k, v in data.items() if k != 'content'}}
+
+    stripped = []
+    for item in knowledge:
+        if not isinstance(item, dict):
+            stripped.append(item)
+            continue
+        item = _drop_content(item)
+        if isinstance(item.get('file'), dict):
+            item = {**item, 'file': _drop_content(item['file'])}
+        stripped.append(item)
+
+    return {**model, 'info': {**model['info'], 'meta': {**meta, 'knowledge': stripped}}}
+
+
 @app.get('/api/models')
 @app.get('/api/v1/models')  # Experimental: Compatibility with OpenAI API
 async def get_models(request: Request, refresh: bool = False, user=Depends(get_verified_user)):
@@ -831,6 +871,10 @@ async def get_models(request: Request, refresh: bool = False, user=Depends(get_v
         # Remove profile image URL to reduce payload size
         if model.get('info', {}).get('meta', {}).get('profile_image_url'):
             model['info']['meta'].pop('profile_image_url', None)
+
+        # Drop attached knowledge file bodies (info.meta.knowledge[*].data.content):
+        # unused by the model list and potentially tens of MB per model.
+        model = _strip_knowledge_content(model)
 
         try:
             model_tags = [tag.get('name') for tag in model.get('info', {}).get('meta', {}).get('tags', [])]


### PR DESCRIPTION
Models with an attached knowledge base inline each file's fully-extracted text (`info.meta.knowledge[*].data.content`, and `.file.data.content` for files uploaded via the model editor) into every `/api/models` response. The model list never uses these bodies — retrieval re-fetches file content by id at query time — so a single model with a large knowledge base can add tens of MB to the response and break clients that consume the model list.

Strip `data.content` from knowledge items in the `/api/models` serialization, copying the affected nested dicts so the cached model reused for chat retrieval keeps its content.

Closes #27287

<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27287
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [x] **Documentation:** No documentation changes needed (internal response-shaping fix, no API/behavior contract change).
- [x] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Manual before/after test performed on a local instance (see Additional Information).
- [x] **No Unchecked AI Code:** This PR has undergone thorough human review AND manual testing.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new settings introduced; the model list simply stops emitting data it never needs.
- [x] **Git Hygiene:** The PR is atomic (one file, one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses the `fix:` prefix.

# Changelog Entry

### Description

`GET /api/models` inlined the full extracted text of every attached knowledge base file into the response, under `data[].info.meta.knowledge[*].data.content` (and `…knowledge[*].file.data.content` for files uploaded via the model editor). The payload grew linearly with the total size of the attached documents, so a single model with a moderately large knowledge base could add tens of MB to the response and break tools that consume the model list.

The model list never uses these bodies: the frontend renders knowledge badges from `id`/`name` only, and retrieval re-fetches file content by id at query time. This PR strips `data.content` from knowledge items (and their nested `file` objects) in the `/api/models` serialization. Nested dicts are copied rather than mutated, so the cached model reused for chat retrieval keeps its content intact.

### Fixed

- Stripped knowledge file contents (`info.meta.knowledge[*].data.content` and nested `file.data.content`) from the `/api/models` response, drastically reducing payload size for models with attached knowledge bases. The cached model used for chat retrieval is left untouched.

---

### Additional Information

Same "don't materialize `data.content` unless requested" concern as #26144 (knowledge files endpoint) and the precedent in #25774 (`content: bool` query param on the files endpoints) — this PR covers the `/api/models` path, which neither of those addresses.

**Manual test** on a local instance (from source, `dev` @ v0.10.2, Python 3.11, SQLite), identical data for both runs — a preset model with 20 attached knowledge files of ~2 MB extracted text each:

| GET /api/models        | before (dev) | after (this PR) |
|------------------------|-------------:|----------------:|
| total response         | 40,002,222 B |         2,142 B |
| the model's entry      | 40,001,991 B |         1,891 B |
| knowledge data.content |      present |          absent |

Knowledge item identity (`id` / `name` / `base_model_id` / `knowledge[].id` / `name`) is preserved; only the file bodies are dropped. The model still lists and renders correctly, and retrieval continues to work (it re-fetches file content by id at query time).

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
