### PR TITLE
fix: validate automation completion before recording success

### DIFF
--- a/backend/open_webui/utils/automations.py
+++ b/backend/open_webui/utils/automations.py
@@ -46,6 +46,7 @@ log = logging.getLogger(__name__)
 SCHEDULER_POLL_INTERVAL = int(os.getenv('SCHEDULER_POLL_INTERVAL', os.getenv('AUTOMATION_POLL_INTERVAL', '10')))
 TIMER_POLL_INTERVAL = int(os.getenv('TIMER_POLL_INTERVAL', '1'))
 CALENDAR_ALERT_LOOKAHEAD_MINUTES = int(os.getenv('CALENDAR_ALERT_LOOKAHEAD_MINUTES', '10'))
+AUTOMATION_COMPLETION_TIMEOUT = max(30, int(os.getenv('AUTOMATION_COMPLETION_TIMEOUT', '1800')))
 
 
 ####################
@@ -290,6 +291,46 @@ def _resolve_model_tool_ids(app, model_id: str) -> list[str]:
     return list(tool_ids) if tool_ids else []
 
 
+def _has_final_assistant_message(message: dict) -> bool:
+    """Return whether a terminal assistant row contains visible final text."""
+    output = message.get('output')
+    if not isinstance(output, list):
+        return False
+
+    return any(
+        isinstance(item, dict)
+        and item.get('type') == 'message'
+        and any(
+            isinstance(content, dict) and content.get('type') == 'output_text' and str(content.get('text', '')).strip()
+            for content in item.get('content', [])
+        )
+        for item in output
+    )
+
+
+async def _wait_for_automation_completion(chat_id: str, message_id: str) -> dict:
+    """Wait for the detached chat task and validate its persisted result."""
+    deadline = time.monotonic() + AUTOMATION_COMPLETION_TIMEOUT
+
+    while time.monotonic() < deadline:
+        message = await Chats.get_message_by_id_and_message_id(chat_id, message_id)
+        if message:
+            error = message.get('error')
+            if error:
+                if isinstance(error, dict):
+                    error = error.get('content') or error.get('message') or str(error)
+                raise RuntimeError(f'Automation assistant failed: {error}')
+
+            if message.get('done'):
+                if not _has_final_assistant_message(message):
+                    raise RuntimeError('Automation completed without a final assistant message')
+                return message
+
+        await asyncio.sleep(0.5)
+
+    raise TimeoutError(f'Automation did not complete within {AUTOMATION_COMPLETION_TIMEOUT} seconds')
+
+
 async def _resolve_model_features(app, model_id: str) -> dict:
     """Read model default features from model config.
 
@@ -398,6 +439,7 @@ async def execute_automation(app, automation: AutomationModel) -> None:
     session_id + chat_id + message_id → async task → pipeline handles everything
     (filters, model params, knowledge/RAG, tools, DB saves, webhooks).
     """
+    chat_id = None
     try:
         user = await Users.get_user_by_id(automation.user_id)
         if not user:
@@ -547,6 +589,7 @@ async def execute_automation(app, automation: AutomationModel) -> None:
         )
         request = _build_request(app, token=token)
         await app.state.CHAT_COMPLETION_HANDLER(request, form_data, user=user)
+        await _wait_for_automation_completion(chat.id, assistant_msg_id)
 
         # Notify user
         from open_webui.socket.main import sio
@@ -574,7 +617,7 @@ async def execute_automation(app, automation: AutomationModel) -> None:
     except Exception as e:
         log.exception(f'Automation {automation.id} failed')
         error = str(e)[:4000]
-        await _record_run(automation.id, 'error', error=error)
+        await _record_run(automation.id, 'error', chat_id=chat_id, error=error)
         await publish_event(
             app,
             EVENTS.AUTOMATION_RUN_FAILED,

--- a/backend/tests/test_automation_completion.py
+++ b/backend/tests/test_automation_completion.py
@@ -1,0 +1,65 @@
+import unittest
+from unittest.mock import patch
+
+from open_webui.utils import automations
+
+
+class FinalMessageTests(unittest.TestCase):
+    def test_accepts_visible_text(self):
+        message = {
+            'output': [
+                {'type': 'reasoning', 'content': [{'type': 'output_text', 'text': 'thinking'}]},
+                {'type': 'message', 'content': [{'type': 'output_text', 'text': 'done'}]},
+            ]
+        }
+
+        self.assertTrue(automations._has_final_assistant_message(message))
+
+    def test_rejects_non_final_output(self):
+        cases = [
+            {'output': [{'type': 'reasoning', 'content': [{'type': 'output_text', 'text': 'thinking'}]}]},
+            {'output': [{'type': 'message', 'content': []}]},
+            {'output': None},
+        ]
+
+        for message in cases:
+            with self.subTest(message=message):
+                self.assertFalse(automations._has_final_assistant_message(message))
+
+
+class CompletionWaitTests(unittest.IsolatedAsyncioTestCase):
+    async def test_returns_final_message(self):
+        message = {
+            'done': True,
+            'error': None,
+            'output': [{'type': 'message', 'content': [{'type': 'output_text', 'text': 'done'}]}],
+        }
+
+        async def get_message(chat_id, message_id):
+            return message
+
+        with patch.object(automations.Chats, 'get_message_by_id_and_message_id', get_message):
+            self.assertEqual(
+                await automations._wait_for_automation_completion('chat', 'message'),
+                message,
+            )
+
+    async def test_rejects_reasoning_only(self):
+        async def get_message(chat_id, message_id):
+            return {'done': True, 'error': None, 'output': [{'type': 'reasoning', 'content': []}]}
+
+        with patch.object(automations.Chats, 'get_message_by_id_and_message_id', get_message):
+            with self.assertRaisesRegex(RuntimeError, 'without a final assistant message'):
+                await automations._wait_for_automation_completion('chat', 'message')
+
+    async def test_propagates_stored_error(self):
+        async def get_message(chat_id, message_id):
+            return {'done': True, 'error': {'message': 'tool failed'}, 'output': []}
+
+        with patch.object(automations.Chats, 'get_message_by_id_and_message_id', get_message):
+            with self.assertRaisesRegex(RuntimeError, 'tool failed'):
+                await automations._wait_for_automation_completion('chat', 'message')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Relates to #27364 and Discussion #27375.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included below.
- [x] **Documentation:** No user-facing documentation change is required for this backend correctness fix; the optional timeout environment variable and its default are described in the implementation and below.
- [x] **Dependencies:** This change adds or updates no dependencies.
- [x] **Testing:** Focused automated tests and manual live-Docker validation have been performed.
- [x] **No Unchecked AI Code:** The proposed changes have undergone thorough human review and manual testing.
- [x] **Self-Review:** A self-review of the code has been performed, including focused lint, formatting, syntax, and diff checks.
- [x] **Architecture:** The change is confined to detached Automation completion validation and does not alter foreground chat behavior or introduce tool-routing policy.
- [x] **Git Hygiene:** The PR is atomic, based on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses the `fix` prefix.

## Description

Detached Automation chats currently return from `generate_chat_completion` before their background response is complete. As a result, an Automation can be recorded as successful even when the persisted assistant row finishes with reasoning only, an empty output list, or a stored error and never produces a final assistant message.

This change makes the Automation runner:

- wait for the persisted assistant response to reach a terminal state;
- propagate stored assistant errors;
- require a non-empty final `message` output before recording success;
- fail with a bounded timeout, configured by `AUTOMATION_COMPLETION_TIMEOUT` (default: 1800 seconds, minimum: 30 seconds); and
- retain the generated chat ID when recording a failed run.

The change is intentionally narrow. It does not add automatic tool-selection or routing policy upstream, and it does not change normal foreground chat completion behavior.

## Testing

- Five focused unit tests passed in an ephemeral Open WebUI Docker runtime, covering a visible final message, reasoning-only output, empty output, a stored assistant error, and a valid final output.
- Python compilation passed for the modified implementation and test module.
- Ruff formatting and targeted error-level lint checks passed; `git diff --check` passed.
- Manual validation on an Open WebUI v0.10.2 Docker deployment ran a real scheduled tool workflow to completion with a non-empty final answer, and the run was recorded as successful only after completion.

# Changelog Entry

### Description

- Validate the persisted terminal assistant output before marking an Automation run successful.

### Added

- Focused tests for valid final output, reasoning-only output, empty output, and stored completion errors.

### Changed

- The Automation runner now waits for the detached assistant response to reach a terminal persisted state, with a bounded configurable timeout.

### Deprecated

- None.

### Removed

- None.

### Fixed

- Reasoning-only and empty Automation responses are no longer recorded as successful.
- Stored assistant errors and completion timeouts now fail the Automation run.
- Failed Automation runs retain their generated chat ID for diagnosis.

### Security

- None.

### Breaking Changes

- **BREAKING CHANGE**: None.

---

### Additional Information

- Issue: https://github.com/open-webui/open-webui/issues/27364
- Discussion: https://github.com/open-webui/open-webui/discussions/27375

### Screenshots or Videos

- Not applicable; this is a backend lifecycle correctness fix.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
