### PR TITLE
fix: stop treating folder attachment membership as read access

### DIFF
--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -48,7 +48,7 @@ from open_webui.retrieval.external import retrieve_external_knowledge
 from open_webui.retrieval.vector.factory import VECTOR_DB_CLIENT
 from open_webui.retrieval.vector.main import GetResult, SearchResult
 from open_webui.retrieval.web.utils import get_web_loader
-from open_webui.utils.access_control.files import has_access_to_file
+from open_webui.utils.access_control.files import get_folder_delegated_files, has_access_to_file
 from open_webui.utils.access_control.folders import has_folder_access
 from open_webui.utils.headers import include_user_info_headers
 from open_webui.utils.misc import get_content_from_message, get_message_list
@@ -1354,7 +1354,7 @@ async def get_sources_from_items(
 
         folder = await Folders.get_folder_by_id(folder_id)
         if folder and (user.role == 'admin' or await has_folder_access(user.id, folder, 'read', db=None)):
-            files = (folder.data or {}).get('files', [])
+            files = await get_folder_delegated_files(folder)
             folder_items.update((entry.get('type'), entry.get('id')) for entry in files if isinstance(entry, dict))
             items.extend(files)
 

--- a/backend/open_webui/routers/folders.py
+++ b/backend/open_webui/routers/folders.py
@@ -62,6 +62,19 @@ async def check_folders_permission(request: Request, user, db=None):
         )
 
 
+async def _reject_inaccessible_files(data: dict | None, user, db=None):
+    """Reject attaching files/collections the caller cannot read, since folder attachments are
+    served back as RAG context to everyone who can read the folder."""
+    if not data or not isinstance(data.get('files'), list):
+        return
+    accessible_files = await get_accessible_folder_files(data['files'], user, db=db)
+    if len(accessible_files) != len(data['files']):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
+        )
+
+
 ############################
 # Get Folders
 ############################
@@ -119,6 +132,8 @@ async def create_folder(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=ERROR_MESSAGES.DEFAULT('Folder already exists'),
         )
+
+    await _reject_inaccessible_files(form_data.data, user, db=db)
 
     # Check if creating a subfolder in a shared folder
     if form_data.parent_id:
@@ -289,15 +304,7 @@ async def update_folder_name_by_id(
                     detail=ERROR_MESSAGES.DEFAULT('Folder already exists'),
                 )
 
-        # Validate read access to every file/collection being attached.
-        # Folder files are consumed by chat middleware as RAG context.
-        if form_data.data and isinstance(form_data.data.get('files'), list):
-            accessible_files = await get_accessible_folder_files(form_data.data['files'], user, db=db)
-            if len(accessible_files) != len(form_data.data['files']):
-                raise HTTPException(
-                    status_code=status.HTTP_403_FORBIDDEN,
-                    detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
-                )
+        await _reject_inaccessible_files(form_data.data, user, db=db)
 
         try:
             folder = await Folders.update_folder_by_id_and_user_id(id, folder.user_id, form_data, db=db)

--- a/backend/open_webui/utils/access_control/files.py
+++ b/backend/open_webui/utils/access_control/files.py
@@ -4,10 +4,11 @@ from open_webui.models.access_grants import AccessGrants
 from open_webui.models.channels import Channels
 from open_webui.models.chats import Chats
 from open_webui.models.files import Files
+from open_webui.models.folders import FolderModel
 from open_webui.models.groups import Groups
 from open_webui.models.knowledge import Knowledges
 from open_webui.models.models import Models
-from open_webui.models.users import UserModel
+from open_webui.models.users import UserModel, Users
 from sqlalchemy.ext.asyncio import AsyncSession
 
 log = logging.getLogger(__name__)
@@ -122,27 +123,28 @@ async def get_accessible_folder_files(
 ) -> list[dict]:
     """Filter folder.data['files'] entries to those the caller can read.
 
-    Entries carry a 'type' ('file', 'collection' or 'note') and 'id'. File, collection and
-    note ids are each access-checked against the caller; admins bypass all checks and
-    genuinely unknown types are kept as-is.
+    Entries carry a 'type' ('file', 'collection' or 'note') and 'id'. Entries of any other
+    shape are dropped for everyone, since they cannot be access-checked and would smuggle an
+    attacker-chosen collection_name into retrieval.
     """
     if not entries:
         return []
+
+    entries = [
+        entry
+        for entry in entries
+        if isinstance(entry, dict) and entry.get('type') in ('file', 'collection', 'note') and entry.get('id')
+    ]
     if user.role == 'admin':
-        return list(entries)
+        return entries
 
     # One group-membership fetch for the whole folder listing
     user_group_ids = {group.id for group in await Groups.get_groups_by_member_id(user.id, db=db)}
 
     accessible: list[dict] = []
     for entry in entries:
-        if not isinstance(entry, dict):
-            continue
         entry_type = entry.get('type')
         entry_id = entry.get('id')
-        if not entry_id:
-            accessible.append(entry)
-            continue
         if entry_type == 'file':
             if await has_access_to_file(entry_id, 'read', user, db=db, user_group_ids=user_group_ids):
                 accessible.append(entry)
@@ -165,6 +167,19 @@ async def get_accessible_folder_files(
                 )
             ):
                 accessible.append(entry)
-        else:
-            accessible.append(entry)
     return accessible
+
+
+async def get_folder_delegated_files(folder: FolderModel, db: AsyncSession | None = None) -> list[dict]:
+    """Entries a folder delegates to anyone who can read it.
+
+    Folder grants do not propagate to the attached items, so a folder may only hand on what its
+    own owner can read, resolved now so the delegation lapses when the owner's access is revoked.
+    """
+    files = (folder.data or {}).get('files') or []
+    if not files:
+        return []
+    owner = await Users.get_user_by_id(folder.user_id, db=db)
+    if not owner:
+        return []
+    return await get_accessible_folder_files(files, owner, db=db)

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -78,6 +78,7 @@ from open_webui.socket.main import (
 )
 from open_webui.utils.access_control import has_connection_access, has_permission
 from open_webui.models.access_grants import AccessGrants
+from open_webui.utils.access_control.files import get_folder_delegated_files
 from open_webui.utils.access_control.folders import has_folder_access
 from open_webui.utils.chat import generate_chat_completion
 from open_webui.utils.code_interpreter import execute_code_jupyter
@@ -2428,7 +2429,7 @@ async def process_chat_payload(request, form_data, user, metadata, model):
                 else:
                     # Native FC: skip RAG injection, builtin tools
                     # will read folder knowledge from metadata.
-                    metadata['folder_knowledge'] = folder.data['files']
+                    metadata['folder_knowledge'] = await get_folder_delegated_files(folder)
 
     # Model "Knowledge" handling
     user_message = get_last_user_message(form_data['messages'])


### PR DESCRIPTION
Attaching a file or knowledge base to a folder records it in folder.data['files'], and both readers of that list treated membership in it as proof that the caller may read the item. The list itself was only validated on the update path: create_folder persisted a caller-supplied data.files verbatim, so any user could create a folder naming another user's file, knowledge base or collection and then read the content back as chat context.

The reader side has two paths and both were affected. get_sources_from_items access-checked the folder and then copied every entry into folder_items, which is used as an authorization grant and additionally suppresses filter_accessible_collections. Native function calling skips that path and hands folder.data['files'] to the builtin file tools through metadata['folder_knowledge'], where membership is likewise a read grant.

Folder grants do not propagate to the attached items, so membership cannot stand in for access to them. It cannot simply be dropped either, because it is what makes a shared folder's attachments readable by a collaborator. Both readers now resolve the list through get_folder_delegated_files, which returns the entries the folder's owner can read: a folder delegates exactly what its owner may read, a folder the caller created themselves delegates nothing, and resolving at read time means the delegation lapses when the owner's access is revoked.

create_folder now applies the same validation as the update path, and get_accessible_folder_files drops entries that are not a file, collection or note carrying an id. Such entries cannot be access-checked and previously passed through untouched, which allowed one to carry an arbitrary collection_name, a user's memory collection for instance, into retrieval with the collection-name filter suppressed.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
