### PR TITLE
perf: replace blocking I/O with aiofiles in speech endpoint

### DIFF
--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -8,6 +8,7 @@ import re
 from typing import Optional
 from urllib.parse import quote, urlparse
 
+import aiofiles
 import aiohttp
 from aiocache import cached
 from azure.identity import DefaultAzureCredential, get_bearer_token_provider
@@ -491,13 +492,13 @@ async def speech(request: Request, user=Depends(get_verified_user)):
 
             r.raise_for_status()
 
-            # Save the streaming content to a file
-            with open(file_path, 'wb') as f:
+            # Save the streaming content to a file (async to avoid blocking the event loop)
+            async with aiofiles.open(file_path, 'wb') as f:
                 async for chunk in r.content.iter_chunked(8192):
-                    f.write(chunk)
+                    await f.write(chunk)
 
-            with open(file_body_path, 'w') as f:
-                json.dump(json.loads(body.decode('utf-8')), f)
+            async with aiofiles.open(file_body_path, 'w') as f:
+                await f.write(json.dumps(json.loads(body.decode('utf-8'))))
 
             # Return the saved file
             return FileResponse(file_path)


### PR DESCRIPTION
## Description

The speech endpoint (`POST /openai/audio/speech`) in `routers/openai.py` uses synchronous `open()` and `f.write()` for streaming audio file writes. This blocks the entire asyncio event loop during file I/O, causing request queuing and timeouts under concurrent TTS requests.

The rest of the codebase (`audio.py`, `files.py`) already uses `aiofiles` for all async file I/O — this was the only remaining place using blocking `open()` inside an async function for streaming writes.

### Changes

- Added `import aiofiles`
- Replaced `open()` / `f.write()` with `aiofiles.open()` / `await f.write()`
- Replaced `json.dump(f, ...)` with `await f.write(json.dumps(...))` for aiofiles compatibility

## Changelog Entry

### Fixed

- **perf**: Replace blocking I/O with aiofiles in speech endpoint. Synchronous `f.write()` calls inside the streaming loop blocked the event loop during TTS audio downloads, causing request timeouts under concurrent load.

---

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
