### PR TITLE
fix: make native date/time picker icons visible in dark theme

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -185,6 +185,16 @@ select {
 	@apply bg-gray-850 text-white;
 }
 
+/* Dark theme native date/time controls: render the picker (and its calendar/clock
+   indicator) in dark mode so the icon isn't dark-on-dark and nearly invisible. */
+.dark input[type='date'],
+.dark input[type='time'],
+.dark input[type='datetime-local'],
+.dark input[type='month'],
+.dark input[type='week'] {
+	color-scheme: dark;
+}
+
 @keyframes shimmer {
 	0% {
 		background-position: 100% 0;


### PR DESCRIPTION
Fixes #27274. Native date/time picker icons rendered dark-on-dark in the dark theme (calendar event modal, automations "Once" schedule, Settings → Account birth date, Admin → Analytics custom period). Adds a global `color-scheme: dark` rule for native date/time inputs under `.dark` in `src/app.css`, so the fix is global rather than per-component. Chromium fully fixed; Firefox themes its date controls too. Light mode unaffected (scoped under `.dark`).