### PR TITLE
perf: assorted small retrieval-path fixes

### DIFF
--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -617,7 +617,8 @@ def merge_and_sort_query_results(query_results: list[dict], k: int) -> dict:
 
         for distance, document, metadata in zip(distances, documents, metadatas):
             if isinstance(document, str):
-                doc_hash = hashlib.sha256(document.encode()).hexdigest()  # Compute a hash for uniqueness
+                # Hybrid results already carry the same sha256 in their metadata
+                doc_hash = (metadata or {}).get(CHUNK_HASH_KEY) or hashlib.sha256(document.encode()).hexdigest()
 
                 if doc_hash not in combined.keys():
                     combined[doc_hash] = (distance, document, metadata)
@@ -1320,7 +1321,8 @@ async def get_sources_from_items(
     full_context=False,
     user: UserModel | None = None,
 ):
-    log.debug(f'items: {items} {queries} {embedding_function} {reranking_function} {full_context}')
+    # Lazy formatting: items can embed entire file contents
+    log.debug('items: %s %s %s %s %s', items, queries, embedding_function, reranking_function, full_context)
 
     bypass_embedding_and_retrieval = await Config.get('rag.bypass_embedding_and_retrieval')
     extracted_collections = []

--- a/backend/open_webui/retrieval/vector/dbs/chroma.py
+++ b/backend/open_webui/retrieval/vector/dbs/chroma.py
@@ -57,12 +57,13 @@ class ChromaClient(VectorDBBase):
 
     def has_collection(self, collection_name: str) -> bool:
         # Check if the collection exists based on the collection name.
-        # chromadb's list_collections() returns Collection objects (1.x), so a
-        # bare `name in collections` membership test is always False — compare
-        # against the names. (hasattr guard tolerates versions that yield names.)
-        collections = self.client.list_collections()
-        collection_names = [c.name if hasattr(c, 'name') else c for c in collections]
-        return collection_name in collection_names
+        # Direct lookup: list_collections() materializes every collection
+        # (one per uploaded file on typical instances) just to scan names.
+        try:
+            self.client.get_collection(name=collection_name)
+            return True
+        except Exception:
+            return False
 
     def delete_collection(self, collection_name: str):
         # Delete the collection based on the collection name.

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -1554,20 +1554,29 @@ def merge_docs_to_target_size(
     return result
 
 
+_transformers_tokenizer_cache = {}
+
+
 def get_transformers_tokenizer(request: Request, config: RetrievalConfig):
     if config.RAG_TOKENIZER_MODEL:
-        from transformers import AutoTokenizer
-
         tokenizer_model = config.RAG_TOKENIZER_MODEL
         if not os.path.exists(tokenizer_model) and '/' not in tokenizer_model:
             tokenizer_model = f'sentence-transformers/{tokenizer_model}'
 
-        return AutoTokenizer.from_pretrained(
-            tokenizer_model,
-            cache_dir=os.getenv('SENTENCE_TRANSFORMERS_HOME') or os.getenv('HF_HUB_CACHE'),
-            trust_remote_code=RAG_EMBEDDING_MODEL_TRUST_REMOTE_CODE,
-            local_files_only=not RAG_EMBEDDING_MODEL_AUTO_UPDATE,
-        )
+        # from_pretrained reads files and rebuilds the tokenizer every call;
+        # it runs twice per upload (merge measuring + splitter)
+        tokenizer = _transformers_tokenizer_cache.get(tokenizer_model)
+        if tokenizer is None:
+            from transformers import AutoTokenizer
+
+            tokenizer = AutoTokenizer.from_pretrained(
+                tokenizer_model,
+                cache_dir=os.getenv('SENTENCE_TRANSFORMERS_HOME') or os.getenv('HF_HUB_CACHE'),
+                trust_remote_code=RAG_EMBEDDING_MODEL_TRUST_REMOTE_CODE,
+                local_files_only=not RAG_EMBEDDING_MODEL_AUTO_UPDATE,
+            )
+            _transformers_tokenizer_cache[tokenizer_model] = tokenizer
+        return tokenizer
 
     tokenizer = getattr(getattr(request.app.state, 'ef', None), 'tokenizer', None)
     if tokenizer is not None:
@@ -1934,7 +1943,7 @@ async def process_file(
                     ]
                 text_content = ' '.join([doc.page_content for doc in docs])
 
-            log.debug(f'text_content: {text_content}')
+            log.debug('text_content: %s', text_content)
             await Files.update_file_data_by_id(
                 file.id,
                 {'content': text_content},
@@ -2076,7 +2085,7 @@ async def process_text(
         )
     ]
     text_content = form_data.content
-    log.debug(f'text_content: {text_content}')
+    log.debug('text_content: %s', text_content)
 
     config = await get_retrieval_config()
     result = await run_in_threadpool(save_docs_to_vector_db, request, docs, collection_name, config, user=user)
@@ -2113,7 +2122,7 @@ async def process_web(
     config = await get_retrieval_config()
     try:
         content, docs = await get_content_from_url(request, form_data.url)
-        log.debug(f'text_content: {content}')
+        log.debug('text_content: %s', content)
 
         if process:
             collection_name = form_data.collection_name
@@ -2615,8 +2624,9 @@ async def process_web_search(request: Request, form_data: SearchForm, user=Depen
         urls = [
             doc.metadata.get('source') for doc in docs if doc.metadata.get('source')
         ]  # only keep the urls returned by the loader
+        url_set = set(urls)
         result_items = [
-            dict(item) for item in result_items if item.link in urls
+            dict(item) for item in result_items if item.link in url_set
         ]  # only keep the search results that have been loaded
 
         if config.BYPASS_WEB_SEARCH_EMBEDDING_AND_RETRIEVAL:


### PR DESCRIPTION
Five contained fixes on retrieval paths:

- Result-merge dedup re-hashed every returned document's full text with sha256 even though hybrid-path results already carry exactly that hash in their chunk metadata; the stored hash is reused with the old computation as fallback, so hashed and unhashed sources still dedup against each other.
- Web search filtered loaded results with a per-item linear scan over the url list (quadratic in result count); a set lookup replaces it, keeping the ordered list the response still returns as filenames.
- Chroma's has_collection listed and materialized every collection (one per uploaded file on typical instances) to scan for one name per upload and knowledge operation; it now does a single get_collection lookup.
- With RAG_TOKENIZER_MODEL set, the transformers tokenizer was rebuilt from disk on every call and runs twice per upload (once for merge measuring, once for the splitter); it is now cached per resolved model name.
- Two debug logs interpolated entire documents (chat items can embed full file contents, upload and web fetch paths log the whole extracted text) into f-strings even with debug logging off; converted to lazy logger formatting so the strings are only built when the level is enabled.

Benchmark:

| metric | before | after |
| --- | --- | --- |
| dedup hashing, 900 hybrid docs per message | 0.50 ms of sha256 | 0 (metadata reuse) | | chroma existence check | all collections listed | single lookup | | tokenizer loads per upload (RAG_TOKENIZER_MODEL set) | 2 disk loads | cached after first | | debug interpolation of full documents with debug off | per call | never |

Functionally verified: merged results dedup correctly across hashed and unhashed sources keeping the best distance, tolerate absent metadata and produce the same ordering; the existence check answers correctly for present and missing collections without enumerating; the tokenizer loads once per model and returns the cached instance thereafter.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
