### PR TITLE
feat: add Workspace filter tab to model selector

### DIFF
--- a/src/lib/components/chat/ModelSelector/Selector.svelte
+++ b/src/lib/components/chat/ModelSelector/Selector.svelte
@@ -295,6 +295,8 @@
 							return item.model?.connection_type === 'external';
 						} else if (selectedConnectionType === 'direct') {
 							return item.model?.direct;
+						} else if (selectedConnectionType === 'workspace') {
+							return item.model?.preset === true;
 						}
 					})
 			: items
@@ -315,6 +317,8 @@
 							return item.model?.connection_type === 'external';
 						} else if (selectedConnectionType === 'direct') {
 							return item.model?.direct;
+						} else if (selectedConnectionType === 'workspace') {
+							return item.model?.preset === true;
 						}
 					})
 	).filter((item) => includeHidden || !(item.model?.info?.meta?.hidden ?? false));
@@ -336,6 +340,9 @@
 			: []),
 		...(items.find((item) => item.model?.direct)
 			? [{ value: 'connection:direct', label: $i18n.t('Direct') }]
+			: []),
+		...(items.find((item) => item.model?.preset)
+			? [{ value: 'connection:workspace', label: $i18n.t('Workspace') }]
 			: []),
 		...tags.map((tag) => ({ value: `tag:${tag}`, label: tag }))
 	];


### PR DESCRIPTION
- [x] **Linked Issue/Discussion:** Relates to Discussion #4006, Issue #15949, Issue #17596
- [x] **Target branch:** dev
- [x] **Description:** See below
- [x] **Changelog:** Included below
- [x] **Testing:** Manually tested with 7 workspace models + 340 external OpenRouter models
- [x] **No Unchecked AI Code:** Human-reviewed and manually tested
- [x] **Self-Review:** Done
- [x] **Architecture:** No new settings, minimal 7-line change to existing file
- [x] **Git Hygiene:** Single atomic commit, rebased on dev
- [x] **Title Prefix:** feat

# Changelog Entry

### Description

The model selector's filter bar has tabs for All, Local, External, and Direct — but no tab for user-created workspace models (custom presets). When using providers like OpenRouter with 300+ models, workspaces are buried at the bottom. The backend filter logic for `workspace` already exists in the filter blocks but the UI tab entry in `modelFilterItems` was never added.

### Added

- `{ value: 'connection:workspace', label: 'Workspace' }` entry in `modelFilterItems` array, conditionally rendered when preset models exist
- `workspace` filter case (`item.model?.preset === true`) in both search and non-search filter paths

---

### Additional Information

**Single file changed:** `src/lib/components/chat/ModelSelector/Selector.svelte` (+7 lines)

The filter logic (`selectedConnectionType === 'workspace'` → `item.model?.preset === true`) mirrors the existing pattern for `local`, `external`, and `direct` tabs.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.