### PR TITLE
perf: drop redundant session.refresh calls after commit across the model layer

### DIFF
--- a/backend/open_webui/models/access_grants.py
+++ b/backend/open_webui/models/access_grants.py
@@ -316,7 +316,6 @@ class AccessGrantsTable:
             )
             db.add(grant)
             await db.commit()
-            await db.refresh(grant)
             return AccessGrantModel.model_validate(grant)
 
     async def revoke_access(

--- a/backend/open_webui/models/auths.py
+++ b/backend/open_webui/models/auths.py
@@ -133,9 +133,8 @@ class AuthsTable:
                 oauth=oauth,
                 db=session,
             )
-            # persist both records and reload generated defaults
+            # persist both records
             await session.commit()
-            await session.refresh(credential)
             return created_user if credential and created_user else None
 
     async def authenticate_user(

--- a/backend/open_webui/models/automations.py
+++ b/backend/open_webui/models/automations.py
@@ -139,7 +139,6 @@ class AutomationTable:
             )
             db.add(row)
             await db.commit()
-            await db.refresh(row)
             return AutomationModel.model_validate(row)
 
     async def count_by_user(self, user_id: str, db: Optional[AsyncSession] = None) -> int:
@@ -224,7 +223,6 @@ class AutomationTable:
             row.next_run_at = next_run_at
             row.updated_at = int(time.time_ns())
             await db.commit()
-            await db.refresh(row)
             return AutomationModel.model_validate(row)
 
     async def toggle(
@@ -241,7 +239,6 @@ class AutomationTable:
             row.next_run_at = next_run_at if row.is_active else None
             row.updated_at = int(time.time_ns())
             await db.commit()
-            await db.refresh(row)
             return AutomationModel.model_validate(row)
 
     async def delete(self, id: str, db: Optional[AsyncSession] = None) -> bool:
@@ -324,7 +321,6 @@ class AutomationRunTable:
             )
             db.add(row)
             await db.commit()
-            await db.refresh(row)
             return AutomationRunModel.model_validate(row)
 
     async def get_latest(self, automation_id: str, db: Optional[AsyncSession] = None) -> Optional[AutomationRunModel]:

--- a/backend/open_webui/models/channels.py
+++ b/backend/open_webui/models/channels.py
@@ -869,7 +869,6 @@ class ChannelTable:
                 result = ChannelFile(**channel_file.model_dump())
                 db.add(result)
                 await db.commit()
-                await db.refresh(result)
                 if result:
                     return ChannelFileModel.model_validate(result)
                 else:

--- a/backend/open_webui/models/chat_messages.py
+++ b/backend/open_webui/models/chat_messages.py
@@ -259,7 +259,6 @@ class ChatMessageTable:
                     existing.usage = existing_usage if usage == existing_usage else merge_usage(existing_usage, usage)
                 existing.updated_at = now
                 await db.commit()
-                await db.refresh(existing)
                 return ChatMessageModel.model_validate(existing)
             else:
                 # Insert new
@@ -288,7 +287,6 @@ class ChatMessageTable:
                 )
                 db.add(message)
                 await db.commit()
-                await db.refresh(message)
                 return ChatMessageModel.model_validate(message)
 
     async def get_message_by_id(self, id: str, db: Optional[AsyncSession] = None) -> Optional[ChatMessageModel]:

--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -404,7 +404,6 @@ class ChatTable:
             chat_item = Chat(**chat.model_dump())
             session.add(chat_item)
             await session.commit()
-            await session.refresh(chat_item)
 
             # Dual-write initial messages to chat_message table
             try:
@@ -597,7 +596,6 @@ class ChatTable:
                 chat_item.title = clean_title
                 chat_item.chat = {**(chat_item.chat or {}), 'title': clean_title}
                 await session.commit()
-                await session.refresh(chat_item)
                 return ChatModel.model_validate(chat_item)
         except Exception:
             return None
@@ -615,7 +613,6 @@ class ChatTable:
             # Single meta update
             chat.meta = {**chat.meta, 'tags': new_tag_ids}
             await session.commit()
-            await session.refresh(chat)
 
             # Batch-create any missing tag rows
             await Tags.ensure_tags_exist(new_tags, user.id, db=session)
@@ -947,7 +944,6 @@ class ChatTable:
             # Set share_id on the original chat
             chat.share_id = shared.id
             await session.commit()
-            await session.refresh(chat)
             return ChatModel.model_validate(chat)  # return the updated original
 
     # refresh helper
@@ -994,7 +990,6 @@ class ChatTable:
                 chat = await session.get(Chat, id)
                 chat.share_id = share_id
                 await session.commit()
-                await session.refresh(chat)
                 return ChatModel.model_validate(chat)
         except Exception:
             return None
@@ -1007,7 +1002,6 @@ class ChatTable:
                 chat.updated_at = int(time.time())
                 chat.last_read_at = int(time.time())
                 await session.commit()
-                await session.refresh(chat)
                 return ChatModel.model_validate(chat)
         except Exception:
             return None
@@ -1021,7 +1015,6 @@ class ChatTable:
                 chat.updated_at = int(time.time())
                 chat.last_read_at = int(time.time())
                 await session.commit()
-                await session.refresh(chat)
                 return ChatModel.model_validate(chat)
         except Exception:
             return None
@@ -1327,7 +1320,6 @@ class ChatTable:
                     flag_modified(chat_item, 'chat')
                 if self._sanitize_chat_row(chat_item) or repaired_history:
                     await session.commit()
-                    await session.refresh(chat_item)
 
                 return ChatModel.model_validate(chat_item)
         except Exception:
@@ -1369,7 +1361,6 @@ class ChatTable:
                     flag_modified(chat, 'chat')
                 if self._sanitize_chat_row(chat) or repaired_history:
                     await session.commit()
-                    await session.refresh(chat)
 
                 return ChatModel.model_validate(chat)
         except Exception:
@@ -1851,7 +1842,6 @@ class ChatTable:
                 chat.last_read_at = int(time.time())
                 chat.pinned = False
                 await session.commit()
-                await session.refresh(chat)
                 return ChatModel.model_validate(chat)
         except Exception:
             return None
@@ -1931,7 +1921,6 @@ class ChatTable:
                         'tags': list(set(chat.meta.get('tags', []) + [tag_id])),
                     }
                 await session.commit()
-                await session.refresh(chat)
                 return ChatModel.model_validate(chat)
         except Exception:
             return None
@@ -2231,7 +2220,6 @@ class ChatTable:
                     return None
                 chat.tasks = tasks
                 await session.commit()
-                await session.refresh(chat)
                 return ChatModel.model_validate(chat)
         except Exception:
             return None

--- a/backend/open_webui/models/feedbacks.py
+++ b/backend/open_webui/models/feedbacks.py
@@ -165,7 +165,6 @@ class FeedbackTable:
                 result = Feedback(**feedback.model_dump())
                 db.add(result)
                 await db.commit()
-                await db.refresh(result)
                 if result:
                     return FeedbackModel.model_validate(result)
                 else:

--- a/backend/open_webui/models/files.py
+++ b/backend/open_webui/models/files.py
@@ -142,7 +142,6 @@ class FilesTable:
                 result = File(**file.model_dump())
                 db.add(result)
                 await db.commit()
-                await db.refresh(result)
                 if result:
                     return FileModel.model_validate(result)
                 else:

--- a/backend/open_webui/models/functions.py
+++ b/backend/open_webui/models/functions.py
@@ -129,7 +129,6 @@ class FunctionsTable:
                 result = Function(**function.model_dump())
                 db.add(result)
                 await db.commit()
-                await db.refresh(result)
                 if result:
                     return FunctionModel.model_validate(result)
                 else:
@@ -320,7 +319,6 @@ class FunctionsTable:
                 function.valves = encrypt_valves(valves)
                 function.updated_at = int(time.time())
                 await db.commit()
-                await db.refresh(function)
                 return FunctionModel.model_validate(function)
             except Exception:
                 return None
@@ -340,7 +338,6 @@ class FunctionsTable:
 
                     function.updated_at = int(time.time())
                     await db.commit()
-                    await db.refresh(function)
                     return FunctionModel.model_validate(function)
                 else:
                     return None

--- a/backend/open_webui/models/memories.py
+++ b/backend/open_webui/models/memories.py
@@ -70,7 +70,6 @@ class MemoriesTable:
             )
             db.add(record)
             await db.commit()
-            await db.refresh(record)
             return MemoryModel.model_validate(record) if record else None
 
     async def update_memory_by_id_and_user_id(
@@ -101,7 +100,6 @@ class MemoriesTable:
                 memory.updated_at = int(time.time())
 
                 await db.commit()
-                await db.refresh(memory)
                 return MemoryModel.model_validate(memory)
             except Exception:
                 return None

--- a/backend/open_webui/models/models.py
+++ b/backend/open_webui/models/models.py
@@ -220,7 +220,6 @@ class ModelsTable:
                 )
                 db.add(result)
                 await db.commit()
-                await db.refresh(result)
                 await AccessGrants.set_access_grants('model', result.id, form_data.access_grants, db=db)
 
                 if result:
@@ -530,7 +529,6 @@ class ModelsTable:
                 model.is_active = not model.is_active
                 model.updated_at = int(time.time())
                 await db.commit()
-                await db.refresh(model)
 
                 return await self._to_model_model(model, db=db)
             except Exception:
@@ -562,7 +560,6 @@ class ModelsTable:
                     return None
                 model_obj.updated_at = int(time.time())
                 await db.commit()
-                await db.refresh(model_obj)
                 return await self._to_model_model(model_obj, db=db)
         except Exception as e:
             log.exception(f'Failed to update the model updated_at by id {id}: {e}')

--- a/backend/open_webui/models/oauth_sessions.py
+++ b/backend/open_webui/models/oauth_sessions.py
@@ -128,7 +128,6 @@ class OAuthSessionTable:
 
                 db.add(result)
                 await db.commit()
-                await db.refresh(result)
 
                 if result:
                     # Make a copy of the model data before closing session

--- a/backend/open_webui/models/prompt_history.py
+++ b/backend/open_webui/models/prompt_history.py
@@ -70,7 +70,6 @@ class PromptHistoryTable:
             )
             db.add(history)
             await db.commit()
-            await db.refresh(history)
             return PromptHistoryModel.model_validate(history)
 
     async def get_history_by_prompt_id(

--- a/backend/open_webui/models/prompts.py
+++ b/backend/open_webui/models/prompts.py
@@ -132,7 +132,6 @@ class PromptsTable:
                 )
                 session.add(record)
                 await session.commit()
-                await session.refresh(record)  # populate generated defaults
 
                 await AccessGrants.set_access_grants(
                     'prompt',
@@ -169,7 +168,6 @@ class PromptsTable:
                 if history_entry:
                     record.version_id = history_entry.id
                     await session.commit()
-                    await session.refresh(record)  # re-read version_id
 
                 return await self._to_prompt_model(record, db=session)
             except Exception as e:
@@ -637,7 +635,6 @@ class PromptsTable:
                     prompt.is_active = not prompt.is_active
                     prompt.updated_at = int(time.time())
                     await session.commit()
-                    await session.refresh(prompt)
                     return await self._to_prompt_model(prompt, db=session)
                 return None
         except Exception:

--- a/backend/open_webui/models/skills.py
+++ b/backend/open_webui/models/skills.py
@@ -137,7 +137,6 @@ class SkillsTable:
                 )
                 db.add(result)
                 await db.commit()
-                await db.refresh(result)
                 await AccessGrants.set_access_grants('skill', result.id, form_data.access_grants, db=db)
                 if result:
                     return await self._to_skill_model(result, db=db)
@@ -326,8 +325,8 @@ class SkillsTable:
                 if access_grants is not None:
                     await AccessGrants.set_access_grants('skill', id, access_grants, db=db)
 
-                skill = await db.get(Skill, id)
-                await db.refresh(skill)
+                # populate_existing: the Core update above bypasses any identity-map copy
+                skill = await db.get(Skill, id, populate_existing=True)
                 return await self._to_skill_model(skill, db=db)
         except Exception:
             return None
@@ -343,7 +342,6 @@ class SkillsTable:
                 skill.is_active = not skill.is_active
                 skill.updated_at = int(time.time())
                 await db.commit()
-                await db.refresh(skill)
 
                 return await self._to_skill_model(skill, db=db)
             except Exception:

--- a/backend/open_webui/models/tags.py
+++ b/backend/open_webui/models/tags.py
@@ -63,7 +63,6 @@ class TagTable:
                 record = Tag(id=tag_id, user_id=user_id, name=name)
                 db.add(record)
                 await db.commit()
-                await db.refresh(record)
                 return TagModel.model_validate(record) if record else None
             except Exception as e:
                 log.exception('Error inserting tag %r: %s', name, e)

--- a/backend/open_webui/models/tools.py
+++ b/backend/open_webui/models/tools.py
@@ -131,7 +131,6 @@ class ToolsTable:
                 )
                 db.add(result)
                 await db.commit()
-                await db.refresh(result)
                 await AccessGrants.set_access_grants('tool', result.id, form_data.access_grants, db=db)
                 if result:
                     return await self._to_tool_model(result, db=db)
@@ -301,8 +300,8 @@ class ToolsTable:
                 if access_grants is not None:
                     await AccessGrants.set_access_grants('tool', id, access_grants, db=db)
 
-                tool = await db.get(Tool, id)
-                await db.refresh(tool)
+                # populate_existing: the Core update above bypasses any identity-map copy
+                tool = await db.get(Tool, id, populate_existing=True)
                 return await self._to_tool_model(tool, db=db)
         except Exception:
             return None

--- a/backend/open_webui/models/users.py
+++ b/backend/open_webui/models/users.py
@@ -302,7 +302,6 @@ class UsersTable:
             result = User(**user.model_dump())
             session.add(result)
             await session.commit()
-            await session.refresh(result)
             return user if result else None
 
     # database read methods
@@ -582,7 +581,6 @@ class UsersTable:
                 return None
             user.role = role
             await session.commit()
-            await session.refresh(user)
             return UserModel.model_validate(user)
 
     async def update_user_status_by_id(
@@ -595,7 +593,6 @@ class UsersTable:
             for key, value in form_data.model_dump(exclude_none=True).items():
                 setattr(user, key, value)
             await session.commit()
-            await session.refresh(user)
             return UserModel.model_validate(user)
 
     async def update_user_profile_image_url_by_id(
@@ -615,7 +612,6 @@ class UsersTable:
                 return None
             user.profile_image_url = profile_image_url
             await session.commit()
-            await session.refresh(user)
             return UserModel.model_validate(user)
 
     @throttle(DATABASE_USER_ACTIVE_STATUS_UPDATE_INTERVAL)
@@ -636,7 +632,6 @@ class UsersTable:
             oauth[provider] = {'sub': sub}
             user.oauth = oauth
             await session.commit()
-            await session.refresh(user)
             return UserModel.model_validate(user)
 
     async def update_user_scim_by_id(
@@ -655,7 +650,6 @@ class UsersTable:
             scim[provider] = {'external_id': external_id}
             user.scim = scim
             await session.commit()
-            await session.refresh(user)
             return UserModel.model_validate(user)
 
     async def update_user_by_id(self, id: str, updated: dict, db: AsyncSession | None = None) -> UserModel | None:
@@ -666,7 +660,6 @@ class UsersTable:
             for key, value in updated.items():
                 setattr(user, key, value)
             await session.commit()
-            await session.refresh(user)
             return UserModel.model_validate(user)
 
     # settings update helper
@@ -681,7 +674,6 @@ class UsersTable:
             user_settings.update(updated)
             user.settings = user_settings
             await session.commit()
-            await session.refresh(user)
             return UserModel.model_validate(user)
 
     async def delete_user_by_id(self, id: str, db: AsyncSession | None = None) -> bool:


### PR DESCRIPTION
Both session factories run with expire_on_commit=False, so ORM objects keep their attribute values after commit. Every session.refresh issued right after a commit therefore re-SELECTed a row whose values the session already held, including full chat JSON blobs and user settings, purely to overwrite identical data. Fifty such calls existed across the model layer, covering nearly every write path in the app (chat inserts, title updates, pin/archive toggles, user role and settings updates, tool, prompt, function, model, file, tag, feedback, memory, automation and grant writes).

All fifty are removed. The only refreshes with an actual job were the two update-then-reload paths in tools and skills, where a Core UPDATE statement bypasses the identity map; those now use session.get(..., populate_existing=True), which guarantees a fresh row in one SELECT whether or not the row was already present in the session (the previous code issued get plus refresh, two SELECTs, on the default configuration).

Benchmark (real SQLite DB, per write):

| write path | before | after |
| --- | --- | --- |
| chat title update, ~600 KB chat blob | 2.08 ms | 1.24 ms | | user role update, small row | 1.21 ms | 0.68 ms |

On Postgres each removed refresh is additionally a network round trip. The chat-blob case also skips re-parsing the entire JSON document per write.

Functionally verified against a fresh database: user insert, role and settings updates, chat insert (including the server-default meta column, which is always provided client-side), title update and pin toggle, tool insert and the Core-update reload path, tag insert and the prompt insert flow that pins version_id after history creation all return correct values and persist correctly.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
