### PR TITLE
fix: surface tool-call and code-interpreter continuation errors instead of silently swallowing them

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -5131,7 +5131,20 @@ async def streaming_chat_response_handler(response, ctx):
                         else:
                             break
                     except Exception as e:
-                        log.debug(e)
+                        log.exception('Error in tool-call continuation: %s', e)
+                        error_content = str(e) or 'Error during tool-call continuation.'
+                        if not metadata.get('chat_id', '').startswith('channel:'):
+                            await Chats.upsert_message_to_chat_by_id_and_message_id(
+                                metadata['chat_id'],
+                                metadata['message_id'],
+                                {'error': {'content': error_content}},
+                            )
+                        await event_emitter(
+                            {
+                                'type': 'chat:message:error',
+                                'data': {'error': {'content': error_content}},
+                            }
+                        )
                         break
 
                 if (
@@ -5321,7 +5334,20 @@ async def streaming_chat_response_handler(response, ctx):
                             else:
                                 break
                         except Exception as e:
-                            log.debug(e)
+                            log.exception('Error in code-interpreter continuation: %s', e)
+                            error_content = str(e) or 'Error during code-interpreter continuation.'
+                            if not metadata.get('chat_id', '').startswith('channel:'):
+                                await Chats.upsert_message_to_chat_by_id_and_message_id(
+                                    metadata['chat_id'],
+                                    metadata['message_id'],
+                                    {'error': {'content': error_content}},
+                                )
+                            await event_emitter(
+                                {
+                                    'type': 'chat:message:error',
+                                    'data': {'error': {'content': error_content}},
+                                }
+                            )
                             break
 
                 # Mark all in-progress items as completed


### PR DESCRIPTION
﻿# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27411
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following Keep a Changelog format is included at the bottom.
- [ ] **Documentation:** No docs change needed (no new setting or behavior surface — errors now use the existing error-display path).
- [x] **Dependencies:** No new or updated dependencies.
- [ ] **Testing:** The failure mode itself was diagnosed and verified on a production v0.10.2 deployment (proxy-side HTTP 400 in the continuation round → silent empty message, confirmed via chat DB + provider invocation logs). The patched build is scheduled for a manual negative test (forced continuation failure → visible error) in our deployment; I will report the result on this PR.
- [ ] **No Unchecked AI Code:** Transparent note: this patch was produced with AI assistance during the incident investigation. It mirrors the existing iteration-limit error path in the same function 1:1 and is undergoing human diff review and manual testing on our side; I will confirm both on this PR before asking for review.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new settings; reuses the established error path (`chat:message:error` + persisted `error` field) of the same function.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

In `streaming_chat_response_handler` (`backend/open_webui/utils/middleware.py`), the native tool-call continuation loop and the code-interpreter continuation loop both wrap the follow-up model invocation in `except Exception as e: log.debug(e); break`. Any failure in a continuation round (proxy/backend 4xx or 5xx, transient network error, stream-parsing error) is therefore swallowed: the chat ends with an empty assistant message (`content=''`, `done=true`), no error event reaches the frontend, no `error` field is persisted, and nothing is logged at default log levels.

This PR handles those exceptions exactly like the tool-call iteration limit a few lines below already does:

- persist `{'error': {'content': ...}}` on the message (skipping `channel:` chats, same guard as the limit path),
- emit a `chat:message:error` event so the user sees the failure,
- use `log.exception` so the stack trace is available without a DEBUG deploy.

Real-world impact example (how we found it): a LiteLLM/Bedrock-guardrail 400 on the round-2 request made every affected chat end as a silent empty answer — the model provider's logs showed a fully streamed response while users saw nothing. Diagnosing this required a DEBUG-level redeploy; with this patch the cause is visible in the UI, the DB, and the default logs. The bug is generic: **any** continuation-round failure is currently invisible.

### Fixed

- Errors during native tool-call and code-interpreter continuation rounds are now shown to the user and persisted on the message instead of being silently swallowed (empty assistant message).

---

### Additional Information

- The two patched `except` blocks are at the tool-call continuation (~line 5131) and the code-interpreter continuation (~line 5334) on current `dev`; the same pattern exists in v0.10.x releases.
- No behavior change on the success path; the `break` semantics of the loops are unchanged.

### Screenshots or Videos

- n/a (server-side; before: empty assistant message with `done=true` in the chat DB — after: standard error box via `chat:message:error`).

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.

