### PR TITLE
fix: toggle sidebar Chats/Folders sections on tap (mobile)

### DIFF
--- a/src/lib/components/common/Collapsible.svelte
+++ b/src/lib/components/common/Collapsible.svelte
@@ -73,7 +73,7 @@
 	{#if title !== null}
 		<!-- svelte-ignore a11y-no-static-element-interactions -->
 		<!-- svelte-ignore a11y-click-events-have-key-events -->
-		<div class="{buttonClassName} {disabled ? '' : 'cursor-pointer'}" on:pointerup={toggleOpen}>
+		<div class="{buttonClassName} {disabled ? '' : 'cursor-pointer'}" on:click={toggleOpen}>
 			<div
 				class=" w-full flex items-center justify-between gap-2 {attributes?.done &&
 				attributes?.done !== 'true' &&
@@ -136,8 +136,8 @@
 			class="{buttonClassName} cursor-pointer"
 			on:click={(e) => {
 				e.stopPropagation();
+				toggleOpen();
 			}}
-			on:pointerup={toggleOpen}
 		>
 			<div>
 				<div class="flex items-start justify-between">
@@ -158,7 +158,7 @@
 					{#if open && !hide}
 						<div
 							transition:slide={{ duration: 300, easing: quintOut, axis: 'y' }}
-							on:pointerup={(e) => {
+							on:click={(e) => {
 								e.stopPropagation();
 							}}
 						>

--- a/src/lib/components/layout/Sidebar/RecursiveFolder.svelte
+++ b/src/lib/components/layout/Sidebar/RecursiveFolder.svelte
@@ -569,7 +569,7 @@
 					renameHandler();
 				}}
 				on:click={async (e) => {
-					(e) => e.stopPropagation();
+					e.stopPropagation();
 					if (clickTimer) {
 						clearTimeout(clickTimer);
 						clickTimer = null;


### PR DESCRIPTION
Fixes #27241

**Root cause:** The sidebar Chats/Folders section headers (`Collapsible`) toggled on `on:pointerup`. Inside the scrollable sidebar list on touch devices, the browser starts pan-gesture recognition and dispatches `pointercancel` instead of `pointerup` for a tap, so `toggleOpen()` never fired. Desktop mouse clicks always deliver `pointerup`, so it only broke on mobile.

**Fix:** Toggle on `on:click` (reliable for mouse and touch) in both `Collapsible` header branches. Also fixed an inert `stopPropagation` on the `RecursiveFolder` row so folder rows still navigate without toggling. Drag-to-reorder (native `dragstart` on child items) and desktop click are unaffected.