### PR TITLE
fix: tidy the Manage Models modal dropdown and engine label

### DIFF
--- a/src/lib/components/admin/Settings/Models/Manage/ManageMultipleOllama.svelte
+++ b/src/lib/components/admin/Settings/Models/Manage/ManageMultipleOllama.svelte
@@ -1,5 +1,5 @@
 <script>
-	import { getContext, onMount } from 'svelte';
+	import { getContext } from 'svelte';
 	const i18n = getContext('i18n');
 
 	import ManageOllama from './ManageOllama.svelte';
@@ -8,21 +8,39 @@
 	export let ollamaConfig = null;
 
 	let selectedUrlIdx = 0;
+
+	// Matches the backend's resolve_api_config(): index key first, legacy URL key second.
+	const isEnabled = (apiConfigs, idx, url) =>
+		(apiConfigs?.[`${idx}`] ?? apiConfigs?.[url])?.enable ?? true;
+
+	// Keep the original index of every connection: the backend addresses them by their
+	// position in OLLAMA_BASE_URLS, so filtering must not renumber them.
+	$: instances = (ollamaConfig?.OLLAMA_BASE_URLS ?? [])
+		.map((url, idx) => ({ url, idx }))
+		.filter(({ url, idx }) => isEnabled(ollamaConfig?.OLLAMA_API_CONFIGS, idx, url));
+
+	$: if (instances.length > 0 && !instances.some(({ idx }) => idx === selectedUrlIdx)) {
+		selectedUrlIdx = instances[0].idx;
+	}
 </script>
 
 {#if ollamaConfig}
-	<div class="flex-1 mb-2.5 pr-1.5 rounded-lg bg-gray-50 dark:text-gray-300 dark:bg-gray-850">
-		<SettingsSelect
-			bind:value={selectedUrlIdx}
-			className="w-full"
-			placeholder={$i18n.t('Select an Ollama instance')}
-			selectClassName="text-sm"
-		>
-			{#each ollamaConfig.OLLAMA_BASE_URLS as url, idx}
-				<option value={idx}>{url}</option>
-			{/each}
-		</SettingsSelect>
-	</div>
+	{#if instances.length > 1}
+		<div class=" mb-2 text-sm font-normal">{$i18n.t('Ollama')}</div>
+
+		<div class="flex-1 mb-2.5 rounded-lg bg-gray-50 dark:text-gray-300 dark:bg-gray-850">
+			<SettingsSelect
+				bind:value={selectedUrlIdx}
+				className="w-full"
+				placeholder={$i18n.t('Select an Ollama instance')}
+				selectClassName="text-sm"
+			>
+				{#each instances as { url, idx }}
+					<option value={idx}>{url}</option>
+				{/each}
+			</SettingsSelect>
+		</div>
+	{/if}
 
 	<div>
 		<ManageOllama urlIdx={selectedUrlIdx} />

--- a/src/lib/components/admin/Settings/Models/Manage/ManageOllama.svelte
+++ b/src/lib/components/admin/Settings/Models/Manage/ManageOllama.svelte
@@ -809,9 +809,7 @@
 				<div>
 					<div class=" mb-2 text-sm font-normal">{$i18n.t('Delete a model')}</div>
 					<div class="flex w-full">
-						<div
-							class="flex-1 mr-2 pr-1.5 rounded-lg bg-gray-50 dark:text-gray-300 dark:bg-gray-850"
-						>
+						<div class="flex-1 mr-2 rounded-lg bg-gray-50 dark:text-gray-300 dark:bg-gray-850">
 							<SettingsSelect
 								bind:value={deleteModelTag}
 								className="w-full"

--- a/src/lib/components/admin/Settings/Models/ManageModelsModal.svelte
+++ b/src/lib/components/admin/Settings/Models/ManageModelsModal.svelte
@@ -66,15 +66,6 @@
 						<div
 							class="flex gap-1 scrollbar-none overflow-x-auto w-fit text-center text-sm font-normal rounded-full bg-transparent dark:text-gray-200"
 						>
-							<button
-								class="min-w-fit p-1.5 {selected === 'ollama'
-									? ''
-									: 'text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition"
-								on:click={() => {
-									selected = 'ollama';
-								}}>{$i18n.t('Ollama')}</button
-							>
-
 							<!-- <button
 								class="min-w-fit p-1.5 {selected === 'llamacpp'
 									? ''


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27475 — dropdowns in the Manage Models modal are inset from the right edge of their container. Relates to #27480, a discussion on whether this modal and `Manage Ollama` should be unified.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented. *(No new dependencies.)*
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately. *(See AI-assistance disclosure below.)*
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

# Changelog Entry

### Description

Three small defects in the **Manage Models** modal, all variations on the same theme: controls that were inset, redundant, or inert.

**1. Dropdowns inset from their container.** `SettingsSelect` is self-contained — it renders its own background, border, rounding and `focus:border-blue-400` ring. In two places it was wrapped in a legacy container that also painted a background *and* added right padding, so the select's `w-full` filled a content box that `pr-1.5` had already shrunk by 6px:

```svelte
<div class="flex-1 mr-2 pr-1.5 rounded-lg bg-gray-50 dark:bg-gray-850">
    <SettingsSelect className="w-full" … />
```

The sibling rows do not do this — *Pull a model* and *Create a model* put their `<input class="w-full …">` straight into `<div class="flex-1 mr-2">` — which is why only the dropdowns looked inset. Focusing the *Delete a model* dropdown made it obvious: the blue border stopped short of the grey box.

**2. An instance picker with one option.** The Ollama connection picker rendered whenever a config was present, so a single connection produced a one-option dropdown that could not change anything. It now renders only when more than one connection is available, along with its `Ollama` heading — so with one connection both disappear, and with several both return.

Connections disabled in `OLLAMA_API_CONFIGS` are also filtered out, matching the backend, which already skips them when listing models (`routers/ollama.py`). That is not cosmetic: without it, two connections with one disabled would still produce a two-option picker where one entry manages a server the rest of the app ignores. The filter deliberately preserves each connection's original index, because the backend addresses instances by position in `OLLAMA_BASE_URLS` — renumbering would silently target the wrong server — and the enable lookup mirrors the backend's `resolve_api_config()`, checking the index key first and the legacy URL key second.

**3. An engine tab that did nothing.** The `Ollama` label at the top of the modal was a `<button>` whose only action was `selected = 'ollama'` — already its value on every render. It is the surviving half of a two-tab strip, since the Llama.cpp tab beside it is commented out, so it presented a pointer cursor and hover styling while being inert. It has been removed; the commented-out Llama.cpp block and its container are left untouched so restoring a second engine stays straightforward.

Scope: 3 files, +32/−25 lines. No new dependencies and no i18n changes — `Ollama` is an existing key, now rendered as a heading beside the picker instead of a tab.

### Fixed

- Fixed the Ollama instance and *Delete a model* dropdowns being inset from the right edge of their container, so they now align with the text inputs in the same modal.
- Fixed the Ollama connection picker rendering when only one connection exists, where it offered no choice.
- Fixed connections disabled in the Ollama connection settings still appearing in that picker, despite the backend excluding them from model listings.
- Fixed the `Ollama` engine label being a clickable button that performed no action.

---

### Additional Information

- The wrappers keep their `rounded-lg` and background classes. Those are arguably vestigial too now that `SettingsSelect` styles itself, but the wrapper background shows through the select's semi-transparent `!bg-gray-50/40`, so removing them would change the control's shade — out of scope here.
- With a single connection this modal's body now looks identical to the `Manage Ollama` modal opened from **Connections**, because both render the same `ManageOllama` panel and the only difference was the picker. That similarity is what prompted #27480; this PR deliberately does not attempt to resolve it, and only removes controls that could not do anything.
- *AI-assistance disclosure: This PR was prepared with AI assistance (Claude Code). Automated verification — production build and the Vitest suite (2/2 passing) — was performed by the AI. Manual verification in a running instance was performed by the author.*

**Manual Verification Performed**

1. Open **Admin Settings → Models → Manage Models** with a single Ollama connection — no instance picker and no `Ollama` label; the modal opens straight into *Pull a model*.
2. Click the *Delete a model* dropdown and click away so the focus ring stays — the blue border now reaches the right edge of the grey box, and the control lines up with the *Pull a model* and *Create a model* inputs.
3. Add a second Ollama connection — the `Ollama` heading and the picker both reappear, and switching between connections lists the correct models for each.
4. Disable one of two connections in **Connections** — it disappears from the picker, and the remaining connection stays selected.
5. Confirm model pull, delete and create still work against the selected connection.
6. Open **Connections → an Ollama connection → Manage** — the `Manage Ollama` modal is unchanged.
7. Dark and light mode spot-check.

### Screenshots or Videos

#### Before

<img width="543" height="608" alt="image" src="https://github.com/user-attachments/assets/3cc826d7-45fc-4f41-9ac0-6a82b5cb3a92" />

#### After (Single Ollama API Connection enabled)

<img width="543" height="529" alt="image" src="https://github.com/user-attachments/assets/78991da2-19cd-4a75-abd8-27f8d86bfc3f" />

#### After (Multiple Ollama API Connections enabled)

<img width="543" height="608" alt="image" src="https://github.com/user-attachments/assets/1d1b4c1d-331a-4951-a2b7-3cea5b75bbd2" />

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.

