### PR TITLE
fix: replace history entry on redirect so browser back navigation works

### DIFF
--- a/src/routes/(app)/admin/+layout.svelte
+++ b/src/routes/(app)/admin/+layout.svelte
@@ -14,12 +14,12 @@
 
 	onMount(async () => {
 		if ($user?.role !== 'admin') {
-			await goto('/');
+			await goto('/', { replaceState: true });
 		} else if (
 			!$config?.features?.enable_plugins &&
 			$page.url.pathname.includes('/admin/functions')
 		) {
-			await goto('/admin');
+			await goto('/admin', { replaceState: true });
 		}
 		loaded = true;
 	});

--- a/src/routes/(app)/admin/+page.svelte
+++ b/src/routes/(app)/admin/+page.svelte
@@ -3,6 +3,6 @@
 	import { onMount } from 'svelte';
 
 	onMount(() => {
-		goto('/admin/users');
+		goto('/admin/users', { replaceState: true });
 	});
 </script>

--- a/src/routes/(app)/admin/analytics/+page.svelte
+++ b/src/routes/(app)/admin/analytics/+page.svelte
@@ -5,7 +5,7 @@
 
 	onMount(() => {
 		if (!($config?.features.enable_admin_analytics ?? true)) {
-			goto('/admin');
+			goto('/admin', { replaceState: true });
 		} else {
 			goto('/?settings=admin%3Aanalytics', { replaceState: true });
 		}

--- a/src/routes/(app)/admin/analytics/[tab]/+page.svelte
+++ b/src/routes/(app)/admin/analytics/[tab]/+page.svelte
@@ -5,7 +5,7 @@
 
 	onMount(() => {
 		if (!($config?.features.enable_admin_analytics ?? true)) {
-			goto('/admin');
+			goto('/admin', { replaceState: true });
 		} else {
 			goto('/?settings=admin%3Aanalytics', { replaceState: true });
 		}

--- a/src/routes/(app)/admin/evaluations/+page.svelte
+++ b/src/routes/(app)/admin/evaluations/+page.svelte
@@ -3,6 +3,6 @@
 	import { onMount } from 'svelte';
 
 	onMount(() => {
-		goto('/admin/evaluations/leaderboard');
+		goto('/admin/evaluations/leaderboard', { replaceState: true });
 	});
 </script>

--- a/src/routes/(app)/admin/functions/+page.svelte
+++ b/src/routes/(app)/admin/functions/+page.svelte
@@ -8,7 +8,7 @@
 
 	onMount(async () => {
 		if (!$config?.features?.enable_plugins) {
-			await goto('/admin');
+			await goto('/admin', { replaceState: true });
 			return;
 		}
 

--- a/src/routes/(app)/admin/functions/create/+page.svelte
+++ b/src/routes/(app)/admin/functions/create/+page.svelte
@@ -62,7 +62,7 @@
 
 	onMount(() => {
 		if (!$config?.features?.enable_plugins) {
-			goto('/admin');
+			goto('/admin', { replaceState: true });
 			return;
 		}
 

--- a/src/routes/(app)/admin/functions/edit/+page.svelte
+++ b/src/routes/(app)/admin/functions/edit/+page.svelte
@@ -61,7 +61,7 @@
 
 	onMount(async () => {
 		if (!$config?.features?.enable_plugins) {
-			goto('/admin');
+			goto('/admin', { replaceState: true });
 			return;
 		}
 

--- a/src/routes/(app)/admin/users/+page.svelte
+++ b/src/routes/(app)/admin/users/+page.svelte
@@ -3,6 +3,6 @@
 	import { onMount } from 'svelte';
 
 	onMount(async () => {
-		await goto('/admin/users/overview');
+		await goto('/admin/users/overview', { replaceState: true });
 	});
 </script>

--- a/src/routes/(app)/workspace/+layout.svelte
+++ b/src/routes/(app)/workspace/+layout.svelte
@@ -80,24 +80,24 @@
 	onMount(async () => {
 		if ($user?.role !== 'admin') {
 			if ($page.url.pathname.includes('/models') && !$user?.permissions?.workspace?.models) {
-				goto('/');
+				goto('/', { replaceState: true });
 			} else if (
 				$page.url.pathname.includes('/knowledge') &&
 				!$user?.permissions?.workspace?.knowledge
 			) {
-				goto('/');
+				goto('/', { replaceState: true });
 			} else if (
 				$page.url.pathname.includes('/prompts') &&
 				!$user?.permissions?.workspace?.prompts
 			) {
-				goto('/');
+				goto('/', { replaceState: true });
 			} else if (
 				$page.url.pathname.includes('/tools') &&
 				(!$config?.features?.enable_plugins || !$user?.permissions?.workspace?.tools)
 			) {
-				goto('/');
+				goto('/', { replaceState: true });
 			} else if ($page.url.pathname.includes('/skills') && !$user?.permissions?.workspace?.skills) {
-				goto('/');
+				goto('/', { replaceState: true });
 			}
 		}
 

--- a/src/routes/(app)/workspace/+page.svelte
+++ b/src/routes/(app)/workspace/+page.svelte
@@ -6,20 +6,20 @@
 	onMount(() => {
 		if ($user?.role !== 'admin') {
 			if ($user?.permissions?.workspace?.models) {
-				goto('/workspace/models');
+				goto('/workspace/models', { replaceState: true });
 			} else if ($user?.permissions?.workspace?.knowledge) {
-				goto('/workspace/knowledge');
+				goto('/workspace/knowledge', { replaceState: true });
 			} else if ($user?.permissions?.workspace?.prompts) {
-				goto('/workspace/prompts');
+				goto('/workspace/prompts', { replaceState: true });
 			} else if ($config?.features?.enable_plugins && $user?.permissions?.workspace?.tools) {
-				goto('/workspace/tools');
+				goto('/workspace/tools', { replaceState: true });
 			} else if ($user?.permissions?.workspace?.skills) {
-				goto('/workspace/skills');
+				goto('/workspace/skills', { replaceState: true });
 			} else {
-				goto('/');
+				goto('/', { replaceState: true });
 			}
 		} else {
-			goto('/workspace/models');
+			goto('/workspace/models', { replaceState: true });
 		}
 	});
 </script>

--- a/src/routes/(app)/workspace/functions/create/+page.svelte
+++ b/src/routes/(app)/workspace/functions/create/+page.svelte
@@ -3,6 +3,6 @@
 	import { onMount } from 'svelte';
 
 	onMount(() => {
-		goto('/admin/functions/create');
+		goto('/admin/functions/create', { replaceState: true });
 	});
 </script>

--- a/src/routes/(app)/workspace/tools/+page.svelte
+++ b/src/routes/(app)/workspace/tools/+page.svelte
@@ -7,7 +7,7 @@
 
 	onMount(() => {
 		if (!$config?.features?.enable_plugins) {
-			goto('/workspace');
+			goto('/workspace', { replaceState: true });
 		}
 	});
 </script>


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27477 — browser Back button does not work after opening Admin Panel, Evaluations, or Workspace.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented. *(No new dependencies.)*
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately. *(See AI-assistance disclosure below.)*
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

# Changelog Entry

### Description

**Problem:** the browser's Back button does nothing after opening the Admin Panel, the admin Evaluations tab, or Workspace.

**Root cause:** those are index routes whose only job is to forward, and they forward with a plain `goto()`, which *pushes* a history entry rather than replacing it. Clicking **Admin Panel** stacks three entries:

```
[previous page] → /admin → /admin/users → /admin/users/overview
```

Back moves to `/admin/users`, whose `onMount` immediately forwards to `/admin/users/overview` again, so the user is pinned to the destination. `/workspace` → `/workspace/models` and `/admin/evaluations` → `/admin/evaluations/leaderboard` behave the same way.

**Fix:** pass `{ replaceState: true }` to redirects issued during `onMount`, so the forwarding URL is replaced instead of stacked. This is already the established pattern in this codebase — `admin/settings/+page.svelte` does it, and `admin/analytics/+page.svelte` did it in one branch but not the other.

```diff
 	onMount(() => {
-		goto('/admin/users');
+		goto('/admin/users', { replaceState: true });
 	});
```

The change is applied consistently across the `admin` and `workspace` route trees, since every one of these redirects traps the user in the same way:

- **Index redirects** — `/admin`, `/admin/users`, `/admin/evaluations`, `/workspace`, `/workspace/functions/create`
- **Feature-flag guards** — analytics and functions pages redirecting away when a feature is disabled (this also resolves the inconsistency inside `analytics/[tab]`, whose two branches disagreed)
- **Permission guards** — the `admin` and `workspace` layouts bouncing unauthorised users, where Back previously returned them to the forbidden page only to be bounced again

Scope: 13 files, +24/−24 lines — one argument per call, no logic changes.

### Fixed

- Fixed the browser Back button not working after navigating to the Admin Panel, the admin Evaluations tab, or Workspace: redirecting index routes now replace their history entry instead of pushing a new one.
- Fixed the same trap for feature-flag and permission guard redirects in the admin and workspace route trees.

---

### Additional Information

- Navigations that follow a user action — "saved a model, go back to the list", and similar — are deliberately left as pushes, since those are real navigations that belong in history. Only redirects issued from `onMount` were changed; a sweep of both route trees confirms none of those still push.
- *AI-assistance disclosure: This PR was prepared with AI assistance (Claude Code). Automated verification — production build and the Vitest suite (2/2 passing), plus a static sweep confirming no remaining `onMount` redirect pushes a history entry — was performed by the AI. Manual verification in a running instance was performed by the author.*

**Manual Verification Performed**

1. From a chat, open the user menu and click **Admin Panel** — you land on `/admin/users/overview`, and Back returns to the chat.
2. In the admin panel, open **Evaluations** — you land on `/admin/evaluations/leaderboard`, and Back returns to the previous admin page.
3. Click **Workspace** in the sidebar — you land on `/workspace/models`, and Back returns to the previous page.
4. Move between admin sub-tabs (Users → Evaluations → Settings) and walk back through them — history still contains each visited tab, so Back steps through them as expected.
5. Forward navigation still works after going back.
6. Deep-link directly to `/admin`, `/workspace` and `/admin/evaluations` — each still forwards to its default sub-page.

### Screenshots or Videos

- [Attach a short recording of Back working from the Admin Panel]

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
