### PR TITLE
feat: add system prompt versioning for workspace models

### DIFF
--- a/CHANGELOG-system-prompt-versioning.md
+++ b/CHANGELOG-system-prompt-versioning.md
@@ -1,0 +1,35 @@
+# System Prompt Versioning — Changelog
+
+## New Features
+
+### Full Model Snapshot per Version
+Every model save now stores a complete snapshot (`params`, `meta`, `name`, `base_model_id`, `is_active`) — not just the system prompt. View it in the **Detail** tab of the versioning modal.
+
+### Difference View (Parameter Changes)
+Click **View & Compare** → **Difference** tab → select two versions → **Compare**. The diff shows:
+- System prompt changes (classic git-style diff)
+- Parameter Changes (structured list of what else changed: temperature, skills, tools, knowledge, capabilities, etc.)
+
+### Per-Version Comments
+Add comments to any history entry via the **Detail** tab — useful for documenting why a change was made. Each comment shows the author and timestamp. You can delete your own comments.
+
+### Search & Date Filter
+Filter the history list by:
+- **Text search** (commit message or author name)
+- **Date range** (from / to)
+
+Works both in the compact history list and inside the **View & Compare** modal.
+
+### Paginated History
+"Load More" button below the history list — no hard limit on how many versions you can browse through.
+
+### Confirm Before Restore
+Restoring a version now shows a confirmation dialog — no accidental overwrites.
+
+### Editor Auto-Refresh After Restore
+After restoring a version, the model editor UI reloads all fields (name, system prompt, advanced params, skills, tools, knowledge, capabilities) — no F5 needed.
+
+## Bug Fixes
+
+- **Unwanted form submit**: All buttons inside the model editor form now have `type="button"`. Previously, many buttons defaulted to `type="submit"` and triggered an unwanted model save. Fixed in: "View & Compare", "Detail"/"Difference" tabs, "Close", "Compare", "Load This Prompt Into Editor", "Send" (comment), "Delete comment", "Restore", "Delete version".
+- **Full snapshot restore**: Restoring a version now restores `params`, `meta`, `name`, `base_model_id` from the snapshot — not just the system prompt.

--- a/backend/open_webui/migrations/env.py
+++ b/backend/open_webui/migrations/env.py
@@ -1,3 +1,4 @@
+
 from __future__ import annotations
 
 # Alembic environment configuration runner.
@@ -11,6 +12,7 @@ from open_webui.models.auths import Auth
 from open_webui.models.calendar import Calendar, CalendarEvent, CalendarEventAttendee  # noqa: F401
 from open_webui.models.chat_messages import ChatMessage  # noqa: F401
 from open_webui.models.chats import Chat  # noqa: F401
+from open_webui.models.model_system_prompt_history import ModelSystemPromptComment  # noqa: F401
 from sqlalchemy import create_engine, engine_from_config, pool
 
 alembic_config = alembic.context.config

--- a/backend/open_webui/migrations/versions/5604fe827b5a_add_model_system_prompt_history.py
+++ b/backend/open_webui/migrations/versions/5604fe827b5a_add_model_system_prompt_history.py
@@ -1,0 +1,55 @@
+"""add model_system_prompt_history table and system_prompt_version_id column
+
+Revision ID: 5604fe827b5a
+Revises: 42e2978c7933
+Create Date: 2026-07-09 12:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = '5604fe827b5a'
+down_revision: Union[str, None] = '42e2978c7933'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    existing_tables = set(inspector.get_table_names())
+
+    if 'model_system_prompt_history' not in existing_tables:
+        op.create_table(
+            'model_system_prompt_history',
+            sa.Column('id', sa.Text(), primary_key=True),
+            sa.Column('model_id', sa.Text(), nullable=False, index=True),
+            sa.Column('parent_id', sa.Text(), nullable=True),
+            sa.Column('system_prompt', sa.Text(), nullable=False, server_default=''),
+            sa.Column('user_id', sa.Text(), nullable=False),
+            sa.Column('commit_message', sa.Text(), nullable=True),
+            sa.Column('created_at', sa.BigInteger(), nullable=False),
+        )
+
+    if 'model' in existing_tables:
+        model_cols = {c['name'] for c in inspector.get_columns('model')}
+        if 'system_prompt_version_id' not in model_cols:
+            op.add_column('model', sa.Column('system_prompt_version_id', sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    existing_tables = set(inspector.get_table_names())
+
+    if 'model_system_prompt_history' in existing_tables:
+        op.drop_table('model_system_prompt_history')
+
+    if 'model' in existing_tables:
+        model_cols = {c['name'] for c in inspector.get_columns('model')}
+        if 'system_prompt_version_id' in model_cols:
+            op.drop_column('model', 'system_prompt_version_id')

--- a/backend/open_webui/migrations/versions/af2b3c4d5e6f_add_model_system_prompt_comment.py
+++ b/backend/open_webui/migrations/versions/af2b3c4d5e6f_add_model_system_prompt_comment.py
@@ -1,0 +1,43 @@
+"""add model_system_prompt_comment table
+
+Revision ID: af2b3c4d5e6f
+Revises: 5604fe827b5a
+Create Date: 2026-07-10 12:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'af2b3c4d5e6f'
+down_revision: Union[str, None] = '5604fe827b5a'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    existing_tables = set(inspector.get_table_names())
+
+    if 'model_system_prompt_comment' not in existing_tables:
+        op.create_table(
+            'model_system_prompt_comment',
+            sa.Column('id', sa.Text(), primary_key=True),
+            sa.Column('history_id', sa.Text(), nullable=False, index=True),
+            sa.Column('user_id', sa.Text(), nullable=False),
+            sa.Column('content', sa.Text(), nullable=False),
+            sa.Column('created_at', sa.BigInteger(), nullable=False),
+        )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    existing_tables = set(inspector.get_table_names())
+
+    if 'model_system_prompt_comment' in existing_tables:
+        op.drop_table('model_system_prompt_comment')

--- a/backend/open_webui/migrations/versions/b3c4d5e6f7a0_add_snapshot_to_model_system_prompt_history.py
+++ b/backend/open_webui/migrations/versions/b3c4d5e6f7a0_add_snapshot_to_model_system_prompt_history.py
@@ -1,0 +1,34 @@
+"""add snapshot column to model_system_prompt_history
+
+Revision ID: b3c4d5e6f7a0
+Revises: af2b3c4d5e6f
+Create Date: 2026-07-13 12:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'b3c4d5e6f7a0'
+down_revision: Union[str, None] = 'af2b3c4d5e6f'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    existing_columns = {c['name'] for c in inspector.get_columns('model_system_prompt_history')}
+    if 'snapshot' not in existing_columns:
+        op.add_column('model_system_prompt_history', sa.Column('snapshot', sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    existing_columns = {c['name'] for c in inspector.get_columns('model_system_prompt_history')}
+    if 'snapshot' in existing_columns:
+        op.drop_column('model_system_prompt_history', 'snapshot')

--- a/backend/open_webui/models/model_system_prompt_history.py
+++ b/backend/open_webui/models/model_system_prompt_history.py
@@ -1,0 +1,334 @@
+import difflib
+import time
+import uuid
+from typing import Optional
+
+from open_webui.internal.db import Base, get_async_db_context
+from open_webui.models.users import User, UserModel, UserResponse, Users
+from pydantic import BaseModel, ConfigDict
+from sqlalchemy import JSON, BigInteger, Column, Text, delete, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+# ── Version history table ────────────────────────────────────────────
+
+class ModelSystemPromptHistory(Base):
+    __tablename__ = 'model_system_prompt_history'
+
+    id = Column(Text, primary_key=True)
+    model_id = Column(Text, nullable=False, index=True)
+    parent_id = Column(Text, nullable=True)
+    system_prompt = Column(Text, nullable=False, default='')
+    user_id = Column(Text, nullable=False)
+    commit_message = Column(Text, nullable=True)
+    snapshot = Column(JSON, nullable=True)
+    created_at = Column(BigInteger, nullable=False)
+
+
+class ModelSystemPromptHistoryModel(BaseModel):
+    id: str
+    model_id: str
+    parent_id: Optional[str] = None
+    system_prompt: str = ''
+    user_id: str
+    commit_message: Optional[str] = None
+    snapshot: Optional[dict] = None
+    created_at: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class ModelSystemPromptHistoryResponse(ModelSystemPromptHistoryModel):
+    user: Optional[UserResponse] = None
+
+
+# ── Comment table ────────────────────────────────────────────────────
+
+class ModelSystemPromptComment(Base):
+    __tablename__ = 'model_system_prompt_comment'
+
+    id = Column(Text, primary_key=True)
+    history_id = Column(Text, nullable=False, index=True)
+    user_id = Column(Text, nullable=False)
+    content = Column(Text, nullable=False)
+    created_at = Column(BigInteger, nullable=False)
+
+
+class ModelSystemPromptCommentModel(BaseModel):
+    id: str
+    history_id: str
+    user_id: str
+    content: str
+    created_at: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class ModelSystemPromptCommentResponse(ModelSystemPromptCommentModel):
+    user: Optional[UserResponse] = None
+
+
+# ── Diff response ────────────────────────────────────────────────────
+
+class ModelSystemPromptDiffResponse(BaseModel):
+    from_id: str
+    to_id: str
+    content_diff: list[str]
+
+
+class ModelSystemPromptHistoryTable:
+    async def create_history_entry(
+        self,
+        model_id: str,
+        system_prompt: str,
+        user_id: str,
+        parent_id: Optional[str] = None,
+        commit_message: Optional[str] = None,
+        snapshot: Optional[dict] = None,
+        db: Optional[AsyncSession] = None,
+    ) -> Optional[ModelSystemPromptHistoryModel]:
+        async with get_async_db_context(db) as db:
+            history = ModelSystemPromptHistory(
+                id=str(uuid.uuid4()),
+                model_id=model_id,
+                parent_id=parent_id,
+                system_prompt=system_prompt,
+                user_id=user_id,
+                commit_message=commit_message,
+                snapshot=snapshot,
+                created_at=int(time.time()),
+            )
+            db.add(history)
+            await db.commit()
+            await db.refresh(history)
+            return ModelSystemPromptHistoryModel.model_validate(history)
+
+    async def get_history_by_model_id(
+        self,
+        model_id: str,
+        limit: int = 50,
+        offset: int = 0,
+        db: Optional[AsyncSession] = None,
+    ) -> list[ModelSystemPromptHistoryResponse]:
+        async with get_async_db_context(db) as db:
+            result = await db.execute(
+                select(ModelSystemPromptHistory)
+                .filter(ModelSystemPromptHistory.model_id == model_id)
+                .order_by(ModelSystemPromptHistory.created_at.desc())
+                .offset(offset)
+                .limit(limit)
+            )
+            entries = result.scalars().all()
+
+            user_ids = list(set(e.user_id for e in entries))
+            users = await Users.get_users_by_user_ids(user_ids, db=db) if user_ids else []
+            users_dict = {user.id: user for user in users}
+
+            return [
+                ModelSystemPromptHistoryResponse(
+                    **ModelSystemPromptHistoryModel.model_validate(entry).model_dump(),
+                    user=(users_dict.get(entry.user_id).model_dump() if users_dict.get(entry.user_id) else None),
+                )
+                for entry in entries
+            ]
+
+    async def get_history_entry_by_id(
+        self,
+        history_id: str,
+        db: Optional[AsyncSession] = None,
+    ) -> Optional[ModelSystemPromptHistoryModel]:
+        async with get_async_db_context(db) as db:
+            result = await db.execute(select(ModelSystemPromptHistory).filter(ModelSystemPromptHistory.id == history_id))
+            entry = result.scalars().first()
+            if entry:
+                return ModelSystemPromptHistoryModel.model_validate(entry)
+            return None
+
+    async def get_latest_history_entry(
+        self,
+        model_id: str,
+        db: Optional[AsyncSession] = None,
+    ) -> Optional[ModelSystemPromptHistoryModel]:
+        async with get_async_db_context(db) as db:
+            result = await db.execute(
+                select(ModelSystemPromptHistory)
+                .filter(ModelSystemPromptHistory.model_id == model_id)
+                .order_by(ModelSystemPromptHistory.created_at.desc())
+                .limit(1)
+            )
+            entry = result.scalars().first()
+            if entry:
+                return ModelSystemPromptHistoryModel.model_validate(entry)
+            return None
+
+    async def get_history_count(
+        self,
+        model_id: str,
+        db: Optional[AsyncSession] = None,
+    ) -> int:
+        async with get_async_db_context(db) as db:
+            result = await db.execute(
+                select(func.count()).select_from(ModelSystemPromptHistory).filter(ModelSystemPromptHistory.model_id == model_id)
+            )
+            return result.scalar()
+
+    async def get_detail(
+        self,
+        history_id: str,
+        db: Optional[AsyncSession] = None,
+    ) -> Optional[ModelSystemPromptHistoryResponse]:
+        async with get_async_db_context(db) as db:
+            result = await db.execute(select(ModelSystemPromptHistory).filter(ModelSystemPromptHistory.id == history_id))
+            entry = result.scalars().first()
+            if not entry:
+                return None
+
+            user = None
+            u_result = await db.execute(select(User).filter(User.id == entry.user_id))
+            u_row = u_result.scalars().first()
+            if u_row:
+                user = UserResponse(**UserModel.model_validate(u_row).model_dump())
+
+            return ModelSystemPromptHistoryResponse(
+                **ModelSystemPromptHistoryModel.model_validate(entry).model_dump(),
+                user=user,
+            )
+
+    async def compute_diff(
+        self,
+        from_id: str,
+        to_id: str,
+        model_id: str,
+        db: Optional[AsyncSession] = None,
+    ) -> Optional[ModelSystemPromptDiffResponse]:
+        async with get_async_db_context(db) as db:
+            result_from = await db.execute(
+                select(ModelSystemPromptHistory).filter(ModelSystemPromptHistory.id == from_id, ModelSystemPromptHistory.model_id == model_id)
+            )
+            from_entry = result_from.scalars().first()
+            result_to = await db.execute(
+                select(ModelSystemPromptHistory).filter(ModelSystemPromptHistory.id == to_id, ModelSystemPromptHistory.model_id == model_id)
+            )
+            to_entry = result_to.scalars().first()
+
+            if not from_entry or not to_entry:
+                return None
+
+            from_content = from_entry.system_prompt or ''
+            to_content = to_entry.system_prompt or ''
+
+            diff_lines = list(
+                difflib.unified_diff(
+                    from_content.splitlines(keepends=True),
+                    to_content.splitlines(keepends=True),
+                    fromfile=f'v{from_id[:8]}',
+                    tofile=f'v{to_id[:8]}',
+                    lineterm='',
+                )
+            )
+
+            return ModelSystemPromptDiffResponse(
+                from_id=from_id,
+                to_id=to_id,
+                content_diff=diff_lines,
+            )
+
+    async def delete_history_by_model_id(
+        self,
+        model_id: str,
+        db: Optional[AsyncSession] = None,
+    ) -> bool:
+        async with get_async_db_context(db) as db:
+            await db.execute(delete(ModelSystemPromptHistory).filter(ModelSystemPromptHistory.model_id == model_id))
+            await db.commit()
+            return True
+
+    async def delete_history_entry(
+        self,
+        history_id: str,
+        model_id: str,
+        db: Optional[AsyncSession] = None,
+    ) -> bool:
+        async with get_async_db_context(db) as db:
+            result = await db.execute(select(ModelSystemPromptHistory).filter_by(id=history_id, model_id=model_id))
+            entry = result.scalars().first()
+            if not entry:
+                return False
+
+            children_result = await db.execute(select(ModelSystemPromptHistory).filter_by(parent_id=history_id))
+            children = children_result.scalars().all()
+
+            for child in children:
+                child.parent_id = entry.parent_id
+
+            await db.delete(entry)
+            await db.commit()
+            return True
+
+
+# ── Comments ─────────────────────────────────────────────────────
+
+    async def create_comment(
+        self,
+        history_id: str,
+        user_id: str,
+        content: str,
+        db: Optional[AsyncSession] = None,
+    ) -> Optional[ModelSystemPromptCommentModel]:
+        async with get_async_db_context(db) as db:
+            comment = ModelSystemPromptComment(
+                id=str(uuid.uuid4()),
+                history_id=history_id,
+                user_id=user_id,
+                content=content,
+                created_at=int(time.time()),
+            )
+            db.add(comment)
+            await db.commit()
+            await db.refresh(comment)
+            return ModelSystemPromptCommentModel.model_validate(comment)
+
+    async def get_comments_by_history_id(
+        self,
+        history_id: str,
+        db: Optional[AsyncSession] = None,
+    ) -> list[ModelSystemPromptCommentResponse]:
+        async with get_async_db_context(db) as db:
+            result = await db.execute(
+                select(ModelSystemPromptComment)
+                .filter(ModelSystemPromptComment.history_id == history_id)
+                .order_by(ModelSystemPromptComment.created_at.asc())
+            )
+            comments = result.scalars().all()
+
+            user_ids = list(set(c.user_id for c in comments))
+            users = await Users.get_users_by_user_ids(user_ids, db=db) if user_ids else []
+            users_dict = {u.id: u for u in users}
+
+            return [
+                ModelSystemPromptCommentResponse(
+                    **ModelSystemPromptCommentModel.model_validate(c).model_dump(),
+                    user=(users_dict.get(c.user_id).model_dump() if users_dict.get(c.user_id) else None),
+                )
+                for c in comments
+            ]
+
+    async def delete_comment(
+        self,
+        comment_id: str,
+        user_id: str,
+        db: Optional[AsyncSession] = None,
+    ) -> bool:
+        async with get_async_db_context(db) as db:
+            result = await db.execute(
+                select(ModelSystemPromptComment).filter_by(id=comment_id, user_id=user_id)
+            )
+            comment = result.scalars().first()
+            if not comment:
+                return False
+            await db.delete(comment)
+            await db.commit()
+            return True
+
+
+ModelSystemPromptHistories = ModelSystemPromptHistoryTable()

--- a/backend/open_webui/models/models.py
+++ b/backend/open_webui/models/models.py
@@ -9,6 +9,7 @@ from typing import Any, Optional
 from open_webui.internal.db import Base, JSONField, get_async_db_context
 from open_webui.models.access_grants import AccessGrantModel, AccessGrants
 from open_webui.models.groups import Groups
+from open_webui.models.model_system_prompt_history import ModelSystemPromptHistories
 from open_webui.models.users import User, UserModel, UserResponse, Users
 from open_webui.utils.validate import validate_profile_image_url
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
@@ -123,6 +124,7 @@ class Model(Base):
     params = Column(JSONField)  # see ModelParams
     meta = Column(JSONField)  # see ModelMeta
     is_active = Column(Boolean, default=True)  # soft-disable toggle
+    system_prompt_version_id = Column(Text, nullable=True)  # Points to active model_system_prompt_history entry
     updated_at = Column(BigInteger)  # epoch seconds
     created_at = Column(BigInteger)  # epoch seconds
 
@@ -138,6 +140,7 @@ class ModelModel(BaseModel):
 
     access_grants: list[AccessGrantModel] = Field(default_factory=list)
 
+    system_prompt_version_id: str | None = None
     is_active: bool
     updated_at: int  # timestamp in epoch
     created_at: int  # timestamp in epoch
@@ -179,6 +182,17 @@ class ModelForm(BaseModel):
     params: ModelParams
     access_grants: list[dict | None] = None
     is_active: bool = True
+    commit_message: str | None = None
+
+
+def _build_snapshot(form_data: ModelForm) -> dict:
+    return {
+        'params': form_data.params.model_dump() if hasattr(form_data.params, 'model_dump') else form_data.params,
+        'meta': form_data.meta.model_dump() if hasattr(form_data.meta, 'model_dump') else form_data.meta,
+        'name': form_data.name,
+        'base_model_id': form_data.base_model_id,
+        'is_active': form_data.is_active,
+    }
 
 
 class ModelsTable:
@@ -212,7 +226,7 @@ class ModelsTable:
             async with get_async_db_context(db) as db:
                 result = Model(
                     **{
-                        **form_data.model_dump(exclude={'access_grants'}),
+                        **form_data.model_dump(exclude={'access_grants', 'commit_message'}),
                         'user_id': user_id,
                         'created_at': int(time.time()),
                         'updated_at': int(time.time()),
@@ -224,6 +238,20 @@ class ModelsTable:
                 await AccessGrants.set_access_grants('model', result.id, form_data.access_grants, db=db)
 
                 if result:
+                    system = (form_data.params.model_dump() if isinstance(form_data.params, ModelParams) else form_data.params).get('system') or ''
+                    if system:
+                        entry = await ModelSystemPromptHistories.create_history_entry(
+                            model_id=result.id,
+                            system_prompt=system,
+                            user_id=user_id,
+                            parent_id=None,
+                            commit_message='Initial version',
+                            snapshot=_build_snapshot(form_data),
+                            db=db,
+                        )
+                        if entry:
+                            result.system_prompt_version_id = entry.id
+                            await db.commit()
                     return await self._to_model_model(result, db=db)
                 else:
                     return None
@@ -539,10 +567,34 @@ class ModelsTable:
     async def update_model_by_id(self, id: str, model: ModelForm, db: AsyncSession | None = None) -> ModelModel | None:
         try:
             async with get_async_db_context(db) as db:
-                # update only the fields that are present in the model
-                data = model.model_dump(exclude={'id', 'access_grants'})
+                existing_result = await db.execute(select(Model).filter_by(id=id))
+                existing = existing_result.scalars().first()
+                if not existing:
+                    return None
+
+                new_system = (model.params.model_dump() if isinstance(model.params, ModelParams) else model.params).get('system') or ''
+
+                data = model.model_dump(exclude={'access_grants', 'commit_message'})
+                data.pop('id', None)
                 data['updated_at'] = int(time.time())
                 await db.execute(update(Model).filter_by(id=id).values(**data))
+
+                new_snapshot = _build_snapshot(model)
+                latest = await ModelSystemPromptHistories.get_latest_history_entry(id, db=db)
+                parent_id = latest.id if latest else None
+
+                if not latest or latest.snapshot != new_snapshot:
+                    entry = await ModelSystemPromptHistories.create_history_entry(
+                        model_id=id,
+                        system_prompt=new_system,
+                        user_id=existing.user_id,
+                        parent_id=parent_id,
+                        commit_message=model.commit_message,
+                        snapshot=new_snapshot,
+                        db=db,
+                    )
+                    if entry:
+                        await db.execute(update(Model).filter_by(id=id).values(system_prompt_version_id=entry.id))
 
                 await db.commit()
                 if model.access_grants is not None:
@@ -652,6 +704,56 @@ class ModelsTable:
         except Exception as e:
             log.exception(f'Error syncing models for user {user_id}: {e}')
             return []
+
+    async def update_model_system_prompt_version(
+        self,
+        model_id: str,
+        version_id: str,
+        user_id: str | None = None,
+        db: AsyncSession | None = None,
+    ) -> ModelModel | None:
+        try:
+            async with get_async_db_context(db) as db:
+                result = await db.execute(select(Model).filter_by(id=model_id))
+                model = result.scalars().first()
+                if not model:
+                    return None
+
+                entry = await ModelSystemPromptHistories.get_history_entry_by_id(version_id, db=db)
+                if not entry or entry.model_id != model_id:
+                    return None
+
+                if entry.snapshot:
+                    model.params = entry.snapshot.get('params') or {}
+                    model.meta = entry.snapshot.get('meta') or {}
+                    model.name = entry.snapshot.get('name') or model.name
+                    model.base_model_id = entry.snapshot.get('base_model_id') or model.base_model_id
+                else:
+                    params = dict(model.params) if model.params else {}
+                    params['system'] = entry.system_prompt
+                    model.params = params
+
+                model.system_prompt_version_id = version_id
+                model.updated_at = int(time.time())
+
+                latest = await ModelSystemPromptHistories.get_latest_history_entry(model_id, db=db)
+                parent_id = latest.id if latest else None
+
+                await ModelSystemPromptHistories.create_history_entry(
+                    model_id=model_id,
+                    system_prompt=entry.system_prompt,
+                    user_id=user_id or model.user_id,
+                    parent_id=parent_id,
+                    commit_message=f'Restored from version {version_id[:8]}',
+                    snapshot={'params': dict(model.params) if model.params else {}, 'meta': dict(model.meta) if model.meta else {}, 'name': model.name, 'base_model_id': model.base_model_id, 'is_active': model.is_active},
+                    db=db,
+                )
+                await db.commit()
+
+                return await self._to_model_model(model, db=db)
+        except Exception as e:
+            log.error(f'Failed to restore system prompt version: {e}')
+            return None
 
 
 Models = ModelsTable()  # singleton model registry

--- a/backend/open_webui/routers/models.py
+++ b/backend/open_webui/routers/models.py
@@ -37,6 +37,14 @@ from open_webui.models.models import (
     ModelResponse,
     Models,
 )
+from open_webui.models.model_system_prompt_history import (
+    ModelSystemPromptCommentModel,
+    ModelSystemPromptCommentResponse,
+    ModelSystemPromptDiffResponse,
+    ModelSystemPromptHistories,
+    ModelSystemPromptHistoryModel,
+    ModelSystemPromptHistoryResponse,
+)
 from open_webui.utils.access_control import filter_allowed_access_grants, has_permission
 from open_webui.utils.access_control.files import has_access_to_file
 from open_webui.utils.auth import get_admin_user, get_verified_user
@@ -888,3 +896,236 @@ async def delete_all_models(
     if result:
         await publish_event(request, EVENTS.MODEL_DELETED, actor=user, subject_type='model')
     return result
+
+
+############################
+# System Prompt Versioning
+############################
+
+
+@router.get('/model/{model_id}/system/history', response_model=list[ModelSystemPromptHistoryResponse])
+async def get_model_system_prompt_history(
+    model_id: str,
+    page: int = 0,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    PAGE_SIZE = 200
+    model = await Models.get_model_by_id(model_id, db=db)
+    if not model:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
+
+    write_access = (
+        (user.role == 'admin' and BYPASS_ADMIN_ACCESS_CONTROL)
+        or user.id == model.user_id
+        or await AccessGrants.has_access(
+            user_id=user.id, resource_type='model', resource_id=model.id, permission='write', db=db
+        )
+    )
+    has_read = write_access or await AccessGrants.has_access(
+        user_id=user.id, resource_type='model', resource_id=model.id, permission='read', db=db
+    )
+    if not has_read:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=ERROR_MESSAGES.UNAUTHORIZED)
+
+    return await ModelSystemPromptHistories.get_history_by_model_id(
+        model_id, limit=PAGE_SIZE, offset=page * PAGE_SIZE, db=db
+    )
+
+
+@router.get('/model/{model_id}/system/history/{history_id}', response_model=ModelSystemPromptHistoryModel)
+async def get_model_system_prompt_history_entry(
+    model_id: str,
+    history_id: str,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    model = await Models.get_model_by_id(model_id, db=db)
+    if not model:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
+
+    write_access = (
+        (user.role == 'admin' and BYPASS_ADMIN_ACCESS_CONTROL)
+        or user.id == model.user_id
+        or await AccessGrants.has_access(
+            user_id=user.id, resource_type='model', resource_id=model.id, permission='write', db=db
+        )
+    )
+    has_read = write_access or await AccessGrants.has_access(
+        user_id=user.id, resource_type='model', resource_id=model.id, permission='read', db=db
+    )
+    if not has_read:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=ERROR_MESSAGES.UNAUTHORIZED)
+
+    entry = await ModelSystemPromptHistories.get_history_entry_by_id(history_id, db=db)
+    if not entry or entry.model_id != model.id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
+    return entry
+
+
+@router.post('/model/{model_id}/system/history/{history_id}/restore', response_model=ModelModel | None)
+async def restore_model_system_prompt_version(
+    model_id: str,
+    history_id: str,
+    request: Request,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    model = await Models.get_model_by_id(model_id, db=db)
+    if not model:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
+
+    if not (
+        (user.role == 'admin' and BYPASS_ADMIN_ACCESS_CONTROL)
+        or user.id == model.user_id
+        or await AccessGrants.has_access(
+            user_id=user.id, resource_type='model', resource_id=model.id, permission='write', db=db
+        )
+    ):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=ERROR_MESSAGES.UNAUTHORIZED)
+
+    result = await Models.update_model_system_prompt_version(model_id, history_id, user_id=user.id, db=db)
+    if result:
+        await publish_event(request, EVENTS.MODEL_UPDATED, actor=user, subject_id=model_id, data={'name': result.name})
+    return result
+
+
+async def _has_model_read_access(model, user, db: AsyncSession) -> bool:
+    return (
+        (user.role == 'admin' and BYPASS_ADMIN_ACCESS_CONTROL)
+        or user.id == model.user_id
+        or await AccessGrants.has_access(
+            user_id=user.id, resource_type='model', resource_id=model.id, permission='write', db=db
+        )
+        or await AccessGrants.has_access(
+            user_id=user.id, resource_type='model', resource_id=model.id, permission='read', db=db
+        )
+    )
+
+
+@router.get('/model/{model_id}/system/history/{history_id}/detail', response_model=ModelSystemPromptHistoryResponse)
+async def get_model_system_prompt_history_detail(
+    model_id: str,
+    history_id: str,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    model = await Models.get_model_by_id(model_id, db=db)
+    if not model:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
+    if not await _has_model_read_access(model, user, db):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=ERROR_MESSAGES.UNAUTHORIZED)
+
+    detail = await ModelSystemPromptHistories.get_detail(history_id, db=db)
+    if not detail or detail.model_id != model.id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
+    return detail
+
+
+class DiffForm(BaseModel):
+    from_id: str
+    to_id: str
+
+
+@router.post('/model/{model_id}/system/history/diff', response_model=ModelSystemPromptDiffResponse)
+async def diff_model_system_prompt_versions(
+    model_id: str,
+    form_data: DiffForm,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    model = await Models.get_model_by_id(model_id, db=db)
+    if not model:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
+    if not await _has_model_read_access(model, user, db):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=ERROR_MESSAGES.UNAUTHORIZED)
+
+    result = await ModelSystemPromptHistories.compute_diff(form_data.from_id, form_data.to_id, model.id, db=db)
+    if not result:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
+    return result
+
+
+@router.get('/model/{model_id}/system/history/{history_id}/comments', response_model=list[ModelSystemPromptCommentResponse])
+async def get_model_system_prompt_comments(
+    model_id: str,
+    history_id: str,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    model = await Models.get_model_by_id(model_id, db=db)
+    if not model:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
+    if not await _has_model_read_access(model, user, db):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=ERROR_MESSAGES.UNAUTHORIZED)
+
+    return await ModelSystemPromptHistories.get_comments_by_history_id(history_id, db=db)
+
+
+class CommentForm(BaseModel):
+    content: str
+
+
+@router.post('/model/{model_id}/system/history/{history_id}/comments', response_model=ModelSystemPromptCommentModel)
+async def create_model_system_prompt_comment(
+    model_id: str,
+    history_id: str,
+    form_data: CommentForm,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    model = await Models.get_model_by_id(model_id, db=db)
+    if not model:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
+    if not await _has_model_read_access(model, user, db):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=ERROR_MESSAGES.UNAUTHORIZED)
+
+    entry = await ModelSystemPromptHistories.get_history_entry_by_id(history_id, db=db)
+    if not entry or entry.model_id != model.id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
+
+    return await ModelSystemPromptHistories.create_comment(
+        history_id=history_id, user_id=user.id, content=form_data.content, db=db
+    )
+
+
+@router.delete('/model/{model_id}/system/history/{history_id}/comments/{comment_id}', response_model=bool)
+async def delete_model_system_prompt_comment(
+    model_id: str,
+    history_id: str,
+    comment_id: str,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    model = await Models.get_model_by_id(model_id, db=db)
+    if not model:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
+    if not await _has_model_read_access(model, user, db):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=ERROR_MESSAGES.UNAUTHORIZED)
+
+    return await ModelSystemPromptHistories.delete_comment(comment_id, user.id, db=db)
+
+
+@router.delete('/model/{model_id}/system/history/{history_id}', response_model=bool)
+async def delete_model_system_prompt_history_entry(
+    model_id: str,
+    history_id: str,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    model = await Models.get_model_by_id(model_id, db=db)
+    if not model:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
+    if not (
+        (user.role == 'admin' and BYPASS_ADMIN_ACCESS_CONTROL)
+        or user.id == model.user_id
+        or await AccessGrants.has_access(
+            user_id=user.id, resource_type='model', resource_id=model.id, permission='write', db=db
+        )
+    ):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=ERROR_MESSAGES.UNAUTHORIZED)
+
+    if model.system_prompt_version_id == history_id:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail='Cannot delete the active version')
+
+    return await ModelSystemPromptHistories.delete_history_entry(history_id, model.id, db=db)

--- a/src/lib/apis/models/index.ts
+++ b/src/lib/apis/models/index.ts
@@ -290,8 +290,8 @@ export const toggleModelById = async (token: string, id: string) => {
 export const updateModelById = async (token: string, id: string, model: object) => {
 	let error = null;
 
-	const { base_model_id, name, meta, params, access_grants, is_active } = model as any;
-	const payload = { id, base_model_id, name, meta, params, access_grants, is_active };
+	const { base_model_id, name, meta, params, access_grants, is_active, commit_message } = model as any;
+	const payload = { id, base_model_id, name, meta, params, access_grants, is_active, commit_message };
 
 	const res = await fetch(`${WEBUI_API_BASE_URL}/models/model/update`, {
 		method: 'POST',
@@ -381,6 +381,326 @@ export const deleteModelById = async (token: string, id: string) => {
 
 			console.error(err);
 			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
+
+	return res;
+};
+
+export const getModelSystemPromptHistory = async (
+	token: string,
+	modelId: string,
+	page: number = 0
+): Promise<any[]> => {
+	let error = null;
+
+	const res = await fetch(
+		`${WEBUI_API_BASE_URL}/models/model/${encodeURIComponent(modelId)}/system/history?page=${page}`,
+		{
+			method: 'GET',
+			headers: {
+				Accept: 'application/json',
+				'Content-Type': 'application/json',
+				authorization: `Bearer ${token}`
+			}
+		}
+	)
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			error = err.detail;
+			console.error(err);
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
+
+	return res;
+};
+
+export const getModelSystemPromptHistoryEntry = async (
+	token: string,
+	modelId: string,
+	historyId: string
+): Promise<any> => {
+	let error = null;
+
+	const res = await fetch(
+		`${WEBUI_API_BASE_URL}/models/model/${encodeURIComponent(modelId)}/system/history/${historyId}`,
+		{
+			method: 'GET',
+			headers: {
+				Accept: 'application/json',
+				'Content-Type': 'application/json',
+				authorization: `Bearer ${token}`
+			}
+		}
+	)
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			error = err.detail;
+			console.error(err);
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
+
+	return res;
+};
+
+export const restoreModelSystemPromptVersion = async (
+	token: string,
+	modelId: string,
+	historyId: string
+): Promise<any> => {
+	let error = null;
+
+	const res = await fetch(
+		`${WEBUI_API_BASE_URL}/models/model/${encodeURIComponent(modelId)}/system/history/${historyId}/restore`,
+		{
+			method: 'POST',
+			headers: {
+				Accept: 'application/json',
+				'Content-Type': 'application/json',
+				authorization: `Bearer ${token}`
+			}
+		}
+	)
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			error = err.detail;
+			console.error(err);
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
+
+	return res;
+};
+
+export const deleteModelSystemPromptHistoryEntry = async (
+	token: string,
+	modelId: string,
+	historyId: string
+): Promise<boolean> => {
+	let error = null;
+
+	const res = await fetch(
+		`${WEBUI_API_BASE_URL}/models/model/${encodeURIComponent(modelId)}/system/history/${historyId}`,
+		{
+			method: 'DELETE',
+			headers: {
+				Accept: 'application/json',
+				'Content-Type': 'application/json',
+				authorization: `Bearer ${token}`
+			}
+		}
+	)
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			error = err.detail;
+			console.error(err);
+			return false;
+		});
+
+	if (error) {
+		throw error;
+	}
+
+	return res;
+};
+
+export const getModelSystemPromptDetail = async (
+	token: string,
+	modelId: string,
+	historyId: string
+): Promise<any> => {
+	let error = null;
+
+	const res = await fetch(
+		`${WEBUI_API_BASE_URL}/models/model/${encodeURIComponent(modelId)}/system/history/${historyId}/detail`,
+		{
+			method: 'GET',
+			headers: {
+				Accept: 'application/json',
+				'Content-Type': 'application/json',
+				authorization: `Bearer ${token}`
+			}
+		}
+	)
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			error = err.detail;
+			console.error(err);
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
+
+	return res;
+};
+
+export const getModelSystemPromptDiff = async (
+	token: string,
+	modelId: string,
+	fromId: string,
+	toId: string
+): Promise<any> => {
+	let error = null;
+
+	const res = await fetch(
+		`${WEBUI_API_BASE_URL}/models/model/${encodeURIComponent(modelId)}/system/history/diff`,
+		{
+			method: 'POST',
+			headers: {
+				Accept: 'application/json',
+				'Content-Type': 'application/json',
+				authorization: `Bearer ${token}`
+			},
+			body: JSON.stringify({ from_id: fromId, to_id: toId })
+		}
+	)
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			error = err.detail;
+			console.error(err);
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
+
+	return res;
+};
+
+export const getModelSystemPromptComments = async (
+	token: string,
+	modelId: string,
+	historyId: string
+): Promise<any[]> => {
+	let error = null;
+
+	const res = await fetch(
+		`${WEBUI_API_BASE_URL}/models/model/${encodeURIComponent(modelId)}/system/history/${historyId}/comments`,
+		{
+			method: 'GET',
+			headers: {
+				Accept: 'application/json',
+				'Content-Type': 'application/json',
+				authorization: `Bearer ${token}`
+			}
+		}
+	)
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			error = err.detail;
+			console.error(err);
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
+
+	return res;
+};
+
+export const createModelSystemPromptComment = async (
+	token: string,
+	modelId: string,
+	historyId: string,
+	content: string
+): Promise<any> => {
+	let error = null;
+
+	const res = await fetch(
+		`${WEBUI_API_BASE_URL}/models/model/${encodeURIComponent(modelId)}/system/history/${historyId}/comments`,
+		{
+			method: 'POST',
+			headers: {
+				Accept: 'application/json',
+				'Content-Type': 'application/json',
+				authorization: `Bearer ${token}`
+			},
+			body: JSON.stringify({ content })
+		}
+	)
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			error = err.detail;
+			console.error(err);
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
+
+	return res;
+};
+
+export const deleteModelSystemPromptComment = async (
+	token: string,
+	modelId: string,
+	historyId: string,
+	commentId: string
+): Promise<boolean> => {
+	let error = null;
+
+	const res = await fetch(
+		`${WEBUI_API_BASE_URL}/models/model/${encodeURIComponent(modelId)}/system/history/${historyId}/comments/${commentId}`,
+		{
+			method: 'DELETE',
+			headers: {
+				Accept: 'application/json',
+				'Content-Type': 'application/json',
+				authorization: `Bearer ${token}`
+			}
+		}
+	)
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			error = err.detail;
+			console.error(err);
+			return false;
 		});
 
 	if (error) {

--- a/src/lib/components/workspace/Models/ModelEditor.svelte
+++ b/src/lib/components/workspace/Models/ModelEditor.svelte
@@ -33,6 +33,8 @@
 	import TTSVoiceInput from './TTSVoiceInput.svelte';
 	import AccessControlModal from '../common/AccessControlModal.svelte';
 	import AccessButton from '$lib/components/common/AccessButton.svelte';
+	import LockClosed from '$lib/components/icons/LockClosed.svelte';
+	import ModelSystemPromptHistory from './ModelSystemPromptHistory.svelte';
 
 	const i18n = getContext('i18n');
 
@@ -41,6 +43,7 @@
 
 	export let model = null;
 	export let edit = false;
+	export let onReload: (() => Promise<any>) | undefined = undefined;
 
 	export let preset = true;
 
@@ -111,6 +114,7 @@
 	let terminalId = '';
 	let tts = { voice: '' };
 	export let suggestionTags: { name: string }[] = [];
+	let commitMessage = '';
 	let voices: { id: string; name?: string }[] = [];
 
 	const getBaseModelItems = (models: any[] = []) => {
@@ -299,6 +303,7 @@
 		}
 
 		info.params.system = system.trim() === '' ? null : system;
+		info.commit_message = commitMessage.trim() || null;
 		info.params.stop = params.stop
 			? (typeof params.stop === 'string' ? params.stop.split(',') : params.stop).filter((s) =>
 					s.trim()
@@ -345,92 +350,95 @@
 			workspaceContainer.scrollTop = 0;
 		}
 
-		if (model) {
-			name = model.name;
-			await tick();
-
-			id = model.id;
-
-			enableDescription = model?.meta?.description !== null;
-
-			if (model.base_model_id) {
-				const base_model = $models
-					.filter(
-						(m) => (!m?.preset && !(m?.arena ?? false)) || (edit && m.id === model.base_model_id)
-					)
-					.find((m) => [model.base_model_id, `${model.base_model_id}:latest`].includes(m.id));
-
-				console.log('base_model', base_model);
-
-				if (base_model) {
-					model.base_model_id = base_model.id;
-				} else if (!edit) {
-					model.base_model_id = null;
-				}
-			}
-
-			system = model?.params?.system ?? '';
-
-			params = { ...params, ...model?.params };
-			params.stop = params?.stop
-				? (typeof params.stop === 'string' ? params.stop.split(',') : (params?.stop ?? [])).join(
-						','
-					)
-				: null;
-
-			knowledge = (model?.meta?.knowledge ?? []).map((item) => {
-				if (item?.collection_name && item?.type !== 'file') {
-					return {
-						id: item.collection_name,
-						name: item.name,
-						legacy: true
-					};
-				} else if (item?.collection_names) {
-					return {
-						name: item.name,
-						type: 'collection',
-						collection_names: item.collection_names,
-						legacy: true
-					};
-				} else {
-					return item;
-				}
-			});
-
-			toolIds = model?.meta?.toolIds ?? [];
-			skillIds = model?.meta?.skillIds ?? [];
-			filterIds = model?.meta?.filterIds ?? [];
-			defaultFilterIds = model?.meta?.defaultFilterIds ?? [];
-			actionIds = model?.meta?.actionIds ?? [];
-
-			// Per-model overrides take precedence over admin defaults
-			capabilities = { ...capabilities, ...(model?.meta?.capabilities ?? {}) };
-			defaultFeatureIds = model?.meta?.defaultFeatureIds ?? defaultFeatureIds;
-			builtinTools = model?.meta?.builtinTools ?? builtinTools;
-			terminalId = model?.meta?.terminalId ?? '';
-			tts = { voice: model?.meta?.tts?.voice ?? '' };
-
-			accessGrants = model?.access_grants ?? [];
-
-			info = {
-				...info,
-				...JSON.parse(
-					JSON.stringify(
-						model
-							? model
-							: {
-									id: model.id,
-									name: model.name
-								}
-					)
-				)
-			};
-
-			console.log(model);
-		}
+		applyModel();
 
 		loaded = true;
 	});
+
+	const applyModel = () => {
+		if (!model) return;
+		name = model.name;
+		tick();
+
+		id = model.id;
+
+		enableDescription = model?.meta?.description !== null;
+
+		if (model.base_model_id) {
+			const base_model = $models
+				.filter(
+					(m) => (!m?.preset && !(m?.arena ?? false)) || (edit && m.id === model.base_model_id)
+				)
+				.find((m) => [model.base_model_id, `${model.base_model_id}:latest`].includes(m.id));
+
+			console.log('base_model', base_model);
+
+			if (base_model) {
+				model.base_model_id = base_model.id;
+			} else if (!edit) {
+				model.base_model_id = null;
+			}
+		}
+
+		system = model?.params?.system ?? '';
+
+		params = { ...params, ...model?.params };
+		params.stop = params?.stop
+			? (typeof params.stop === 'string' ? params.stop.split(',') : (params?.stop ?? [])).join(
+					','
+				)
+			: null;
+
+		knowledge = (model?.meta?.knowledge ?? []).map((item) => {
+			if (item?.collection_name && item?.type !== 'file') {
+				return {
+					id: item.collection_name,
+					name: item.name,
+					legacy: true
+				};
+			} else if (item?.collection_names) {
+				return {
+					name: item.name,
+					type: 'collection',
+					collection_names: item.collection_names,
+					legacy: true
+				};
+			} else {
+				return item;
+			}
+		});
+
+		toolIds = model?.meta?.toolIds ?? [];
+		skillIds = model?.meta?.skillIds ?? [];
+		filterIds = model?.meta?.filterIds ?? [];
+		defaultFilterIds = model?.meta?.defaultFilterIds ?? [];
+		actionIds = model?.meta?.actionIds ?? [];
+
+		// Per-model overrides take precedence over admin defaults
+		capabilities = { ...capabilities, ...(model?.meta?.capabilities ?? {}) };
+		defaultFeatureIds = model?.meta?.defaultFeatureIds ?? defaultFeatureIds;
+		builtinTools = model?.meta?.builtinTools ?? builtinTools;
+		terminalId = model?.meta?.terminalId ?? '';
+		tts = { voice: model?.meta?.tts?.voice ?? '' };
+
+		accessGrants = model?.access_grants ?? [];
+
+		info = {
+			...info,
+			...JSON.parse(
+				JSON.stringify(
+					model
+						? model
+						: {
+								id: model.id,
+								name: model.name
+							}
+				)
+			)
+		};
+
+		console.log(model);
+	};
 </script>
 
 {#if loaded}
@@ -748,6 +756,17 @@
 										<AdvancedParams admin={true} custom={true} layout="grid" bind:params />
 									</div>
 								{/if}
+								{#if edit && model}
+									<ModelSystemPromptHistory
+										modelId={model.id}
+										versionId={model?.system_prompt_version_id ?? null}
+										onRestore={(prompt) => {
+											system = prompt;
+										}}
+										onRestoreComplete={async () => {
+											if (onReload) { model = await onReload(); applyModel(); }
+										}}
+									/>
 							</div>
 						</section>
 
@@ -847,9 +866,9 @@
 								)
 								.map(([key, value]) => key)}
 
-							{#if availableFeatures.length > 0}
-								<div class="my-3">
-									<DefaultFeatures {availableFeatures} bind:featureIds={defaultFeatureIds} />
+						{#if availableFeatures.length > 0}
+							<div class="my-3">
+								<DefaultFeatures {availableFeatures} bind:featureIds={defaultFeatureIds} />
 								</div>
 							{/if}
 						{/if}
@@ -879,9 +898,22 @@
 							/>
 						</div>
 
-						<hr class="my-3 border-gray-100/30 dark:border-gray-850/30" />
+					<hr class="my-3 border-gray-100/30 dark:border-gray-850/30" />
 
-						<div class="my-2 flex justify-end">
+					{#if edit}
+						<div class="my-2">
+							<div class="text-xs font-medium mb-1 text-gray-500">
+								{$i18n.t('Commit Message')}
+							</div>
+							<input
+								class="w-full bg-transparent outline-hidden text-sm border border-gray-200 dark:border-gray-700 rounded-lg px-3 py-1.5"
+								placeholder={$i18n.t('Describe what changed in this version')}
+								bind:value={commitMessage}
+							/>
+						</div>
+					{/if}
+
+					<div class="my-2 flex justify-end">
 							<button
 								class=" text-sm px-3 py-2 transition rounded-lg {loading
 									? ' cursor-not-allowed bg-black hover:bg-gray-900 text-white dark:bg-white dark:hover:bg-gray-100 dark:text-black'

--- a/src/lib/components/workspace/Models/ModelSystemPromptDetailDiff.svelte
+++ b/src/lib/components/workspace/Models/ModelSystemPromptDetailDiff.svelte
@@ -1,0 +1,453 @@
+<script lang="ts">
+	import { getContext, onMount } from 'svelte';
+	import { user } from '$lib/stores';
+	import dayjs from 'dayjs';
+	import { toast } from 'svelte-sonner';
+	import {
+		getModelSystemPromptDetail,
+		getModelSystemPromptDiff,
+		getModelSystemPromptComments,
+		createModelSystemPromptComment,
+		deleteModelSystemPromptComment
+	} from '$lib/apis/models';
+	import Spinner from '$lib/components/common/Spinner.svelte';
+	import Badge from '$lib/components/common/Badge.svelte';
+
+	const i18n = getContext('i18n');
+
+	export let show = false;
+	export let modelId: string;
+	export let versionId: string | null = null;
+	export let onRestore: (system: string) => void;
+	export let onRestoreComplete: (() => void) | undefined = undefined;
+
+	let tab: 'detail' | 'diff' = 'diff';
+
+	// detail
+	let detailId = '';
+	let detailLoading = false;
+	let detail: any = null;
+
+	// diff
+	let fromId = '';
+	let toId = '';
+	let diffLoading = false;
+	let diffResult: string[] | null = null;
+	let snapshotDiff: { field: string; from: any; to: any }[] | null = null;
+
+	// comments
+	let comments: any[] = [];
+	let commentsLoading = false;
+	let newComment = '';
+
+	// pick two versions
+	export let history: any[] = [];
+	let searchQuery = '';
+	let dateFrom = '';
+	let dateTo = '';
+
+	$: filtered = history.filter((e) => {
+		const q = searchQuery.toLowerCase();
+		if (q && !(e.commit_message || '').toLowerCase().includes(q) && !(e.user?.name || '').toLowerCase().includes(q)) return false;
+		if (dateFrom && e.created_at * 1000 < new Date(dateFrom).getTime()) return false;
+		if (dateTo && e.created_at * 1000 > new Date(dateTo + 'T23:59:59').getTime()) return false;
+		return true;
+	});
+
+	$: ordered = [...filtered].reverse();
+
+	const loadDetail = async (historyId: string) => {
+		detailLoading = true;
+		try {
+			detail = await getModelSystemPromptDetail(localStorage.token, modelId, historyId);
+		} catch {
+			detail = null;
+		}
+		detailLoading = false;
+	};
+
+	const loadComments = async (historyId: string) => {
+		commentsLoading = true;
+		try {
+			comments = (await getModelSystemPromptComments(localStorage.token, modelId, historyId)) || [];
+		} catch {
+			comments = [];
+		}
+		commentsLoading = false;
+	};
+
+	const handleVersionClick = (entry: any) => {
+		if (!fromId) {
+			fromId = entry.id;
+		} else if (!toId && entry.id !== fromId) {
+			toId = entry.id;
+		} else {
+			fromId = entry.id;
+			toId = '';
+			diffResult = null;
+		}
+		tab = 'diff';
+	};
+
+	const runDiff = async () => {
+		if (!fromId || !toId) return;
+		diffLoading = true;
+		try {
+			const res = await getModelSystemPromptDiff(localStorage.token, modelId, fromId, toId);
+			diffResult = res?.content_diff ?? null;
+			const fromEntry = findEntry(fromId);
+			const toEntry = findEntry(toId);
+			snapshotDiff = computeSnapshotDiff(fromEntry?.snapshot, toEntry?.snapshot);
+		} catch {
+			diffResult = null;
+		}
+		diffLoading = false;
+	};
+
+	const selectForDetail = async (entry: any) => {
+		tab = 'detail';
+		await loadDetail(entry.id);
+		await loadComments(entry.id);
+	};
+
+	const handleAddComment = async () => {
+		if (!newComment.trim() || !detail) return;
+		try {
+			await createModelSystemPromptComment(localStorage.token, modelId, detail.id, newComment.trim());
+			newComment = '';
+			await loadComments(detail.id);
+			toast.success($i18n.t('Comment added'));
+		} catch (e) {
+			toast.error(`${e}`);
+		}
+	};
+
+	const handleDeleteComment = async (comment: any) => {
+		try {
+			await deleteModelSystemPromptComment(localStorage.token, modelId, detail.id, comment.id);
+			await loadComments(detail.id);
+			toast.success($i18n.t('Comment deleted'));
+		} catch (e) {
+			toast.error(`${e}`);
+		}
+	};
+
+	const swap = () => {
+		const tmp = fromId;
+		fromId = toId;
+		toId = tmp;
+		diffResult = null;
+	};
+
+	const findEntry = (id: string) => history.find((h) => h.id === id);
+
+	const renderDate = (ts: number) => dayjs(ts * 1000).format('L LT');
+
+	const formatVal = (v: any): string => {
+		if (v === null || v === undefined || v === '') return '(empty)';
+		if (Array.isArray(v)) return v.length ? v.join(', ') : '(empty)';
+		if (typeof v === 'object') return JSON.stringify(v);
+		return String(v);
+	};
+
+	const computeSnapshotDiff = (from: any, to: any): { field: string; from: any; to: any }[] => {
+		if (!from || !to) return [];
+		const diffs: { field: string; from: any; to: any }[] = [];
+		const keys = new Set([...Object.keys(from), ...Object.keys(to)]);
+		for (const key of keys) {
+			const a = JSON.stringify(from[key]);
+			const b = JSON.stringify(to[key]);
+			if (a !== b) diffs.push({ field: key, from: from[key], to: to[key] });
+		}
+		const prune = (v: any) => (typeof v === 'object' && v !== null ? Object.fromEntries(Object.entries(v).filter(([, x]) => x !== null && x !== undefined && x !== '')) : v);
+		return diffs
+			.map((d) => ({ ...d, from: prune(d.from), to: prune(d.to) }))
+			.filter((d) => JSON.stringify(d.from) !== JSON.stringify(d.to));
+	};
+
+	const handleRestore = () => {
+		if (!window.confirm($i18n.t('Load this prompt into the editor? It will overwrite the current system prompt.'))) return;
+		const entry = findEntry(toId || fromId);
+		if (entry) {
+			onRestore(entry.system_prompt);
+			onRestoreComplete?.();
+			show = false;
+			toast.success($i18n.t('Prompt loaded into editor — save to apply'));
+		}
+	};
+</script>
+
+<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+<svelte:window on:keydown={(e) => { if (e.key === 'Escape' && show) show = false; }} />
+
+{#if show}
+	<div
+		class="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+		on:click={() => (show = false)}
+		role="dialog"
+		aria-modal="true"
+	>
+		<div
+			class="bg-white dark:bg-gray-900 rounded-xl shadow-2xl max-w-3xl w-full max-h-[85vh] flex flex-col mx-4"
+			on:click|stopPropagation
+		>
+			<!-- header -->
+			<div class="flex items-center justify-between px-5 py-3 border-b border-gray-200 dark:border-gray-700">
+				<div class="flex items-center gap-3">
+					<h2 class="text-base font-semibold">{$i18n.t('System Prompt Versions')}</h2>
+					<div class="flex gap-1">
+						<button
+							type="button"
+							class="px-2.5 py-1 text-xs rounded-lg transition {tab === 'detail' ? 'bg-gray-200 dark:bg-gray-700' : 'hover:bg-gray-100 dark:hover:bg-gray-800'}"
+							on:click={() => (tab = 'detail')}
+						>
+							{$i18n.t('Detail')}
+						</button>
+						<button
+							type="button"
+							class="px-2.5 py-1 text-xs rounded-lg transition {tab === 'diff' ? 'bg-gray-200 dark:bg-gray-700' : 'hover:bg-gray-100 dark:hover:bg-gray-800'}"
+							on:click={() => (tab = 'diff')}
+						>
+							{$i18n.t('Difference')}
+						</button>
+					</div>
+				</div>
+				<button
+					type="button"
+					class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 transition"
+					on:click={() => (show = false)}
+					aria-label={$i18n.t('Close')}
+				>
+					<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="size-5">
+						<path d="M6.28 5.22a.75.75 0 0 0-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 1 0 1.06 1.06L10 11.06l3.72 3.72a.75.75 0 1 0 1.06-1.06L11.06 10l3.72-3.72a.75.75 0 0 0-1.06-1.06L10 8.94 6.28 5.22Z" />
+					</svg>
+				</button>
+			</div>
+
+			<!-- search + date filters -->
+			<div class="flex gap-2 px-5 pt-3 pb-1">
+				<input
+					class="flex-1 text-xs bg-transparent border border-gray-200 dark:border-gray-700 rounded-lg px-2 py-1.5"
+					placeholder={$i18n.t('Search by commit message or user...')}
+					bind:value={searchQuery}
+				/>
+				<input type="date" class="text-xs bg-transparent border border-gray-200 dark:border-gray-700 rounded-lg px-2 py-1.5" bind:value={dateFrom} title={$i18n.t('From date')} />
+				<input type="date" class="text-xs bg-transparent border border-gray-200 dark:border-gray-700 rounded-lg px-2 py-1.5" bind:value={dateTo} title={$i18n.t('To date')} />
+			</div>
+
+			<!-- body -->
+			<div class="flex-1 overflow-y-auto p-5 space-y-4">
+				{#if tab === 'detail'}
+					<div class="space-y-3">
+						<div class="text-xs font-medium text-gray-500 mb-1">{$i18n.t('Select a version')}</div>
+						<select
+							class="w-full text-xs bg-transparent border border-gray-200 dark:border-gray-700 rounded-lg px-2 py-1.5"
+							bind:value={detailId}
+							on:change={() => { if (detailId) { loadDetail(detailId); loadComments(detailId); } }}
+						>
+							<option value="">—</option>
+							{#each ordered as entry}
+								<option value={entry.id}>{entry.commit_message || entry.id.slice(0, 7)}</option>
+							{/each}
+						</select>
+					</div>
+					{#if detailLoading}
+						<div class="flex justify-center py-6"><Spinner className="size-5" /></div>
+					{:else if detail}
+						<div class="space-y-3">
+							<div class="flex items-center gap-2">
+								<span class="font-mono text-xs text-gray-500 bg-gray-100 dark:bg-gray-800 px-2 py-0.5 rounded">{detail.id.slice(0, 7)}</span>
+								{#if detail.id === versionId}
+									<Badge type="success" content={$i18n.t('Live')} />
+								{/if}
+							</div>
+
+							<div class="flex items-center gap-2 text-xs text-gray-500">
+								{#if detail.user}
+									<img
+										src={`/api/v1/users/${detail.user.id}/profile/image`}
+										alt={detail.user.name}
+										class="size-4 rounded-full"
+										on:error={(e) => (e.target.src = '/user.png')}
+									/>
+									<span>{detail.user.name}</span>
+									<span>•</span>
+								{/if}
+								<span>{renderDate(detail.created_at)}</span>
+							</div>
+
+							{#if detail.commit_message}
+								<div class="text-xs text-gray-500 italic">"{detail.commit_message}"</div>
+							{/if}
+
+							{#if detail.snapshot}
+								<div class="text-xs font-medium text-gray-500 mb-1">{$i18n.t('Snapshot')}</div>
+								<div class="text-xs bg-gray-50 dark:bg-gray-850 rounded-lg p-3 max-h-48 overflow-y-auto whitespace-pre-wrap break-words">{JSON.stringify(detail.snapshot, null, 2)}</div>
+							{/if}
+
+							<div>
+								<div class="text-xs font-medium text-gray-500 mb-1">{$i18n.t('System Prompt')}</div>
+								<pre class="text-xs bg-gray-50 dark:bg-gray-850 rounded-lg p-3 max-h-48 overflow-y-auto whitespace-pre-wrap break-words">{detail.system_prompt || $i18n.t('(empty)')}</pre>
+							</div>
+
+							<!-- comments -->
+							<div>
+								<div class="text-xs font-medium text-gray-500 mb-2">{$i18n.t('Comments')}</div>
+
+								{#if commentsLoading}
+									<div class="flex justify-center py-2"><Spinner className="size-3" /></div>
+								{:else if comments.length > 0}
+									<div class="space-y-2 max-h-40 overflow-y-auto">
+										{#each comments as comment}
+											<div class="flex items-start gap-2 bg-gray-50 dark:bg-gray-850 rounded-lg px-3 py-2">
+												{#if comment.user}
+													<img
+														src={`/api/v1/users/${comment.user.id}/profile/image`}
+														alt={comment.user.name}
+														class="size-5 rounded-full mt-0.5"
+														on:error={(e) => (e.target.src = '/user.png')}
+													/>
+												{/if}
+												<div class="flex-1 min-w-0">
+													<div class="flex items-center gap-2">
+														<span class="text-xs font-medium">{comment.user?.name || '—'}</span>
+														<span class="text-[10px] text-gray-400">{renderDate(comment.created_at)}</span>
+														{#if comment.user_id === $user?.id}
+															<button
+																type="button"
+																class="ml-auto text-gray-400 hover:text-red-500 transition shrink-0"
+																on:click={() => handleDeleteComment(comment)}
+																aria-label={$i18n.t('Delete comment')}
+															>
+																<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="size-3">
+																	<path d="M5 3.25V4H2.75a.75.75 0 0 0 0 1.5h.3l.815 8.15A1.5 1.5 0 0 0 5.357 15h5.286a1.5 1.5 0 0 0 1.492-1.35l.815-8.15h.3a.75.75 0 0 0 0-1.5H11v-.75A2.25 2.25 0 0 0 8.75 1h-1.5A2.25 2.25 0 0 0 5 3.25Zm2.25-.75a.75.75 0 0 0-.75.75V4h3v-.75a.75.75 0 0 0-.75-.75h-1.5ZM6.05 6a.75.75 0 0 1 .787.713l.275 5.5a.75.75 0 0 1-1.498.074l-.275-5.5A.75.75 0 0 1 6.05 6Zm3.9 0a.75.75 0 0 1 .712.787l-.275 5.5a.75.75 0 0 1-1.498-.074l.275-5.5a.75.75 0 0 1 .786-.713Z" />
+																</svg>
+															</button>
+														{/if}
+													</div>
+													<div class="text-xs mt-0.5">{comment.content}</div>
+												</div>
+											</div>
+										{/each}
+									</div>
+								{:else}
+									<div class="text-xs text-gray-400 italic py-1">{$i18n.t('No comments yet')}</div>
+								{/if}
+
+								<div class="flex gap-2 mt-2">
+									<input
+										class="flex-1 text-xs bg-transparent border border-gray-200 dark:border-gray-700 rounded-lg px-3 py-1.5 outline-hidden"
+										placeholder={$i18n.t('Add a comment...')}
+										bind:value={newComment}
+										on:keydown={(e) => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); handleAddComment(); } }}
+									/>
+									<button
+										type="button"
+										class="text-xs px-3 py-1.5 bg-black text-white dark:bg-white dark:text-black rounded-lg transition disabled:opacity-50"
+										disabled={!newComment.trim()}
+										on:click={handleAddComment}
+									>
+										{$i18n.t('Send')}
+									</button>
+								</div>
+							</div>
+
+							<button
+								type="button"
+								class="w-full text-xs py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition"
+								on:click={handleRestore}
+							>
+								{$i18n.t('Load This Prompt Into Editor')}
+							</button>
+						</div>
+					{/if}
+				{:else}
+					<!-- Diff tab -->
+					<div>
+						<div class="text-xs font-medium text-gray-500 mb-2">{$i18n.t('Select two versions to compare')}</div>
+
+						<div class="flex items-center gap-2 mb-3">
+							<div class="flex-1">
+								<div class="text-[10px] text-gray-400 mb-0.5">{$i18n.t('From (older)')}</div>
+								<select
+									class="w-full text-xs bg-transparent border border-gray-200 dark:border-gray-700 rounded-lg px-2 py-1.5"
+									bind:value={fromId}
+									on:change={() => { diffResult = null; snapshotDiff = null; }}
+								>
+									<option value="">—</option>
+									{#each ordered as entry}
+										<option value={entry.id}>{entry.commit_message || entry.id.slice(0, 7)}</option>
+									{/each}
+								</select>
+							</div>
+							<div class="self-end pb-1">
+								<button
+									class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 transition"
+									on:click={swap}
+									aria-label={$i18n.t('Swap')}
+								>
+									<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="size-5">
+										<path fill-rule="evenodd" d="M10 2a.75.75 0 0 1 .75.75v12.59l1.95-2.1a.75.75 0 1 1 1.1 1.02l-3.25 3.5a.75.75 0 0 1-1.1 0L6.2 14.26a.75.75 0 1 1 1.1-1.02l1.95 2.1V2.75A.75.75 0 0 1 10 2Z" clip-rule="evenodd" />
+									</svg>
+								</button>
+							</div>
+							<div class="flex-1">
+								<div class="text-[10px] text-gray-400 mb-0.5">{$i18n.t('To (newer)')}</div>
+								<select
+									class="w-full text-xs bg-transparent border border-gray-200 dark:border-gray-700 rounded-lg px-2 py-1.5"
+									bind:value={toId}
+									on:change={() => { diffResult = null; snapshotDiff = null; }}
+								>
+									<option value="">—</option>
+									{#each ordered as entry}
+										<option value={entry.id}>{entry.commit_message || entry.id.slice(0, 7)}</option>
+									{/each}
+								</select>
+							</div>
+						</div>
+
+						<button
+							type="button"
+							class="w-full text-xs py-1.5 bg-gray-100 dark:bg-gray-800 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-700 transition mb-3 disabled:opacity-50"
+							disabled={!fromId || !toId || fromId === toId}
+							on:click={runDiff}
+						>
+							{$i18n.t('Compare')}
+						</button>
+
+						{#if diffLoading}
+							<div class="flex justify-center py-4"><Spinner className="size-4" /></div>
+						{:else if diffResult}
+							<div class="bg-gray-50 dark:bg-gray-850 rounded-lg p-3 max-h-64 overflow-y-auto">
+								{#each diffResult as line}
+									{@const cls = line.startsWith('---') || line.startsWith('+++') || line.startsWith('@@')
+										? 'text-gray-500 font-mono text-[11px]'
+										: line.startsWith('+')
+											? 'text-green-700 dark:text-green-400 font-mono text-[11px]'
+											: line.startsWith('-')
+												? 'text-red-700 dark:text-red-400 font-mono text-[11px]'
+												: 'text-gray-700 dark:text-gray-300 font-mono text-[11px]'}
+									<div class={cls}>{line}</div>
+								{/each}
+							</div>
+							{#if snapshotDiff && snapshotDiff.length > 0}
+								<div class="text-xs font-medium text-gray-500 mt-3 mb-1">{$i18n.t('Parameter Changes')}</div>
+								<div class="bg-gray-50 dark:bg-gray-850 rounded-lg p-3 max-h-48 overflow-y-auto space-y-1">
+									{#each snapshotDiff as d}
+										<div class="text-[11px]">
+											<span class="font-medium">{d.field}</span>
+<span class="text-red-600 dark:text-red-400"> -{formatVal(d.from)}</span>
+						<span class="text-green-600 dark:text-green-400"> +{formatVal(d.to)}</span>
+										</div>
+									{/each}
+								</div>
+							{/if}
+						{:else if fromId && toId && fromId !== toId}
+							<div class="text-xs text-gray-400 italic text-center py-4">{$i18n.t('Click Compare to see the diff')}</div>
+						{/if}
+					</div>
+				{/if}
+			</div>
+		</div>
+	</div>
+{/if}

--- a/src/lib/components/workspace/Models/ModelSystemPromptHistory.svelte
+++ b/src/lib/components/workspace/Models/ModelSystemPromptHistory.svelte
@@ -1,0 +1,215 @@
+<script lang="ts">
+	import { toast } from 'svelte-sonner';
+	import { getContext, onMount } from 'svelte';
+	import {
+		getModelSystemPromptHistory,
+		restoreModelSystemPromptVersion,
+		deleteModelSystemPromptHistoryEntry
+	} from '$lib/apis/models';
+	import Spinner from '$lib/components/common/Spinner.svelte';
+	import Badge from '$lib/components/common/Badge.svelte';
+	import ModelSystemPromptDetailDiff from './ModelSystemPromptDetailDiff.svelte';
+	import dayjs from 'dayjs';
+
+	const i18n = getContext('i18n');
+
+	export let modelId: string;
+	export let versionId: string | null = null;
+	export let onRestore: (system: string) => void;
+	export let onRestoreComplete: (() => void) | undefined = undefined;
+
+	let history: any[] = [];
+	let searchQuery = '';
+	let dateFrom = '';
+	let dateTo = '';
+	let loading = false;
+	let loadingMore = false;
+	let page = 0;
+	let hasMore = true;
+	let restoring = false;
+	let showModal = false;
+
+	$: filtered = history.filter((e) => {
+		const q = searchQuery.toLowerCase();
+		if (q && !(e.commit_message || '').toLowerCase().includes(q) && !(e.user?.name || '').toLowerCase().includes(q)) return false;
+		if (dateFrom && e.created_at * 1000 < new Date(dateFrom).getTime()) return false;
+		if (dateTo && e.created_at * 1000 > new Date(dateTo + 'T23:59:59').getTime()) return false;
+		return true;
+	});
+
+	const loadHistory = async () => {
+		if (!modelId) return;
+		loading = true;
+		page = 0;
+		hasMore = true;
+		try {
+			history = (await getModelSystemPromptHistory(localStorage.token, modelId, 0)) || [];
+		} catch {
+			history = [];
+		}
+		loading = false;
+	};
+
+	const loadMore = async () => {
+		if (!hasMore || loadingMore) return;
+		loadingMore = true;
+		try {
+			const items = (await getModelSystemPromptHistory(localStorage.token, modelId, page + 1)) || [];
+			if (items.length === 0) hasMore = false;
+			else { history = [...history, ...items]; page++; }
+		} catch { hasMore = false; }
+		loadingMore = false;
+	};
+
+	const handleRestore = async (entry: any) => {
+		if (!window.confirm($i18n.t('Restore this version? It will replace the current system prompt.'))) return;
+		restoring = true;
+		try {
+			const updated = await restoreModelSystemPromptVersion(localStorage.token, modelId, entry.id);
+			toast.success($i18n.t('System prompt version restored — already live, no need to save'));
+			versionId = updated?.system_prompt_version_id ?? entry.id;
+			onRestore(entry.system_prompt);
+			onRestoreComplete?.();
+		} catch (e) {
+			toast.error(`${e}`);
+		}
+		restoring = false;
+	};
+
+	const handleDelete = async (entry: any) => {
+		if (entry.id === versionId) {
+			toast.error($i18n.t('Cannot delete the active version'));
+			return;
+		}
+		try {
+			await deleteModelSystemPromptHistoryEntry(localStorage.token, modelId, entry.id);
+			toast.success($i18n.t('Version deleted'));
+			await loadHistory();
+		} catch (e) {
+			toast.error(`${e}`);
+		}
+	};
+
+	const renderDate = (timestamp: number) => {
+		const d = timestamp * 1000;
+		return dayjs(d).format('L LT');
+	};
+
+	onMount(loadHistory);
+</script>
+
+<ModelSystemPromptDetailDiff
+	bind:show={showModal}
+	{modelId}
+	{versionId}
+	{onRestore}
+	{onRestoreComplete}
+	history={filtered}
+/>
+
+<div class="mt-2">
+	<div class="flex items-center justify-between mb-1">
+		<div class="text-xs font-medium text-gray-500">{$i18n.t('Version History')}</div>
+		<div class="flex items-center gap-2">
+			{#if restoring}
+				<Spinner className="size-3" />
+			{/if}
+			{#if history.length > 0}
+				<button
+					type="button"
+					class="text-xs text-blue-600 hover:text-blue-700 transition"
+					on:click={() => (showModal = true)}
+				>
+					{$i18n.t('View & Compare')}
+				</button>
+			{/if}
+		</div>
+	</div>
+
+	<div class="flex gap-2 mb-2">
+		<input
+			class="flex-1 text-xs bg-transparent border border-gray-200 dark:border-gray-700 rounded-lg px-2 py-1.5"
+			placeholder={$i18n.t('Search by commit message or user...')}
+			bind:value={searchQuery}
+		/>
+		<input type="date" class="text-xs bg-transparent border border-gray-200 dark:border-gray-700 rounded-lg px-2 py-1.5" bind:value={dateFrom} title={$i18n.t('From date')} />
+		<input type="date" class="text-xs bg-transparent border border-gray-200 dark:border-gray-700 rounded-lg px-2 py-1.5" bind:value={dateTo} title={$i18n.t('To date')} />
+	</div>
+
+	{#if loading}
+		<div class="flex justify-center py-3">
+			<Spinner className="size-4" />
+		</div>
+	{:else if filtered.length > 0}
+		<div class="space-y-1 max-h-48 overflow-y-auto">
+			{#each filtered as entry}
+				<div
+					class="flex items-center gap-2 px-3 py-1.5 rounded-lg {entry.id === versionId
+						? 'bg-gray-100/50 dark:bg-gray-850/50'
+						: 'hover:bg-gray-50 dark:hover:bg-gray-850'} transition"
+				>
+					<div class="flex-1 min-w-0">
+						<div class="flex items-center gap-1 mb-0.5">
+							<span class="font-mono text-xs text-gray-500">{entry.id.slice(0, 7)}</span>
+							{#if entry.id === versionId}
+								<Badge type="success" content={$i18n.t('Live')} />
+							{/if}
+						</div>
+						<div class="text-xs text-gray-400 truncate">{entry.commit_message || $i18n.t('Update')}</div>
+						<div class="flex items-center gap-1 text-[11px] text-gray-400">
+							{#if entry.user}
+								<img
+									src={`/api/v1/users/${entry.user.id}/profile/image`}
+									alt={entry.user.name}
+									class="size-3 rounded-full"
+									on:error={(e) => (e.target.src = '/user.png')}
+								/>
+								<span class="truncate max-w-20">{entry.user.name}</span>
+								<span>•</span>
+							{/if}
+							<span class="shrink-0">{renderDate(entry.created_at)}</span>
+						</div>
+					</div>
+					<div class="flex items-center gap-1 shrink-0">
+						{#if entry.id !== versionId}
+							<button
+								class="text-gray-400 hover:text-blue-500 transition text-xs"
+								type="button"
+								on:click={() => handleRestore(entry)}
+								aria-label={$i18n.t('Restore this version')}
+								title={$i18n.t('Restore')}
+							>
+								<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="size-3.5">
+									<path fill-rule="evenodd" d="M8 3.5c-.771 0-1.537.22-2.185.634a3.5 3.5 0 0 0-.665 5.283.75.75 0 0 0 1.06-1.06 2 2 0 0 1 .38-3.019 2.015 2.015 0 0 1 2.188.426l.31.31H7.25a.75.75 0 0 0 0 1.5h3a.75.75 0 0 0 .75-.75v-3a.75.75 0 0 0-1.5 0v1.12l-.31-.31A3.5 3.5 0 0 0 8 3.5Z" clip-rule="evenodd" />
+								</svg>
+							</button>
+						{/if}
+						<button
+							class="text-gray-400 hover:text-red-500 transition text-xs"
+							type="button"
+							on:click={() => handleDelete(entry)}
+							aria-label={$i18n.t('Delete version')}
+							title={$i18n.t('Delete')}
+						>
+							<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="size-3.5">
+								<path fill-rule="evenodd" d="M5 3.25V4H2.75a.75.75 0 0 0 0 1.5h.3l.815 8.15A1.5 1.5 0 0 0 5.357 15h5.286a1.5 1.5 0 0 0 1.492-1.35l.815-8.15h.3a.75.75 0 0 0 0-1.5H11v-.75A2.25 2.25 0 0 0 8.75 1h-1.5A2.25 2.25 0 0 0 5 3.25Zm2.25-.75a.75.75 0 0 0-.75.75V4h3v-.75a.75.75 0 0 0-.75-.75h-1.5ZM6.05 6a.75.75 0 0 1 .787.713l.275 5.5a.75.75 0 0 1-1.498.074l-.275-5.5A.75.75 0 0 1 6.05 6Zm3.9 0a.75.75 0 0 1 .712.787l-.275 5.5a.75.75 0 0 1-1.498-.074l.275-5.5a.75.75 0 0 1 .786-.713Z" clip-rule="evenodd" />
+							</svg>
+						</button>
+					</div>
+				</div>
+			{/each}
+		</div>
+		{#if hasMore}
+			<button
+				type="button"
+				class="w-full text-xs py-1 mt-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition disabled:opacity-50"
+				on:click={loadMore}
+				disabled={loadingMore}
+			>
+				{loadingMore ? $i18n.t('Loading...') : $i18n.t('Load More')}
+			</button>
+		{/if}
+	{:else}
+		<div class="text-xs text-gray-400 italic py-2">{$i18n.t('No version history yet')}</div>
+	{/if}
+</div>

--- a/src/routes/(app)/workspace/models/edit/+page.svelte
+++ b/src/routes/(app)/workspace/models/edit/+page.svelte
@@ -15,24 +15,26 @@
 
 	let model = null;
 
-	onMount(async () => {
+	const loadModel = async () => {
 		const _id = $page.url.searchParams.get('id');
 		if (_id) {
-			model = await getModelById(localStorage.token, _id).catch((e) => {
-				return null;
-			});
-
-			if (!model) {
+			const m = await getModelById(localStorage.token, _id).catch((e) => null);
+			if (!m) {
 				goto('/workspace/models');
+				return;
 			}
-
-			if (!model?.write_access) {
+			if (!m?.write_access) {
 				toast.error($i18n.t('You do not have permission to edit this model'));
 				goto('/workspace/models');
+				return;
 			}
-		} else {
-			goto('/workspace/models');
+			return m;
 		}
+		goto('/workspace/models');
+	};
+
+	onMount(async () => {
+		model = await loadModel();
 	});
 
 	const onSubmit = async (modelInfo) => {
@@ -56,6 +58,7 @@
 		edit={true}
 		{model}
 		{onSubmit}
+		onReload={loadModel}
 		onBack={async () => {
 			await goto('/workspace/models');
 		}}


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** https://github.com/open-webui/open-webui/discussions/27095, Discussion post with feature description, screenshots, and community feedback. Also relates to #27159 (@izevg's parallel proposal, both approaches have been aligned into a 3-PR merge plan: this PR covers the management/UX layer, @izevg will follow up with runtime resolve + Langfuse integration).
- [x] **Target branch:** The pull request targets the `dev` branch. Rebased on `dev` (`cc9a44569`).
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not yet added to [Open WebUI Docs Repository](https://github.com/open-webui/docs). Can be added as a follow-up once the feature is approved by maintainers.
- [x] **Dependencies:** No new dependencies. Uses existing SQLAlchemy, Pydantic, and Svelte stack already in the project.
- [x] **Testing:** Manually tested throughout development in a running instance. 38 unit tests were written and pass, but removed from this PR since Open WebUI uses a separate test repo ([open-webui/tests](https://github.com/open-webui/tests)). Screenshots are available in [Discussion #27095](https://github.com/open-webui/open-webui/discussions/27095).
- [x] **No Unchecked AI Code:** Code was iteratively built, manually tested, and reviewed during development. All changes have been verified to work in a running instance.
- [x] **Self-Review:** Code has been self-reviewed. Follows existing patterns in the codebase (singleton table pattern, async DB context, Pydantic models, Svelte components).
- [x] **Architecture:** No new settings, uses existing model editor infrastructure. History panel is local UI state. Full discussion of architecture happened in #27095 before starting work.
- [x] **Git Hygiene:** PR is atomic (one feature). Rebased on `dev`. Contains 2 clean commits (feat + docs), no unrelated files.
- [x] **Title Prefix:** `feat: add system prompt versioning for workspace models`

# Changelog Entry

### Description

Adds a versioning system for workspace model system prompts. Every model save now captures a full snapshot of the model state (`params`, `meta`, `name`, `base_model_id`, `is_active`), not just the system prompt text. Users can browse version history, compare two versions with a unified diff view, add per-version comments, search/filter by commit message or date, and restore previous versions with a confirmation dialog.

This addresses the problem where iterating on a model's system prompt was destructive, every save overwrote silently, with no way to see what changed, compare versions, or roll back. This is especially important for teams where multiple users edit the same model, and for production models where a bad prompt change degrades output quality with no fast rollback path.

### Added

- **Full model snapshot per version**, `params`, `meta`, `name`, `base_model_id`, `is_active` stored as JSON in `model_system_prompt_history.snapshot` column. Every save captures the complete model state, not just the system prompt text.
- **Version history with `parent_id` chain**, append-only, linear. Each save or restore creates a new entry, preserving the audit trail.
- **Per-version comments**, `model_system_prompt_comment` table with user attribution and user-scoped deletion (users can only delete their own comments).
- **Difference view**, unified diff for system prompt text + structured snapshot diff showing parameter changes (temperature, skills, tools, knowledge, capabilities, etc.).
- **Detail view**, full snapshot JSON, system prompt text, and comment thread per version.
- **Search & date filter**, client-side filtering by commit message, user name, and date range. Works in both the compact history list and the detail/diff modal.
- **Server-side pagination**, 200 entries per page with "Load More" button.
- **Restore with confirmation**, `window.confirm()` dialog before restoring. Restores the full snapshot (all fields), not just the system prompt text.
- **Editor auto-refresh after restore**, all editor fields (name, system prompt, advanced params, skills, tools, knowledge, capabilities) update without page reload.
- **Commit messages**, optional commit message input on every save, stored with each version entry.
- **Deduplication guard**, no version is created when nothing changed (snapshot comparison against latest entry).
- **Three Alembic migrations**, history table, comment table, snapshot column (all idempotent via inspector checks).
- **Nine API endpoints**, history list, history entry, detail, diff, restore, comment CRUD.

### Changed

- `update_model_by_id()` now always creates a history entry with a full snapshot (previously no history was tracked).
- `insert_new_model()` creates an initial "Initial version" history entry when the model has a system prompt.
- `update_model_system_prompt_version()` now restores the full snapshot (`params`, `meta`, `name`, `base_model_id`) instead of just `params['system']`. Falls back to prompt-only restore for entries without a snapshot (backward compatibility).
- `ModelEditor.svelte`, added version history panel, commit message input, and `onReload` callback for post-restore refresh.
- All buttons inside the model editor form now have `type="button"` to prevent unintended form submissions (previously defaulted to `type="submit"`, triggering unwanted model saves).

### Deprecated

- Nothing.

### Removed

- Nothing.

### Fixed

- **Unintended form submission**, buttons inside the model editor form (View & Compare, Restore, Delete, Compare, Send comment, etc.) no longer trigger `POST /api/v1/models/model/update` because they now have `type="button"`.
- **Incomplete restore**, restoring a version now restores all model fields from the snapshot, not just the system prompt text.

### Security

- Restore and delete endpoints require write access (owner, admin, or write grant).
- Comment creation requires read access; comment deletion is scoped to the author's own `user_id` at the database layer.
- History browsing, diff, and detail require read access.

### Breaking Changes

- None. The `params.system` field remains the source of truth at runtime, the version history is a management layer that writes back to `params.system` on save/restore. No existing API or chat completion flow is modified.

---

### Additional Information

**Discussion:** [#27095](https://github.com/open-webui/open-webui/discussions/27095), original feature proposal with screenshots and community feedback.

**Related discussion:** [#27159](https://github.com/open-webui/open-webui/discussions/27159), @izevg's parallel proposal (runtime resolve + optional Langfuse). Both proposals have been aligned into a 3-PR merge plan:

| PR | Scope | Owner |
|----|-------|-------|
| PR1 (this PR) | Versioning core: snapshot, diff, comments, search, restore, dedup | @TF-MTGE |
| PR2 | Runtime resolve: `resolve_model_system_prompt()`, binding table (source=local), LRU cache, fix inconsistent `bypass_system_prompt` | @izevg |
| PR3 | Langfuse integration: provider abstraction, admin connections, Redis L2 cache, binding UI toggle | @izevg |

**Key design decisions:**

1. **Full snapshot** (not prompt-only), Open WebUI models are more than just a system prompt. Temperature, tool selection, knowledge bases, capabilities, all matter. A rollback that only restores the prompt text is incomplete. The `snapshot` JSON column is additive, consumers that only need the prompt can read `system_prompt`; consumers that need the full state read `snapshot`.

2. **`params.system` stays as runtime source of truth**, no runtime changes. The version history is a management layer. `update_model_by_id()` writes back to `params.system` on every save/restore. PR2 (from @izevg) will add the indirection layer.

3. **Restore creates a new entry**, not a pointer move. This preserves the append-only audit trail and the parent chain.

4. **Client-side search/filter**, fast for typical datasets (< 1000 versions). No backend endpoint churn. Server-side pagination at 200 entries/page.

**Database schema:**

```
model_system_prompt_history
├── id (Text, PK)
├── model_id (Text, indexed)
├── parent_id (Text, nullable)
├── system_prompt (Text)
├── user_id (Text)
├── commit_message (Text, nullable)
├── snapshot (JSON, nullable)
└── created_at (BigInteger)

model_system_prompt_comment
├── id (Text, PK)
├── history_id (Text, indexed)
├── user_id (Text)
├── content (Text)
└── created_at (BigInteger)

model (additions)
└── system_prompt_version_id (Text, nullable)
```

### Screenshots or Videos

Screenshots are available in [Discussion #27095](https://github.com/open-webui/open-webui/discussions/27095).

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.