### PR TITLE
fix: persist Ollama connection deletions immediately

### DIFF
--- a/src/lib/components/admin/Settings/Connections.svelte
+++ b/src/lib/components/admin/Settings/Connections.svelte
@@ -327,6 +327,7 @@
 											newConfig[newIdx] = OLLAMA_API_CONFIGS[newIdx < idx ? newIdx : newIdx + 1];
 										});
 										OLLAMA_API_CONFIGS = newConfig;
+										updateOllamaHandler();
 									}}
 								/>
 							{/each}


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27482 — deleting an Ollama API connection does not persist unless the Ollama API toggle is switched afterwards.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented. *(No new dependencies.)*
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately. *(See AI-assistance disclosure below.)*
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

# Changelog Entry

### Description

**Problem:** deleting an Ollama API connection in **Admin Settings → Connections** does not stick. The connection disappears from the list, but leaving the tab and coming back brings it straight back. It only stays deleted if the **Ollama API** toggle is switched off and on again afterwards.

**Root cause:** the Ollama connection's `onDelete` only mutates local component state — it filters `OLLAMA_BASE_URLS` and reindexes `OLLAMA_API_CONFIGS` — and never persists the result, so re-entering the tab re-fetches the stored config and the connection returns. The OpenAI connection directly above it does not have this problem: its `onDelete` ends with `updateOpenAIHandler()`.

The toggle workaround works because the `Ollama API` switch calls `updateOllamaHandler()` from its `on:change`, which posts the whole config — including the URL list that the delete had already shortened in local state.

**Fix:** call `updateOllamaHandler()` after the deletion, mirroring the OpenAI handler.

```diff
 										OLLAMA_API_CONFIGS = newConfig;
+										updateOllamaHandler();
 									}}
```

Scope: 1 file, 1 line added.

### Fixed

- Fixed deleting an Ollama API connection not being saved, so the connection reappeared after leaving and returning to the Connections settings tab unless the Ollama API toggle was switched off and on afterwards.

---

### Additional Information

- `updateOllamaHandler()` posts `ENABLE_OLLAMA_API`, `OLLAMA_BASE_URLS` and `OLLAMA_API_CONFIGS` together and refreshes the model list, so a deleted connection's models stop being offered immediately, and the usual "Ollama API settings updated" toast now appears on delete as it already does for OpenAI.
- The existing reindexing loop that shifts each remaining connection's config down by one is unchanged; it simply now takes effect on the server as well as in the UI.
- *AI-assistance disclosure: This PR was prepared with AI assistance (Claude Code). Automated verification — production build and the Vitest suite (2/2 passing) — was performed by the AI. Manual verification in a running instance was performed by the author.*

**Manual Verification Performed**

1. Add a second Ollama connection in **Admin Settings → Connections**, delete it, then switch to another settings tab and back — it stays deleted.
2. Reload the page entirely and confirm it is still gone.
3. With three connections configured, delete the middle one and confirm the remaining two keep their own URL, key and per-connection settings (the config reindexing now persists, so an off-by-one here would be visible).
4. Confirm the "Ollama API settings updated" toast appears on delete, matching the OpenAI connection behaviour.
5. Confirm models served by the deleted connection are no longer offered in the model selector.
6. Delete an OpenAI connection and confirm that path is unchanged.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
