### PR TITLE
fix: resolve the web loader parser per URL instead of locking in the first one

### DIFF
--- a/backend/open_webui/retrieval/web/utils.py
+++ b/backend/open_webui/retrieval/web/utils.py
@@ -785,13 +785,11 @@ class SafeWebBaseLoader(WebBaseLoader):
         final_results = []
         for i, result in enumerate(results):
             url = urls[i]
-            if parser is None:
-                if url.endswith('.xml'):
-                    parser = 'xml'
-                else:
-                    parser = self.default_parser
-                self._check_parser(parser)
-            final_results.append(BeautifulSoup(result, parser, **self.bs_kwargs))
+            url_parser = parser
+            if url_parser is None:
+                url_parser = 'xml' if url.endswith('.xml') else self.default_parser
+                self._check_parser(url_parser)
+            final_results.append(BeautifulSoup(result, url_parser, **self.bs_kwargs))
         return final_results
 
     async def ascrape_all(self, urls: List[str], parser: Union[str, None] = None) -> List[Any]:


### PR DESCRIPTION
SafeWebBaseLoader._unpack_fetch_results assigned the resolved parser to the parser parameter itself, so the None check only ran for the first URL. In a mixed batch every later document was parsed with whatever the first URL happened to select: an .xml feed first meant all following HTML pages went through the xml parser (broken text extraction), and an HTML page first meant .xml URLs were parsed as HTML. Web search regularly fetches mixed batches, so this silently degraded extraction quality depending on result order.

The parser is now resolved per URL; an explicitly passed parser still applies to the whole batch as before. Verified with mixed xml/html batches in both orders and with an explicit parser override.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
