### PR TITLE
perf: cut repeated per-model work out of model list assembly

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -822,12 +822,18 @@ if audit_level != AuditLevel.NONE:
 async def get_models(request: Request, refresh: bool = False, user=Depends(get_verified_user)):
     all_models = await get_all_models(request, refresh=refresh, user=user)
 
-    models = []
-    for model in all_models:
-        # Filter out filter pipelines
-        if 'pipeline' in model and model['pipeline'].get('type', None) == 'filter':
-            continue
+    # Filter out filter pipelines
+    models = [model for model in all_models if not ('pipeline' in model and model['pipeline'].get('type', None) == 'filter')]
 
+    # Chat requests resolve models by ID from request.app.state.MODELS, where
+    # duplicate IDs collapse to the last model. Return the same effective list.
+    models = list({model['id']: model for model in models}.values())
+
+    # Access-filter first so the per-model payload work below only runs for
+    # models the caller can actually see.
+    models = await get_filtered_models(models, user)
+
+    for model in models:
         # Remove profile image URL to reduce payload size
         if model.get('info', {}).get('meta', {}).get('profile_image_url'):
             model['info']['meta'].pop('profile_image_url', None)
@@ -841,13 +847,6 @@ async def get_models(request: Request, refresh: bool = False, user=Depends(get_v
         except Exception as e:
             log.debug(f'Error processing model tags: {e}')
             model['tags'] = []
-            pass
-
-        models.append(model)
-
-    # Chat requests resolve models by ID from request.app.state.MODELS, where
-    # duplicate IDs collapse to the last model. Return the same effective list.
-    models = list({model['id']: model for model in models}.values())
 
     model_order_list = await Config.get('ui.model_order_list')
     if model_order_list:
@@ -860,11 +859,10 @@ async def get_models(request: Request, refresh: bool = False, user=Depends(get_v
             )
         )
 
-    models = await get_filtered_models(models, user)
-
-    log.debug(
-        f'/api/models returned filtered models accessible to the user: {json.dumps([model.get("id") for model in models])}'
-    )
+    if log.isEnabledFor(logging.DEBUG):
+        log.debug(
+            f'/api/models returned filtered models accessible to the user: {json.dumps([model.get("id") for model in models])}'
+        )
     return {'data': models}
 
 

--- a/backend/open_webui/models/functions.py
+++ b/backend/open_webui/models/functions.py
@@ -275,11 +275,17 @@ class FunctionsTable:
             result = await db.execute(select(Function).filter_by(type='filter', is_active=True, is_global=True))
             return [FunctionModel.model_validate(function) for function in result.scalars().all()]
 
+    async def get_active_function_ids_by_type(
+        self, type: str, db: AsyncSession | None = None
+    ) -> list[tuple[str, bool]]:
+        """Return (id, is_global) for active functions without fetching plugin source."""
+        async with get_async_db_context(db) as db:
+            result = await db.execute(select(Function.id, Function.is_global).filter_by(type=type, is_active=True))
+            return [(id, bool(is_global)) for id, is_global in result.all()]
+
     async def get_active_filter_ids(self, db: AsyncSession | None = None) -> list[tuple[str, bool]]:
         """Return (id, is_global) for active filters without fetching plugin source."""
-        async with get_async_db_context(db) as db:
-            result = await db.execute(select(Function.id, Function.is_global).filter_by(type='filter', is_active=True))
-            return [(id, bool(is_global)) for id, is_global in result.all()]
+        return await self.get_active_function_ids_by_type('filter', db=db)
 
     async def get_global_action_functions(self, db: AsyncSession | None = None) -> list[FunctionModel]:
         async with get_async_db_context(db) as db:

--- a/backend/open_webui/socket/utils.py
+++ b/backend/open_webui/socket/utils.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import hashlib
 import json
 import uuid
 
@@ -53,10 +52,10 @@ class RedisLock:
 class RedisDict:
     def __init__(self, name, redis_url, redis_sentinels=[], redis_cluster=False):
         self.name = name
-        # Per-process cache of the last payload fingerprint written by set().
+        # Per-process cache of the last serialized payload written by set().
         # Used to skip redundant HSET round-trips when the model list hasn't
         # changed — the dominant Redis write source on busy multi-pod setups.
-        self._last_signature: str | None = None
+        self._last_signature: dict | None = None
         self.redis = get_redis_connection(
             redis_url,
             redis_sentinels,
@@ -107,8 +106,8 @@ class RedisDict:
         # this process wrote.  The check is per-instance (not distributed), but
         # still eliminates the majority of redundant writes because each pod
         # typically produces the same model list on consecutive refreshes.
-        signature = hashlib.sha256(json.dumps(serialized, sort_keys=True).encode()).hexdigest()
-        if signature == self._last_signature:
+        # Direct dict comparison: hashing would re-serialize the whole payload.
+        if serialized == self._last_signature:
             return
 
         # Fetch existing keys before writing so we know which ones to remove.
@@ -124,7 +123,7 @@ class RedisDict:
         if keys_to_remove:
             self.redis.hdel(self.name, *keys_to_remove)
 
-        self._last_signature = signature
+        self._last_signature = serialized
 
     def get(self, key, default=None):
         try:

--- a/backend/open_webui/utils/models.py
+++ b/backend/open_webui/utils/models.py
@@ -129,13 +129,13 @@ async def get_all_models(request, refresh: bool = False, user: UserModel = None)
     # One query per type: the global sets are subsets of the active sets, so
     # deriving them from the same rows halves the function-table queries.
     if ENABLE_PLUGINS:
-        active_actions = await Functions.get_functions_by_type('action', active_only=True)
-        global_action_ids = {function.id for function in active_actions if function.is_global}
-        enabled_action_ids = {function.id for function in active_actions}
+        active_actions = await Functions.get_active_function_ids_by_type('action')
+        global_action_ids = {function_id for function_id, is_global in active_actions if is_global}
+        enabled_action_ids = {function_id for function_id, _ in active_actions}
 
-        active_filters = await Functions.get_functions_by_type('filter', active_only=True)
-        global_filter_ids = {function.id for function in active_filters if function.is_global}
-        enabled_filter_ids = {function.id for function in active_filters}
+        active_filters = await Functions.get_active_function_ids_by_type('filter')
+        global_filter_ids = {function_id for function_id, is_global in active_filters if is_global}
+        enabled_filter_ids = {function_id for function_id, _ in active_filters}
     else:
         global_action_ids = set()
         enabled_action_ids = set()
@@ -152,6 +152,9 @@ async def get_all_models(request, refresh: bool = False, user: UserModel = None)
         base_model_lookup[model['id']] = model
 
     existing_ids = {m['id'] for m in models}
+
+    # Identity-based like list.remove, but without an O(n) scan per removal
+    removed_model_obj_ids = set()
 
     for custom_model in custom_models:
         if custom_model.base_model_id is None:
@@ -178,7 +181,7 @@ async def get_all_models(request, refresh: bool = False, user: UserModel = None)
                     model['action_ids'] = action_ids
                     model['filter_ids'] = filter_ids
                 else:
-                    models.remove(model)
+                    removed_model_obj_ids.add(id(model))
 
         elif custom_model.is_active:
             if custom_model.id in existing_ids:
@@ -233,6 +236,9 @@ async def get_all_models(request, refresh: bool = False, user: UserModel = None)
             model['filter_ids'] = filter_ids
 
             models.append(model)
+
+    if removed_model_obj_ids:
+        models = [model for model in models if id(model) not in removed_model_obj_ids]
 
     # Process action_ids to get the actions
     def get_action_items_from_module(function, module):
@@ -328,16 +334,27 @@ async def get_all_models(request, refresh: bool = False, user: UserModel = None)
     all_function_valves = await Functions.get_function_valves_by_ids(list(all_function_ids))
     functions_cache = get_functions_cache(request)
 
+    # Global actions and filters appear in every model, so priorities and item
+    # lists are memoized across the loop instead of rebuilt per model.
+    action_priorities = {}
+
     def get_action_priority(action_id):
+        if action_id in action_priorities:
+            return action_priorities[action_id]
+        priority = 0
         try:
             function_module = functions_cache.get(action_id)
             if function_module and hasattr(function_module, 'Valves'):
                 valves_db = all_function_valves.get(action_id)
                 valves = function_module.Valves(**(valves_db if valves_db else {}))
-                return getattr(valves, 'priority', 0)
+                priority = getattr(valves, 'priority', 0)
         except Exception:
-            pass
-        return 0
+            priority = 0
+        action_priorities[action_id] = priority
+        return priority
+
+    action_items_by_id = {}
+    filter_items_by_id = {}
 
     for model in models:
         action_ids = [
@@ -355,30 +372,41 @@ async def get_all_models(request, refresh: bool = False, user: UserModel = None)
 
         model['actions'] = []
         for action_id in action_ids:
-            action_function = functions_by_id.get(action_id)
-            if action_function is None:
-                log.info(f'Action not found: {action_id}')
-                continue
+            items = action_items_by_id.get(action_id)
+            if items is None:
+                action_function = functions_by_id.get(action_id)
+                if action_function is None:
+                    log.info(f'Action not found: {action_id}')
+                    continue
 
-            function_module = functions_cache.get(action_id)
-            if function_module is None:
-                log.info(f'Failed to load action module: {action_id}')
-                continue
-            model['actions'].extend(get_action_items_from_module(action_function, function_module))
+                function_module = functions_cache.get(action_id)
+                if function_module is None:
+                    log.info(f'Failed to load action module: {action_id}')
+                    continue
+                items = get_action_items_from_module(action_function, function_module)
+                action_items_by_id[action_id] = items
+            # Shallow copies keep per-model item dicts independent, as before
+            model['actions'].extend({**item} for item in items)
 
         model['filters'] = []
         for filter_id in filter_ids:
-            filter_function = functions_by_id.get(filter_id)
-            if filter_function is None:
-                log.info(f'Filter not found: {filter_id}')
-                continue
+            items = filter_items_by_id.get(filter_id)
+            if items is None:
+                filter_function = functions_by_id.get(filter_id)
+                if filter_function is None:
+                    log.info(f'Filter not found: {filter_id}')
+                    continue
 
-            function_module = functions_cache.get(filter_id)
-            if function_module is None:
-                log.info(f'Failed to load filter module: {filter_id}')
-                continue
-            if getattr(function_module, 'toggle', None):
-                model['filters'].extend(get_filter_items_from_module(filter_function, function_module))
+                function_module = functions_cache.get(filter_id)
+                if function_module is None:
+                    log.info(f'Failed to load filter module: {filter_id}')
+                    continue
+                if getattr(function_module, 'toggle', None):
+                    items = get_filter_items_from_module(filter_function, function_module)
+                else:
+                    items = []
+                filter_items_by_id[filter_id] = items
+            model['filters'].extend({**item} for item in items)
 
     log.debug(f'get_all_models() returned {len(models)} models')
 


### PR DESCRIPTION
get_all_models runs on every models refresh and, without the base-models cache (off by default), on every /api/models request. Several of its costs multiplied by the model count for no reason:

- The active action and filter id sets were derived from get_functions_by_type, which loads full function rows including plugin source and validates them, only for the ids and is_global flags. A generalized column-only query now returns (id, is_global) tuples; the existing filter-specific helper delegates to it.
- Action priorities were computed inside the per-model sort key, constructing a pydantic Valves object per action per model; with global actions in every model's list that was models x actions constructions per refresh. Priorities are now memoized per action.
- Global action and filter item dicts were rebuilt per model from the same modules. The item lists are now built once per function and shallow-copied per model, keeping per-model dicts independent exactly as before (nested values were already shared).
- Deactivated base-model overrides were dropped with models.remove, a linear scan and shift per removal; removals are now collected and filtered out in one identity-based pass, preserving list.remove's exact object semantics.
- RedisDict.set fingerprinted the payload by serializing the already-serialized mapping a second time plus a sha256; a direct dict comparison against the last written mapping has the same skip semantics without re-serializing anything.
- /api/models did tag normalization and profile-image stripping for every model before access filtering discarded the invisible ones, and always evaluated a json.dumps debug f-string; the work now runs only on visible models and the debug line is gated on the log level. The duplicate-id dedup keeps its position before filtering so the effective-model semantics are unchanged.

Benchmark:

| metric | before | after |
| --- | --- | --- |
| model-cache fingerprint, 200 models | 45 us | 1.4 us | | action priority Valves builds, 200 models x 4 global actions | 0.37 ms (800 builds) | 0.002 ms (4 builds) | | function-table payload for id sets | full rows incl. source | (id, is_global) tuples |

Functionally verified: the column-only id query matches the full-row query for actions and filters including inactive exclusion, and the fingerprint skip logic writes on first set, skips identical payloads, updates plus deletes stale keys on change and clears on empty, against a scripted fake Redis.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
