### PR TITLE
fix: prevent TypeError in tool call arguments parsing and SQLite PRAGMA key single-quote escape

### DIFF
--- a/backend/open_webui/internal/db.py
+++ b/backend/open_webui/internal/db.py
@@ -246,12 +246,18 @@ if SQLALCHEMY_DATABASE_URL.startswith('sqlite+sqlcipher://'):
     # Extract database path from SQLCipher URL
     db_path = SQLALCHEMY_DATABASE_URL.replace('sqlite+sqlcipher://', '')
 
+    # Escape single quotes in password for safe SQLite PRAGMA usage.
+    # SQLite PRAGMA statements do not support parameterised queries,
+    # so we must escape the value manually to avoid syntax errors when
+    # the password contains a single quote.
+    _escaped_password = database_password.replace("'", "''")
+
     # Create a custom creator function that uses sqlcipher3
     def create_sqlcipher_connection():
         import sqlcipher3
 
         conn = sqlcipher3.connect(db_path, check_same_thread=False)
-        conn.execute(f"PRAGMA key = '{database_password}'")
+        conn.execute(f"PRAGMA key = '{_escaped_password}'")
         return conn
 
     # The dummy "sqlite://" URL would cause SQLAlchemy to auto-select

--- a/backend/open_webui/migrations/env.py
+++ b/backend/open_webui/migrations/env.py
@@ -50,11 +50,15 @@ def _get_engine_connectable():
         if raw_db_path.startswith('/'):
             raw_db_path = raw_db_path[1:]
 
+        # Escape single quotes in password for safe SQLite PRAGMA usage.
+        # SQLite PRAGMA statements do not support parameterised queries.
+        _escaped_pw = DATABASE_PASSWORD.replace("'", "''")
+
         def _sqlite_cipher_creator():
             import sqlcipher3
 
             cipher_conn = sqlcipher3.connect(raw_db_path, check_same_thread=False)
-            cipher_conn.execute(f"PRAGMA key = '{DATABASE_PASSWORD}'")
+            cipher_conn.execute(f"PRAGMA key = '{_escaped_pw}'")
             return cipher_conn
 
         return create_engine('sqlite://', creator=_sqlite_cipher_creator, echo=False)

--- a/backend/open_webui/utils/payload.py
+++ b/backend/open_webui/utils/payload.py
@@ -244,7 +244,7 @@ def convert_messages_openai_to_ollama(messages: list[dict]) -> list[dict]:
                     'id': tool_call.get('id', None),
                     'function': {
                         'name': tool_call.get('function', {}).get('name', ''),
-                        'arguments': json.loads(tool_call.get('function', {}).get('arguments', {})),
+                        'arguments': json.loads(tool_call.get('function', {}).get('arguments', '{}')),
                     },
                 }
                 ollama_tool_calls.append(ollama_tool_call)


### PR DESCRIPTION
## Summary

Fixes two bugs in the backend:

### 1. TypeError crash in tool call arguments parsing (`payload.py`)

```python
# BEFORE (line 247):
'arguments': json.loads(tool_call.get('function', {}).get('arguments', {})),
# If 'arguments' key is missing, .get() returns {} (dict) and json.loads({}) crashes:
# TypeError: the JSON object must be str, bytes or bytearray, not dict

# AFTER:
'arguments': json.loads(tool_call.get('function', {}).get('arguments', '{}')),
# Default is now '{}' (string), matching the pattern already used in anthropic.py
```

**Impact:** When a model sends a tool_call with a `function` key but no `arguments` key, the entire chat completion would crash. This is a regression compared to how `anthropic.py` handles the same case (line 431 uses `'{}'` as default).

### 2. SQLite PRAGMA key single-quote crash (`db.py` + `env.py`)

SQLite's `PRAGMA` statements don't support parameterized queries, forcing the use of f-string interpolation. If `DATABASE_PASSWORD` contains a single quote (e.g., `pass'word`), it causes a SQL syntax error and the application fails to start.

This PR adds proper single-quote escaping (`replace("'", "''")`) before interpolation in both `internal/db.py` and `migrations/env.py`.

## Changes

- `backend/open_webui/utils/payload.py`: Changed default argument from `{}` to `'{}'`
- `backend/open_webui/internal/db.py`: Escape single quotes in database password before PRAGMA key
- `backend/open_webui/migrations/env.py`: Same escape fix for Alembic migrations

## CLA

I have read the CLA Document and I hereby sign the CLA.

By submitting my contributions to this repository in any form, I grant Open WebUI Inc. a perpetual, worldwide, irrevocable, royalty-free license, under copyright and patent, to use, modify, distribute, sublicense, and commercialize my work under any terms they choose, both now and in the future.