### PR TITLE
fix: stop empty audit path entries from silently disabling all auditing

### DIFF
--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -1094,14 +1094,14 @@ except ValueError:
 
 # Comma separated list for urls to exclude from audit
 AUDIT_EXCLUDED_PATHS = os.getenv('AUDIT_EXCLUDED_PATHS', '/chats,/chat,/folders').split(',')
-AUDIT_EXCLUDED_PATHS = [path.strip() for path in AUDIT_EXCLUDED_PATHS]
-AUDIT_EXCLUDED_PATHS = [path.lstrip('/') for path in AUDIT_EXCLUDED_PATHS]
+AUDIT_EXCLUDED_PATHS = [path.strip().lstrip('/') for path in AUDIT_EXCLUDED_PATHS]
+AUDIT_EXCLUDED_PATHS = [path for path in AUDIT_EXCLUDED_PATHS if path]
 
 # Comma separated list of urls to include in audit (whitelist mode)
 # When set, only these paths are audited and AUDIT_EXCLUDED_PATHS is ignored
 AUDIT_INCLUDED_PATHS = os.getenv('AUDIT_INCLUDED_PATHS', '').split(',')
-AUDIT_INCLUDED_PATHS = [path.strip() for path in AUDIT_INCLUDED_PATHS]
-AUDIT_INCLUDED_PATHS = [path.lstrip('/') for path in AUDIT_INCLUDED_PATHS if path]
+AUDIT_INCLUDED_PATHS = [path.strip().lstrip('/') for path in AUDIT_INCLUDED_PATHS]
+AUDIT_INCLUDED_PATHS = [path for path in AUDIT_INCLUDED_PATHS if path]
 
 # When enabled, GET requests are also audited (disabled by default to avoid log noise)
 ENABLE_AUDIT_GET_REQUESTS = os.getenv('ENABLE_AUDIT_GET_REQUESTS', 'False').lower() == 'true'

--- a/backend/open_webui/utils/audit.py
+++ b/backend/open_webui/utils/audit.py
@@ -235,10 +235,12 @@ class AuditLoggingMiddleware:
                 return True  # Skip: path not in whitelist
             return False  # Do NOT skip: path is in whitelist
 
-        # Blacklist mode: skip paths that match excluded_paths
-        pattern = re.compile(r'^/api(?:/v1)?/(' + '|'.join(self.excluded_paths) + r')\b')
-        if pattern.match(request.url.path):
-            return True
+        # Blacklist mode: skip paths that match excluded_paths.
+        # An empty alternation would match every path, so guard the empty list.
+        if self.excluded_paths:
+            pattern = re.compile(r'^/api(?:/v1)?/(' + '|'.join(self.excluded_paths) + r')\b')
+            if pattern.match(request.url.path):
+                return True
 
         return False
 


### PR DESCRIPTION
Setting AUDIT_EXCLUDED_PATHS to an empty string (the natural way to say "exclude nothing") produced [''], and a bare '/' entry survived parsing as '' too. The blacklist regex then became ^/api(?:/v1)?/()\b, whose empty alternation matches every API path, so auditing silently recorded nothing except the always-logged auth endpoints. The same match-everything pattern was also built when the exclusion list was genuinely empty, since the pattern was compiled unconditionally.

Empty entries are now dropped after normalization (for both AUDIT_EXCLUDED_PATHS and AUDIT_INCLUDED_PATHS, which had the same '/' edge), and blacklist matching is skipped entirely when the exclusion list is empty, which is the correct semantics: nothing is excluded.

Verified: with AUDIT_EXCLUDED_PATHS='' normal API requests are audited again and unauthenticated requests remain skipped; with '/,chats' only chats is excluded; the default '/chats,/chat,/folders' behavior is unchanged, including the always-audited auth endpoints.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
