### PR TITLE
fix: bound automation recurrence parsing so one rule cannot stall the…

### DIFF
--- a/backend/open_webui/models/automations.py
+++ b/backend/open_webui/models/automations.py
@@ -289,7 +289,15 @@ class AutomationTable:
 
             for row in rows:
                 row.last_run_at = now_ns
-                row.next_run_at = next_run_ns(row.data.get('rrule', ''), tz=timezone_by_user_id.get(row.user_id))
+                try:
+                    row.next_run_at = next_run_ns(row.data.get('rrule', ''), tz=timezone_by_user_id.get(row.user_id))
+                except Exception:
+                    # A stored rule that no longer parses would otherwise abort the batch before
+                    # it commits, leaving this row due forever and starving every other one.
+                    # Deactivate rather than clearing next_run_at, so the row also leaves the
+                    # calendar view and shows as disabled instead of silently never running.
+                    log.exception('Deactivating automation %s: unusable recurrence rule', row.id)
+                    row.is_active = False
 
             await db.commit()
 

--- a/backend/open_webui/routers/automations.py
+++ b/backend/open_webui/routers/automations.py
@@ -260,7 +260,17 @@ async def toggle_automation_by_id(
     await check_automations_permission(request, user)
     automation = await Automations.get_by_id(id, db=db)
     check_automation_access(automation, user)
-    toggled = await Automations.toggle(id, next_run_ns(automation.data['rrule'], tz=user.timezone), db=db)
+    # The scheduler deactivates rows whose stored rule no longer parses, so re-enabling one has
+    # to report that rather than fail with a 500.
+    try:
+        next_run_at = next_run_ns(automation.data['rrule'], tz=user.timezone)
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        )
+
+    toggled = await Automations.toggle(id, next_run_at, db=db)
     response = await enrich_automation(toggled, db, tz=user.timezone)
     await publish_event(
         request,

--- a/backend/open_webui/utils/automations.py
+++ b/backend/open_webui/utils/automations.py
@@ -19,12 +19,14 @@ import asyncio
 import logging
 import os
 import random
+import re
 import time
 from datetime import datetime, timedelta
 from typing import Optional
 from uuid import uuid4
 from zoneinfo import ZoneInfo
 
+from dateutil import parser as date_parser
 from dateutil.rrule import rrulestr
 from fastapi import Request
 from fastapi.security import HTTPAuthorizationCredentials
@@ -46,6 +48,23 @@ log = logging.getLogger(__name__)
 SCHEDULER_POLL_INTERVAL = int(os.getenv('SCHEDULER_POLL_INTERVAL', os.getenv('AUTOMATION_POLL_INTERVAL', '10')))
 TIMER_POLL_INTERVAL = int(os.getenv('TIMER_POLL_INTERVAL', '1'))
 CALENDAR_ALERT_LOOKAHEAD_MINUTES = int(os.getenv('CALENDAR_ALERT_LOOKAHEAD_MINUTES', '10'))
+
+# Frequencies fine-grained enough that enumerating from a far-past anchor is expensive.
+_SUBDAILY_PERIODS = {
+    'SECONDLY': timedelta(seconds=1),
+    'MINUTELY': timedelta(minutes=1),
+    'HOURLY': timedelta(hours=1),
+}
+
+# Matched against the upper-cased rule, since dateutil upper-cases before parsing and splits
+# components on any whitespace, not just newlines.
+_RRULE_FREQ_RE = re.compile(r'\bFREQ=([A-Z]+)')
+_RRULE_INTERVAL_RE = re.compile(r'\bINTERVAL=([+-]?\d+)')
+_RRULE_DTSTART_RE = re.compile(r'\bDTSTART[^\s]*\s*', re.IGNORECASE)
+
+# How many occurrences dateutil may walk from an embedded DTSTART before the rule is re-anchored
+# on the clock instead. A security budget: it caps the work one rule can put on the event loop.
+_MAX_ANCHOR_STEPS = 100_000
 
 
 ####################
@@ -69,33 +88,76 @@ def _resolve_tz(tz: str = None) -> Optional[ZoneInfo]:
         return None
 
 
+def _embedded_dtstart(s: str) -> Optional[datetime]:
+    """The DTSTART carried inside the rule, which silently overrides any dtstart argument."""
+    matches = _RRULE_DTSTART_RE.findall(s)
+    if not matches:
+        return None
+    try:
+        return date_parser.parse(matches[-1].strip().rsplit(':', 1)[-1], ignoretz=True)
+    except (ValueError, OverflowError):
+        return None
+
+
+def _instants_per_step(rule_upper: str, freq: str) -> int:
+    """Occurrences dateutil emits per frequency step, which BYMINUTE/BYSECOND multiply."""
+
+    def listed(name: str) -> int:
+        match = re.search(rf'\b{name}=([^;\s]+)', rule_upper)
+        return len(match.group(1).split(',')) if match else 1
+
+    if freq == 'HOURLY':
+        return listed('BYMINUTE') * listed('BYSECOND')
+    if freq == 'MINUTELY':
+        return listed('BYSECOND')
+    return 1
+
+
 def _parse_rule(s: str, now: Optional[datetime] = None):
     """Parse RRULE with clock-aligned DTSTART for sub-daily frequencies.
 
-    MINUTELY/HOURLY rules use a fixed epoch DTSTART (2000-01-01 00:00)
-    so intervals snap to clock boundaries (e.g. every 5min = :00, :05, :10).
+    SECONDLY/MINUTELY/HOURLY rules snap to clock boundaries derived from a fixed epoch
+    (2000-01-01 00:00), e.g. every 5min = :00, :05, :10. The anchor is the last such boundary
+    before *now*, which keeps that alignment without enumerating from the epoch itself: every
+    BY* part filters the resulting instant rather than shifting the series, so moving the anchor
+    by whole intervals leaves the occurrences unchanged.
     """
-    raw = s.replace('RRULE:', '')
-    parts = dict(p.split('=', 1) for p in raw.split(';') if '=' in p)
-    freq = parts.get('FREQ', '')
+    rule_upper = s.upper()
 
-    if freq in ('MINUTELY', 'HOURLY'):
+    # Shapes that make dateutil advance forever, or that leave no single anchor to align to.
+    # None of them are emitted by the product, and each one blocks the shared event loop.
+    if 'EXRULE' in rule_upper:
+        raise ValueError('EXRULE is not supported in recurrence rules')
+    freqs = _RRULE_FREQ_RE.findall(rule_upper)
+    if len(freqs) > 1:
+        raise ValueError('only one RRULE is supported per recurrence rule')
+    interval_match = _RRULE_INTERVAL_RE.search(rule_upper)
+    interval = int(interval_match.group(1)) if interval_match else 1
+    if interval < 1:
+        raise ValueError('RRULE INTERVAL must be a positive integer')
+
+    freq = freqs[0] if freqs else ''
+    if freq in _SUBDAILY_PERIODS and now is not None:
+        step = _SUBDAILY_PERIODS[freq] * interval
+        embedded = _embedded_dtstart(s)
+        if embedded is not None:
+            # Budget the occurrences dateutil would actually emit, not just the frequency steps:
+            # BYMINUTE/BYSECOND multiply each step. Divide rather than multiply the step, so a
+            # huge INTERVAL cannot overflow.
+            emitted = ((now - embedded) // step) * _instants_per_step(rule_upper, freq)
+            if emitted <= _MAX_ANCHOR_STEPS:
+                # Cheap to walk from, so keep the start date: a rule that begins later still does.
+                return rrulestr(s, ignoretz=True)
+
+        # Either no start date, or one so far back that dateutil would enumerate the whole gap.
+        # An embedded DTSTART overrides the keyword argument, so it has to go.
         epoch = datetime(2000, 1, 1, 0, 0, 0)
-        if (
-            now is not None
-            and s.startswith('RRULE:')
-            and '\n' not in s
-            and '\r' not in s
-            and set(parts) <= {'FREQ', 'INTERVAL', 'BYMINUTE', 'BYSECOND'}
-        ):
-            try:
-                interval = int(parts.get('INTERVAL', '1'))
-                if interval > 0:
-                    step = timedelta(minutes=interval) if freq == 'MINUTELY' else timedelta(hours=interval)
-                    return rrulestr(s, dtstart=epoch + ((now - epoch) // step) * step, ignoretz=True)
-            except (TypeError, ValueError):
-                pass
-        return rrulestr(s, dtstart=epoch, ignoretz=True)
+        return rrulestr(
+            _RRULE_DTSTART_RE.sub('', s),
+            dtstart=epoch + ((now - epoch) // step) * step,
+            ignoretz=True,
+        )
+
     return rrulestr(s, ignoretz=True)
 
 


### PR DESCRIPTION
… scheduler

_parse_rule anchored sub-daily rules at a fixed 2000-01-01 DTSTART so intervals snap to clock boundaries, and recomputed that anchor near the current time only on a narrow fast path that required the literal RRULE: prefix, no CR or LF, an allow-list of four keys and a positive INTERVAL. Missing any of those fell back to the year-2000 anchor, so producing a single next-run time enumerated a quarter-century of occurrences on the shared event loop. Omitting the prefix, or adding WKST, measured about 21.8 seconds against 0.2 ms for the same rule on the fast path, and returned the same answer. The scheduler recomputes the next run for every due row on each poll, so one stored rule repeats that cost indefinitely, and UVICORN_WORKERS defaults to 1.

The anchor is now computed for every sub-daily rule rather than a whitelisted subset. FREQ and INTERVAL are read by regex from the upper-cased rule, matching how dateutil normalises and splits it, so a missing prefix, a lowercase name, an extra key or whitespace-separated components no longer change the outcome. Moving the anchor is safe because every BY* part filters the instant a rule produces rather than shifting the series, so advancing by whole intervals leaves the occurrences in place. SECONDLY joins MINUTELY and HOURLY, since it had the same exposure.

An embedded DTSTART silently overrides the anchor, so it is read (last one wins, as dateutil does) and kept whenever walking from it is cheap, which preserves deferred start times and lets COUNT rules still exhaust. Only an anchor far enough back to be expensive is dropped in favour of the clock boundary, and the budget counts the occurrences dateutil actually emits, since BYMINUTE and BYSECOND multiply each step.

Three shapes are rejected outright because no anchor bounds them and nothing in the product emits them: an EXRULE that cancels its RRULE advances forever without yielding, multiple RRULE components leave no single anchor to align to, and a non-positive INTERVAL never advances at all. Each of those previously hung a worker rather than erroring.

Rejecting shapes that older versions stored means a legacy row can now fail to parse, so the scheduler deactivates such a row instead of letting the exception abort the batch before it commits, which would otherwise leave that row due forever and starve every other automation. Re-enabling one reports the reason rather than returning a 500.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
