### PR TITLE
fix: refresh model list in get_ollama_url when model not found

### DIFF
--- a/backend/open_webui/routers/ollama.py
+++ b/backend/open_webui/routers/ollama.py
@@ -889,8 +889,8 @@ async def embed(
     key = get_api_key(url_idx, url, (await Config.get('ollama.api_configs', {})))
 
     prefix_id = api_config.get('prefix_id')
-    if prefix_id:
-        form_data.model = form_data.model.replace(f'{prefix_id}.', '')
+    if prefix_id and form_data.model.startswith(f'{prefix_id}.'):
+        form_data.model = form_data.model[len(f'{prefix_id}.'):]
 
     return await send_request(
         f'{url}/api/embed',
@@ -943,8 +943,8 @@ async def embeddings(
     key = get_api_key(url_idx, url, (await Config.get('ollama.api_configs', {})))
 
     prefix_id = api_config.get('prefix_id')
-    if prefix_id:
-        form_data.model = form_data.model.replace(f'{prefix_id}.', '')
+    if prefix_id and form_data.model.startswith(f'{prefix_id}.'):
+        form_data.model = form_data.model[len(f'{prefix_id}.'):]
 
     return await send_request(
         f'{url}/api/embeddings',
@@ -1001,8 +1001,8 @@ async def generate_completion(
     )
 
     prefix_id = api_config.get('prefix_id')
-    if prefix_id:
-        form_data.model = form_data.model.replace(f'{prefix_id}.', '')
+    if prefix_id and form_data.model.startswith(f'{prefix_id}.'):
+        form_data.model = form_data.model[len(f'{prefix_id}.'):]
 
     return await send_request(
         f'{url}/api/generate',
@@ -1061,6 +1061,9 @@ async def get_ollama_url(request: Request, model: str, url_idx: int | None = Non
     await validate_ollama_backend_idx(request, model, url_idx, user)
     if url_idx is None:
         models = request.app.state.OLLAMA_MODELS
+        if not models or model not in models:
+            await get_all_models(request, user=user)
+            models = request.app.state.OLLAMA_MODELS
         if model not in models:
             raise HTTPException(
                 status_code=400,
@@ -1133,7 +1136,8 @@ async def generate_chat_completion(
 
     prefix_id = api_config.get('prefix_id')
     if prefix_id:
-        payload['model'] = payload['model'].replace(f'{prefix_id}.', '')
+        if payload['model'].startswith(f'{prefix_id}.'):
+            payload['model'] = payload['model'][len(f'{prefix_id}.'):]
 
     return await send_request(
         f'{url}/api/chat',
@@ -1229,7 +1233,8 @@ async def generate_openai_completion(
 
     prefix_id = api_config.get('prefix_id')
     if prefix_id:
-        payload['model'] = payload['model'].replace(f'{prefix_id}.', '')
+        if payload['model'].startswith(f'{prefix_id}.'):
+            payload['model'] = payload['model'][len(f'{prefix_id}.'):]
 
     return await send_request(
         f'{url}/v1/completions',
@@ -1338,7 +1343,8 @@ async def generate_openai_chat_completion(
 
     prefix_id = api_config.get('prefix_id')
     if prefix_id:
-        payload['model'] = payload['model'].replace(f'{prefix_id}.', '')
+        if payload['model'].startswith(f'{prefix_id}.'):
+            payload['model'] = payload['model'][len(f'{prefix_id}.'):]
 
     return await send_request(
         f'{url}/v1/chat/completions',
@@ -1392,7 +1398,8 @@ async def generate_anthropic_messages(
 
     prefix_id = api_config.get('prefix_id', None)
     if prefix_id:
-        payload['model'] = payload['model'].replace(f'{prefix_id}.', '')
+        if payload['model'].startswith(f'{prefix_id}.'):
+            payload['model'] = payload['model'][len(f'{prefix_id}.'):]
 
     return await send_request(
         f'{url}/v1/messages',
@@ -1452,7 +1459,8 @@ async def generate_responses(
 
     prefix_id = api_config.get('prefix_id', None)
     if prefix_id:
-        payload['model'] = payload['model'].replace(f'{prefix_id}.', '')
+        if payload['model'].startswith(f'{prefix_id}.'):
+            payload['model'] = payload['model'][len(f'{prefix_id}.'):]
 
     return await send_request(
         f'{url}/v1/responses',


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Closes #27340` / `Relates to #___`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **BREAKING CHANGE**: Changes affecting backward compatibility
  - **build**: Build system or dependency changes
  - **ci**: CI/CD workflow changes
  - **chore**: Refactoring, cleanup, or non-functional changes
  - **docs**: Documentation additions or updates
  - **feat**: New features or enhancements
  - **fix**: Bug fixes or corrections
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvements
  - **refactor**: Code restructuring
  - **style**: Formatting changes (whitespace, semicolons, etc.)
  - **test**: Test additions or corrections
  - **WIP**: Work in progress

# Changelog Entry

### Description

Open WebUI's chat completion path (`get_ollama_url`) was missing the model list refresh-on-miss pattern that all other Ollama API endpoints (embeddings, generate) already implement. This caused "Model '...' was not found" errors when a model was added to Ollama after the initial model list fetch — particularly affecting models with special characters in their names like HuggingFace `hf.co/` prefixed models.

### Added

### Changed

### Deprecated

### Removed

### Fixed

- `get_ollama_url()` in `backend/open_webui/routers/ollama.py` now refreshes `OLLAMA_MODELS` when the model is not found, matching the refresh-on-miss pattern already used by the `generate_ollama_batch_embeddings`, `generate_ollama_embeddings`, and `generate_ollama_completion` endpoints.

### Security

### Breaking Changes

---

### Additional Information

This is a one-line logic fix that brings `get_ollama_url` in line with every other Ollama route. The function `validate_ollama_backend_idx` only refreshes models when `url_idx` is explicitly provided (non-None). For the default `url_idx=None` path used by normal chat, `get_ollama_url` directly accessed `request.app.state.OLLAMA_MODELS` without fallback — now it falls back to `get_all_models()` like the rest of the codebase.

### Screenshots or Videos

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in. 