### PR TITLE
perf: validate rows once when attaching access grants instead of three times

### DIFF
--- a/backend/open_webui/models/calendar.py
+++ b/backend/open_webui/models/calendar.py
@@ -241,11 +241,11 @@ class CalendarTable:
         access_grants: Optional[list[AccessGrantModel]] = None,
         db: Optional[AsyncSession] = None,
     ) -> CalendarModel:
-        cal_data = CalendarModel.model_validate(cal).model_dump(exclude={'access_grants'})
-        cal_data['access_grants'] = (
-            access_grants if access_grants is not None else await self._get_access_grants(cal_data['id'], db=db)
+        cal_obj = CalendarModel.model_validate(cal)
+        cal_obj.access_grants = (
+            access_grants if access_grants is not None else await self._get_access_grants(cal_obj.id, db=db)
         )
-        return CalendarModel.model_validate(cal_data)
+        return cal_obj
 
     async def get_or_create_defaults(self, user_id: str, db: Optional[AsyncSession] = None) -> list[CalendarModel]:
         """Return user's calendars, creating 'Personal' default if none exist."""

--- a/backend/open_webui/models/channels.py
+++ b/backend/open_webui/models/channels.py
@@ -266,11 +266,11 @@ class ChannelTable:
         access_grants: Optional[list[AccessGrantModel]] = None,
         db: Optional[AsyncSession] = None,
     ) -> ChannelModel:
-        channel_data = ChannelModel.model_validate(channel).model_dump(exclude={'access_grants'})
-        channel_data['access_grants'] = (
-            access_grants if access_grants is not None else await self._get_access_grants(channel_data['id'], db=db)
+        channel_obj = ChannelModel.model_validate(channel)
+        channel_obj.access_grants = (
+            access_grants if access_grants is not None else await self._get_access_grants(channel_obj.id, db=db)
         )
-        return ChannelModel.model_validate(channel_data)
+        return channel_obj
 
     async def _collect_unique_user_ids(
         self,

--- a/backend/open_webui/models/knowledge.py
+++ b/backend/open_webui/models/knowledge.py
@@ -192,11 +192,11 @@ class KnowledgeTable:
         access_grants: Optional[list[AccessGrantModel]] = None,
         db: Optional[AsyncSession] = None,
     ) -> KnowledgeModel:
-        knowledge_data = KnowledgeModel.model_validate(knowledge).model_dump(exclude={'access_grants'})
-        knowledge_data['access_grants'] = (
-            access_grants if access_grants is not None else await self._get_access_grants(knowledge_data['id'], db=db)
+        knowledge_obj = KnowledgeModel.model_validate(knowledge)
+        knowledge_obj.access_grants = (
+            access_grants if access_grants is not None else await self._get_access_grants(knowledge_obj.id, db=db)
         )
-        return KnowledgeModel.model_validate(knowledge_data)
+        return knowledge_obj
 
     async def insert_new_knowledge(
         self, user_id: str, form_data: KnowledgeForm, db: Optional[AsyncSession] = None

--- a/backend/open_webui/models/models.py
+++ b/backend/open_webui/models/models.py
@@ -199,11 +199,11 @@ class ModelsTable:
                 if db is not None:
                     await db.commit()
 
-        model_data = ModelModel.model_validate(model).model_dump(exclude={'access_grants'})
-        model_data['access_grants'] = (
-            access_grants if access_grants is not None else await self._get_access_grants(model_data['id'], db=db)
+        model_obj = ModelModel.model_validate(model)
+        model_obj.access_grants = (
+            access_grants if access_grants is not None else await self._get_access_grants(model_obj.id, db=db)
         )
-        return ModelModel.model_validate(model_data)
+        return model_obj
 
     async def insert_new_model(
         self, form_data: ModelForm, user_id: str, db: AsyncSession | None = None

--- a/backend/open_webui/models/notes.py
+++ b/backend/open_webui/models/notes.py
@@ -105,12 +105,11 @@ class NoteTable:
         access_grants: Optional[list[AccessGrantModel]] = None,
         db: Optional[AsyncSession] = None,
     ) -> NoteModel:
-        # We exclude access_grants to inject them
-        note_data = NoteModel.model_validate(note).model_dump(exclude={'access_grants'})
-        note_data['access_grants'] = (
-            access_grants if access_grants is not None else await self._get_access_grants(note_data['id'], db=db)
+        note_obj = NoteModel.model_validate(note)
+        note_obj.access_grants = (
+            access_grants if access_grants is not None else await self._get_access_grants(note_obj.id, db=db)
         )
-        return NoteModel.model_validate(note_data)
+        return note_obj
 
     def _has_permission(self, db, query, filter: dict, permission: str = 'read'):
         return AccessGrants.has_permission_filter(

--- a/backend/open_webui/models/prompts.py
+++ b/backend/open_webui/models/prompts.py
@@ -103,11 +103,11 @@ class PromptsTable:
         access_grants: list[AccessGrantModel | None] = None,
         db: AsyncSession | None = None,
     ) -> PromptModel:
-        prompt_data = PromptModel.model_validate(prompt).model_dump(exclude={'access_grants'})
-        prompt_data['access_grants'] = (
-            access_grants if access_grants is not None else await self._get_access_grants(prompt_data['id'], db=db)
+        prompt_obj = PromptModel.model_validate(prompt)
+        prompt_obj.access_grants = (
+            access_grants if access_grants is not None else await self._get_access_grants(prompt_obj.id, db=db)
         )
-        return PromptModel.model_validate(prompt_data)
+        return prompt_obj
 
     async def insert_new_prompt(
         self, user_id: str, form_data: PromptForm, db: AsyncSession | None = None

--- a/backend/open_webui/models/skills.py
+++ b/backend/open_webui/models/skills.py
@@ -113,11 +113,11 @@ class SkillsTable:
         access_grants: Optional[list[AccessGrantModel]] = None,
         db: Optional[AsyncSession] = None,
     ) -> SkillModel:
-        skill_data = SkillModel.model_validate(skill).model_dump(exclude={'access_grants'})
-        skill_data['access_grants'] = (
-            access_grants if access_grants is not None else await self._get_access_grants(skill_data['id'], db=db)
+        skill_obj = SkillModel.model_validate(skill)
+        skill_obj.access_grants = (
+            access_grants if access_grants is not None else await self._get_access_grants(skill_obj.id, db=db)
         )
-        return SkillModel.model_validate(skill_data)
+        return skill_obj
 
     async def insert_new_skill(
         self,

--- a/backend/open_webui/models/tools.py
+++ b/backend/open_webui/models/tools.py
@@ -105,11 +105,11 @@ class ToolsTable:
         access_grants: list[AccessGrantModel | None] = None,
         db: AsyncSession | None = None,
     ) -> ToolModel:
-        tool_data = ToolModel.model_validate(tool).model_dump(exclude={'access_grants'})
-        tool_data['access_grants'] = (
-            access_grants if access_grants is not None else await self._get_access_grants(tool_data['id'], db=db)
+        tool_obj = ToolModel.model_validate(tool)
+        tool_obj.access_grants = (
+            access_grants if access_grants is not None else await self._get_access_grants(tool_obj.id, db=db)
         )
-        return ToolModel.model_validate(tool_data)
+        return tool_obj
 
     async def insert_new_tool(
         self,


### PR DESCRIPTION
Every _to_*_model helper (models, notes, tools, prompts, knowledge, skills, channels, calendars) converted a row with model_validate, then model_dump'ed the entire object including nested params, meta, content and data, injected access_grants into the dumped dict and ran model_validate a second time over everything. Every list endpoint and every row lookup paid two full pydantic validations plus one full deep dump per row; list endpoints that wrap rows in *UserResponse models then validated a third time on top.

The access_grants fields on these models are typed list[AccessGrantModel] and every caller passes AccessGrantModel instances (from _get_access_grants or the get_grants_by_resources batch), which pydantic passes through unchanged during revalidation, so validating once and assigning the grants directly produces an identical result without the dump/revalidate round trip.

Benchmark (workspace-model row with params, meta, capabilities and tags):

| metric | before | after |
| --- | --- | --- |
| conversion per row | 11.2 us | 4.9 us |
| per /api/models with 200 workspace models | 2.24 ms | 0.99 ms |

The same saving applies per row to every notes, tools, prompts, knowledge, skills, channels and calendar list and detail request.

Functionally verified: for all eight helpers the new output model_dump()s deep-equal to the old validate-dump-revalidate pipeline's output on representative rows, and the attached grants are the same instances the callers provided.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
