### PR TITLE
fix: render channel replies from external/streaming models

### DIFF
--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -875,6 +875,48 @@ async def disconnect(sid, reason=None):
         # print(f"Unknown session ID {sid} disconnected")
 
 
+def _channel_completion_content(data):
+    """Extract the visible assistant text from a chat:completion event payload.
+
+    The channel emitter historically read only ``data['content']``. Streaming
+    and external OpenAI-compatible backends instead deliver their text in a
+    structured ``data['output']`` array, so their channel replies were persisted
+    empty (``content=''`` with ``done=True``) and never rendered — while 1:1
+    chats worked. Fall back to reconstructing the assistant text from ``output``
+    (and, defensively, a raw ``choices`` payload). Returns the full accumulated
+    string; the caller does a full-replace update, matching existing semantics.
+    """
+    content = data.get('content')
+    if isinstance(content, str) and content:
+        return content
+
+    output = data.get('output')
+    if isinstance(output, list):
+        parts = []
+        for item in output:
+            if not isinstance(item, dict) or item.get('type') != 'message':
+                continue
+            for block in item.get('content', []) or []:
+                if isinstance(block, dict) and block.get('type') in ('output_text', 'text'):
+                    parts.append(block.get('text', '') or '')
+                elif isinstance(block, str):
+                    parts.append(block)
+        if parts:
+            return ''.join(parts)
+
+    choices = data.get('choices')
+    if isinstance(choices, list) and choices:
+        choice = choices[0] or {}
+        message = choice.get('message') or {}
+        if isinstance(message.get('content'), str) and message.get('content'):
+            return message['content']
+        delta = choice.get('delta') or {}
+        if isinstance(delta.get('content'), str):
+            return delta['content']
+
+    return ''
+
+
 async def _make_channel_emitter(request_info):
     """Event emitter that routes pipeline output to a channel message.
 
@@ -924,7 +966,7 @@ async def _make_channel_emitter(request_info):
 
         if event_type == 'chat:completion':
             data = event_data.get('data', {})
-            content = data.get('content', '')
+            content = _channel_completion_content(data)
             done = data.get('done', False)
 
             if not content and not done:


### PR DESCRIPTION
Closes #26656 · Relates to #19106.

## Summary

Model replies in **channels** never render for external OpenAI-compatible / streaming backends (LiteLLM, Ollama function-style models, custom OpenAI-compatible endpoints), even though the same model works fine in 1:1 chats.

**Root cause:** `socket/main.py`'s `__channel_emitter__` reads the completion text only from `data['content']`. For `channel:`-scoped completions the realtime DB save is skipped (`utils/middleware.py`), so the emitter is the sole persister — but streaming/external backends deliver their text in the structured `data['output']` array (middleware emits `{'output': full_output()}`), not `data['content']`. The assistant message is therefore saved with `content=''` and `done=True`, so it renders empty. Reproduced on v0.10.2 against an external OpenAI-compatible endpoint — the message row ends up `content='', meta.done=true`.

**Fix:** add a small `_channel_completion_content(data)` helper that falls back to reconstructing the assistant text from `output` (and, defensively, a raw `choices` payload) when `content` is absent/empty, then route the emitter through it. Full-replace update semantics are unchanged; 1:1 chats are unaffected. One file, no new dependencies, no new settings.

## AI usage disclosure

This change was drafted with **AI assistance (Claude)** and then **human-reviewed and manually tested** by me. I root-caused it against the running source, applied the patch, and verified it end-to-end on a live deployment — the previously-empty channel message now persists and renders the real answer. Disclosed per the "No Unchecked AI Code" checklist item.

## Testing (manual)

- Stock v0.10.2: channel `@model` reply from an external OpenAI-compatible backend persisted empty (`content=''`, `done=true`); 1:1 chats fine.
- With this patch: the channel reply persists and renders; verified the DB message row now holds the full assistant text.
- 1:1 chats unchanged.

---

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #26656; relates to #19106.
- [x] **Target branch:** targets `dev`.
- [x] **Description:** provided above.
- [x] **Changelog:** included below.
- [ ] **Documentation:** N/A — backend bug-fix, no user-facing documentation change.
- [ ] **Dependencies:** N/A — none added or changed.
- [x] **Testing:** manual tests performed (above).
- [x] **No Unchecked AI Code:** AI-assisted, then human-reviewed AND manually tested (see disclosure above).
- [x] **Self-Review:** performed.
- [x] **Architecture:** smart default, no new settings.
- [x] **Git Hygiene:** atomic (one file), rebased on `dev`.
- [x] **Title Prefix:** `fix`.

# Changelog Entry

### Description

- Fix channel model replies from external OpenAI-compatible / streaming backends persisting empty and never rendering.

### Fixed

- Channel replies from external OpenAI-compatible / streaming models now render. The channel emitter previously read only `data['content']` and missed the `data['output']` payload shape those backends use, so the assistant message was saved empty.

---

### Additional Information

The fix is intentionally minimal and self-contained (a fallback extractor in `socket/main.py`). Happy to adjust naming/placement or split further to match project conventions.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
