### PR TITLE
fix: gate artifact panel auto-open on message completion

### DIFF
--- a/src/lib/components/chat/Messages/ContentRenderer.svelte
+++ b/src/lib/components/chat/Messages/ContentRenderer.svelte
@@ -135,6 +135,7 @@
 			const { lang = '', text: code = '' } = token;
 
 			if (
+				done &&
 				($settings?.detectArtifacts ?? true) &&
 				(['html', 'svg'].includes(lang) || (lang === 'xml' && code.includes('svg'))) &&
 				!$mobile &&


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27399
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [x] **Documentation:** No documentation changes needed (behavior-preserving bug fix; auto-open still happens, just once, on completion).
- [x] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Manual tests performed — see Additional Information for the verification matrix.
- [x] **No Unchecked AI Code:** Developed with AI assistance (disclosed in the commit trailer), human-reviewed, and manually verified in a browser against the scenarios listed below.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new settings; uses the component's existing `done` prop.
- [x] **Git Hygiene:** Atomic single-commit change, based on `dev`.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

- While a response streams an `html`/`svg` (or `xml` containing `<svg>`) code block, `markdownUpdateHandler` in `ContentRenderer.svelte` calls `showArtifacts.set(true)` and `showControls.set(true)` on **every** streamed token, with no completion check. The artifacts panel force-reopens continuously during generation, and a user who closes it mid-stream has it snap back open until the stream ends. When the chat already contains a finished artifact, the panel shows the *previous* artifact the whole time, which makes the lock-out especially confusing.
- The fix gates the handler on the component's existing `done` prop (`export let done = true`). Streaming tokens (`done === false`) no longer force the panel open; the auto-open still fires once when the completed message renders, and open-on-load behavior is preserved because the mounted render runs with `done === true`.

### Fixed

- Artifacts panel no longer force-reopens on every streamed token while an `html`/`svg` code block is generating; it can now be closed mid-generation and auto-opens once on completion.

---

### Additional Information

- One-line change: `done &&` added as the first condition of the existing guard in `markdownUpdateHandler` (`src/lib/components/chat/Messages/ContentRenderer.svelte`).
- Manual verification (desktop viewport, "Detect Artifacts Automatically" on):
  1. Second artifact in a chat with a finished artifact: closing the panel mid-stream now sticks; the panel opens once on completion showing the new artifact.
  2. First artifact in a fresh chat: panel opens once on completion (not during streaming).
  3. Loading a finished chat containing an artifact: panel still auto-opens once.
  4. Panel open during generation: rendered content still updates live per token (this fix gates opening only, not rendering).
- Note: `ResponseMessage.svelte` wires `done` as `message?.done` only when `chatFadeStreamingText` is enabled, and passes `true` otherwise — so with the fade setting disabled the guard is inert and behavior is unchanged from today. Wiring `done` unconditionally there would complete the fix for that path; kept out of this PR to stay atomic, happy to follow up if maintainers want it.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
