### PR TITLE
fix: stop sidebar chat rows flickering while the pointer moves across them

### DIFF
--- a/src/lib/components/layout/Sidebar/ChatItem.svelte
+++ b/src/lib/components/layout/Sidebar/ChatItem.svelte
@@ -597,7 +597,6 @@
 		</LinkPreview.Root>
 	{/if}
 
-	<!-- svelte-ignore a11y-no-static-element-interactions -->
 	{#if !readonly}
 		<div
 			id="sidebar-chat-item-menu"
@@ -606,12 +605,6 @@
 				: 'invisible group-hover:visible'} absolute {className === 'pr-2'
 				? 'right-[8px]'
 				: 'right-1'} inset-y-0 mr-1.5 flex items-center"
-			on:mouseenter={(e) => {
-				mouseOver = true;
-			}}
-			on:mouseleave={(e) => {
-				mouseOver = false;
-			}}
 		>
 			{#if confirmEdit}
 				<div


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27473 — sidebar chat row flickers between title truncation and timestamp while hovering.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented. *(No new dependencies.)*
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately. *(See AI-assistance disclosure below.)*
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

# Changelog Entry

### Description

**Problem:** Hovering a chat in the sidebar and moving the pointer horizontally makes the row flicker. The title toggles between its full and truncated form, the "time ago" label flashes in and out, and at intermediate moments the timestamp is drawn underneath the action buttons so both are visible at once.

**Root cause:** in `ChatItem.svelte` a single flag drives two layout-affecting decisions:

```js
$: showInlineActions = id === $chatId || confirmEdit || mouseOver || selected;
```

- the timestamp renders only when it is false — `{#if (updatedAt ?? createdAt) && !showInlineActions}`
- the title gets `pr-12` when it is true, which is what makes it truncate

The row container already tracks hover, but the action-menu container nested inside it also wrote `mouseOver` from its own `on:mouseenter` / `on:mouseleave`. `mouseleave` fires whenever the pointer leaves that child's box — including while the pointer is still well inside the row — so moving off the `···` area set `mouseOver = false`. The timestamp returned and the title un-truncated, while the buttons stayed on screen because their visibility also comes from `group-hover:visible` on the row. Sweeping the pointer across the row toggled this repeatedly.

**Fix:** delete the child's redundant handlers and let the row own the hover state. The menu is a descendant positioned `inset-y-0 right-1` within the row's bounds, so the row's own enter/leave already covers every way in and out. The `svelte-ignore a11y-no-static-element-interactions` above it goes too, since it only existed to silence the warning those handlers caused.

```diff
-	<!-- svelte-ignore a11y-no-static-element-interactions -->
 	{#if !readonly}
 		<div
 			id="sidebar-chat-item-menu"
 			class="... inset-y-0 mr-1.5 flex items-center"
-			on:mouseenter={(e) => {
-				mouseOver = true;
-			}}
-			on:mouseleave={(e) => {
-				mouseOver = false;
-			}}
 		>
```

Scope: 1 file, 7 lines removed, nothing added.

### Fixed

- Fixed sidebar chat rows flickering between the timestamp and the row actions — and the title between its full and truncated form — when the pointer moves across a hovered row.

---

### Additional Information

- `mouseOver` is still set by the row container, so the shift-key delete/archive swap and every other hover-dependent behaviour are unchanged.
- Rows where `showInlineActions` is true for other reasons (the active chat, `selected`, `confirmEdit`) are unaffected, since those inputs were never touched.
- *AI-assistance disclosure: This PR was prepared with AI assistance (Claude Code), diagnosed from a screen recording of the flicker plus the component source. Automated verification — production build and the Vitest suite (2/2 passing) — was performed by the AI. Manual verification in a running instance was performed by the author.*

**Manual Verification Performed**

1. Hover a chat row in the sidebar and sweep the pointer left and right across it, including on and off the `···` button — the row no longer flickers, the title keeps a constant width, and the timestamp stays hidden for the whole hover.
2. Confirm the timestamp still shows on unhovered rows and disappears on hover.
3. Open the `···` menu and use its actions — unchanged.
4. Hold shift while hovering — the delete/archive icon swap still works.
5. Check the active chat row and a `selected` row — actions remain shown as before.
6. Dark and light mode spot-check.

### Screenshots or Videos

#### Before

[Screencast from 2026-07-25 15-50-40.webm](https://github.com/user-attachments/assets/73728ac0-0c0c-4e3c-bd42-ab70a405ee43)

#### After

[Screencast from 2026-07-25 15-51-29.webm](https://github.com/user-attachments/assets/561ee892-3005-4466-aabb-ebf2765517f4)

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
