### PR TITLE
feat: post channel model replies in the channel root, not a thread

### DIFF
--- a/backend/open_webui/routers/channels.py
+++ b/backend/open_webui/routers/channels.py
@@ -993,7 +993,10 @@ async def model_response_handler(request, channel, message, user, db=None):
                     channel.id,
                     MessageForm(
                         **{
-                            'parent_id': (message.parent_id if message.parent_id else message.id),
+                            # Reply in the channel root when the model was tagged
+                            # at the top level; only stay in a thread when the
+                            # triggering message was itself in one.
+                            'parent_id': message.parent_id,
                             'content': f'',
                             'data': {},
                             'meta': {


### PR DESCRIPTION
Relates to #19106.

## This is a proposal / preference — not a bug fix

Submitting this as a **proposed behaviour change** that reflects my own preference; it is **not** a defect. Happy to move it to a [Discussion](https://github.com/open-webui/open-webui/discussions) first if the team would rather vet the idea before a PR — just say the word.

## Summary

When a model is `@`-tagged at the **top level** of a channel, its reply is currently anchored to the tagging message (`parent_id` falls back to `message.id`), so the answer lands in a **new thread** rather than the channel's main timeline. For a shared, chat-style channel this hides the model's answers away from the conversation.

**Proposed change:** anchor the reply to `message.parent_id` instead. Effect:
- Tag at the **channel root** → reply appears in the **main channel timeline**.
- Tag **inside a thread** → reply still stays **within that thread** (unchanged).

One line in `routers/channels.py`, no new setting (kept as a default rather than a config flag, per the "smart defaults over new settings" guidance).

## Open question for maintainers

The adjacent thread-history fetch a few lines up (`get_messages_by_parent_id(..., message.parent_id if message.parent_id else message.id)`) still scopes the model's context to the tagged message's thread. I left it unchanged to keep this diff minimal, but if root-level replies become the default it may be worth scoping context to the channel root too. Guidance welcome.

## AI usage disclosure

Drafted with **AI assistance (Claude)** and **human-reviewed and manually tested** by me on a live deployment (a root-level tag now replies in the channel main area; in-thread tags still reply in-thread). Disclosed per the "No Unchecked AI Code" checklist item.

## Testing (manual)

- Root-level `@model` tag → reply renders in the channel main timeline. ✅
- `@model` tag inside a thread → reply stays in that thread. ✅

---

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Relates to #19106.
- [x] **Target branch:** targets `dev`.
- [x] **Description:** provided above.
- [x] **Changelog:** included below.
- [ ] **Documentation:** N/A — behaviour change, no documented setting.
- [ ] **Dependencies:** N/A — none added or changed.
- [x] **Testing:** manual tests performed (above).
- [x] **No Unchecked AI Code:** AI-assisted, then human-reviewed AND manually tested (see disclosure above).
- [x] **Self-Review:** performed.
- [ ] **Architecture / discuss-first:** this is a UX behaviour change offered as a proposal — flagging it here rather than claiming prior discussion. Glad to convert to a Discussion if preferred.
- [x] **Git Hygiene:** atomic (one file), rebased on `dev`.
- [x] **Title Prefix:** `feat`.

# Changelog Entry

### Description

- Proposal: post a channel model's reply in the channel root when it was tagged at the top level, instead of opening a thread.

### Changed

- Channel model replies are anchored to `message.parent_id`, so a top-level `@model` tag replies in the channel main timeline; tags made inside a thread still reply within that thread.

---

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
