### PR TITLE
feat: add OpenAI-compatible /v1/embeddings proxy to Ollama router

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - 2026-07-22
+
+### Added
+
+- 🧩 **OpenAI-compatible Ollama embeddings.** The Ollama OpenAI-compatible proxy now supports `/v1/embeddings`, so `openai.embeddings.create()` works against `.../ollama/v1/` the same way chat and text completions already do.
+
 ## [0.10.2] - 2026-07-01
 
 ### Added

--- a/backend/open_webui/routers/ollama.py
+++ b/backend/open_webui/routers/ollama.py
@@ -1294,6 +1294,57 @@ async def generate_openai_chat_completion(
     )
 
 
+class OpenAIEmbeddingsForm(BaseModel):
+    """Payload for the OpenAI-compatible /v1/embeddings proxy."""
+
+    model: str
+    input: list[str] | str
+    model_config = ConfigDict(extra='allow')
+
+
+@router.post('/v1/embeddings')
+@router.post('/v1/embeddings/{url_idx}')
+async def generate_openai_embeddings(
+    request: Request,
+    form_data: dict,
+    url_idx: int | None = None,
+    user=Depends(get_verified_user),  # noqa: B008
+):
+    """Forward an embeddings request via the OpenAI-compatible proxy."""
+    try:
+        form_data = OpenAIEmbeddingsForm(**form_data)
+    except Exception as exc:
+        log.exception(exc)
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    payload = {**form_data.model_dump(exclude_none=True)}
+
+    model_id = form_data.model
+    model_info = await Models.get_model_by_id(model_id)
+    if model_info is not None:
+        if model_info.base_model_id:
+            payload['model'] = model_info.base_model_id
+        await check_model_access(user, model_info)
+    else:
+        await check_model_access(user, None)
+
+    url, url_idx = await get_ollama_url(request, payload['model'], url_idx, user)
+    api_config = resolve_api_config((await Config.get('ollama.api_configs', {})), url_idx, url)
+
+    prefix_id = api_config.get('prefix_id')
+    if prefix_id:
+        payload['model'] = payload['model'].replace(f'{prefix_id}.', '')
+
+    return await send_request(
+        f'{url}/v1/embeddings',
+        payload=json.dumps(payload),
+        key=get_api_key(url_idx, url, (await Config.get('ollama.api_configs', {}))),
+        user=user,
+        api_config=api_config,
+        request=request,
+    )
+
+
 @router.post('/v1/messages')
 @router.post('/v1/messages/{url_idx}')
 async def generate_anthropic_messages(


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Relates to #27328
- [x] **Target branch:** dev
- [x] **Description:** provided below
- [x] **Changelog:** included below
- [x] **Documentation:** Docs: open-webui/docs#1331
- [x] **Dependencies:** None — no new or updated dependencies.
- [x] **Testing:** Manually tested against a live OpenWebUI+Ollama backend with `nomic-embed-text` pulled, using both raw `curl` and the official `openai` Python SDK (`client.embeddings.create(...)`), for both single-string and batch (`list[str]`) input. Also verified a rebuilt Docker image boots and serves correctly.
- [x] **No Unchecked AI Code:**
- [x] **Self-Review:** 
- [x] **Architecture:** No new settings added; the route follows the exact existing pattern of the sibling `/v1/completions` and `/v1/chat/completions` proxies in the same file (multi-node URL resolution, access control, model-prefix stripping, error handling) — no new abstractions introduced.
- [x] **Git Hygiene:** Single atomic commit with actual code changes, one commit fixing issue due to wrongfully updated changelog, rebased on `dev`, no unrelated changes.
- [x] **Title Prefix:** `feat`

# Changelog Entry

### Description

Open WebUI's Ollama router already exposes an OpenAI-compatible proxy surface at `/ollama/v1/...` (`/v1/completions`, `/v1/chat/completions`, `/v1/messages`, `/v1/responses`), letting the official `openai` SDK (or any OpenAI-compatible client) talk directly to Open WebUI as if it were an OpenAI endpoint, with full multi-node Ollama routing, per-model access control, and connection-level model-name prefixing.

`/v1/embeddings` was the one gap in that surface: `openai.embeddings.create(...)` returned 404 even though Ollama itself has supported an OpenAI-compatible `/v1/embeddings` endpoint since 0.1.26, which this router simply hadn't wired up. This PR adds that missing proxy route, modeled directly on the existing `/v1/completions` handler in `backend/open_webui/routers/ollama.py`, so it inherits the same URL-resolution, auth, and error-handling behavior as the rest of the router with no new code paths.

### Added

-  **OpenAI-compatible Ollama embeddings.** The Ollama OpenAI-compatible proxy now supports `/v1/embeddings`, so `openai.embeddings.create()` works against `.../ollama/v1/` the same way chat and text completions already do.

### Changed

- 

### Deprecated

-

### Removed

- 
### Fixed

-

### Security

- 

### Breaking Changes

- 

---

### Additional Information

Discussion: #27328

Implementation notes for reviewers:
- New route + form (`OpenAIEmbeddingsForm`, `generate_openai_embeddings`) added in `backend/open_webui/routers/ollama.py`, placed alongside the other `/v1/*` OpenAI-compat routes.
- Deliberately does **not** touch `backend/open_webui/utils/embeddings.py` or `backend/open_webui/routers/openai.py` — those are separate, already-working code paths (the app-level `/api/embeddings` dispatcher used internally for RAG) and are out of scope here.
- No streaming/system-prompt/generation-param handling needed, since embeddings requests are single JSON responses with no sampling parameters.

### Screenshots or Videos

- [Attach relevant screenshots or videos demonstrating the changes]

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
