### PR TITLE
fix: allow setting model order via MODEL_ORDER_LIST env var

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -1664,7 +1664,13 @@ if default_prompt_suggestions == []:
 
 DEFAULT_PROMPT_SUGGESTIONS = default_prompt_suggestions
 
-MODEL_ORDER_LIST = []
+try:
+    model_order_list = json.loads(os.getenv('MODEL_ORDER_LIST', '[]'))
+except Exception as e:
+    log.exception(f'Error loading MODEL_ORDER_LIST: {e}')
+    model_order_list = []
+
+MODEL_ORDER_LIST = model_order_list
 
 try:
     default_model_metadata = json.loads(os.getenv('DEFAULT_MODEL_METADATA', '{}'))


### PR DESCRIPTION
With ENABLE_PERSISTENT_CONFIG=False the admin's model order is reset on every restart because ui.model_order_list falls back to its DEFAULT_CONFIG default, and unlike every other Models setting (DEFAULT_MODELS, DEFAULT_PINNED_MODELS, DEFAULT_MODEL_METADATA and DEFAULT_MODEL_PARAMS) that default was hardcoded to an empty list with no environment variable to source it from. This adds a MODEL_ORDER_LIST environment variable parsed as a JSON array using the same guarded pattern as the neighbouring DEFAULT_MODEL_METADATA and DEFAULT_MODEL_PARAMS defaults, falling back to an empty list on parse errors. Behaviour when the variable is unset is unchanged.

Fixes #27206

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
