### PR TITLE
perf: skip chat event emits to rooms with no local listeners

### DIFF
--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -117,6 +117,15 @@ else:
 
 # Timeout duration in seconds
 TIMEOUT_DURATION = 3
+
+_LOCAL_MANAGER = WEBSOCKET_MANAGER != 'redis'
+
+
+def room_is_known_empty(room: str) -> bool:
+    """Exact only in local manager mode: rooms is authoritative there and empty
+    rooms are pruned on leave. In Redis mode another instance may host the room,
+    so never claim empty."""
+    return _LOCAL_MANAGER and room not in sio.manager.rooms.get('/', {})
 SESSION_POOL_TIMEOUT = 120  # seconds without heartbeat before session is reaped
 
 # Dictionary to maintain the user pool
@@ -960,16 +969,21 @@ async def get_event_emitter(request_info, update_db=True):
         if internal and event_data.get('type') == 'notification':
             return
 
-        await sio.emit(
-            'events',
-            {
-                'chat_id': chat_id,
-                'message_id': message_id,
-                **({'internal': True} if internal else {}),
-                'data': event_data,
-            },
-            room=f'user:{user_id}',
-        )
+        # Streams keep running after the tab closes (background tasks, API and
+        # internal chats); encoding every event for a room with no listeners is
+        # wasted CPU that grows with the accumulated content.
+        room = f'user:{user_id}'
+        if not room_is_known_empty(room):
+            await sio.emit(
+                'events',
+                {
+                    'chat_id': chat_id,
+                    'message_id': message_id,
+                    **({'internal': True} if internal else {}),
+                    'data': event_data,
+                },
+                room=room,
+            )
 
         if update_db and message_id and not (request_info.get('chat_id') or '').startswith('local:'):
             event_type = event_data.get('type')


### PR DESCRIPTION
Chat generations keep running when nobody is listening: the user closes the tab mid-stream and the background task continues, API completions have no socket client at all, and internal chats plus title/tag/follow-up task events emit to a user who may not be connected. In local websocket-manager mode (the default), python-socketio's AsyncManager.emit encodes the full packet before iterating participants whenever the namespace has any connection, so every one of those events is fully JSON-encoded and then dropped. Because each streamed event carries the full accumulated content, that wasted encoding grows quadratically over a stream.

The local manager's rooms mapping is authoritative and empty rooms are pruned on leave, so a dict containment check is an exact "someone is listening" test. Skip only the emit when the user room is absent; the DB persistence branches below still run unchanged. Redis mode is untouched: the send side must still publish for other instances, and the receive side is already filtered by LocalFilteredRedisManager.

Benchmark (python-socketio 5.16.1, one other user connected so the namespace is live, target room empty):

| scenario | before | after |
| --- | --- | --- |
| per event, 50 KB accumulated content | 45.5 us | 0.024 us | | 500-chunk stream growing to 100 KB | 23.1 ms | 0.012 ms |

Functionally verified: events are still delivered once a session joins the room, skipped again after the room empties, and the Redis-mode helper never claims a room is empty.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
