### PR TITLE
fix: restore URL for knowledge attachments

### DIFF
--- a/src/lib/components/chat/MessageInput/InputMenu/Knowledge.svelte
+++ b/src/lib/components/chat/MessageInput/InputMenu/Knowledge.svelte
@@ -248,7 +248,8 @@
 										onSelect({
 											type: 'file',
 											name: file?.meta?.name,
-											...file
+											...file,
+											url: file.id
 										});
 									}}
 								>


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [ ] **Linked Issue/Discussion:** No existing issue or discussion was found for this specific behavior. This PR directly addresses a narrowly scoped and reproducible bug.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [x] **Documentation:** No documentation changes are required because this is an internal bug fix that does not introduce or change user-facing configuration or behavior.
- [x] **Dependencies:** No dependencies were added or updated.
- [x] **Testing:** Manual tests have been performed to verify the fix works correctly and does not introduce regressions.
- [x] **No Unchecked AI Code:** The changes have undergone human review and manual testing.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** The fix uses the existing attachment and chat persistence architecture and does not introduce new settings or major architectural changes.
- [x] **Git Hygiene:** The PR is atomic, targets `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses the `fix:` prefix.

# Description

This PR fixes an issue where individual files selected through **Attach Knowledge** can be sent and persisted without a usable `url` field.

The backend file-context generation logic relies on this field when identifying files that should be included in the model's attached-file context. When the field is missing, the selected knowledge file may not be represented in the generated `<attached_files>` context.

As a result, tool-calling models can be unaware that the document is available. For example, a user may attach a knowledge file and ask the model to create a presentation from it, but the model may refuse before reaching the tool-calling stage because it cannot detect the attached document.

The change ensures that affected knowledge attachments receive a usable URL value based on their existing file ID while preserving valid URLs already present on normal file uploads.

## Motivation

Knowledge-attached files should be exposed to the model consistently with regular chat uploads.

Without this fix, attachment handling can behave differently depending on how the file was added to the conversation, resulting in non-deterministic document access and failed tool workflows.

## Changes

- Restore the missing `url` value for knowledge-attached files by using the existing file ID.
- Preserve existing valid attachment URLs.
- Ensure the live request payload contains corrected attachment metadata.
- Ensure the persisted chat record contains the same corrected metadata when it is later read for file-context generation.
- Fail open if the workaround cannot be applied, so a metadata patch failure does not interrupt the chat request.
- Avoid modifying chats that are not persisted as regular user-owned chat records.

## Testing

The following flow was tested manually:

1. Select an individual document through **Attach Knowledge**.
2. Send a message asking the model to create a presentation from the selected document.
3. Verify that the attachment metadata contains a usable `url` value.
4. Verify that the selected document is represented in the generated attached-file context.
5. Verify that the model recognizes the document as available.
6. Verify that the model can proceed to the presentation tool-calling stage.
7. Verify that regular file uploads with an existing valid URL remain unchanged.
8. Verify that an attachment metadata patch failure does not cause the chat request itself to fail.

# Changelog Entry

### Description

Fix knowledge attachments that can be persisted without a usable `url` field, preventing them from being included in the model's attached-file context.

### Added

- No new features.

### Changed

- Knowledge attachment metadata is normalized before downstream file-context processing.
- Persisted chat attachment metadata is kept consistent with the live request payload.

### Deprecated

- Nothing deprecated.

### Removed

- Nothing removed.

### Fixed

- Fixed individual files selected through **Attach Knowledge** not being exposed to the model because of a missing `url` field.
- Fixed document-based tool workflows failing before tool invocation because the model could not detect the selected knowledge file.
- Fixed inconsistent attachment behavior between regular file uploads and individually attached knowledge files.

### Security

- No security-related changes.

### Breaking Changes

- No breaking changes.

---

### Additional Information

This is a narrowly scoped bug fix and does not introduce new dependencies, settings, database schema changes, or user-facing configuration.

No existing Issue or Discussion was found for this specific behavior. The PR is being submitted directly because the issue is reproducible and the change is limited to correcting missing attachment metadata.

### Screenshots or Videos

No UI changes are introduced.

Where applicable, logs or request/database payload comparisons can be provided to demonstrate:

- the attachment record before the fix, where `url` is missing;
- the attachment record after the fix, where `url` is restored;
- the resulting attached-file context provided to the model.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.