### PR TITLE
fix: persist previous_response_id across chat turns for stateful Responses API

### DIFF
--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -701,6 +701,33 @@ class ChatTable:
 
         return chat.chat.get('history', {}).get('messages', {}).get(message_id, {})
 
+    async def get_last_assistant_response_id(self, chat_id: str, parent_id: str | None = None) -> str | None:
+        """Return the response_id of the most recent assistant message.
+
+        When ``parent_id`` is given, walks up from that parent; otherwise
+        scans all messages in reverse chronological order.
+        """
+        chat = await self.get_chat_by_id(chat_id)
+        if chat is None:
+            return None
+        messages = chat.chat.get('history', {}).get('messages', {})
+        if not messages:
+            return None
+        # Walk up from parent_id if provided
+        if parent_id:
+            current = parent_id
+            while current in messages:
+                msg = messages[current]
+                if msg.get('role') == 'assistant' and msg.get('response_id'):
+                    return msg['response_id']
+                current = msg.get('parentId')
+            return None
+        # Scan all messages, returning the most recent assistant response_id
+        for msg in sorted(messages.values(), key=lambda m: m.get('timestamp', 0), reverse=True):
+            if msg.get('role') == 'assistant' and msg.get('response_id'):
+                return msg['response_id']
+        return None
+
     async def upsert_message_to_chat_by_id_and_message_id(
         self, id: str, message_id: str, message: dict
     ) -> ChatModel | None:

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -4935,14 +4935,32 @@ async def streaming_chat_response_handler(response, ctx):
                             'metadata': metadata,
                         }
 
-                        if ENABLE_RESPONSES_API_STATEFUL and last_response_id:
+                        # Resolve previous_response_id for stateful Responses API.
+                        # Prefer the locally-tracked id from the current request
+                        # (tool-call loop); otherwise look up the last assistant
+                        # message in the database (cross-request continuation).
+                        previous_response_id = None
+                        if ENABLE_RESPONSES_API_STATEFUL:
+                            if last_response_id:
+                                previous_response_id = last_response_id
+                            elif form_data.get('parent_id'):
+                                previous_response_id = await Chats.get_last_assistant_response_id(
+                                    metadata['chat_id'],
+                                    parent_id=form_data['parent_id'],
+                                )
+                            else:
+                                previous_response_id = await Chats.get_last_assistant_response_id(
+                                    metadata['chat_id']
+                                )
+
+                        if previous_response_id:
                             system_message = get_system_message(form_data['messages'])
                             new_form_data['messages'] = (
                                 [system_message] if system_message else []
                             ) + convert_output_to_messages(
                                 output, raw=True, reasoning_format=get_reasoning_format(model)
                             )
-                            new_form_data['previous_response_id'] = last_response_id
+                            new_form_data['previous_response_id'] = previous_response_id
                         else:
                             tool_messages = convert_output_to_messages(
                                 output, raw=True, reasoning_format=get_reasoning_format(model)
@@ -5232,6 +5250,7 @@ async def streaming_chat_response_handler(response, ctx):
                                 'done': True,
                                 'output': output,
                                 **({'usage': usage} if usage else {}),
+                                **({'response_id': last_response_id} if ENABLE_RESPONSES_API_STATEFUL and last_response_id else {}),
                             },
                         )
                     elif usage:


### PR DESCRIPTION
## Summary

Fixes #27150

When `ENABLE_RESPONSES_API_STATEFUL=true`, multi-turn chats were still sending the full conversation history without `previous_response_id`, causing every turn to create a new upstream session.

## Root Cause

`last_response_id` was a per-request local variable reset to `None` on every HTTP request. Cross-request state was never persisted.

## Changes

**`backend/open_webui/models/chats.py`** - Added `get_last_assistant_response_id()` to walk parent chain or scan messages for the most recent assistant `response_id`.

**`backend/open_webui/utils/middleware.py`** - Save `response_id` to message DB; resolve `previous_response_id` from local var or DB lookup before upstream calls.

## openjobs.bot

https://openjobs.bot/jobs/46d996fe-858a-418c-bf94-eb0cfe03f7ab