### PR TITLE
fix: handle concurrent duplicate user creation in trusted-header signin

### DIFF
--- a/backend/open_webui/models/auths.py
+++ b/backend/open_webui/models/auths.py
@@ -133,6 +133,9 @@ class AuthsTable:
                 oauth=oauth,
                 db=session,
             )
+            if not created_user:
+                await session.rollback()
+                return None
             # persist both records and reload generated defaults
             await session.commit()
             await session.refresh(credential)

--- a/backend/open_webui/models/users.py
+++ b/backend/open_webui/models/users.py
@@ -27,6 +27,7 @@ from sqlalchemy import (
     select,
     update,
 )
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -301,7 +302,11 @@ class UsersTable:
             )
             result = User(**user.model_dump())
             session.add(result)
-            await session.commit()
+            try:
+                await session.commit()
+            except IntegrityError:
+                await session.rollback()
+                return None
             await session.refresh(result)
             return user if result else None
 

--- a/backend/open_webui/routers/auths.py
+++ b/backend/open_webui/routers/auths.py
@@ -681,14 +681,20 @@ async def signin(
                 pass
 
         if not await Users.get_user_by_email(email.lower(), db=db):
-            await signup_handler(
-                request,
-                email,
-                str(uuid.uuid4()),
-                name,
-                db=db,
-                source='trusted_header',
-            )
+            try:
+                await signup_handler(
+                    request,
+                    email,
+                    str(uuid.uuid4()),
+                    name,
+                    db=db,
+                    source='trusted_header',
+                )
+            except HTTPException as e:
+                if e.status_code != 409:
+                    raise
+                # Concurrent request already created the user — fall through
+                # to authenticate_user_by_email below.
 
         user = await Auths.authenticate_user_by_email(email, db=db)
         if user:
@@ -791,7 +797,7 @@ async def signup_handler(
         db=db,
     )
     if not user:
-        raise HTTPException(500, detail=ERROR_MESSAGES.CREATE_USER_ERROR)
+        raise HTTPException(409, detail=ERROR_MESSAGES.EMAIL_TAKEN)
 
     # Atomically check if this is the only user *after* the insert.
     # Only the single user present at this point should become admin.


### PR DESCRIPTION
## Summary
- Fixes a TOCTOU race condition in the trusted-header sign-in path where concurrent requests for the same new email both pass get_user_by_email() before either completes, causing a DB IntegrityError from the unique constraint on User.email.
- Catch IntegrityError in Users.insert_new_user and return None on conflict
- Short-circuit in Auths.insert_new_auth when the nested user insert fails
- signup_handler raises 409 Conflict (not 500) on duplicate detection
- Trusted-header path catches the 409 and falls through to authenticate_user_by_email

## Test plan
- Deploy to multi-replica environment and verify concurrent trusted-header requests for the same new email do not create duplicate users
- Verify existing signup flows (password, LDAP, no-auth) still work
- Verify that when insert_new_user catches IntegrityError, the session is rolled back cleanly and no zombie rows remain