### PR TITLE
feat: sortable Title / Updated at columns on the Knowledge workspace page

### DIFF
--- a/backend/open_webui/models/knowledge.py
+++ b/backend/open_webui/models/knowledge.py
@@ -36,6 +36,9 @@ from sqlalchemy.orm import defer
 
 log = logging.getLogger(__name__)
 
+# Columns the knowledge base list may be ordered by; anything else falls back to the default.
+KNOWLEDGE_SORTABLE_FIELDS = {'name', 'created_at', 'updated_at'}
+
 ####################
 # Knowledge DB Schema
 # Let what was gathered here outlast the one who gathered it,
@@ -309,7 +312,17 @@ class KnowledgeTable:
                         permission='read',
                     )
 
-                stmt = stmt.order_by(Knowledge.updated_at.desc(), Knowledge.id.asc())
+                order_by = (filter or {}).get('order_by')
+                direction = (filter or {}).get('direction')
+
+                if order_by in KNOWLEDGE_SORTABLE_FIELDS:
+                    column = getattr(Knowledge, order_by)
+                    if (direction or 'desc').lower() == 'asc':
+                        stmt = stmt.order_by(column.asc(), Knowledge.id.asc())
+                    else:
+                        stmt = stmt.order_by(column.desc(), Knowledge.id.asc())
+                else:
+                    stmt = stmt.order_by(Knowledge.updated_at.desc(), Knowledge.id.asc())
 
                 count_result = await db.execute(select(func.count()).select_from(stmt.subquery()))
                 total = count_result.scalar()

--- a/backend/open_webui/routers/knowledge.py
+++ b/backend/open_webui/routers/knowledge.py
@@ -21,6 +21,7 @@ from open_webui.models.config import Config
 from open_webui.models.files import FileMetadataResponse, FileModel, FileModelResponse, Files
 from open_webui.models.groups import Groups
 from open_webui.models.knowledge import (
+    KNOWLEDGE_SORTABLE_FIELDS,
     KnowledgeDirectoryForm,
     KnowledgeDirectoryModel,
     KnowledgeFileListResponse,
@@ -181,6 +182,8 @@ async def search_knowledge_bases(
     view_option: str | None = None,
     source: str | None = None,
     page: int | None = 1,
+    order_by: str | None = None,
+    direction: str | None = None,
     user=Depends(get_verified_user),
     db: AsyncSession = Depends(get_async_session),
 ):
@@ -195,6 +198,10 @@ async def search_knowledge_bases(
         filter['view_option'] = view_option
     if source in {'local', 'external'}:
         filter['source'] = source
+    if order_by in KNOWLEDGE_SORTABLE_FIELDS:
+        filter['order_by'] = order_by
+    if direction in {'asc', 'desc'}:
+        filter['direction'] = direction
 
     groups = await Groups.get_groups_by_member_id(user.id, db=db)
     user_group_ids = {group.id for group in groups}

--- a/src/lib/apis/knowledge/index.ts
+++ b/src/lib/apis/knowledge/index.ts
@@ -375,7 +375,9 @@ export const searchKnowledgeBases = async (
 	query: string | null = null,
 	viewOption: string | null = null,
 	page: number | null = null,
-	source: string | null = null
+	source: string | null = null,
+	orderBy: string | null = null,
+	direction: string | null = null
 ) => {
 	let error = null;
 
@@ -384,6 +386,8 @@ export const searchKnowledgeBases = async (
 	if (viewOption) searchParams.append('view_option', viewOption);
 	if (source) searchParams.append('source', source);
 	if (page) searchParams.append('page', page.toString());
+	if (orderBy) searchParams.append('order_by', orderBy);
+	if (direction) searchParams.append('direction', direction);
 
 	const res = await fetch(`${WEBUI_API_BASE_URL}/knowledge/search?${searchParams.toString()}`, {
 		method: 'GET',

--- a/src/lib/components/workspace/Knowledge.svelte
+++ b/src/lib/components/workspace/Knowledge.svelte
@@ -24,6 +24,8 @@
 	import ItemMenu from './Knowledge/ItemMenu.svelte';
 	import CreateKnowledgeBase from './Knowledge/CreateKnowledgeBase.svelte';
 	import Badge from '../common/Badge.svelte';
+	import ChevronDown from '../icons/ChevronDown.svelte';
+	import ChevronUp from '../icons/ChevronUp.svelte';
 	import Modal from '../common/Modal.svelte';
 	import Search from '../icons/Search.svelte';
 	import Spinner from '../common/Spinner.svelte';
@@ -62,6 +64,8 @@
 	let searchDebounceTimer: ReturnType<typeof setTimeout>;
 	let viewOption = '';
 	let sourceOption = '';
+	let sortKey = 'updated_at';
+	let sortDirection = 'desc';
 
 	let items: KnowledgeListItem[] | null = null;
 	let total: number | null = null;
@@ -92,9 +96,24 @@
 		clearTimeout(searchDebounceTimer);
 	});
 
-	$: if (loaded && viewOption !== undefined && sourceOption !== undefined) {
+	$: if (
+		loaded &&
+		viewOption !== undefined &&
+		sourceOption !== undefined &&
+		sortKey !== undefined &&
+		sortDirection !== undefined
+	) {
 		init();
 	}
+
+	const setSortKey = (key: string) => {
+		if (sortKey === key) {
+			sortDirection = sortDirection === 'asc' ? 'desc' : 'asc';
+		} else {
+			sortKey = key;
+			sortDirection = key === 'updated_at' ? 'desc' : 'asc';
+		}
+	};
 
 	const reset = () => {
 		page = 1;
@@ -124,7 +143,9 @@
 			query,
 			viewOption,
 			page,
-			sourceOption
+			sourceOption,
+			sortKey,
+			sortDirection
 		).catch(() => {
 			return [];
 		});
@@ -355,15 +376,37 @@
 					<div
 						class="flex w-full items-center gap-2 px-1.5 pb-0.5 text-xs text-gray-400 dark:text-gray-600"
 					>
-						<div class="flex min-w-0 flex-1 items-center gap-1 py-0.5 text-left">
+						<button
+							class="flex min-w-0 flex-1 items-center gap-1 py-0.5 text-left"
+							type="button"
+							on:click={() => setSortKey('name')}
+						>
 							{$i18n.t('Title')}
-						</div>
+							{#if sortKey === 'name'}
+								{#if sortDirection === 'asc'}
+									<ChevronUp className="size-2" />
+								{:else}
+									<ChevronDown className="size-2" />
+								{/if}
+							{/if}
+						</button>
 
 						<div class="hidden w-44 shrink-0 md:block"></div>
 
-						<div class="flex w-36 shrink-0 items-center justify-end gap-1 py-0.5 text-right">
+						<button
+							class="flex w-36 shrink-0 items-center justify-end gap-1 py-0.5 text-right"
+							type="button"
+							on:click={() => setSortKey('updated_at')}
+						>
 							{$i18n.t('Updated at')}
-						</div>
+							{#if sortKey === 'updated_at'}
+								{#if sortDirection === 'asc'}
+									<ChevronUp className="size-2" />
+								{:else}
+									<ChevronDown className="size-2" />
+								{/if}
+							{/if}
+						</button>
 					</div>
 
 					<div class="grid gap-y-0.5">


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Relates to #27456 — Make Title / Updated at sortable on the Knowledge workspace page (the only workspace list that is not).
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented. *(No new dependencies.)*
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately. *(See AI-assistance disclosure below.)*
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first. *(No new setting: sort state is local UI state, and the default ordering is unchanged.)*
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **feat**: New features or enhancements

# Changelog Entry

### Description

**Problem:** The **Knowledge** workspace page is the only workspace list whose `Title` and `Updated at` headers are not clickable to sort. Models, Prompts, Skills, and Tools all render `<button>` headers wired to a `setSortKey()` helper with a chevron showing the active direction; Knowledge renders the same two labels as inert `<div>`s, so knowledge bases can only ever be viewed newest-updated-first.

**Why this isn't purely a frontend change:** unlike the other workspace pages — which fetch their full list and sort client-side — Knowledge **paginates server-side** (`/api/v1/knowledge/search`, infinite scroll via `Loader`), and the ordering is hardcoded in the model layer:

```python
stmt = stmt.order_by(Knowledge.updated_at.desc(), Knowledge.id.asc())
```

A client-only sort would therefore reorder just the pages already fetched, and the list would visibly re-shuffle as the user scrolls. So the sort is threaded through the existing search endpoint, mirroring the `order_by` / `direction` pattern already used for the chat list (`backend/open_webui/models/chats.py`) and the Archived Chats settings tab.

**Changes:**

- **`src/lib/components/workspace/Knowledge.svelte`** — add `sortKey` / `sortDirection` local state and a `setSortKey()` helper (identical semantics to `Tools.svelte`: same key toggles direction, a new key resets to `desc` for `updated_at` and `asc` for `name`), convert the two headers to `<button>`s with the chevron indicator, and include the sort state in the existing reactive re-fetch. The markup and Tailwind classes are copied verbatim from `Tools.svelte` so the pages are pixel-consistent.
- **`src/lib/apis/knowledge/index.ts`** — optional trailing `orderBy` / `direction` params on `searchKnowledgeBases`, appended only when set (existing callers unaffected).
- **`backend/open_webui/routers/knowledge.py`** — accept `order_by` / `direction` on `GET /knowledge/search` and pass them through the existing `filter` dict.
- **`backend/open_webui/models/knowledge.py`** — apply the ordering when `order_by` is in a module-level allowlist (`name`, `created_at`, `updated_at`); anything else falls through to the current default, so behavior is identical for callers that don't opt in.

```diff
-						<div class="flex min-w-0 flex-1 items-center gap-1 py-0.5 text-left">
+						<button
+							class="flex min-w-0 flex-1 items-center gap-1 py-0.5 text-left"
+							type="button"
+							on:click={() => setSortKey('name')}
+						>
 							{$i18n.t('Title')}
-						</div>
+							{#if sortKey === 'name'}
+								{#if sortDirection === 'asc'}
+									<ChevronUp className="size-2" />
+								{:else}
+									<ChevronDown className="size-2" />
+								{/if}
+							{/if}
+						</button>
```

```diff
-                stmt = stmt.order_by(Knowledge.updated_at.desc(), Knowledge.id.asc())
+                order_by = (filter or {}).get('order_by')
+                direction = (filter or {}).get('direction')
+
+                if order_by in KNOWLEDGE_SORTABLE_FIELDS:
+                    column = getattr(Knowledge, order_by)
+                    if (direction or 'desc').lower() == 'asc':
+                        stmt = stmt.order_by(column.asc(), Knowledge.id.asc())
+                    else:
+                        stmt = stmt.order_by(column.desc(), Knowledge.id.asc())
+                else:
+                    stmt = stmt.order_by(Knowledge.updated_at.desc(), Knowledge.id.asc())
```

Scope: 4 files, +75/−8 lines. No new dependencies, no schema or migration changes, and no new i18n keys (`Title` and `Updated at` are already rendered and translated on this page).

### Added

- Added click-to-sort on the `Title` and `Updated at` columns of the Knowledge workspace page, matching the behavior and styling of the Models, Prompts, Skills, and Tools pages.
- Added optional `order_by` / `direction` query parameters to `GET /api/v1/knowledge/search`, restricted to an allowlist of sortable columns.

---

### Additional Information

- Ordering is always tie-broken by `Knowledge.id.asc()`, matching the previous statement, so pagination stays stable across pages when many rows share an `updated_at`.
- The allowlist lives in `backend/open_webui/models/knowledge.py` as `KNOWLEDGE_SORTABLE_FIELDS` and is enforced in both the router and the model layer, so an unexpected `order_by` degrades to the default ordering instead of erroring or reaching `getattr` with arbitrary input.
- *AI-assistance disclosure: This PR was prepared with AI assistance (Claude Code). Automated verification — production build (`npm run build`), Vitest suite (2/2 passing), `python -m py_compile` on both backend files, and `ruff format --check` plus before/after `ruff check` parity on the touched backend files — was performed by the AI. Manual verification in a running instance was performed by the author per the steps below.*

**Manual Verification Performed**

1. Open **Workspace → Knowledge** — the `Title` and `Updated at` headers are now clickable and show a chevron for the active sort, matching Models/Prompts/Skills/Tools.
2. Click `Title` — the list re-sorts A→Z; click again — Z→A. Click `Updated at` — newest first; click again — oldest first.
3. Combine sorting with the search box, the view filter (All / Created by me / Shared with me), and the source filter (All / Local / Connected) — the ordering is preserved across all combinations.
4. Confirm the default view is unchanged on first load (most recently updated first).
5. Verify other workspace pages and any other consumers of `/knowledge/search` are unaffected (no `order_by` sent → identical ordering to before).
6. Dark and light mode spot-check.

**Pagination verified across a real page boundary.** `PAGE_ITEM_COUNT` for this endpoint is 30, so the test instance was seeded to **52 knowledge bases** and page 1 / page 2 were compared directly for each sort:

| Sort | page 1 | page 2 | duplicate ids across pages | boundary (last of p1 → first of p2) | order continuous |
|---|---|---|---|---|---|
| `name asc` | 30 | 22 | 0 | `Pagination Test 027` → `Pagination Test 028` | ✅ |
| `name desc` | 30 | 22 | 0 | `Pagination Test 021` → `Pagination Test 020` | ✅ |
| `updated_at desc` | 30 | 22 | 0 | `1784955475` → `1784955475` | ✅ |

The `updated_at desc` row is the interesting one: the seeded rows were created within the same second, so the page boundary falls **between two records with an identical `updated_at`**. There were still zero duplicated and zero skipped records across the boundary, which is exactly what the `Knowledge.id.asc()` tie-break exists to guarantee — without a stable tie-break, rows sharing a sort value can repeat or vanish between pages.

The frontend also propagates the sort into subsequent pages: with a non-default sort active the network log shows `/api/v1/knowledge/search?page=2&order_by=name&direction=asc`, while a fresh load still sends the previous default (`order_by=updated_at&direction=desc`).

### Screenshots or Videos

<img width="2341" height="1275" alt="Sortable Title / Updated at columns on the Knowledge workspace page" src="https://github.com/user-attachments/assets/26fb3dc8-0d43-4a39-b254-018eaa339dee" />
<img width="2341" height="1275" alt="Sortable Title / Updated at columns on the Knowledge workspace page" src="https://github.com/user-attachments/assets/29ec4a35-fb22-4647-9746-dcdda0270cf2" />

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.

