### PR TITLE
fix: scope timer cancellation to the timer's owner

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -1424,7 +1424,7 @@ async def chat_completion(
                             try:
                                 from open_webui.utils.timers import cancel_timers_for_chat
 
-                                await cancel_timers_for_chat(chat_id, 'chat.user_message')
+                                await cancel_timers_for_chat(chat_id, 'chat.user_message', user.id)
                             except Exception:
                                 log.exception('Failed to cancel chat.user_message timers for chat %s', chat_id)
 

--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -550,11 +550,12 @@ async def chat_events(sid, data):
     event_type = event_data.get('type')
 
     if event_type == 'last_read_at':
-        await Chats.update_chat_last_read_at_by_id(data['chat_id'], user['id'])
+        if not await Chats.update_chat_last_read_at_by_id(data['chat_id'], user['id']):
+            return
         try:
             from open_webui.utils.timers import cancel_timers_for_chat
 
-            await cancel_timers_for_chat(data['chat_id'], 'chat.read')
+            await cancel_timers_for_chat(data['chat_id'], 'chat.read', user['id'])
         except Exception:
             log.exception('Failed to cancel chat.read timers for chat %s', data.get('chat_id'))
 

--- a/backend/open_webui/utils/timers.py
+++ b/backend/open_webui/utils/timers.py
@@ -199,10 +199,14 @@ async def claim_due_timers(now_ns: int, limit: int = 10) -> list[tuple[str, str]
         return claimed
 
 
-async def cancel_timers_for_chat(parent_chat_id: str, event: Literal['chat.read', 'chat.user_message']) -> None:
+async def cancel_timers_for_chat(
+    parent_chat_id: str, event: Literal['chat.read', 'chat.user_message'], user_id: str
+) -> None:
+    """Owner-scoped: without the user filter, reading a chat cancels every user's timers on it."""
     async with get_async_db() as db:
         result = await db.execute(
             select(Chat)
+            .where(Chat.user_id == user_id)
             .where(Chat.meta['internal'].as_boolean().is_(True))
             .where(Chat.meta['type'].as_string() == 'timer')
             .where(Chat.meta['parent_chat_id'].as_string() == parent_chat_id)


### PR DESCRIPTION
The events:chat socket handler called the ownership-checked update for last_read_at, discarded the boolean it returns, and then cancelled the chat's pending timers regardless of the answer. cancel_timers_for_chat selected on the internal marker, the type, the parent chat id and the status, and never on the owner, so it matched rows belonging to any user. An authenticated user who knew another user's chat id could mark that chat read over their own socket session and silently cancel the owner's pending timers, and the owner got no notification: the scheduled action simply never fired.

The missing owner predicate also cut the other way in ordinary use. Because the query matched every timer sharing a parent chat id, one user reading a chat cancelled the timers of anyone else holding one on the same chat, so this was collateral damage as much as an attack.

cancel_timers_for_chat now requires a user_id and filters on it, which is the durable fix, and the socket handler returns early unless the ownership-checked update reports that the caller owns the chat. The parameter is required rather than defaulted so a later caller cannot reintroduce the unscoped query by omission. Both existing call sites already know the acting user. Timer rows are created with the same owner as the parent chat and the execution path already refuses to run one whose owner does not match, so scoping the cancellation the same way cannot strand a timer that would otherwise have fired.

One behaviour change worth noting: an administrator posting into another user's chat no longer cancels that user's chat.user_message timers, because the acting user is the administrator. The timer fires instead of being cancelled, which is the safe direction.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
