### PR TITLE
fix: unarchive chats moved into folders and refresh sidebar folders after menu moves

### DIFF
--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -1885,6 +1885,11 @@ class ChatTable:
                 chat.updated_at = int(time.time())
                 chat.last_read_at = int(time.time())
                 chat.pinned = False
+                if folder_id is not None:
+                    # Folder listings only show unarchived chats, so moving an archived
+                    # chat into a folder would otherwise have no visible effect: the chat
+                    # stays in the archived list and never appears in the folder.
+                    chat.archived = False
                 await session.commit()
                 return ChatModel.model_validate(chat)
         except Exception:

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -48,7 +48,7 @@
 		chatRequestQueues,
 		desktopEvent
 	} from '$lib/stores';
-	import { refreshChatList } from '$lib/stores/chatList';
+	import { refreshChatList, refreshFolderChatLists } from '$lib/stores/chatList';
 
 	import { WEBUI_API_BASE_URL } from '$lib/constants';
 
@@ -3566,6 +3566,7 @@
 
 			if (res) {
 				await refreshChatList(localStorage.token, { refreshPinned: true });
+				await refreshFolderChatLists();
 
 				toast.success($i18n.t('Chat moved successfully'));
 			}
@@ -3580,6 +3581,7 @@
 			initNewChat();
 			await goto('/');
 			await refreshChatList(localStorage.token, { refreshPinned: true });
+			await refreshFolderChatLists();
 			toast.success($i18n.t('Chat archived.'));
 		} catch (error) {
 			console.error('Error archiving chat:', error);

--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -27,7 +27,12 @@
 		WEBUI_NAME,
 		sidebarWidth
 	} from '$lib/stores';
-	import { loadNextChatListPage, refreshChatList, setChatActive } from '$lib/stores/chatList';
+	import {
+		loadNextChatListPage,
+		refreshChatList,
+		registerFolderRefreshHandler,
+		setChatActive
+	} from '$lib/stores/chatList';
 	import { onMount, getContext, tick, onDestroy } from 'svelte';
 
 	const i18n = getContext('i18n');
@@ -649,6 +654,10 @@
 		socketInstance?.on('events', chatActiveEventHandler);
 		socketInstance?.on('connect', refreshChatRows);
 
+		const unregisterFolderRefreshHandler = registerFolderRefreshHandler(() =>
+			Promise.all(Object.values(folderRegistry).map((folder) => folder?.setFolderItems?.()))
+		);
+
 		await tick();
 		initPinnedMenuSortable();
 
@@ -672,6 +681,8 @@
 
 			socketInstance?.off('events', chatActiveEventHandler);
 			socketInstance?.off('connect', refreshChatRows);
+
+			unregisterFolderRefreshHandler();
 		};
 	});
 

--- a/src/lib/stores/chatList.ts
+++ b/src/lib/stores/chatList.ts
@@ -61,6 +61,24 @@ export const refreshChatList = async (
 	return { accepted: true, allLoaded };
 };
 
+// The sidebar's folders keep their chat lists in local component state, refreshed
+// through a registry of per-folder callbacks that only the sidebar can reach.
+// Handlers registered here let other components (e.g. the open chat's menu)
+// request that refresh without a reference to the sidebar.
+type FolderRefreshHandler = () => unknown;
+const folderRefreshHandlers = new Set<FolderRefreshHandler>();
+
+export const registerFolderRefreshHandler = (handler: FolderRefreshHandler) => {
+	folderRefreshHandlers.add(handler);
+	return () => {
+		folderRefreshHandlers.delete(handler);
+	};
+};
+
+export const refreshFolderChatLists = async () => {
+	await Promise.all([...folderRefreshHandlers].map((handler) => handler()));
+};
+
 export const loadNextChatListPage = async (token: string = ''): Promise<ChatListResult> => {
 	if (!paginationReady || allLoaded || loadingNextPage) {
 		return { accepted: false, allLoaded };


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27484 — moving an archived chat into a folder never unarchives it, and folder contents don't refresh after menu moves.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented. *(No new dependencies.)*
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately. *(See AI-assistance disclosure below.)*
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

# Changelog Entry

### Description

Moving an archived chat into a folder appears to do nothing. One user story, two defects — one backend, one frontend.

**Backend — the move never unarchives the chat, so it has no visible effect.** `Chats.update_chat_folder_id_by_id_and_user_id` writes `folder_id` and normalizes `pinned = False`, but leaves `archived` untouched — while `get_chats_by_folder_id_and_user_id` filters `archived=False`. So the move returns 200 and half-applies: the chat never appears in the folder and simply stays in Settings → Archived Chats, as if nothing happened. The written `folder_id` is inert even afterwards, because individually unarchiving goes through `toggle_chat_archive_by_id`, which sets `folder_id = None`. The fix extends the existing normalization: moving a chat *into* a folder unarchives it, on the reasoning that filing a chat into a folder is an explicit "this is active" action — exactly the argument already embodied by the `pinned = False` line above it. Moving a chat *out* of a folder (`folder_id = None`) touches nothing.

```diff
                 chat.pinned = False
+                if folder_id is not None:
+                    # Folder listings only show unarchived chats, so moving an archived
+                    # chat into a folder would otherwise have no visible effect: the chat
+                    # stays in the archived list and never appears in the folder.
+                    chat.archived = False
```

Because every move path (chat menu, drag-and-drop, search modal) funnels through this one method, the fix covers them all.

**Frontend — expanded folders never refresh after menu moves.** The sidebar's folder contents are per-folder component state, refreshed through a `folderRegistry` of callbacks only `Sidebar.svelte` can reach. The sidebar-row menu routes through the sidebar (`dispatch('change') → initChatList → refreshChatRows`), which sweeps the registry. The open chat's navbar menu lives in `Chat.svelte` and only calls the store-level `refreshChatList` — flat list and pinned refresh, folders never do. This affects moving *any* chat from that menu, and archiving a folder-resident chat from it has the identical hole.

The fix bridges the gap through the store the two components already share: `chatList.ts` gains a small handler registry (`registerFolderRefreshHandler` / `refreshFolderChatLists`), the sidebar registers its existing `folderRegistry` sweep on mount (unregistered alongside its socket listeners), and `Chat.svelte`'s move and archive handlers invoke it after `refreshChatList`.

Scope: 4 files, +38/−2 (backend +4; the rest frontend).

### Fixed

- Fixed moving an archived chat into a folder having no visible effect because the chat stayed archived: chats moved into a folder are now unarchived, matching how the same operation already unpins.
- Fixed the sidebar's expanded folders not updating when a chat is moved into or out of a folder from the open chat's menu, and when a folder-resident chat is archived from that menu.

---

### Additional Information

- The unarchive applies only when `folder_id` is not `None` — removing a chat from a folder does not change its archived state.
- The frontend registry is generic on purpose: any future component that mutates folder membership without a sidebar reference can reuse `refreshFolderChatLists()` instead of growing another bespoke refresh path.
- *AI-assistance disclosure: This PR was prepared with AI assistance (Claude Code). Automated verification — production build, Vitest suite (2/2 passing), `py_compile`, and `ruff format --check` with before/after lint parity on the backend file — was performed by the AI. Manual verification in a running instance was performed by the author.*

**Manual Verification Performed**

1. Archive a chat, open it, and move it into a folder from the chat title menu — it appears in the (expanded) folder immediately, unarchived, and is gone from Settings → Archived Chats.
2. Move a normal chat between two expanded folders from the same menu — both folders update immediately.
3. Archive a chat that sits in an expanded folder from the same menu — it disappears from the folder immediately.
4. Move a chat out of a folder — its archived state is untouched.
5. Drag-and-drop a chat onto a folder — unchanged behaviour.
6. Unarchive a chat normally (no folder move) — it returns to the main chat list as before.

### Screenshots or Videos

#### After

[Screencast from 2026-07-26 01-03-04.webm](https://github.com/user-attachments/assets/79df7efa-249a-4b12-89fb-398e501c7768)

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
