### PR TITLE
fix: keep the Analytics settings tab contained within the settings modal

### DIFF
--- a/src/lib/components/admin/Analytics/ChartLine.svelte
+++ b/src/lib/components/admin/Analytics/ChartLine.svelte
@@ -47,7 +47,7 @@
 <div class="relative w-full" style="height:{height}px">
 	<svg
 		viewBox="0 0 {w} {height - 20}"
-		class="h-[calc(100%-20px)] w-full"
+		class="absolute inset-x-0 top-0 h-[calc(100%-20px)] w-full"
 		preserveAspectRatio="none"
 		onmousemove={onMove}
 		onmouseleave={() => (hoveredIdx = null)}
@@ -88,7 +88,7 @@
 			: period === 'year' || period === 'all'
 				? 'M/D/YY'
 				: 'M/D'}
-		<div class="flex justify-between px-0.5 text-[10px] text-gray-400">
+		<div class="absolute inset-x-0 bottom-0 flex justify-between px-0.5 text-[10px] text-gray-400">
 			{#each Array(labelCount) as _, i}
 				{@const idx = i === labelCount - 1 ? data.length - 1 : Math.min(i * step, data.length - 1)}
 				{#if data[idx]}

--- a/src/lib/components/chat/SettingsModal.svelte
+++ b/src/lib/components/chat/SettingsModal.svelte
@@ -1151,7 +1151,7 @@
 		</div>
 	</nav>
 
-	<div class="flex-1 min-h-0 p-4 md:px-5 flex flex-col">
+	<div class="flex-1 min-w-0 min-h-0 p-4 md:px-5 flex flex-col">
 		<div class="flex-1 min-h-0 overflow-hidden">
 			{#if selectedTab === 'general'}
 				<General


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27329 — admin Analytics settings tab expands outside the settings modal.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented. *(No new dependencies.)*
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately. *(See AI-assistance disclosure below.)*
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

**Suggested PR title:** `fix: keep the Analytics settings tab contained within the settings modal`

# Changelog Entry

### Description

**Problem:** The admin **Settings → Analytics** tab can render outside the settings modal: the Model Usage / User Activity tables and the daily-messages chart extend past the modal's right edge with clipped columns and no horizontal scrolling (readily reproducible with an "All time" range and a modest viewport width).

**Root cause (two containment gaps):**

1. The settings content column in `SettingsModal.svelte` is a `flex-1` item of the modal's `md:flex-row` **without `min-w-0`** — its automatic minimum size is its min-content width, so any intrinsically wide tab content pushes the entire column (and everything in it) beyond the modal boundary instead of shrinking.
2. `ChartLine.svelte`'s SVG (`viewBox="0 0 1000 …"` + `w-full`) participates in normal flow inside its fixed-height `relative` container. A `viewBox` gives an SVG an intrinsic **aspect ratio**, so with a definite ~180px height it contributes roughly 1000px of min-content width to every ancestor — even though `preserveAspectRatio="none"` makes that ratio visually meaningless.

**Fix (both one-liners in spirit):**

- Add `min-w-0` to the settings content column so it clamps to the modal like any constrained flex item. Once the column has a definite width, the tab's `grid md:grid-cols-2` tables shrink into their existing `overflow-x-auto` wrappers and scroll internally, exactly as designed. This also protects **every other settings tab** from wide content breaking the modal layout. *(Note: draft PR #27306 contains this identical one-line change for the Archived Chats overflow — the two PRs merge cleanly in either order, and the maintainer can drop the duplicate hunk from whichever lands second.)*
- Absolutely position the chart SVG (and its x-axis label row) within the chart's fixed-height `relative w-full` container. Absolutely positioned elements are removed from intrinsic sizing, so the chart no longer imposes ~1000px of min-content width on its ancestors; its rendered size is unchanged (the container already dictates width and height).

```diff
-	<div class="flex-1 min-h-0 p-4 md:px-5 flex flex-col">
+	<div class="flex-1 min-w-0 min-h-0 p-4 md:px-5 flex flex-col">
```

```diff
 	<svg
 		viewBox="0 0 {w} {height - 20}"
-		class="h-[calc(100%-20px)] w-full"
+		class="absolute inset-x-0 top-0 h-[calc(100%-20px)] w-full"
 		preserveAspectRatio="none"
```

```diff
-		<div class="flex justify-between px-0.5 text-[10px] text-gray-400">
+		<div class="absolute inset-x-0 bottom-0 flex justify-between px-0.5 text-[10px] text-gray-400">
```

Scope: 2 files, +3/−3 lines (`src/lib/components/chat/SettingsModal.svelte`, `src/lib/components/admin/Analytics/ChartLine.svelte`).

### Fixed

- Fixed the admin Analytics settings tab expanding outside the settings modal; the content column now shrinks to the modal, the usage tables scroll horizontally inside their own containers, and the chart no longer forces an intrinsic ~1000px minimum width on the layout.

---

### Additional Information

- `ChartLine.svelte`'s visual output is unchanged: the SVG previously filled the full width of its fixed-height container and it still does, with the label row pinned where it already rendered (bottom 20px of the container); only its participation in intrinsic-width calculation is removed.
- The `min-w-0` hunk deliberately matches draft PR #27306 (Archived Chats truncation) so the shared root cause is fixed regardless of merge order; git resolves the identical change cleanly.
- *AI-assistance disclosure: This PR was prepared with AI assistance (Claude Code). Automated verification — production build (`npm run build`), Vitest suite (2/2 passing), and CSS-containment analysis in an isolated browser reconstruction of the modal DOM — was performed by the AI. Manual verification on a live instance was performed by the author per the steps below.*

**Manual Verification Performed**

1. Open **Settings → Analytics** as an admin with a large history and **All time** selected — the tab now stays fully inside the modal; the Model Usage / User Activity tables scroll horizontally within their own containers when space is tight.
2. Narrow the browser window through tablet widths — the content column shrinks with the modal at every width; nothing renders past the rounded modal edge.
3. Chart sanity: the daily/hourly messages chart renders at the same size as before, x-axis labels sit at the bottom of the chart area, and hover tooltips/crosshair still work.
4. Spot-check other settings tabs (General, Interface, Archived Chats) for layout regressions from the `min-w-0` change — none expected, as it only allows shrinking that the modal previously clipped or overflowed.
5. Dark and light mode spot-check.

### Screenshots or Videos

#### Before

<img width="1511" height="879" alt="image" src="https://github.com/user-attachments/assets/d72e04da-8e42-4cbc-b7b7-2eddb8cfb9ff" />

#### After

<img width="1291" height="880" alt="image" src="https://github.com/user-attachments/assets/f6a2b181-6438-44b0-a643-99e84c9708cb" />

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
