### PR TITLE
fix: show download preparation toast and prevent duplicate zip jobs

### DIFF
--- a/src/lib/apis/terminal/index.ts
+++ b/src/lib/apis/terminal/index.ts
@@ -143,7 +143,8 @@ export const downloadFileBlob = async (
 	if (!res || !res.ok) return null;
 
 	const filename = path.split('/').pop() ?? 'file';
-	const blob = await res.blob();
+	const blob = await res.blob().catch(() => null);
+	if (!blob) return null;
 	return { blob, filename };
 };
 
@@ -170,7 +171,8 @@ export const archiveFromTerminal = async (
 	const disposition = res.headers.get('content-disposition') ?? '';
 	const match = disposition.match(/filename="?([^"]+)"?/);
 	const filename = match?.[1] ?? 'download.zip';
-	const blob = await res.blob();
+	const blob = await res.blob().catch(() => null);
+	if (!blob) return null;
 	return { blob, filename };
 };
 

--- a/src/lib/components/chat/FileNav.svelte
+++ b/src/lib/components/chat/FileNav.svelte
@@ -521,22 +521,31 @@
 		fileLoading = false;
 	};
 
+	let downloading = false;
+
 	const downloadFile = async (path: string) => {
 		const terminal = selectedTerminal;
-		if (!terminal) return;
+		if (!terminal || downloading) return;
 
-		// Directories end with '/' — download as ZIP archive
-		const isDir = path.endsWith('/');
-		const result = isDir
-			? await archiveFromTerminal(terminal.url, terminal.key, [path.replace(/\/$/, '')])
-			: await downloadFileBlob(terminal.url, terminal.key, path, chatId ?? undefined);
-		if (!result) return;
-		const url = URL.createObjectURL(result.blob);
-		const a = document.createElement('a');
-		a.href = url;
-		a.download = result.filename;
-		a.click();
-		URL.revokeObjectURL(url);
+		downloading = true;
+		const toastId = toast.loading($i18n.t('Preparing download...'));
+		try {
+			// Directories end with '/', downloaded as a ZIP archive
+			const isDir = path.endsWith('/');
+			const result = isDir
+				? await archiveFromTerminal(terminal.url, terminal.key, [path.replace(/\/$/, '')])
+				: await downloadFileBlob(terminal.url, terminal.key, path, chatId ?? undefined);
+			if (!result) return;
+			const url = URL.createObjectURL(result.blob);
+			const a = document.createElement('a');
+			a.href = url;
+			a.download = result.filename;
+			a.click();
+			URL.revokeObjectURL(url);
+		} finally {
+			toast.dismiss(toastId);
+			downloading = false;
+		}
 	};
 
 	// ── Drag-and-drop upload ─────────────────────────────────────────────
@@ -785,7 +794,7 @@
 
 	const bulkDownload = async () => {
 		const terminal = selectedTerminal;
-		if (!terminal) return;
+		if (!terminal || downloading) return;
 
 		const paths = [...selectedEntries].map((p) => p.replace(/\/$/, ''));
 		if (paths.length === 0) return;
@@ -796,15 +805,22 @@
 			return;
 		}
 
-		// Archive everything into a single ZIP
-		const result = await archiveFromTerminal(terminal.url, terminal.key, paths);
-		if (!result) return;
-		const url = URL.createObjectURL(result.blob);
-		const a = document.createElement('a');
-		a.href = url;
-		a.download = result.filename;
-		a.click();
-		URL.revokeObjectURL(url);
+		downloading = true;
+		const toastId = toast.loading($i18n.t('Preparing download...'));
+		try {
+			// Archive everything into a single ZIP
+			const result = await archiveFromTerminal(terminal.url, terminal.key, paths);
+			if (!result) return;
+			const url = URL.createObjectURL(result.blob);
+			const a = document.createElement('a');
+			a.href = url;
+			a.download = result.filename;
+			a.click();
+			URL.revokeObjectURL(url);
+		} finally {
+			toast.dismiss(toastId);
+			downloading = false;
+		}
 	};
 
 	// Escape to clear selection

--- a/src/lib/components/chat/FileNav.svelte
+++ b/src/lib/components/chat/FileNav.svelte
@@ -535,7 +535,10 @@
 			const result = isDir
 				? await archiveFromTerminal(terminal.url, terminal.key, [path.replace(/\/$/, '')])
 				: await downloadFileBlob(terminal.url, terminal.key, path, chatId ?? undefined);
-			if (!result) return;
+			if (!result) {
+				toast.error($i18n.t('Download failed'));
+				return;
+			}
 			const url = URL.createObjectURL(result.blob);
 			const a = document.createElement('a');
 			a.href = url;
@@ -810,7 +813,10 @@
 		try {
 			// Archive everything into a single ZIP
 			const result = await archiveFromTerminal(terminal.url, terminal.key, paths);
-			if (!result) return;
+			if (!result) {
+				toast.error($i18n.t('Download failed'));
+				return;
+			}
 			const url = URL.createObjectURL(result.blob);
 			const a = document.createElement('a');
 			a.href = url;


### PR DESCRIPTION
Failures are now reported rather than silently dropping the preparation toast. The two terminal download helpers declare a nullable return but could still reject once the response body had started streaming, so an interrupted transfer escaped as an unhandled rejection and produced the same silent dismissal. They now return null in that case, which additionally stops an interrupted file preview from leaving its spinner running. Fixes #27055

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
