### PR TITLE
fix(ui): constrain analytics tab content within settings modal

### DIFF
--- a/src/lib/components/admin/Analytics/ChartLine.svelte
+++ b/src/lib/components/admin/Analytics/ChartLine.svelte
@@ -44,7 +44,7 @@
 	let hovered = $derived(hoveredIdx !== null ? data[hoveredIdx] : null);
 </script>
 
-<div class="relative w-full" style="height:{height}px">
+<div class="relative w-full min-w-0" style="height:{height}px">
 	<svg
 		viewBox="0 0 {w} {height - 20}"
 		class="h-[calc(100%-20px)] w-full"

--- a/src/lib/components/admin/Settings.svelte
+++ b/src/lib/components/admin/Settings.svelte
@@ -552,7 +552,7 @@
 	</div>
 
 	<div
-		class="flex-1 mt-3 lg:mt-1 px-[16px] lg:pr-[16px] lg:pl-0 overflow-y-scroll scrollbar-hidden"
+		class="flex-1 min-w-0 mt-3 lg:mt-1 px-[16px] lg:pr-[16px] lg:pl-0 overflow-y-scroll scrollbar-hidden"
 	>
 		{#if selectedTab === 'general'}
 			<General


### PR DESCRIPTION
## Relevant issues
Fixes #27329

## Problem

The Analytics tab in the admin Settings modal overflows horizontally. Two things are responsible:

1. The settings content div uses `flex-1` without `min-w-0`, so its SVG child (with a `viewBox="0 0 1000 ..."`) contributes its intrinsic viewBox-aspect-ratio width as `min-content` in flex layout, pushing the column wider than the modal.

2. The chart wrapper `<div class="relative w-full">` similarly needs `min-w-0` to let Tailwind's `w-full` actually constrain it inside the flex row.

## Fix

Added `min-w-0` to:
- `src/lib/components/admin/Settings.svelte` content flex-child
- `src/lib/components/admin/Analytics/ChartLine.svelte` wrapper div

This is the standard Tailwind pattern for constraining flex children with wide content.

## Screenshots / Proof of Fix

After applying this fix, open Settings -> Analytics in the admin UI. The line chart should fit comfortably within the modal and the page should stop scrolling horizontally.

## Type

🐛 Bug Fix