### PR TITLE
fix: fall back to uv when pip is missing for requirements install

### DIFF
--- a/backend/open_webui/utils/plugin.py
+++ b/backend/open_webui/utils/plugin.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 import os
 import re
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -438,9 +439,17 @@ def install_frontmatter_requirements(requirements: str):
                 return
 
             log.info(f'Installing requirements: {" ".join(new_reqs)}')
-            subprocess.check_call(
-                [sys.executable, '-m', 'pip', 'install'] + PIP_OPTIONS + new_reqs + PIP_PACKAGE_INDEX_OPTIONS
-            )
+            if util.find_spec('pip'):
+                install_command = [sys.executable, '-m', 'pip', 'install']
+            elif uv_path := shutil.which('uv'):
+                # uv-managed environments (e.g. uv tool install) ship without pip
+                install_command = [uv_path, 'pip', 'install', '--python', sys.executable]
+            else:
+                raise RuntimeError(
+                    'Cannot install requirements: this Python environment has no pip module and uv was not found '
+                    'on PATH. Install pip into the environment or make uv available.'
+                )
+            subprocess.check_call(install_command + PIP_OPTIONS + new_reqs + PIP_PACKAGE_INDEX_OPTIONS)
             _installed_requirements.update(new_reqs)
         except Exception as e:
             log.error(f'Error installing packages: {" ".join(new_reqs)}')


### PR DESCRIPTION
Functions, tools and pipes that declare a requirements frontmatter line are installed through install_frontmatter_requirements, which always shells out to "sys.executable -m pip install". When Open WebUI is installed with "uv tool install open-webui", the created venv deliberately ships without pip, so every such install fails with "No module named pip" and the chat request that triggered it errors out on every turn.

The fix selects the installer at the single chokepoint that all install paths go through (per-function load, per-tool load and startup dependency installation). If the running interpreter has pip, the existing pip command is used unchanged. Otherwise, if uv is on PATH, the packages are installed with "uv pip install --python" pointing at the running interpreter, which accepts the same index options passed via PIP_PACKAGE_INDEX_OPTIONS. If neither is available, an actionable RuntimeError names the missing pip module and the workaround instead of an opaque non-zero exit status.

Fixes #27214

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
