### PR TITLE
fix: Set color-scheme: dark in dark mode for native date/time picker icons

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -725,6 +725,7 @@ body {
 .dark body {
 	background: #171717;
 	color: #eee;
+	color-scheme: dark;
 }
 
 /* Position the handle relative to each LI */


### PR DESCRIPTION
## Summary

Native date/time picker icons (calendar, clock) were invisible in dark mode because the browser renders them using the current `color-scheme` value, which defaults to "light" even when the page has a dark background.

## Changes

One line added to `src/app.css`:

```css
.dark body {
    background: #171717;
    color: #eee;
+   color-scheme: dark;
}
```

This tells the browser to render native form controls with the dark color scheme, making their icons visible against the dark background.

Fixes #27274

## Checklist
- [x] Bug fix
- [x] No breaking changes