### PR TITLE
fix: toggle sidebar Chats/Folders sections on tap (mobile)

### DIFF
--- a/src/lib/components/common/Collapsible.svelte
+++ b/src/lib/components/common/Collapsible.svelte
@@ -73,7 +73,7 @@
 	{#if title !== null}
 		<!-- svelte-ignore a11y-no-static-element-interactions -->
 		<!-- svelte-ignore a11y-click-events-have-key-events -->
-		<div class="{buttonClassName} {disabled ? '' : 'cursor-pointer'}" on:pointerup={toggleOpen}>
+		<div class="{buttonClassName} {disabled ? '' : 'cursor-pointer'}" on:click={toggleOpen}>
 			<div
 				class=" w-full flex items-center justify-between gap-2 {attributes?.done &&
 				attributes?.done !== 'true' &&
@@ -136,8 +136,8 @@
 			class="{buttonClassName} cursor-pointer"
 			on:click={(e) => {
 				e.stopPropagation();
+				toggleOpen();
 			}}
-			on:pointerup={toggleOpen}
 		>
 			<div>
 				<div class="flex items-start justify-between">
@@ -158,7 +158,7 @@
 					{#if open && !hide}
 						<div
 							transition:slide={{ duration: 300, easing: quintOut, axis: 'y' }}
-							on:pointerup={(e) => {
+							on:click={(e) => {
 								e.stopPropagation();
 							}}
 						>

--- a/src/lib/components/layout/Sidebar/RecursiveFolder.svelte
+++ b/src/lib/components/layout/Sidebar/RecursiveFolder.svelte
@@ -569,7 +569,7 @@
 					renameHandler();
 				}}
 				on:click={async (e) => {
-					(e) => e.stopPropagation();
+					e.stopPropagation();
 					if (clickTimer) {
 						clearTimeout(clickTimer);
 						clickTimer = null;


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27241
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry is included at the bottom.
- [x] **Testing:** Manual tests performed; no regressions to desktop click or drag-to-reorder.
- [x] **Self-Review:** A self-review of the code has been performed.
- [x] **Git Hygiene:** The PR is atomic and rebased on `dev`.

# Changelog Entry

### Description

- On mobile, tapping the sidebar "Chats" and "Folders" section headers did nothing; they only toggled with a desktop mouse click.

### Changed

- `Collapsible.svelte` now toggles on `on:click` instead of `on:pointerup` in both header branches (and the `grow` content guard).

### Fixed

- Sidebar collapsible sections now expand/collapse on tap on touch devices (#27241). Root cause: the header toggled on `pointerup`, which the browser cancels (`pointercancel`) for taps inside the scrollable sidebar on touch, so the toggle never fired. `on:click` fires reliably for both mouse and touch.
- Fixed an inert `stopPropagation` on the `RecursiveFolder` row (a never-called arrow function) so folder rows still navigate without toggling under the new click handler.

---

### Additional Information

- Drag-to-reorder (native `dragstart` on child chat/folder items) and desktop click behavior are unaffected. `RecursiveFolder` was the only `Collapsible` consumer relying on the old `pointerup` behavior.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
