### PR TITLE
feat: add PKCE (OAUTH_CODE_CHALLENGE_METHOD) support to google/github/microsoft OAuth providers

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -2572,15 +2572,25 @@ def load_oauth_providers():
     if GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET:
 
         def google_oauth_register(oauth: OAuth):
+            client_kwargs = {
+                'scope': GOOGLE_OAUTH_SCOPE,
+                **({'timeout': int(OAUTH_TIMEOUT)} if OAUTH_TIMEOUT else {}),
+            }
+
+            if OAUTH_CODE_CHALLENGE_METHOD and OAUTH_CODE_CHALLENGE_METHOD == 'S256':
+                client_kwargs['code_challenge_method'] = 'S256'
+            elif OAUTH_CODE_CHALLENGE_METHOD:
+                raise Exception(
+                    'Code challenge methods other than "%s" not supported. Given: "%s"'
+                    % ('S256', OAUTH_CODE_CHALLENGE_METHOD)
+                )
+
             client = oauth.register(
                 name='google',
                 client_id=GOOGLE_CLIENT_ID,
                 client_secret=GOOGLE_CLIENT_SECRET,
                 server_metadata_url='https://accounts.google.com/.well-known/openid-configuration',
-                client_kwargs={
-                    'scope': GOOGLE_OAUTH_SCOPE,
-                    **({'timeout': int(OAUTH_TIMEOUT)} if OAUTH_TIMEOUT else {}),
-                },
+                client_kwargs=client_kwargs,
                 redirect_uri=GOOGLE_REDIRECT_URI,
                 **({'authorize_params': GOOGLE_OAUTH_AUTHORIZE_PARAMS} if GOOGLE_OAUTH_AUTHORIZE_PARAMS else {}),
             )
@@ -2593,15 +2603,25 @@ def load_oauth_providers():
     if MICROSOFT_CLIENT_ID and MICROSOFT_CLIENT_SECRET and MICROSOFT_CLIENT_TENANT_ID:
 
         def microsoft_oauth_register(oauth: OAuth):
+            client_kwargs = {
+                'scope': MICROSOFT_OAUTH_SCOPE,
+                **({'timeout': int(OAUTH_TIMEOUT)} if OAUTH_TIMEOUT else {}),
+            }
+
+            if OAUTH_CODE_CHALLENGE_METHOD and OAUTH_CODE_CHALLENGE_METHOD == 'S256':
+                client_kwargs['code_challenge_method'] = 'S256'
+            elif OAUTH_CODE_CHALLENGE_METHOD:
+                raise Exception(
+                    'Code challenge methods other than "%s" not supported. Given: "%s"'
+                    % ('S256', OAUTH_CODE_CHALLENGE_METHOD)
+                )
+
             client = oauth.register(
                 name='microsoft',
                 client_id=MICROSOFT_CLIENT_ID,
                 client_secret=MICROSOFT_CLIENT_SECRET,
                 server_metadata_url=f'{MICROSOFT_CLIENT_LOGIN_BASE_URL}/{MICROSOFT_CLIENT_TENANT_ID}/v2.0/.well-known/openid-configuration?appid={MICROSOFT_CLIENT_ID}',
-                client_kwargs={
-                    'scope': MICROSOFT_OAUTH_SCOPE,
-                    **({'timeout': int(OAUTH_TIMEOUT)} if OAUTH_TIMEOUT else {}),
-                },
+                client_kwargs=client_kwargs,
                 redirect_uri=MICROSOFT_REDIRECT_URI,
             )
             return client
@@ -2614,6 +2634,19 @@ def load_oauth_providers():
     if GITHUB_CLIENT_ID and GITHUB_CLIENT_SECRET:
 
         def github_oauth_register(oauth: OAuth):
+            client_kwargs = {
+                'scope': GITHUB_CLIENT_SCOPE,
+                **({'timeout': int(OAUTH_TIMEOUT)} if OAUTH_TIMEOUT else {}),
+            }
+
+            if OAUTH_CODE_CHALLENGE_METHOD and OAUTH_CODE_CHALLENGE_METHOD == 'S256':
+                client_kwargs['code_challenge_method'] = 'S256'
+            elif OAUTH_CODE_CHALLENGE_METHOD:
+                raise Exception(
+                    'Code challenge methods other than "%s" not supported. Given: "%s"'
+                    % ('S256', OAUTH_CODE_CHALLENGE_METHOD)
+                )
+
             client = oauth.register(
                 name='github',
                 client_id=GITHUB_CLIENT_ID,
@@ -2622,10 +2655,7 @@ def load_oauth_providers():
                 authorize_url='https://github.com/login/oauth/authorize',
                 api_base_url='https://api.github.com',
                 userinfo_endpoint='https://api.github.com/user',
-                client_kwargs={
-                    'scope': GITHUB_CLIENT_SCOPE,
-                    **({'timeout': int(OAUTH_TIMEOUT)} if OAUTH_TIMEOUT else {}),
-                },
+                client_kwargs=client_kwargs,
                 redirect_uri=GITHUB_CLIENT_REDIRECT_URI,
             )
             return client


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Relates to [discussion #13074](https://github.com/open-webui/open-webui/discussions/13074).
- [x] **Target branch:** Targets `dev`.
- [x] **Description:** Provided below.
- [x] **Changelog:** Provided below.
- [ ] **Documentation:** `OAUTH_CODE_CHALLENGE_METHOD` is already documented; can add a provider-applicability note to the docs repo if wanted.
- [x] **Dependencies:** None.
- [x] **Testing:** Six-criteria test matrix with one-command reproduction — see Additional Information.
- [x] **No Unchecked AI Code:** Reviewed line-by-line against the existing `oidc` block and runtime-tested.
- [x] **Self-Review:** Done.
- [x] **Architecture:** No new settings — reuses the `OAUTH_CODE_CHALLENGE_METHOD` config the `oidc` provider already reads.
- [x] **Git Hygiene:** Single atomic commit, rebased on `dev`.
- [x] **Title Prefix:** `feat`

# Changelog Entry

### Description

`OAUTH_CODE_CHALLENGE_METHOD` (PKCE, added in [#12563](https://github.com/open-webui/open-webui/pull/12563)) is only read by the generic `oidc` register block; the dedicated `google`, `microsoft`, and `github` blocks ignore it, so PKCE cannot be enabled on those providers. This bites hardest with Microsoft Entra ID: SPA-platform app registrations reject the token exchange with `AADSTS9002325`, and the only workaround today is abandoning the `microsoft` provider for the generic `oidc` one ([#13074](https://github.com/open-webui/open-webui/discussions/13074)).

This PR mirrors the `oidc` block's existing S256-or-raise handling into the three provider register functions — same control flow, same exception. Nothing changes when `OAUTH_CODE_CHALLENGE_METHOD` is unset: the new branches don't run and `client_kwargs` is built exactly as before.

### Added

- PKCE (`OAUTH_CODE_CHALLENGE_METHOD=S256`) support for the `google`, `microsoft`, and `github` OAuth providers, matching the existing `oidc` provider behavior.

### Changed

- `google_oauth_register`, `microsoft_oauth_register`, and `github_oauth_register` now build `client_kwargs` as a local variable (the `oidc_oauth_register` pattern) so the conditional PKCE key can be added uniformly.

---

### Additional Information

- Precedent: [#15366](https://github.com/open-webui/open-webui/pull/15366) threaded `OAUTH_TIMEOUT` through all provider blocks in one PR the same way. Happy to split to `microsoft`-only if preferred.
- Heads-up: [#26934](https://github.com/open-webui/open-webui/pull/26934) refactors the same register blocks (PKCE stays `oidc`-only there, so the two are complementary). Happy to rebase onto whichever lands first.

**Testing.** Environment: `open-webui==0.10.2` (PyPI wheel), Python 3.12, Linux. Pristine and patched `config.py` are rebuilt from a fresh wheel on every run and checksummed ([checksums.txt](https://github.com/NoobInTheNet/openwebui-pkce-proof/blob/main/proof/checksums.txt)); every criterion is asserted by script against captured evidence (HTTP `Location` headers, server and IdP logs, DB state).

| # | Criterion | Method | Result |
|---|---|---|---|
| C1 | Gap exists (control) | Unpatched + `S256`: capture the `/oauth/microsoft/login` authorize redirect; same-process `oidc` as positive control | `microsoft` emits no `code_challenge`; `oidc` does — pass |
| C2 | Patch works | Patched + `S256`: capture authorize redirects for all four providers | `code_challenge` + `code_challenge_method=S256` on all four — pass |
| C3 | No change when unset | Query-param key-set comparison, patched vs pristine, env unset | Identical sets, no `code_challenge` either side — pass |
| C4 | Invalid value rejected | `OAUTH_CODE_CHALLENGE_METHOD=plain` at startup | Same exception as the `oidc` block, non-zero exit — pass |
| C5 | End-to-end handshake | Full login against a local mock OIDC IdP that fails the token exchange unless `BASE64URL(SHA256(code_verifier)) == code_challenge` | Verifier matched, login completed, user created — pass |
| C6 | Repo lint gates | CI commands: `ruff format --check`, `ruff check --select=F` | Both exit 0 — pass |

**Reproduce:** run [`./run_proof.sh`](https://github.com/NoobInTheNet/openwebui-pkce-proof/tree/main/proof) — pins `open-webui==0.10.2`, rebuilds both configs from a fresh wheel, runs C1–C6, prints the verdict table. Raw per-criterion evidence in [captured/](https://github.com/NoobInTheNet/openwebui-pkce-proof/tree/main/proof/captured).

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
