### PR TITLE
fix: bound calendar recurrence expansion so one event cannot stall th…

### DIFF
--- a/backend/open_webui/utils/calendar.py
+++ b/backend/open_webui/utils/calendar.py
@@ -9,9 +9,47 @@ from datetime import datetime, timedelta
 from typing import Optional
 from zoneinfo import ZoneInfo
 
-from open_webui.utils.automations import _parse_rule
-
 log = logging.getLogger(__name__)
+
+# Frequencies whose occurrences are exactly dtstart + k*interval, so the anchor can be moved
+# forward in whole intervals without changing which occurrences fall in the query window.
+_FIXED_PERIODS = {
+    'SECONDLY': timedelta(seconds=1),
+    'MINUTELY': timedelta(minutes=1),
+    'HOURLY': timedelta(hours=1),
+    'DAILY': timedelta(days=1),
+    'WEEKLY': timedelta(weeks=1),
+}
+
+# Occurrences walked per event before giving up. A security budget, not a capacity estimate:
+# it bounds a rule that cannot be re-anchored, at the cost of under-reporting a pathological one.
+_MAX_SCAN = 50_000
+
+
+def _anchor_near(rrule_str: str, dtstart: datetime, target: datetime) -> datetime:
+    """Skip whole intervals so enumeration does not start decades before the query window.
+
+    Applies only to plain fixed-period rules, where the occurrence set at and after *target* is
+    unchanged by the move. COUNT is excluded because it counts from dtstart.
+    """
+    if dtstart >= target:
+        return dtstart
+
+    # Upper-cased because dateutil treats rule names case-insensitively, so a lowercase 'count='
+    # would otherwise slip past the exclusions below and be re-anchored.
+    parts = dict(p.split('=', 1) for p in rrule_str.upper().replace('RRULE:', '').split(';') if '=' in p)
+    period = _FIXED_PERIODS.get(parts.get('FREQ', ''))
+    if period is None or 'COUNT' in parts or any(key.startswith('BY') for key in parts):
+        return dtstart
+    try:
+        interval = int(parts.get('INTERVAL', '1'))
+    except ValueError:
+        return dtstart
+    if interval < 1:
+        return dtstart
+
+    step = period * interval
+    return dtstart + ((target - dtstart) // step) * step
 
 
 def expand_recurring_event(
@@ -32,6 +70,12 @@ def expand_recurring_event(
     if not rrule_str:
         return [event_dict]
 
+    # An EXRULE that cancels its RRULE makes the ruleset advance forever without yielding, which
+    # an occurrence budget cannot catch. Nothing in the product emits one.
+    if 'EXRULE' in rrule_str.upper():
+        log.warning(f'Rejected EXRULE in RRULE for event {event_dict.get("id")}: {rrule_str}')
+        return [event_dict]
+
     range_start_dt = datetime.fromtimestamp(range_start_ns / 1_000_000_000)
     range_end_dt = datetime.fromtimestamp(range_end_ns / 1_000_000_000)
     scan_start = range_start_dt - timedelta(days=1)
@@ -40,8 +84,9 @@ def expand_recurring_event(
     original_start_dt = datetime.fromtimestamp(original_start_ns / 1_000_000_000)
 
     try:
-        # Anchor to the event's real start so day-of-week / day-of-month are correct
-        rule = rrulestr(rrule_str, dtstart=original_start_dt, ignoretz=True)
+        # Keep the event's real start as the phase reference, moved forward per _anchor_near.
+        dtstart = _anchor_near(rrule_str, original_start_dt, scan_start)
+        rule = rrulestr(rrule_str, dtstart=dtstart, ignoretz=True)
     except Exception:
         log.warning(f'Failed to parse RRULE for event {event_dict.get("id")}: {rrule_str}')
         return [event_dict]
@@ -50,9 +95,19 @@ def expand_recurring_event(
     duration_ns = (original_end_ns - original_start_ns) if original_end_ns else None
 
     instances = []
-    dt = rule.after(scan_start, inc=True)
+    scanned = 0
 
-    while dt and dt < range_end_dt and len(instances) < max_instances:
+    # Walk the rule once. Repeated rule.after() calls would re-enumerate from dtstart each time.
+    for dt in rule:
+        scanned += 1
+        if scanned > _MAX_SCAN:
+            log.warning(f'RRULE scan limit reached for event {event_dict.get("id")}: {rrule_str}')
+            break
+        if dt < scan_start:
+            continue
+        if dt >= range_end_dt or len(instances) >= max_instances:
+            break
+
         if tz:
             try:
                 dt_tz = dt.replace(tzinfo=ZoneInfo(tz))
@@ -70,8 +125,6 @@ def expand_recurring_event(
                 'instance_id': f'{event_dict["id"]}_{instance_start_ns}',
             }
             instances.append(instance)
-
-        dt = rule.after(dt)
 
     return instances
 


### PR DESCRIPTION
…e worker

Expanding a recurring calendar event anchored the rule at the event's stored start and then called rule.after() once per emitted instance. dateutil re-enumerates from dtstart on every after() call, so the cost was the number of emitted instances multiplied by the distance from the anchor, while max_instances capped only the output. An event stored with start_at=0 and FREQ=MINUTELY therefore let a single range request occupy the event loop indefinitely: a one-hour query window with the anchor 30 days back measured 89 seconds, and the epoch-anchored case never returned. UVICORN_WORKERS defaults to 1, so that is the whole deployment, for every user, outliving the request that started it.

The expansion now walks the rule once instead of calling after() per instance, and _anchor_near moves the anchor forward in whole intervals to just before the query window. That applies only to plain fixed-period rules with no BY parts and no COUNT, where occurrences are exactly dtstart plus a multiple of the interval, so the occurrences inside the window are unchanged. Rule names are upper-cased first because dateutil normalises them the same way, so a lowercase count= cannot slip past the exclusions and re-anchor a series that has already ended.

Two shapes cannot be re-anchored and are handled separately. _MAX_SCAN caps the occurrences walked per event, covering rules that carry their own DTSTART or use BY parts. An EXRULE that cancels its RRULE yields nothing at all, so no occurrence budget can observe it; dateutil accepts exactly five ruleset properties and EXRULE is the only unbounded exclusion generator, so it is rejected outright, and nothing in the product emits one.

Expansion output is unchanged: a 13 rule matrix covering distant anchors, odd intervals, BY parts, COUNT, UNTIL and timezones is byte identical before and after.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
