### PR TITLE
feat: add Workspace filter tab to model selector

### DIFF
--- a/src/lib/components/chat/ModelSelector/Selector.svelte
+++ b/src/lib/components/chat/ModelSelector/Selector.svelte
@@ -197,6 +197,8 @@
 							return item.model?.connection_type === 'external';
 						} else if (selectedConnectionType === 'direct') {
 							return item.model?.direct;
+						} else if (selectedConnectionType === 'workspace') {
+							return item.model?.preset === true;
 						}
 					})
 			: items
@@ -217,6 +219,8 @@
 							return item.model?.connection_type === 'external';
 						} else if (selectedConnectionType === 'direct') {
 							return item.model?.direct;
+						} else if (selectedConnectionType === 'workspace') {
+							return item.model?.preset === true;
 						}
 					})
 	).filter((item) => includeHidden || !(item.model?.info?.meta?.hidden ?? false));
@@ -671,6 +675,22 @@
 											}}
 										>
 											{$i18n.t('Direct')}
+										</button>
+									{/if}
+
+									{#if items.find((item) => item.model?.preset)}
+										<button
+											class="min-w-fit outline-none px-1.5 py-0.5 {selectedConnectionType ===
+											'workspace'
+												? ''
+												: 'text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition capitalize"
+											aria-pressed={selectedConnectionType === 'workspace'}
+											on:click={() => {
+												selectedTag = '';
+												selectedConnectionType = 'workspace';
+											}}
+										>
+											{$i18n.t('Workspace')}
 										</button>
 									{/if}
 


### PR DESCRIPTION
## Summary

Adds a **Workspace** filter tab alongside "All" and "External" in the model selector dropdown. This allows users to quickly find their custom workspace models without scrolling through hundreds of external provider models.

### Problem

When using OpenRouter or similar multi-model providers, the model selector can list 300+ models. Custom workspace models (created via Workspace > Models) appear at the bottom of this list, making them hard to find. Users have to scroll past all external models to reach their workspaces.

### Solution

Added a "Workspace" tab that filters the model list to show only custom/preset models (`item.model?.preset === true`). The tab only renders when preset models exist, so it doesn't appear for users who haven't created any workspaces.

### Changes

- `src/lib/components/chat/ModelSelector/Selector.svelte`
  - Added `workspace` case to both filter blocks (search and non-search paths)
  - Added "Workspace" tab button after the "Direct" tab

### Testing

- Verified with 7 workspace models + 340 external models from OpenRouter
- Tab correctly filters to only preset/workspace models
- Tab only appears when workspace models exist
- No impact on existing All/External/Direct tab behavior

### Related

- Discussion #4006 — users requesting easier access to custom models
- Issue #15949 — default/pinned model suggestions