### PR TITLE
fix(channels): persist model replies from Responses-API output blocks

### DIFF
--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -37,6 +37,7 @@ from open_webui.socket.utils import RedisDict, RedisLock, YdocManager
 from open_webui.tasks import create_task, stop_item_tasks
 from open_webui.utils.access_control import has_permission
 from open_webui.utils.auth import decode_token, is_valid_token
+from open_webui.utils.misc import convert_output_to_messages, get_content_from_message
 from open_webui.utils.redis import (
     build_sentinel_url,
     get_redis_connection,
@@ -925,6 +926,19 @@ async def _make_channel_emitter(request_info):
         if event_type == 'chat:completion':
             data = event_data.get('data', {})
             content = data.get('content', '')
+            # Streaming completions emit Responses-API output blocks under
+            # data['output'] rather than data['content']; flatten so channel
+            # messages persist the assistant text.
+            if not content and data.get('output'):
+                content = '\n'.join(
+                    text
+                    for text in (
+                        get_content_from_message(message)
+                        for message in convert_output_to_messages(data['output'])
+                        if message.get('role') == 'assistant'
+                    )
+                    if text
+                )
             done = data.get('done', False)
 
             if not content and not done:


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** `Closes #26656` — `Relates to #19106`.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [x] **Documentation:** N/A — restores intended behavior; no documentation impact.
- [x] **Dependencies:** N/A — no new or updated dependencies (uses existing `open_webui.utils.misc` helpers).
- [x] **Testing:** Manually verified — see below.
- [x] **No Unchecked AI Code:** AI-assisted, then human-reviewed and manually tested.
- [x] **Self-Review:** Performed.
- [x] **Architecture:** No new settings; a one-line behavior fix in the shared channel emitter.
- [x] **Git Hygiene:** Atomic (single file, one logical change), rebased on `dev`.
- [x] **Title Prefix:** `fix`.

## Problem

When a model is @mentioned in a **Channel**, the reply message is created but stays empty — it shows a permanently pulsing / never-rendering state, even though the backend completes generation successfully. The same model preset works fine in 1:1 chats. Reported in #26656 (v0.10.2) and #19106.

## Root cause

The channel path routes the full completion pipeline through `_make_channel_emitter` (`backend/open_webui/socket/main.py`), which is the **only** persistence for channel messages (the regular `Chats.upsert` path is skipped for `chat_id` starting with `channel:`).

That emitter reads the assistant text from `data['content']`:

```python
if event_type == 'chat:completion':
    data = event_data.get('data', {})
    content = data.get('content', '')      # key never present
    done = data.get('done', False)
    if not content and not done:
        return
```

But `process_chat_response` (`backend/open_webui/utils/middleware.py`) emits its `chat:completion` events with the assistant text under **`data['output']`** (the Responses-API output-blocks format) — for content deltas, the final `done` event, tool-call and code-interpreter events alike:

```python
if value:                       # value = delta.get('content')
    data = {'output': full_output()}
    delta_type = 'content'
...
await event_emitter({'type': 'chat:completion', 'data': data})
```

So `content` is always `''`, every event is dropped by the `if not content and not done: return` guard, and the channel message is persisted empty. This affects **all** models (both `connections` and `functions` / pipe models), because the defect is in the shared channel emitter, not in any provider.

## Fix

Flatten `data['output']` to text using the existing helpers (`convert_output_to_messages`, `get_content_from_message`) when `content` is absent. Guarded by `if not content` so it's a no-op if a payload ever does carry `content`.

# Changelog Entry

### Description

- Channel replies from @mentioned models were persisted empty because the channel emitter read `data['content']` while the streaming pipeline emits the assistant text under `data['output']` (Responses-API output blocks).

### Fixed

- Model replies to @mentions in Channels now persist and render their text, for both connection and pipe/function models (#26656, #19106).

---

### Additional Information

- **Testing:** Reproduced on 0.10.2 (empty channel reply, same model fine in 1:1). With the fix, the reply persists the full assistant text — verified via `GET /api/v1/channels/{id}/messages/{message_id}/thread` returning non-empty `content` (observed length 200 vs 0 before). `black` and `ruff format` report the file unchanged; no new `ruff check` findings.
- **Out of scope:** channel model replies are threaded (`parent_id` is set in `model_response_handler`); this PR only addresses the empty-content persistence.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
