### PR TITLE
fix: do not use raw query-generation output as the RAG search query

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -1836,7 +1836,8 @@ async def chat_completion_files_handler(
                     queries_response = queries_response[bracket_start:bracket_end]
                     queries_response = json.loads(queries_response)
                 except Exception as e:
-                    queries_response = {'queries': [queries_response]}
+                    # Non-JSON output (e.g. a refusal) is not a usable query; empty list triggers the last-user-message fallback
+                    queries_response = {'queries': []}
 
                 queries = queries_response.get('queries', [])
             except Exception:


### PR DESCRIPTION
When the retrieval query-generation call returns text without a JSON object, for example a content-filter refusal like "I can't help with that request.", the JSON extraction in chat_completion_files_handler fails and the except branch wrapped the raw model text as the query list. Because the list was then non-empty, the intended last-user-message fallback never fired and the refusal text itself became the vector-search query, silently retrieving irrelevant context. The root cause is the fallback value in the except branch: raw model output that failed JSON extraction is never a usable similarity query. The fix makes the extraction failure yield an empty query list so the existing fallback to the last user message applies. Fixes #27047

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
