### PR TITLE
fix: honor the webhooks permission when saving user notification settings

### DIFF
--- a/backend/open_webui/routers/users.py
+++ b/backend/open_webui/routers/users.py
@@ -475,6 +475,20 @@ async def update_user_settings_by_session_user(
         # If the user is not an admin and does not have permission to use tool servers, remove the key
         updated_user_settings['ui'].pop('toolServers', None)
 
+    notifications = ui_settings.get('notifications') if ui_settings is not None else None
+    if (
+        user.role != 'admin'
+        and isinstance(notifications, dict)
+        and notifications.get('webhook_url')
+        and not await has_permission(
+            user.id,
+            'features.webhooks',
+            await Config.get('user.permissions'),
+        )
+    ):
+        # If the user is not an admin and does not have the webhooks permission, drop the webhook URL
+        updated_user_settings['ui']['notifications'].pop('webhook_url', None)
+
     user = await Users.update_user_settings_by_id(user.id, updated_user_settings, db=db)
     if user:
         await publish_event(


### PR DESCRIPTION
The user settings update route strips `ui.toolServers` for non-admin users who lack the `features.direct_tool_servers` permission, but applies no equivalent check for `ui.notifications.webhook_url` against `features.webhooks`. The notification webhook URL is therefore persisted for users whose webhooks permission is disabled, so the backend does not reflect the configured permission the way the interface does.

Strip `ui.notifications.webhook_url` for non-admin users who lack `features.webhooks`, mirroring the existing tool-servers handling, so a disabled webhooks permission is honored server-side and not only in the UI.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
