### PR TITLE
perf: stop re-resolving the filter pipeline several times per request

### DIFF
--- a/backend/open_webui/utils/filter.py
+++ b/backend/open_webui/utils/filter.py
@@ -8,17 +8,31 @@ from open_webui.utils.plugin import get_function_module_from_cache
 log = logging.getLogger(__name__)
 
 
-async def get_function_module(request, function_id, load_from_db=True):
+async def get_function_module(request, function_id, load_from_db=True, function=None):
     """
-    Get the function module by its ID.
+    Get the function module by its ID. A prefetched row can be passed via
+    ``function`` to skip the per-id fetch inside the module cache.
     """
-    function_module, _, _ = await get_function_module_from_cache(request, function_id, load_from_db=load_from_db)
+    function_module, _, _ = await get_function_module_from_cache(
+        request, function_id, function=function, load_from_db=load_from_db
+    )
     return function_module
 
 
 async def get_sorted_filter_ids(request, model: dict, enabled_filter_ids: list = None):
     if not ENABLE_PLUGINS:
         return []
+
+    # The identical computation runs for the inlet, stream and outlet stages
+    # of one request; cache the result on the request.
+    request_state = getattr(request, 'state', None)
+    cache_key = (
+        model.get('id') if isinstance(model, dict) else str(model),
+        tuple(enabled_filter_ids) if enabled_filter_ids else (),
+    )
+    cache = getattr(request_state, 'sorted_filter_ids_cache', None)
+    if cache is not None and cache_key in cache:
+        return list(cache[cache_key])
 
     active_filters = await Functions.get_active_filter_ids()
     filter_ids = [fid for fid, is_global in active_filters if is_global]
@@ -27,26 +41,31 @@ async def get_sorted_filter_ids(request, model: dict, enabled_filter_ids: list =
         filter_ids = list(set(filter_ids))
     active_filter_ids = {fid for fid, _ in active_filters}
 
+    # Only ids that are both requested and active can survive; anything else
+    # would previously get its module loaded and verified for nothing.
+    filter_ids = [fid for fid in filter_ids if fid in active_filter_ids]
+    functions_by_id = {function.id: function for function in await Functions.get_functions_by_ids(filter_ids)}
+
     async def get_active_status(filter_id):
-        function_module = await get_function_module(request, filter_id)
+        function_module = await get_function_module(request, filter_id, function=functions_by_id.get(filter_id))
 
         if getattr(function_module, 'toggle', None):
             return filter_id in (enabled_filter_ids or set())
 
         return True
 
-    # Pre-compute active status for each filter (async functions can't be used in set comprehensions)
-    resolved_active = {}
-    for filter_id in active_filter_ids:
-        resolved_active[filter_id] = await get_active_status(filter_id)
-    active_filter_ids = {fid for fid, is_active in resolved_active.items() if is_active}
+    # Pre-compute active status for each filter (async functions can't be used in comprehensions)
+    resolved = []
+    for filter_id in filter_ids:
+        if await get_active_status(filter_id):
+            resolved.append(filter_id)
+    filter_ids = resolved
 
-    filter_ids = [fid for fid in filter_ids if fid in active_filter_ids]
     valves_by_id = await Functions.get_function_valves_by_ids(filter_ids)
 
     async def get_priority(function_id):
         try:
-            function_module = await get_function_module(request, function_id)
+            function_module = await get_function_module(request, function_id, function=functions_by_id.get(function_id))
             if function_module and hasattr(function_module, 'Valves'):
                 valves_db = valves_by_id.get(function_id)
                 valves = function_module.Valves(**(valves_db if valves_db else {}))
@@ -60,6 +79,12 @@ async def get_sorted_filter_ids(request, model: dict, enabled_filter_ids: list =
     for fid in filter_ids:
         priorities[fid] = await get_priority(fid)
     filter_ids.sort(key=lambda fid: (priorities.get(fid, 0), fid))
+
+    if request_state is not None:
+        if cache is None:
+            cache = {}
+            request_state.sorted_filter_ids_cache = cache
+        cache[cache_key] = list(filter_ids)
 
     return filter_ids
 
@@ -79,7 +104,11 @@ async def process_filter_functions(request, filter_functions, filter_type, form_
             continue
         filter_id = function.id
 
-        function_module = await get_function_module(request, filter_id, load_from_db=(filter_type != 'stream'))
+        # The caller batch-fetched these rows; passing one skips a per-filter
+        # re-fetch inside the module cache while keeping the freshness check.
+        function_module = await get_function_module(
+            request, filter_id, load_from_db=(filter_type != 'stream'), function=function
+        )
         # Prepare handler function
         handler = getattr(function_module, filter_type, None)
         if not handler:


### PR DESCRIPTION
get_sorted_filter_ids loaded and DB-verified the module of every active filter in the installation even though only filters that are global or attached to the requested model can survive the subsequent intersection: an installation with 20 active filters where the model uses 3 paid 20 module verifications, each a full row fetch (plugin source included) plus a four-pass import-rewrite scan and a content compare. The function then ran again from scratch for the stream setup and outlet stages of the same request, and each per-filter module resolution during inlet and outlet re-fetched a function row the caller had already batch-fetched.

Four changes:
- Active status is now resolved only for ids that are both requested and active; everything else is skipped before any module work.
- The surviving candidates' rows are batch-fetched once and passed into the module cache through the function parameter that already existed for exactly this purpose, so the cache's content-freshness compare still runs against a row fetched in this request without per-filter queries.
- The sorted result is cached on request.state keyed by model id and enabled toggles, so the inlet, stream and outlet stages compute it once. Within a single request this freezes the filter list, which was already effectively true since all three stages ran within moments of each other.
- process_filter_functions passes each caller-provided row into the module cache the same way, removing one row re-fetch per filter for the inlet and outlet hooks.

Effect summary:

| metric | before | after |
| --- | --- | --- |
| module verifications per resolution (A active, C relevant) | A + C | C, rows shared | | full resolutions per chat request | 3 | 1 |
| row fetches inside the module cache per inlet+outlet filter | 1 each | 0 |

Each removed verification was a database round trip plus source-string scans, and each removed resolution repeated the active-ids, rows and valves queries.

Functionally verified with stubbed function accessors: priority ordering and toggle inclusion and exclusion behave exactly as before; non-candidate filters are never fetched; prefetched rows reach the module cache on every load including inlet processing; repeated calls on one request hit the cache without DB work and are mutation-safe; a new request recomputes.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
