### PR TITLE
fix: prevent TypeError when tool call arguments is None during streaming

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -259,7 +259,7 @@ def _split_tool_calls(
 
     expanded = []
     for tool_call in tool_calls:
-        arguments = tool_call.get('function', {}).get('arguments', '')
+        arguments = tool_call.get('function', {}).get('arguments') or ''
         split_arguments = split_json_objects(arguments)
 
         if len(split_arguments) <= 1:


### PR DESCRIPTION
## Description

Fixes a `TypeError` crash during streaming when a tool call's `arguments` field is `None`.

In `_split_tool_calls()` (middleware.py), `tool_call.get('function', {}).get('arguments', '')` returns `None` — not the default `''` — when the `arguments` key exists but has a `None` value. This `None` is then passed to `split_json_objects()` which calls `len(None)`, raising:

```
TypeError: object of type 'NoneType' has no len()
```

The fix uses the `or` operator to coerce `None` to an empty string, which `split_json_objects()` handles correctly.

### Changes

- `backend/open_webui/utils/middleware.py`: Changed `.get('arguments', '')` to `.get('arguments') or ''` to properly handle `None` values

## Changelog Entry

### Fixed

- Fix TypeError crash when streaming tool call arguments are `None` (len() on NoneType). The `_split_tool_calls` function now coerces `None` arguments to empty string before passing to `split_json_objects()`.

---

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
