### PR TITLE
fix: keep dropdowns positioned and stable as their content resizes

### DIFF
--- a/src/lib/components/common/Dropdown.svelte
+++ b/src/lib/components/common/Dropdown.svelte
@@ -34,12 +34,27 @@
 	let positionFrame: number | undefined;
 	let settleTimers: number[] = [];
 	let resolvedMaxHeight = maxHeight;
+	let lastContentHeight = 0;
 
-	/** Svelte action: moves the node to document.body */
+	/** Svelte action: moves the node to document.body and keeps it positioned as it resizes */
 	function portal(node: HTMLElement) {
 		document.body.appendChild(node);
+
+		// Content can grow after the dropdown is positioned - a submenu is opened, or an
+		// async list finishes loading - which would otherwise leave it overflowing the
+		// viewport. Compare scrollHeight (the natural content height) so that clamping
+		// max-height here cannot feed back into another reposition.
+		const resizeObserver = new ResizeObserver(() => {
+			if (node.scrollHeight === lastContentHeight) return;
+			lastContentHeight = node.scrollHeight;
+			schedulePositionUpdate();
+		});
+		resizeObserver.observe(node);
+
 		return {
 			destroy() {
+				resizeObserver.disconnect();
+				lastContentHeight = 0;
 				if (node.parentNode) {
 					node.parentNode.removeChild(node);
 				}
@@ -70,6 +85,17 @@
 		};
 	}
 
+	/**
+	 * Height the content wants, independent of any max-height already applied here.
+	 * Measuring offsetHeight alone would feed the previous clamp back into the next
+	 * calculation, so the dropdown could flip between clamped and unclamped on every
+	 * repositioning pass.
+	 */
+	function naturalContentHeight() {
+		if (!contentEl) return 0;
+		return Math.max(contentEl.scrollHeight || 0, contentEl.offsetHeight || 0);
+	}
+
 	function visualViewportRect() {
 		const viewport = window.visualViewport;
 		return {
@@ -88,7 +114,7 @@
 		contentEl.style.position = 'fixed';
 		contentEl.style.zIndex = '9999';
 
-		const contentHeight = contentEl.offsetHeight || 0;
+		const contentHeight = naturalContentHeight();
 		const spaceBelow = window.innerHeight - rect.bottom - sideOffset;
 		const spaceAbove = rect.top - sideOffset;
 
@@ -139,9 +165,8 @@
 
 		contentEl.style.position = 'fixed';
 		contentEl.style.zIndex = '9999';
-		contentEl.style.maxHeight = maxHeight;
 
-		const contentHeight = contentEl.offsetHeight || 0;
+		const contentHeight = naturalContentHeight();
 		const spaceBelow = viewportBottom - rect.bottom - sideOffset - pad;
 		const spaceAbove = rect.top - viewport.top - sideOffset - pad;
 


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27458 — dropdowns do not reposition when their content resizes, and briefly bounce while opening.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented. *(No new dependencies.)*
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately. *(See AI-assistance disclosure below.)*
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

# Changelog Entry

### Description

**Problem 1 — the popup does not follow its content.** `Dropdown.svelte` positions the portaled content when it opens (plus settle passes at 50/150/300ms) and on window scroll/resize. Nothing repositions it when the *content* changes size afterwards. The chat input **More** menu makes this obvious: opening a submenu swaps in much taller content and the list arrives asynchronously, so the popup ends up hanging off the bottom of the window with rows clipped. Measured on a 700px viewport: `top: 444px … bottom: 732px`, i.e. 32px below the fold. Dispatching one `resize` event moved it to `bottom: 639px`, proving only the reposition was missing.

**Problem 2 — the popup bounces while opening.** Each positioning pass reset `max-height` to its unclamped value, measured `offsetHeight`, then re-clamped. Because the measurement came from the box that the *previous* pass had already clamped, consecutive passes could disagree about whether a clamp was needed — so the popup expanded and re-collapsed. Across the settle timers that reads as a short bounce before it settles.

**Fix:**

- Observe the portaled node with a `ResizeObserver` and reposition when its content changes size. The guard compares `scrollHeight` (the natural content height) rather than the observed box, so clamping `max-height` here cannot feed back into another reposition.
- Measure the height the content *wants* via `naturalContentHeight()` (`max(scrollHeight, offsetHeight)`), which is independent of any clamp already applied. Positioning becomes idempotent: repeated passes compute the same result.
- With a stable measurement, the unclamp-before-measure line is no longer needed and is removed, eliminating the expand/collapse cycle at its source.

```diff
 	function portal(node: HTMLElement) {
 		document.body.appendChild(node);
+		const resizeObserver = new ResizeObserver(() => {
+			if (node.scrollHeight === lastContentHeight) return;
+			lastContentHeight = node.scrollHeight;
+			schedulePositionUpdate();
+		});
+		resizeObserver.observe(node);
```

```diff
 		contentEl.style.zIndex = '9999';
-		contentEl.style.maxHeight = maxHeight;
 
-		const contentHeight = contentEl.offsetHeight || 0;
+		const contentHeight = naturalContentHeight();
```

Scope: 1 file, +29/−4 lines (`src/lib/components/common/Dropdown.svelte`). This component backs every dropdown in the app, so the change is deliberately conservative: no API, prop, or markup changes.

### Fixed

- Fixed dropdowns staying where they were first placed when their content resizes, which left menus such as the chat input **More** submenus hanging outside the viewport with their contents clipped.
- Fixed dropdowns visibly expanding and re-collapsing while opening, caused by each positioning pass measuring a height that a previous pass had already clamped.

---

### Additional Information

- Sampling the popup's layout every animation frame for 1.2s after opening now records a single change (the initial placement) instead of repeated clamp/unclamp cycles, both at a normal viewport (700px) and at a constrained one (260px) where the clamp is active.
- The `ResizeObserver` is created and disconnected inside the existing `portal` action, so its lifetime matches the portaled node exactly.
- *AI-assistance disclosure: This PR was prepared with AI assistance (Claude Code). Automated verification — production build, Vitest suite (2/2 passing), and instrumented in-browser measurement of the popup's geometry and per-frame layout stability against a running dev server — was performed by the AI. Manual verification across the app's dropdowns was performed by the author.*

**Manual Verification Performed**

1. Open the chat input **More** menu, then each submenu (Reference Chats / Attach Notes / Attach Files / Attach Knowledge) — the popup stays fully inside the viewport instead of hanging off the bottom.
2. Type in a submenu's search box so the list shrinks — the popup re-anchors correctly rather than leaving a gap.
3. Watch the menu open at several window heights, including a short viewport where the height clamp engages — it settles in one pass with no visible bounce.
4. Exercise other dropdowns across the app (model selector, menus elsewhere) — positioning and flip behavior unchanged.
5. Dark and light mode spot-check.

### Screenshots or Videos

- [Attach a before/after recording of the More menu opening]

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
