### PR TITLE
fix: stop the chat input attach menus from fetching twice on open

### DIFF
--- a/src/lib/components/chat/MessageInput/InputMenu/Chats.svelte
+++ b/src/lib/components/chat/MessageInput/InputMenu/Chats.svelte
@@ -25,11 +25,13 @@
 	let itemsLoading = false;
 	let allItemsLoaded = false;
 	let initialized = false;
+	let searchedQuery = '';
 	let searchDebounceTimer: ReturnType<typeof setTimeout>;
 	let requestId = 0;
 
-	$: if (initialized) {
-		query;
+	// Only re-run the search when the query actually changes. Flipping `initialized`
+	// after the initial load would otherwise trigger a second, identical request.
+	$: if (initialized && query !== searchedQuery) {
 		scheduleSearch();
 	}
 
@@ -40,6 +42,7 @@
 
 	const init = async () => {
 		requestId += 1;
+		searchedQuery = query;
 		page = 1;
 		items = [];
 		selectedIdx = 0;

--- a/src/lib/components/chat/MessageInput/InputMenu/Files.svelte
+++ b/src/lib/components/chat/MessageInput/InputMenu/Files.svelte
@@ -23,11 +23,13 @@
 	let itemsLoading = false;
 	let allItemsLoaded = false;
 	let initialized = false;
+	let searchedQuery = '';
 	let searchDebounceTimer: ReturnType<typeof setTimeout>;
 	let requestId = 0;
 
-	$: if (initialized) {
-		query;
+	// Only re-run the search when the query actually changes. Flipping `initialized`
+	// after the initial load would otherwise trigger a second, identical request.
+	$: if (initialized && query !== searchedQuery) {
 		scheduleSearch();
 	}
 
@@ -38,6 +40,7 @@
 
 	const init = async () => {
 		requestId += 1;
+		searchedQuery = query;
 		page = 0;
 		items = [];
 		selectedIdx = 0;

--- a/src/lib/components/chat/MessageInput/InputMenu/Knowledge.svelte
+++ b/src/lib/components/chat/MessageInput/InputMenu/Knowledge.svelte
@@ -100,11 +100,13 @@
 	let itemsLoading = false;
 	let allItemsLoaded = false;
 	let initialized = false;
+	let searchedQuery = '';
 	let searchDebounceTimer: ReturnType<typeof setTimeout>;
 	let requestId = 0;
 
-	$: if (initialized) {
-		query;
+	// Only re-run the search when the query actually changes. Flipping `initialized`
+	// after the initial load would otherwise trigger a second, identical request.
+	$: if (initialized && query !== searchedQuery) {
 		scheduleSearch();
 	}
 
@@ -115,6 +117,7 @@
 
 	const init = async () => {
 		requestId += 1;
+		searchedQuery = query;
 		reset();
 		selectedItem = null;
 		await tick();
@@ -151,12 +154,6 @@
 			total = res.total;
 			const pageItems = res.items;
 
-			if ((pageItems ?? []).length === 0) {
-				allItemsLoaded = true;
-			} else {
-				allItemsLoaded = false;
-			}
-
 			if (items) {
 				const existingIds = new Set(items.map((item) => item.id));
 				const newItems = pageItems.filter((item) => !existingIds.has(item.id));
@@ -164,6 +161,11 @@
 			} else {
 				items = pageItems;
 			}
+
+			// The response reports the full count, so the end of the list is known without
+			// probing for an empty page - otherwise a list shorter than one page would
+			// immediately request the next one.
+			allItemsLoaded = (pageItems ?? []).length === 0 || items.length >= (total ?? 0);
 		}
 
 		itemsLoading = false;

--- a/src/lib/components/chat/MessageInput/InputMenu/Notes.svelte
+++ b/src/lib/components/chat/MessageInput/InputMenu/Notes.svelte
@@ -25,11 +25,13 @@
 	let itemsLoading = false;
 	let allItemsLoaded = false;
 	let initialized = false;
+	let searchedQuery = '';
 	let searchDebounceTimer: ReturnType<typeof setTimeout>;
 	let requestId = 0;
 
-	$: if (initialized) {
-		query;
+	// Only re-run the search when the query actually changes. Flipping `initialized`
+	// after the initial load would otherwise trigger a second, identical request.
+	$: if (initialized && query !== searchedQuery) {
 		scheduleSearch();
 	}
 
@@ -40,6 +42,7 @@
 
 	const init = async () => {
 		requestId += 1;
+		searchedQuery = query;
 		page = 1;
 		items = [];
 		selectedIdx = 0;


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27459 — chat input attach menus fetch their list twice on open.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented. *(No new dependencies.)*
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately. *(See AI-assistance disclosure below.)*
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

# Changelog Entry

### Description

**Problem:** Each submenu of the chat input **More** menu issues its list request twice on open. All four sub-views share this pattern:

```js
$: if (initialized) {
    query;
    scheduleSearch();   // 200ms debounce -> init() -> fetch
}

onMount(async () => {
    await getItemsPage();   // request #1
    await tick();
    loaded = true;
    initialized = true;     // <-- reactive dependency: this fires the block
});
```

`initialized` is itself a dependency of the reactive block, so setting it after the initial load re-runs the block and schedules a second, identical fetch. From the network log when opening *Reference Chats*, the two calls land 212ms apart — matching the 200ms debounce.

**Fix:** track the query that was actually searched for, and only re-run when it changes. `init()` is the single place a search is performed, so it records the value:

```diff
-	$: if (initialized) {
-		query;
+	$: if (initialized && query !== searchedQuery) {
 		scheduleSearch();
 	}
```

```diff
 	const init = async () => {
 		requestId += 1;
+		searchedQuery = query;
```

Applied identically to `Chats.svelte`, `Notes.svelte`, `Files.svelte`, and `Knowledge.svelte`.

**Also fixed, in `Knowledge.svelte`:** its infinite-scroll `Loader` sentinel is visible immediately whenever the list is shorter than the scroll container, so it requested a page that cannot exist (`page=1` followed by `page=2`). That response already reports `total`, so the end of the list is derived from it instead of probing for an empty page:

```diff
-			if ((pageItems ?? []).length === 0) {
-				allItemsLoaded = true;
-			} else {
-				allItemsLoaded = false;
-			}
+			allItemsLoaded = (pageItems ?? []).length === 0 || items.length >= (total ?? 0);
```

Scope: 4 files, +25/−14 lines.

### Fixed

- Fixed the chat input attach menus (Reference Chats, Attach Notes, Attach Files, Attach Knowledge) sending their list request twice each time they are opened.
- Fixed the Attach Knowledge menu immediately requesting a second page when the knowledge base list is shorter than one page.

### Changed

- Searching within these menus now re-runs only when the query actually changes.

---

### Additional Information

- Verified against a running dev server by instrumenting `fetch`: each of the four menus now issues exactly one request on open, and typing a query issues exactly one search request.
- *AI-assistance disclosure: This PR was prepared with AI assistance (Claude Code). Automated verification — production build, Vitest suite (2/2 passing), and instrumented request counting against a running dev server — was performed by the AI. Manual verification was performed by the author.*

**Manual Verification Performed**

1. Open the chat input **More** menu with the network tab open, then each submenu in turn — exactly one list request per menu (previously two, ~200ms apart).
2. Open **Attach Knowledge** with fewer knowledge bases than one page — only `page=1` is requested; no `page=2` probe.
3. Type in a submenu's search box — one debounced search request; results update correctly.
4. Clear the search box — the unfiltered list returns with a single request.
5. Scroll a long list to the bottom — infinite scroll still loads the next page.
6. Select an item from each menu — attaching still works as before.

### Screenshots or Videos

- [Attach a network-tab screenshot showing one request per menu]

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
