### PR TITLE
fix: context compaction reads last-call input, not additive usage total

### DIFF
--- a/backend/open_webui/utils/context_compaction.py
+++ b/backend/open_webui/utils/context_compaction.py
@@ -260,9 +260,13 @@ async def get_chat_context_usage(chat: Any, model_id: str | None = None) -> dict
 
     for idx in range(len(messages) - 1, -1, -1):
         usage = messages[idx].get('usage') or (messages[idx].get('info') or {}).get('usage')
-        input_tokens = (usage or {}).get('input_tokens') or (usage or {}).get('prompt_tokens')
+        input_tokens = (
+            (usage or {}).get('last_input_tokens') or (usage or {}).get('input_tokens') or (usage or {}).get('prompt_tokens')
+        )
         if isinstance(usage, dict) and input_tokens:
-            tokens = int(input_tokens or 0) + int(usage.get('output_tokens') or usage.get('completion_tokens') or 0)
+            tokens = int(input_tokens or 0) + int(
+                usage.get('last_output_tokens') or usage.get('output_tokens') or usage.get('completion_tokens') or 0
+            )
             tokens += _estimate_messages_tokens(messages[idx + 1 :])
             return _build_context_usage(tokens, threshold)
 
@@ -301,8 +305,11 @@ def _exceeds_token_threshold(messages: list[dict], system_prompt: str, summary: 
 
     for idx in range(len(messages) - 1, -1, -1):
         usage = messages[idx].get('usage') or (messages[idx].get('info') or {}).get('usage')
-        if isinstance(usage, dict) and usage.get('input_tokens'):
-            total = int(usage.get('input_tokens') or 0) + int(usage.get('output_tokens') or 0)
+        if isinstance(usage, dict) and (usage.get('last_input_tokens') or usage.get('input_tokens')):
+            # Last call's context size, not merge_usage's additive tool-loop total
+            context_input = int(usage.get('last_input_tokens') or usage.get('input_tokens') or 0)
+            context_output = int(usage.get('last_output_tokens') or usage.get('output_tokens') or 0)
+            total = context_input + context_output
             return total + _estimate_messages_tokens(messages[idx + 1 :]) > threshold
 
     estimated = _estimate_tokens(system_prompt) + _estimate_tokens(summary or '') + _estimate_messages_tokens(messages)

--- a/backend/open_webui/utils/response.py
+++ b/backend/open_webui/utils/response.py
@@ -47,6 +47,9 @@ def normalize_usage(usage: dict) -> dict:
     result['input_tokens'] = int(input_tokens)
     result['output_tokens'] = int(output_tokens)
     result['total_tokens'] = int(total_tokens)
+    # Last call's real counts, not summed across a tool loop
+    result['last_input_tokens'] = int(usage.get('last_input_tokens') or input_tokens)
+    result['last_output_tokens'] = int(usage.get('last_output_tokens') or output_tokens)
 
     return result
 
@@ -132,6 +135,10 @@ def merge_usage(current: dict | None, incoming: dict | None) -> dict:
                 current_usage.get(key) if isinstance(current_usage.get(key), dict) else {},
                 incoming_usage.get(key) if isinstance(incoming_usage.get(key), dict) else {},
             )
+
+    # A call that reports no usage must not zero the last-call context fields
+    for key in ('last_input_tokens', 'last_output_tokens'):
+        result[key] = incoming_usage.get(key) or current_usage.get(key, 0)
 
     return result
 


### PR DESCRIPTION
Since 0.10.2 merge_usage() sums token fields across every model call of a native tool loop. The additive totals are intentional cumulative accounting, but each call re-sends the growing conversation, so the summed input_tokens no longer describes the context size. Context compaction and the chat context meter read that value as the current context length, which makes compaction fire far below its real threshold after a few tool calls and inflates the displayed usage.

This reuses the approach from #27032: normalize_usage() records last_input_tokens and last_output_tokens for each call and merge_usage() carries the newest nonzero values through the loop instead of summing them, leaving every additive field untouched. _exceeds_token_threshold() and get_chat_context_usage() now prefer the last-call fields and fall back to the summed ones for messages stored before this change, and a call that reports no usage cannot zero the carried context size.

Fixes #27031

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
