### PR TITLE
fix: make native date/time picker icons visible in dark mode

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -720,11 +720,15 @@ input[type='number'] {
 body {
 	background: #fff;
 	color: #000;
-}
+}.dark body { background: #171717; color: #eee; }
 
-.dark body {
-	background: #171717;
-	color: #eee;
+/* Make native date/time picker icons visible in dark mode */
+.dark input[type="date"],
+.dark input[type="time"],
+.dark input[type="datetime-local"],
+.dark input[type="month"],
+.dark input[type="week"] {
+	color-scheme: dark;
 }
 
 /* Position the handle relative to each LI */


### PR DESCRIPTION
## Description

Fixes [#27274](https://github.com/open-webui/open-webui/issues/27274) - native `<input type="date">` and `<input type="time">` icons are invisible in dark mode because they render dark icons on dark backgrounds.

## Root Cause

Browsers use the OS color scheme to render native date/time picker icons. In dark mode, without an explicit `color-scheme` hint, browsers render dark-colored icons that blend into the dark background.

## Fix

Added a global CSS rule in `src/app.css` that sets `color-scheme: dark` on native date/time inputs when the `.dark` class is active. This forces browsers to render the picker icons with a light color scheme, making them visible on dark backgrounds.

## Affected UI Locations
- Calendar event creation modal
- Settings → Account → Birth Date
- Admin Panel → Analytics → Custom period
- Automations schedule dropdown (already had the fix, this makes it consistent)
- All other date/time inputs across the app

Closes #27274