### PR TITLE
fix: migrate deprecated authlib.jose import to joserfc in oauth utils

### DIFF
--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -16,7 +16,6 @@ from typing import Literal, Optional
 
 import aiohttp
 from authlib.integrations.starlette_client import OAuth
-from authlib.jose.errors import BadSignatureError
 from authlib.oauth2.rfc6749.errors import OAuth2Error
 from authlib.oidc.core import UserInfo
 from cryptography.fernet import Fernet
@@ -24,6 +23,7 @@ from fastapi import (
     HTTPException,
     status,
 )
+from joserfc.errors import BadSignatureError
 from joserfc.jws import JWSRegistry
 from joserfc.registry import HeaderParameter
 from mcp.shared.auth import (

--- a/backend/requirements-min.txt
+++ b/backend/requirements-min.txt
@@ -14,6 +14,7 @@ bcrypt==5.0.0
 argon2-cffi==25.1.0
 PyJWT[crypto]==2.13.0
 authlib==1.7.2
+joserfc==1.7.4
 
 requests==2.34.2
 aiohttp==3.13.5 # do not update to 3.13.3 - broken

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,6 +11,7 @@ bcrypt==5.0.0
 argon2-cffi==25.1.0
 PyJWT[crypto]==2.13.0
 authlib==1.7.2
+joserfc==1.7.4
 
 requests==2.34.2
 aiohttp==3.13.5 # do not update to 3.13.3 - broken

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "argon2-cffi==25.1.0",
     "PyJWT[crypto]==2.13.0",
     "authlib==1.7.2",
+    "joserfc==1.7.4",
 
     "requests==2.34.2",
     "aiohttp==3.13.5", # do not update to 3.13.3 - broken


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #26407 — `AuthlibDeprecationWarning: authlib.jose module` on backend startup. (#27309 was filed before finding the existing report and is closed as its duplicate.)
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented. *(`joserfc==1.7.4` is added as an explicit pin, but it is **not a new install**: it is already a hard dependency of `authlib==1.7.2` and is already imported directly by `backend/open_webui/utils/oauth.py` — it was just never declared. Pinning it makes the direct usage explicit and reproducible.)*
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately. *(See AI-assistance disclosure below.)*
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

**Suggested PR title:** `fix: migrate deprecated authlib.jose import to joserfc in oauth utils`

# Changelog Entry

### Description

**Problem:** Every backend startup logs:

```
/app/backend/open_webui/utils/oauth.py:19: AuthlibDeprecationWarning: authlib.jose module is deprecated, please use joserfc instead.
It will be compatible before version 2.0.0.
  from authlib.jose.errors import BadSignatureError
```

**Root cause — and a hidden bug:** `oauth.py` imports `BadSignatureError` from the deprecated `authlib.jose.errors` and uses it in `handle_callback` to catch bad ID-token signatures so it can evict a stale cached JWKS and retry (the IdP key-rotation recovery path). However, since Authlib 1.7 the OIDC client performs all JOSE operations through **joserfc**: `parse_id_token` calls `joserfc.jwt.decode`, which on a signature failure raises `joserfc.errors.BadSignatureError`. The two exception classes have **completely disjoint hierarchies** (verified against `authlib==1.7.2` / `joserfc==1.7.4`):

- `authlib.jose.errors.BadSignatureError` → `authlib.jose.errors.JoseError` → `AuthlibBaseError`
- `joserfc.errors.BadSignatureError` → `joserfc.errors.JoseError` → `Exception`

So the `except BadSignatureError:` handler could **never fire** — a rotated signing key with an unchanged `kid` fell through to the generic error path (HTTP 400 `INVALID_CRED`) instead of evicting the cached JWKS and retrying. The deprecation warning and this dead recovery path share the same one-line fix.

**Fix:** Import the exception from `joserfc` (which `oauth.py` already imports directly for `JWSRegistry`/`HeaderParameter`), and declare the already-transitively-installed `joserfc` dependency explicitly:

```diff
 from authlib.integrations.starlette_client import OAuth
-from authlib.jose.errors import BadSignatureError
 from authlib.oauth2.rfc6749.errors import OAuth2Error
 ...
+from joserfc.errors import BadSignatureError
 from joserfc.jws import JWSRegistry
 from joserfc.registry import HeaderParameter
```

```diff
 authlib==1.7.2
+joserfc==1.7.4
```

(`joserfc==1.7.4` added to `backend/requirements.txt`, `backend/requirements-min.txt`, and `pyproject.toml` — it is what `authlib==1.7.2` already resolves and installs today.)

Scope: 4 files, +4/−1 lines. No remaining `authlib.jose` references in the backend after this change.

### Fixed

- Fixed the `AuthlibDeprecationWarning: authlib.jose module is deprecated` warning emitted on every backend startup by migrating the last `authlib.jose` import to `joserfc`.
- Fixed the OIDC stale-JWKS recovery path in `handle_callback` never triggering: it caught `authlib.jose.errors.BadSignatureError` while Authlib ≥1.7 raises `joserfc.errors.BadSignatureError`, so signing-key rotation with a reused `kid` failed with `INVALID_CRED` instead of refreshing the cached JWKS and retrying.

---

### Additional Information

- Verified against a clean `authlib==1.7.2` environment: Authlib's `AsyncOpenIDMixin.parse_id_token` decodes via `joserfc.jwt.decode` and propagates `joserfc.errors.BadSignatureError` untranslated; the two `BadSignatureError` classes share no common ancestor below `Exception`; importing only `joserfc` emits no warnings (checked with warnings-as-errors).
- `ruff format --check` passes on the touched file; `ruff check` reports the identical pre-existing findings before and after (no new lint errors).
- *AI-assistance disclosure: This PR was prepared with AI assistance (Claude Code). Automated verification — exception-hierarchy and raise-path verification against a pinned `authlib==1.7.2`/`joserfc==1.7.4` environment, `py_compile`, and ruff format/lint parity checks — was performed by the AI. Manual verification on a live instance was performed by the author per the steps below.*

**Manual Verification Performed**

1. Rebuild/restart the backend on this branch — the `AuthlibDeprecationWarning` no longer appears in startup logs.
2. `grep -rn "authlib.jose" backend/` returns nothing.
3. Log in via an OIDC provider — the standard OAuth login flow works unchanged.
4. `pip install -r backend/requirements.txt` resolves cleanly (`joserfc==1.7.4` is already what authlib pulls; no version conflict).

### Screenshots or Videos

- [Optional: before/after startup log snippet]

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
