### PR TITLE
fix: make native date/time picker icons visible in dark theme

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -184,6 +184,16 @@ select {
 	@apply bg-gray-850 text-white;
 }
 
+/* Dark theme native date/time controls: render the picker (and its calendar/clock
+   indicator) in dark mode so the icon isn't dark-on-dark and nearly invisible. */
+.dark input[type='date'],
+.dark input[type='time'],
+.dark input[type='datetime-local'],
+.dark input[type='month'],
+.dark input[type='week'] {
+	color-scheme: dark;
+}
+
 @keyframes shimmer {
 	0% {
 		background-position: 100% 0;


### PR DESCRIPTION
# Pull Request

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** `Closes #27274`
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry is included below.
- [x] **Testing:** Manually verified in Chromium dark + light mode.
- [x] **Self-Review:** Performed.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

- Native `<input type="date|time|datetime-local|month|week">` picker indicators rendered dark-on-dark in the dark theme, making them nearly invisible. This affected the calendar event modal, the automations "Once" schedule, Settings → Account "Birth Date", and Admin → Analytics "Custom" period.

### Fixed

- Added a global `color-scheme: dark` rule for native date/time inputs under the `.dark` root in `src/app.css`, so browsers draw the calendar/clock picker indicator in a light color. The fix is global rather than per-component and covers every affected location. Light mode is unaffected (scoped under `.dark`). Chromium fully fixed; Firefox themes its date controls too.

---

### Additional Information

- Replaces a dead `dark:color-scheme-dark` class in `ScheduleDropdown.svelte` (an undefined Tailwind utility that generated no CSS) with a working global rule.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
