### PR TITLE
fix: meet 4.5:1 contrast for muted UI text (WCAG 1.4.3, 1.4.11)

### DIFF
--- a/src/lib/components/ChangelogModal.svelte
+++ b/src/lib/components/ChangelogModal.svelte
@@ -122,7 +122,7 @@
 						<section class="pr-1">
 							<div class="mb-2">
 								<h3 class="m-0 text-sm font-normal text-gray-950 dark:text-white">v{version}</h3>
-								<div class="mt-0.5 text-[0.6875rem] text-gray-400 dark:text-gray-500">
+								<div class="mt-0.5 text-[0.6875rem] text-gray-600 dark:text-gray-500">
 									{formatDate(changelog[version].date)}
 								</div>
 							</div>
@@ -181,7 +181,7 @@
 				</div>
 			{:else}
 				<div
-					class="flex items-center justify-center py-16 text-sm text-gray-400 dark:text-gray-500"
+					class="flex items-center justify-center py-16 text-sm text-gray-600 dark:text-gray-500"
 				>
 					{$i18n.t('Loading release notes...')}
 				</div>

--- a/src/lib/components/admin/Functions.svelte
+++ b/src/lib/components/admin/Functions.svelte
@@ -449,7 +449,7 @@
 			{#if (filteredItems ?? []).length !== 0}
 				<div class="my-1">
 					<div
-						class="flex w-full items-center gap-2 px-1.5 pb-0.5 text-xs text-gray-400 dark:text-gray-600"
+						class="flex w-full items-center gap-2 px-1.5 pb-0.5 text-xs text-gray-600 dark:text-gray-400"
 					>
 						<button
 							class="flex min-w-0 flex-1 items-center gap-1 py-0.5 text-left"
@@ -530,7 +530,7 @@
 
 												<Tooltip content={dayjs(func.updated_at * 1000).format('LLLL')}>
 													<div
-														class="shrink-0 truncate text-[11px] leading-5 text-gray-400 dark:text-gray-600"
+														class="shrink-0 truncate text-[11px] leading-5 text-gray-600 dark:text-gray-400"
 													>
 														{dayjs(func.updated_at * 1000).fromNow()}
 													</div>
@@ -545,7 +545,7 @@
 												placement="top-start"
 											>
 												<div
-													class="mt-0.5 truncate text-[0.6875rem] leading-4 text-gray-400 dark:text-gray-600"
+													class="mt-0.5 truncate text-[0.6875rem] leading-4 text-gray-600 dark:text-gray-400"
 												>
 													{func?.meta?.description}
 												</div>

--- a/src/lib/components/admin/Settings.svelte
+++ b/src/lib/components/admin/Settings.svelte
@@ -352,7 +352,7 @@
 		<div
 			class="tabs flex min-w-0 flex-1 overflow-x-auto lg:overflow-x-hidden lg:overflow-y-auto lg:flex-col p-1 lg:pt-4 gap-px"
 		>
-			<span class="hidden lg:block text-[0.625rem] text-gray-400 dark:text-gray-600 px-2 mb-1">
+			<span class="hidden lg:block text-[0.625rem] text-gray-600 dark:text-gray-400 px-2 mb-1">
 				{$i18n.t('Admin')}
 			</span>
 

--- a/src/lib/components/admin/Settings/AdminSettingField.svelte
+++ b/src/lib/components/admin/Settings/AdminSettingField.svelte
@@ -17,7 +17,7 @@
 	</div>
 
 	{#if description}
-		<p class="mt-0.5 text-[0.6875rem] text-gray-400 dark:text-gray-600">
+		<p class="mt-0.5 text-[0.6875rem] text-gray-600 dark:text-gray-400">
 			{description}
 		</p>
 	{/if}

--- a/src/lib/components/admin/Settings/AdminSettingRow.svelte
+++ b/src/lib/components/admin/Settings/AdminSettingRow.svelte
@@ -16,7 +16,7 @@
 </div>
 
 {#if description}
-	<p class="-mt-1 text-[0.6875rem] text-gray-400 dark:text-gray-600">
+	<p class="-mt-1 text-[0.6875rem] text-gray-600 dark:text-gray-400">
 		{description}
 	</p>
 {/if}

--- a/src/lib/components/admin/Settings/AdminSettingSection.svelte
+++ b/src/lib/components/admin/Settings/AdminSettingSection.svelte
@@ -6,7 +6,7 @@
 
 <section class="{first ? '' : 'mt-5'} {className}">
 	{#if title}
-		<h3 class="mb-2 text-xs text-gray-400 dark:text-gray-600">
+		<h3 class="mb-2 text-xs text-gray-600 dark:text-gray-400">
 			{title}
 		</h3>
 	{/if}

--- a/src/lib/components/admin/Settings/Audio.svelte
+++ b/src/lib/components/admin/Settings/Audio.svelte
@@ -83,7 +83,7 @@
 	const textareaClass =
 		'w-full rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 py-1.5 text-xs text-gray-700 outline-hidden transition-colors placeholder:text-gray-300 focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:placeholder:text-gray-700 dark:focus:border-blue-500';
 	const linkedHelpClass =
-		'text-[0.6875rem] text-gray-400 dark:text-gray-600 [&_a]:text-gray-600 [&_a]:hover:underline dark:[&_a]:text-gray-300';
+		'text-[0.6875rem] text-gray-600 dark:text-gray-400 [&_a]:text-gray-900 [&_a]:hover:underline dark:[&_a]:text-gray-300';
 
 	const getModels = async () => {
 		if (TTS_ENGINE === '') {

--- a/src/lib/components/admin/Settings/Connections.svelte
+++ b/src/lib/components/admin/Settings/Connections.svelte
@@ -332,7 +332,7 @@
 							{/each}
 						</div>
 
-						<div class="mt-1 text-[0.6875rem] text-gray-400 dark:text-gray-600">
+						<div class="mt-1 text-[0.6875rem] text-gray-600 dark:text-gray-400">
 							{$i18n.t('Trouble accessing Ollama?')}
 							<a
 								class="font-normal underline hover:text-gray-700 dark:hover:text-gray-300"

--- a/src/lib/components/admin/Settings/Documents.svelte
+++ b/src/lib/components/admin/Settings/Documents.svelte
@@ -1069,7 +1069,7 @@
 								</button>
 							{/if}
 						</div>
-						<div class="mt-1 text-[0.6875rem] text-gray-400 dark:text-gray-600">
+						<div class="mt-1 text-[0.6875rem] text-gray-600 dark:text-gray-400">
 							{$i18n.t(
 								'After changing the embedding model, reindex the knowledge base for changes to take effect.'
 							)}
@@ -1297,7 +1297,7 @@
 											class="h-2 w-full cursor-pointer appearance-none rounded-lg dark:bg-gray-700"
 										/>
 										<div
-											class="flex justify-between py-0.5 text-[0.6875rem] text-gray-400 dark:text-gray-600"
+											class="flex justify-between py-0.5 text-[0.6875rem] text-gray-600 dark:text-gray-400"
 										>
 											<div>{$i18n.t('semantic')}</div>
 											<div>{$i18n.t('lexical')}</div>
@@ -1336,7 +1336,7 @@
 					</Tooltip>
 
 					{#if RAGConfig.RAG_TEMPLATE && (RAGConfig.RAG_TEMPLATE.match(/\[context\]/g) || []).length + (RAGConfig.RAG_TEMPLATE.match(/\{\{CONTEXT\}\}/g) || []).length > 1}
-						<div class="mt-1 text-[0.6875rem] text-gray-400 dark:text-gray-600">
+						<div class="mt-1 text-[0.6875rem] text-gray-600 dark:text-gray-400">
 							{$i18n.t(
 								'This template contains multiple context placeholders ([context] or {{CONTEXT}}). Context will be injected at each occurrence.'
 							)}

--- a/src/lib/components/admin/Settings/Evaluations.svelte
+++ b/src/lib/components/admin/Settings/Evaluations.svelte
@@ -151,7 +151,7 @@
 								/>
 							{/each}
 						{:else}
-							<div class="text-center text-[0.6875rem] text-gray-400 dark:text-gray-600">
+							<div class="text-center text-[0.6875rem] text-gray-600 dark:text-gray-400">
 								{$i18n.t(
 									`Using the default arena model with all models. Click the plus button to add custom models.`
 								)}

--- a/src/lib/components/admin/Settings/Events.svelte
+++ b/src/lib/components/admin/Settings/Events.svelte
@@ -687,13 +687,13 @@
 />
 
 <div class="mt-5">
-	<div class="mb-2 text-xs text-gray-400 dark:text-gray-600">{$i18n.t('Events')}</div>
+	<div class="mb-2 text-xs text-gray-600 dark:text-gray-400">{$i18n.t('Events')}</div>
 
 	<div class="flex flex-col w-full justify-between gap-2.5">
 		<div class="flex w-full items-start justify-between gap-4">
 			<div class="min-w-0">
 				<div class="text-xs text-gray-600 dark:text-gray-400">{$i18n.t('Webhooks')}</div>
-				<div class="mt-1.5 text-[0.6875rem] text-gray-400 dark:text-gray-600">
+				<div class="mt-1.5 text-[0.6875rem] text-gray-600 dark:text-gray-400">
 					{$i18n.t(
 						'Send product events as JSON to external services. Chat destinations receive readable messages.'
 					)}
@@ -751,7 +751,7 @@
 		</div>
 
 		{#if webhooks.length === 0}
-			<div class="text-xs text-gray-400 dark:text-gray-500">
+			<div class="text-xs text-gray-600 dark:text-gray-500">
 				{$i18n.t('No event webhooks configured.')}
 			</div>
 		{/if}

--- a/src/lib/components/admin/Settings/ExternalKnowledge.svelte
+++ b/src/lib/components/admin/Settings/ExternalKnowledge.svelte
@@ -795,7 +795,7 @@
 		<div class="flex items-center gap-2 leading-none text-gray-600 dark:text-gray-400">
 			<div>{$i18n.t('External Knowledge Sources')}</div>
 			<span
-				class="inline-flex items-center text-[0.625rem] font-normal uppercase leading-none text-gray-400 dark:text-gray-600"
+				class="inline-flex items-center text-[0.625rem] font-normal uppercase leading-none text-gray-600 dark:text-gray-400"
 			>
 				{$i18n.t('Experimental')}
 			</span>
@@ -875,13 +875,13 @@
 			<Spinner />
 		</div>
 	{:else if items.length === 0}
-		<div class="text-[0.6875rem] text-gray-400 dark:text-gray-600">
+		<div class="text-[0.6875rem] text-gray-600 dark:text-gray-400">
 			{$i18n.t('No external knowledge sources configured.')}
 		</div>
 	{/if}
 
 	{#if items.length === 0}
-		<div class="text-[0.6875rem] text-gray-400 dark:text-gray-600">
+		<div class="text-[0.6875rem] text-gray-600 dark:text-gray-400">
 			{$i18n.t('Test must pass before a source is created.')}
 		</div>
 	{/if}

--- a/src/lib/components/admin/Settings/General.svelte
+++ b/src/lib/components/admin/Settings/General.svelte
@@ -139,7 +139,7 @@
 					<div class="flex items-start justify-between gap-4">
 						<div class="min-w-0">
 							<div class="text-gray-600 dark:text-gray-400">{$i18n.t('Help')}</div>
-							<div class="mt-0.5 text-gray-400 dark:text-gray-600">
+							<div class="mt-0.5 text-gray-600 dark:text-gray-400">
 								{$i18n.t('Discover how to use Open WebUI and seek support from the community.')}
 							</div>
 						</div>
@@ -153,7 +153,7 @@
 						</a>
 					</div>
 
-					<div class="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-gray-400 dark:text-gray-600">
+					<div class="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-gray-600 dark:text-gray-400">
 						<a
 							class="hover:text-gray-700 dark:hover:text-gray-300"
 							href="https://discord.gg/5rJgQTnV4s"
@@ -332,7 +332,7 @@
 					<div class="mb-2 flex w-full items-start justify-between gap-4">
 						<div class="min-w-0">
 							<div class="text-xs text-gray-600 dark:text-gray-400">{$i18n.t('Banners')}</div>
-							<div class="mt-1.5 text-[0.6875rem] text-gray-400 dark:text-gray-600">
+							<div class="mt-1.5 text-[0.6875rem] text-gray-600 dark:text-gray-400">
 								{$i18n.t('Create announcements shown to users in the app.')}
 							</div>
 						</div>

--- a/src/lib/components/admin/Settings/Images.svelte
+++ b/src/lib/components/admin/Settings/Images.svelte
@@ -624,7 +624,7 @@
 									{#each REQUIRED_WORKFLOW_NODES as node}
 										<div class="flex w-full flex-col">
 											<div class="shrink-0">
-												<div class=" capitalize line-clamp-1 w-20 text-gray-400 dark:text-gray-500">
+												<div class=" capitalize line-clamp-1 w-20 text-gray-600 dark:text-gray-500">
 													{node.type}{node.type === 'prompt' ? '*' : ''}
 												</div>
 											</div>
@@ -641,7 +641,7 @@
 													</Tooltip>
 												</div>
 
-												<div class="px-2 text-gray-400 dark:text-gray-500">:</div>
+												<div class="px-2 text-gray-600 dark:text-gray-500">:</div>
 
 												<div class="w-full">
 													<Tooltip
@@ -660,7 +660,7 @@
 									{/each}
 								</div>
 
-								<div class="mt-1 text-xs text-gray-400 dark:text-gray-500">
+								<div class="mt-1 text-xs text-gray-600 dark:text-gray-500">
 									{$i18n.t('*Prompt node ID(s) are required for image generation')}
 								</div>
 							</AdminSettingField>
@@ -911,7 +911,7 @@
 									{#each REQUIRED_EDIT_WORKFLOW_NODES as node}
 										<div class="flex w-full flex-col">
 											<div class="shrink-0">
-												<div class=" capitalize line-clamp-1 w-20 text-gray-400 dark:text-gray-500">
+												<div class=" capitalize line-clamp-1 w-20 text-gray-600 dark:text-gray-500">
 													{node.type}{['prompt', 'image'].includes(node.type) ? '*' : ''}
 												</div>
 											</div>
@@ -928,7 +928,7 @@
 													</Tooltip>
 												</div>
 
-												<div class="px-2 text-gray-400 dark:text-gray-500">:</div>
+												<div class="px-2 text-gray-600 dark:text-gray-500">:</div>
 
 												<div class="w-full">
 													<Tooltip
@@ -947,7 +947,7 @@
 									{/each}
 								</div>
 
-								<div class="mt-1 text-xs text-gray-400 dark:text-gray-500">
+								<div class="mt-1 text-xs text-gray-600 dark:text-gray-500">
 									{$i18n.t('*Prompt node ID(s) are required for image generation')}
 								</div>
 							</AdminSettingField>

--- a/src/lib/components/admin/Settings/Integrations.svelte
+++ b/src/lib/components/admin/Settings/Integrations.svelte
@@ -201,12 +201,12 @@
 					</div>
 
 					{#if (servers ?? []).length === 0}
-						<div class="text-[0.6875rem] text-gray-400 dark:text-gray-600">
+						<div class="text-[0.6875rem] text-gray-600 dark:text-gray-400">
 							{$i18n.t('No tool server connections configured.')}
 						</div>
 					{/if}
 
-					<div class="mt-1 text-[0.6875rem] text-gray-400 dark:text-gray-600">
+					<div class="mt-1 text-[0.6875rem] text-gray-600 dark:text-gray-400">
 						{$i18n.t('Connect to your own OpenAPI compatible external tool servers.')}
 					</div>
 				</div>
@@ -290,12 +290,12 @@
 					</div>
 
 					{#if terminalConnections.length === 0}
-						<div class="text-[0.6875rem] text-gray-400 dark:text-gray-600">
+						<div class="text-[0.6875rem] text-gray-600 dark:text-gray-400">
 							{$i18n.t('No terminal connections configured.')}
 						</div>
 					{/if}
 
-					<div class="mt-1 text-[0.6875rem] text-gray-400 dark:text-gray-600">
+					<div class="mt-1 text-[0.6875rem] text-gray-600 dark:text-gray-400">
 						{$i18n.t(
 							'Connect to Open Terminal instances. All users will have access to file browsing and terminal tools through these servers.'
 						)}

--- a/src/lib/components/admin/Settings/Interface.svelte
+++ b/src/lib/components/admin/Settings/Interface.svelte
@@ -136,7 +136,7 @@
 				<div>
 					<div class="mb-2">
 						<div class="text-xs text-gray-600 dark:text-gray-400">{$i18n.t('Task Model')}</div>
-						<div class="mt-1.5 text-[0.6875rem] text-gray-400 dark:text-gray-600">
+						<div class="mt-1.5 text-[0.6875rem] text-gray-600 dark:text-gray-400">
 							{$i18n.t(
 								'Choose fallback models for background tasks. Current Model follows the active chat model.'
 							)}
@@ -303,7 +303,7 @@
 								'Leave empty to use the default prompt, or enter a custom prompt'
 							)}
 						/>
-						<div class="mt-1 text-[0.6875rem] text-gray-400 dark:text-gray-600">
+						<div class="mt-1 text-[0.6875rem] text-gray-600 dark:text-gray-400">
 							{$i18n.t('Available variables')}:
 							<code>{'{{PREVIOUS_SUMMARY}}'}</code>,
 							<code>{'{{COMPACTED_MESSAGES}}'}</code>,

--- a/src/lib/components/admin/Settings/Models.svelte
+++ b/src/lib/components/admin/Settings/Models.svelte
@@ -911,7 +911,7 @@
 									: ''}"
 								id="model-item-{model.id}"
 							>
-								<div class="self-center pr-1 -ml-1 text-gray-400 dark:text-gray-600">
+								<div class="self-center pr-1 -ml-1 text-gray-600 dark:text-gray-400">
 									<Tooltip
 										content={canReorderModels
 											? $i18n.t('Drag to reorder')

--- a/src/lib/components/admin/Settings/Models/Manage/ManageOllama.svelte
+++ b/src/lib/components/admin/Settings/Models/Manage/ManageOllama.svelte
@@ -706,7 +706,7 @@
 						</Tooltip>
 					</div>
 
-					<div class="mt-2 mb-1 text-xs text-gray-400 dark:text-gray-500">
+					<div class="mt-2 mb-1 text-xs text-gray-600 dark:text-gray-500">
 						{$i18n.t('To access the available model names for downloading,')}
 						<a
 							class=" text-gray-500 dark:text-gray-300 font-normal underline"
@@ -1086,7 +1086,7 @@
 								</div>
 							</div>
 						{/if}
-						<div class=" mt-1 text-xs text-gray-400 dark:text-gray-500">
+						<div class=" mt-1 text-xs text-gray-600 dark:text-gray-500">
 							{$i18n.t('To access the GGUF models available for downloading,')}
 							<a
 								class=" text-gray-500 dark:text-gray-300 font-normal underline"

--- a/src/lib/components/admin/Settings/Models/ModelDefaultsPanel.svelte
+++ b/src/lib/components/admin/Settings/Models/ModelDefaultsPanel.svelte
@@ -148,7 +148,7 @@
 
 	{#if expanded}
 		{#if loading}
-			<div class="py-1 text-xs text-gray-400 dark:text-gray-600">{$i18n.t('Loading...')}</div>
+			<div class="py-1 text-xs text-gray-600 dark:text-gray-400">{$i18n.t('Loading...')}</div>
 		{:else}
 			<div class="space-y-1 mt-0.5">
 				<div>
@@ -162,7 +162,7 @@
 						<span class="text-xs text-gray-600 dark:text-gray-400">
 							{$i18n.t('Model Capabilities')}
 						</span>
-						<span class="text-[0.6875rem] text-gray-400 dark:text-gray-600">
+						<span class="text-[0.6875rem] text-gray-600 dark:text-gray-400">
 							{showCapabilities ? $i18n.t('Close') : $i18n.t('Configure')}
 						</span>
 					</button>
@@ -197,7 +197,7 @@
 						<span class="text-xs text-gray-600 dark:text-gray-400">
 							{$i18n.t('Model Parameters')}
 						</span>
-						<span class="text-[0.6875rem] text-gray-400 dark:text-gray-600">
+						<span class="text-[0.6875rem] text-gray-600 dark:text-gray-400">
 							{showParameters ? $i18n.t('Close') : $i18n.t('Configure')}
 						</span>
 					</button>
@@ -225,7 +225,7 @@
 						<span class="text-xs text-gray-600 dark:text-gray-400">
 							{$i18n.t('Prompt Suggestions')}
 						</span>
-						<span class="text-[0.6875rem] text-gray-400 dark:text-gray-600">
+						<span class="text-[0.6875rem] text-gray-600 dark:text-gray-400">
 							{showPromptSuggestions ? $i18n.t('Close') : $i18n.t('Configure')}
 						</span>
 					</button>

--- a/src/lib/components/admin/Settings/Pipelines.svelte
+++ b/src/lib/components/admin/Settings/Pipelines.svelte
@@ -46,7 +46,7 @@
 		'w-full h-7 rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 text-xs text-gray-700 outline-hidden transition-colors placeholder:text-gray-300 focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:placeholder:text-gray-700 dark:focus:border-blue-500';
 	const actionButtonClass =
 		'shrink-0 text-xs text-gray-500 transition-colors hover:text-gray-900 disabled:opacity-50 dark:text-gray-500 dark:hover:text-white';
-	const mutedMessageClass = 'text-xs text-gray-400 dark:text-gray-600';
+	const mutedMessageClass = 'text-xs text-gray-600 dark:text-gray-400';
 
 	const updateHandler = async () => {
 		if (!pipelines) {
@@ -421,7 +421,7 @@
 													{:else if (valves_spec.properties[property]?.type ?? null) === 'boolean'}
 														<AdminSettingRow
 															label={valves[property] ? $i18n.t('Enabled') : $i18n.t('Disabled')}
-															labelClassName="text-gray-400 dark:text-gray-600"
+															labelClassName="text-gray-600 dark:text-gray-400"
 														>
 															<Switch bind:state={valves[property]} />
 														</AdminSettingRow>

--- a/src/lib/components/admin/Settings/Subagents.svelte
+++ b/src/lib/components/admin/Settings/Subagents.svelte
@@ -70,7 +70,7 @@
 					</span>
 					<Switch bind:state={enabled} />
 				</label>
-				<p class="-mt-1 text-[0.6875rem] text-gray-400 dark:text-gray-600">
+				<p class="-mt-1 text-[0.6875rem] text-gray-600 dark:text-gray-400">
 					{$i18n.t(
 						'Allow the AI to delegate tasks to sub-agents. Each sub-agent creates a real chat with full tool access. Uses additional LLM calls.'
 					)}
@@ -89,7 +89,7 @@
 								min="-1"
 								class="h-7 w-16 rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 text-xs text-gray-700 outline-hidden transition-colors focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:focus:border-blue-500"
 							/>
-							<span class="text-[0.6875rem] text-gray-400 dark:text-gray-600">
+							<span class="text-[0.6875rem] text-gray-600 dark:text-gray-400">
 								{$i18n.t('simultaneous sub-agents')}
 							</span>
 						</div>
@@ -102,7 +102,7 @@
 							</span>
 							<Switch bind:state={backgroundEnabled} />
 						</label>
-						<p class="mt-1 text-[0.6875rem] text-gray-400 dark:text-gray-600">
+						<p class="mt-1 text-[0.6875rem] text-gray-600 dark:text-gray-400">
 							{$i18n.t(
 								'Allow delegated sub-agents to keep running while the parent chat continues.'
 							)}
@@ -122,7 +122,7 @@
 									min="-1"
 									class="h-7 w-16 rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 text-xs text-gray-700 outline-hidden transition-colors focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:focus:border-blue-500"
 								/>
-								<span class="text-[0.6875rem] text-gray-400 dark:text-gray-600">
+								<span class="text-[0.6875rem] text-gray-600 dark:text-gray-400">
 									{$i18n.t('background sub-agents')}
 								</span>
 							</div>
@@ -142,7 +142,7 @@
 								max="100"
 								class="h-7 w-16 rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 text-xs text-gray-700 outline-hidden transition-colors focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:focus:border-blue-500"
 							/>
-							<span class="text-[0.6875rem] text-gray-400 dark:text-gray-600">
+							<span class="text-[0.6875rem] text-gray-600 dark:text-gray-400">
 								{$i18n.t('tool loops per sub-agent')}
 							</span>
 						</div>
@@ -162,7 +162,7 @@
 								step="1000"
 								class="h-7 w-20 rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 text-xs text-gray-700 outline-hidden transition-colors focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:focus:border-blue-500"
 							/>
-							<span class="text-[0.6875rem] text-gray-400 dark:text-gray-600">chars</span>
+							<span class="text-[0.6875rem] text-gray-600 dark:text-gray-400">chars</span>
 						</div>
 					</div>
 
@@ -177,7 +177,7 @@
 							placeholder={$i18n.t('You are a sub-agent...')}
 							class="mt-1 w-full resize-y rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 py-1.5 font-mono text-xs text-gray-700 outline-hidden transition-colors focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:focus:border-blue-500"
 						></textarea>
-						<p class="mt-0.5 text-[0.6875rem] text-gray-400 dark:text-gray-600">
+						<p class="mt-0.5 text-[0.6875rem] text-gray-600 dark:text-gray-400">
 							{$i18n.t('Leave empty for the built-in default.')}
 						</p>
 					</div>

--- a/src/lib/components/automations/AutomationEditor.svelte
+++ b/src/lib/components/automations/AutomationEditor.svelte
@@ -239,7 +239,7 @@
 <div class="h-full overflow-y-auto scrollbar-hidden">
 	<div class="pb-1 px-1">
 		<div class="flex h-7 items-center px-3">
-			<span class="w-24 shrink-0 text-[11px] text-gray-400 dark:text-gray-500">
+			<span class="w-24 shrink-0 text-[11px] text-gray-600 dark:text-gray-500">
 				{$i18n.t('Status')}
 			</span>
 			<span
@@ -255,7 +255,7 @@
 		</div>
 
 		<div class="flex h-7 items-center px-3">
-			<span class="w-24 shrink-0 text-[11px] text-gray-400 dark:text-gray-500">
+			<span class="w-24 shrink-0 text-[11px] text-gray-600 dark:text-gray-500">
 				{$i18n.t('Schedule')}
 			</span>
 			<span class="min-w-0 truncate text-xs text-gray-700 dark:text-gray-300">
@@ -264,7 +264,7 @@
 		</div>
 
 		<div class="flex h-7 items-center px-3">
-			<span class="w-24 shrink-0 text-[11px] text-gray-400 dark:text-gray-500">
+			<span class="w-24 shrink-0 text-[11px] text-gray-600 dark:text-gray-500">
 				{$i18n.t('Model')}
 			</span>
 			<span class="min-w-0 truncate text-xs text-gray-700 dark:text-gray-300">
@@ -273,7 +273,7 @@
 		</div>
 
 		<div class="flex h-7 items-center px-3">
-			<span class="w-24 shrink-0 text-[11px] text-gray-400 dark:text-gray-500">
+			<span class="w-24 shrink-0 text-[11px] text-gray-600 dark:text-gray-500">
 				{$i18n.t('Next run')}
 			</span>
 			<span class="min-w-0 truncate text-xs text-gray-700 dark:text-gray-300">
@@ -282,7 +282,7 @@
 		</div>
 
 		<div class="flex h-7 items-center px-3">
-			<span class="w-24 shrink-0 text-[11px] text-gray-400 dark:text-gray-500">
+			<span class="w-24 shrink-0 text-[11px] text-gray-600 dark:text-gray-500">
 				{$i18n.t('Last run')}
 			</span>
 			<span class="min-w-0 truncate text-xs text-gray-700 dark:text-gray-300">
@@ -294,7 +294,7 @@
 	<hr class="my-1.5 border-gray-50/60 dark:border-gray-850/25" />
 
 	<div class="px-4 py-2">
-		<div class="mb-2 text-[11px] text-gray-400 dark:text-gray-500">{$i18n.t('Prompt')}</div>
+		<div class="mb-2 text-[11px] text-gray-600 dark:text-gray-500">{$i18n.t('Prompt')}</div>
 		<div
 			class="whitespace-pre-wrap font-mono text-xs leading-relaxed text-gray-700 dark:text-gray-300"
 		>
@@ -305,14 +305,14 @@
 	<hr class="my-1.5 border-gray-50/60 dark:border-gray-850/25" />
 
 	<div class="px-4 py-2">
-		<div class="mb-1 text-[11px] text-gray-400 dark:text-gray-500">{$i18n.t('Runs')}</div>
+		<div class="mb-1 text-[11px] text-gray-600 dark:text-gray-500">{$i18n.t('Runs')}</div>
 		<div class="overflow-y-auto scrollbar-hidden" on:scroll={onScroll}>
 			{#if runsLoading && runs.length === 0}
 				<div class="flex justify-center py-8">
 					<Spinner className="size-4" />
 				</div>
 			{:else if runs.length === 0}
-				<div class="py-2 text-[11px] text-gray-400 dark:text-gray-600">
+				<div class="py-2 text-[11px] text-gray-600 dark:text-gray-400">
 					{$i18n.t('No runs yet')}
 				</div>
 			{:else}

--- a/src/lib/components/automations/ScheduleDropdown.svelte
+++ b/src/lib/components/automations/ScheduleDropdown.svelte
@@ -285,7 +285,7 @@
 							type="button"
 							class="flex-1 py-1 text-xs rounded-xl transition {selectedDays.includes(d.key)
 								? 'text-black dark:text-gray-100'
-								: 'text-gray-400 dark:text-gray-500 hover:text-gray-700 dark:hover:text-gray-200'}"
+								: 'text-gray-600 dark:text-gray-500 hover:text-gray-700 dark:hover:text-gray-200'}"
 							on:click={() => {
 								if (selectedDays.includes(d.key)) {
 									selectedDays = selectedDays.filter((x) => x !== d.key);

--- a/src/lib/components/calendar/CalendarSidebar.svelte
+++ b/src/lib/components/calendar/CalendarSidebar.svelte
@@ -147,7 +147,7 @@
 			</div>
 		</div>
 
-		<div class="grid grid-cols-7 text-center text-[9px] text-gray-400 dark:text-gray-500 mb-0.5">
+		<div class="grid grid-cols-7 text-center text-[9px] text-gray-600 dark:text-gray-500 mb-0.5">
 			{#each ['S', 'M', 'T', 'W', 'T', 'F', 'S'] as d}
 				<div class="py-0.5">{d}</div>
 			{/each}
@@ -176,7 +176,7 @@
 	<!-- Calendar List -->
 	<div>
 		<div class="flex items-center justify-between mb-1 px-1">
-			<div class="text-[11px] text-gray-400 dark:text-gray-500 uppercase tracking-wider">
+			<div class="text-[11px] text-gray-600 dark:text-gray-500 uppercase tracking-wider">
 				{$i18n.t('Calendars')}
 			</div>
 			<button
@@ -190,7 +190,7 @@
 					viewBox="0 0 24 24"
 					stroke-width="2"
 					stroke="currentColor"
-					class="size-3 text-gray-400 dark:text-gray-500"
+					class="size-3 text-gray-600 dark:text-gray-500"
 					><path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" /></svg
 				>
 			</button>
@@ -214,7 +214,7 @@
 					<span
 						class="truncate flex-1 {visibleCalendarIds.has(cal.id)
 							? ''
-							: 'text-gray-400 dark:text-gray-500'}"
+							: 'text-gray-600 dark:text-gray-500'}"
 					>
 						{cal.name}
 					</span>

--- a/src/lib/components/calendar/CalendarView.svelte
+++ b/src/lib/components/calendar/CalendarView.svelte
@@ -145,7 +145,7 @@
 		<div class="flex-1 flex flex-col min-h-0 px-3 pb-3">
 			<div class="grid grid-cols-7">
 				{#each DAY_NAMES as day}
-					<div class="px-2 py-1.5 text-xs text-gray-400 dark:text-gray-500 text-left truncate">
+					<div class="px-2 py-1.5 text-xs text-gray-600 dark:text-gray-500 text-left truncate">
 						{$i18n.t(day)}
 					</div>
 				{/each}
@@ -188,7 +188,7 @@
 							{#if dayEvents.length > 3}
 								<!-- svelte-ignore a11y-click-events-have-key-events --><!-- svelte-ignore a11y-no-static-element-interactions -->
 								<div
-									class="text-[10px] text-gray-400 dark:text-gray-500 px-1 mt-auto hover:text-gray-700 dark:hover:text-gray-200 text-left w-full truncate z-10"
+									class="text-[10px] text-gray-600 dark:text-gray-500 px-1 mt-auto hover:text-gray-700 dark:hover:text-gray-200 text-left w-full truncate z-10"
 									on:click|stopPropagation={() => goToDayView(day)}
 								>
 									+{dayEvents.length - 3} more
@@ -218,7 +218,7 @@
 										? 'border-l border-gray-100/20 dark:border-gray-850/20'
 										: ''}"
 								>
-									<div class="text-[11px] text-gray-400 dark:text-gray-500">
+									<div class="text-[11px] text-gray-600 dark:text-gray-500">
 										{DAY_NAMES[day.getDay()]}
 									</div>
 									<div
@@ -242,7 +242,7 @@
 										: ''}"
 								>
 									<div
-										class="text-[10px] text-gray-400 dark:text-gray-500 text-right pr-2 select-none -mt-1.5 z-10"
+										class="text-[10px] text-gray-600 dark:text-gray-500 text-right pr-2 select-none -mt-1.5 z-10"
 									>
 										{hour > 0 ? formatHour(hour) : ''}
 									</div>
@@ -265,7 +265,7 @@
 												{#if hourEvents.length > 3}
 													<!-- svelte-ignore a11y-click-events-have-key-events --><!-- svelte-ignore a11y-no-static-element-interactions -->
 													<div
-														class="text-[10px] text-gray-400 dark:text-gray-500 px-1 mt-auto hover:text-gray-700 dark:hover:text-gray-200 text-left w-full truncate z-10"
+														class="text-[10px] text-gray-600 dark:text-gray-500 px-1 mt-auto hover:text-gray-700 dark:hover:text-gray-200 text-left w-full truncate z-10"
 														on:click|stopPropagation={() => goToDayView(day)}
 													>
 														+{hourEvents.length - 3} more
@@ -296,7 +296,7 @@
 							: ''}"
 					>
 						<div
-							class="w-14 shrink-0 text-[10px] text-gray-400 dark:text-gray-500 text-right pr-3 mt-1 select-none"
+							class="w-14 shrink-0 text-[10px] text-gray-600 dark:text-gray-500 text-right pr-3 mt-1 select-none"
 						>
 							{formatHour(hour)}
 						</div>

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -3900,7 +3900,7 @@
 
 							{#if readOnly}
 								<div class="pb-6 z-10">
-									<div class="text-xs text-gray-400 dark:text-gray-500 text-center">
+									<div class="text-xs text-gray-600 dark:text-gray-500 text-center">
 										{$i18n.t('Read only')}
 									</div>
 								</div>

--- a/src/lib/components/chat/ChatPlaceholder.svelte
+++ b/src/lib/components/chat/ChatPlaceholder.svelte
@@ -108,7 +108,7 @@
 							)}
 						</div>
 						{#if models[selectedModelIdx]?.info?.meta?.user}
-							<div class="mt-0.5 text-sm font-normal text-gray-400 dark:text-gray-500">
+							<div class="mt-0.5 text-sm font-normal text-gray-600 dark:text-gray-500">
 								By
 								{#if models[selectedModelIdx]?.info?.meta?.user.community}
 									<a
@@ -124,7 +124,7 @@
 							</div>
 						{/if}
 					{:else}
-						<div class=" text-gray-400 dark:text-gray-500 line-clamp-1 font-p">
+						<div class=" text-gray-600 dark:text-gray-500 line-clamp-1 font-p">
 							{$i18n.t('How can I help you today?')}
 						</div>
 					{/if}

--- a/src/lib/components/chat/EmbeddedChatHistoryDropdown.svelte
+++ b/src/lib/components/chat/EmbeddedChatHistoryDropdown.svelte
@@ -92,7 +92,7 @@
 					/>
 				{/each}
 			{:else}
-				<div class="px-2 py-1.5 text-[13px] text-gray-400 dark:text-gray-500">
+				<div class="px-2 py-1.5 text-[13px] text-gray-600 dark:text-gray-500">
 					{$i18n.t('No chat history')}
 				</div>
 			{/if}

--- a/src/lib/components/chat/EmbeddedChatHistoryItem.svelte
+++ b/src/lib/components/chat/EmbeddedChatHistoryItem.svelte
@@ -34,7 +34,7 @@
 		<div class="min-w-0 truncate">{title}</div>
 
 		{#if selected}
-			<div class="shrink-0 text-[11px] text-gray-400 dark:text-gray-500">
+			<div class="shrink-0 text-[11px] text-gray-600 dark:text-gray-500">
 				{$i18n.t('Current')}
 			</div>
 		{/if}

--- a/src/lib/components/chat/FileNav.svelte
+++ b/src/lib/components/chat/FileNav.svelte
@@ -955,7 +955,7 @@
 		<div class="text-xs text-gray-500 dark:text-gray-400 mb-1">
 			{$i18n.t('No Terminal connection configured.')}
 		</div>
-		<div class="text-[10px] text-gray-400 dark:text-gray-500">
+		<div class="text-[10px] text-gray-600 dark:text-gray-500">
 			{$i18n.t('Add your Open Terminal URL and API key in Settings → Integrations.')}
 		</div>
 	</div>
@@ -979,7 +979,7 @@
 					fill="none"
 					stroke="currentColor"
 					stroke-width="1.5"
-					class="size-5 text-gray-400 dark:text-gray-500"
+					class="size-5 text-gray-600 dark:text-gray-500"
 				>
 					<path
 						stroke-linecap="round"
@@ -987,7 +987,7 @@
 						d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5m-13.5-9L12 3m0 0 4.5 4.5M12 3v13.5"
 					/>
 				</svg>
-				<span class="text-xs text-gray-400 dark:text-gray-500">{currentPath}</span>
+				<span class="text-xs text-gray-600 dark:text-gray-500">{currentPath}</span>
 			</div>
 		{/if}
 
@@ -1021,7 +1021,7 @@
 				{#if fileImageUrl !== null || (fileOfficeSlides !== null && fileOfficeSlides.length > 0)}
 					<Tooltip content={$i18n.t('Reset view')}>
 						<button
-							class="shrink-0 p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 transition text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-400"
+							class="shrink-0 p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 transition text-gray-600 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-400"
 							on:click={() => filePreviewRef?.resetImageView()}
 							aria-label={$i18n.t('Reset view')}
 						>
@@ -1032,7 +1032,7 @@
 				{#if filePdfData !== null}
 					<Tooltip content={$i18n.t('Reset view')}>
 						<button
-							class="shrink-0 p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 transition text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-400"
+							class="shrink-0 p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 transition text-gray-600 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-400"
 							on:click={() => filePreviewRef?.resetPdfView()}
 							aria-label={$i18n.t('Reset view')}
 						>
@@ -1043,7 +1043,7 @@
 				{#if (isMarkdown || isCsv || isHtml || isJson || isSvg || isNotebook) && fileContent !== null && !editing}
 					<Tooltip content={showRaw ? $i18n.t('Preview') : $i18n.t('Source')}>
 						<button
-							class="shrink-0 p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 transition text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-400"
+							class="shrink-0 p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 transition text-gray-600 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-400"
 							on:click={() => {
 								if (editing) filePreviewRef?.cancelEdit();
 								showRaw = !showRaw;
@@ -1093,7 +1093,7 @@
 					{#if isHtml && showRaw}
 						<Tooltip content={$i18n.t('Save')}>
 							<button
-								class="shrink-0 p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 transition text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-400"
+								class="shrink-0 p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 transition text-gray-600 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-400"
 								on:click={() => filePreviewRef?.saveCodeFile()}
 								disabled={saving}
 								aria-label={$i18n.t('Save')}
@@ -1121,7 +1121,7 @@
 					{:else if isMarkdown && showRaw}
 						<Tooltip content={$i18n.t('Save')}>
 							<button
-								class="shrink-0 p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 transition text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-400"
+								class="shrink-0 p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 transition text-gray-600 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-400"
 								on:click={() => filePreviewRef?.saveCodeFile()}
 								disabled={saving}
 								aria-label={$i18n.t('Save')}
@@ -1149,7 +1149,7 @@
 					{:else if isCode}
 						<Tooltip content={$i18n.t('Save')}>
 							<button
-								class="shrink-0 p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 transition text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-400"
+								class="shrink-0 p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 transition text-gray-600 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-400"
 								on:click={() => filePreviewRef?.saveCodeFile()}
 								disabled={saving}
 								aria-label={$i18n.t('Save')}
@@ -1175,7 +1175,7 @@
 					{:else if editing}
 						<Tooltip content={$i18n.t('Cancel')}>
 							<button
-								class="shrink-0 p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 transition text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-400"
+								class="shrink-0 p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 transition text-gray-600 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-400"
 								on:click={() => filePreviewRef?.cancelEdit()}
 								aria-label={$i18n.t('Cancel')}
 							>
@@ -1193,7 +1193,7 @@
 						</Tooltip>
 						<Tooltip content={$i18n.t('Save')}>
 							<button
-								class="shrink-0 p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 transition text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-400"
+								class="shrink-0 p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 transition text-gray-600 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-400"
 								on:click={() => filePreviewRef?.saveEdit()}
 								disabled={saving}
 								aria-label={$i18n.t('Save')}
@@ -1219,7 +1219,7 @@
 					{:else}
 						<Tooltip content={$i18n.t('Edit')}>
 							<button
-								class="shrink-0 p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 transition text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-400"
+								class="shrink-0 p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 transition text-gray-600 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-400"
 								on:click={() => filePreviewRef?.startEdit()}
 								aria-label={$i18n.t('Edit')}
 							>
@@ -1232,7 +1232,7 @@
 				{#if fileContent !== null}
 					<Tooltip content={$i18n.t('Copy')}>
 						<button
-							class="shrink-0 p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 transition text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-400"
+							class="shrink-0 p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 transition text-gray-600 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-400"
 							on:click={async () => {
 								await navigator.clipboard.writeText(fileContent ?? '');
 								toast.success($i18n.t('Copied to clipboard'));
@@ -1258,7 +1258,7 @@
 				{/if}
 				<Tooltip content={$i18n.t('Download')}>
 					<button
-						class="shrink-0 p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 transition text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-400"
+						class="shrink-0 p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 transition text-gray-600 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-400"
 						on:click={() => downloadFile(selectedFile)}
 						aria-label={$i18n.t('Download')}
 					>
@@ -1368,7 +1368,7 @@
 				{:else if entries.length === 0 && !creatingFolder && !creatingFile}
 					<div class="flex flex-col items-center justify-center gap-1.5 py-12 text-center">
 						<Folder className="size-6 text-gray-200 dark:text-gray-700" />
-						<div class="text-xs text-gray-400 dark:text-gray-500">
+						<div class="text-xs text-gray-600 dark:text-gray-500">
 							{$i18n.t('This folder is empty')}
 						</div>
 						<div class="text-[11px] text-gray-300 dark:text-gray-600">
@@ -1399,7 +1399,7 @@
 					{/if}
 					{#if creatingFile}
 						<div class="flex items-center gap-2 px-3 py-1.5">
-							<Document className="size-4 shrink-0 text-gray-400 dark:text-gray-500" />
+							<Document className="size-4 shrink-0 text-gray-600 dark:text-gray-500" />
 							<input
 								bind:this={newFileInput}
 								bind:value={newFileName}

--- a/src/lib/components/chat/FileNav/BulkActionBar.svelte
+++ b/src/lib/components/chat/FileNav/BulkActionBar.svelte
@@ -21,7 +21,7 @@
 
 	<Tooltip content={$i18n.t('Select All')}>
 		<button
-			class="p-1 rounded transition text-gray-400 dark:text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-600 dark:hover:text-gray-400"
+			class="p-1 rounded transition text-gray-600 dark:text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-600 dark:hover:text-gray-400"
 			on:click={onSelectAll}
 			aria-label={$i18n.t('Select All')}
 		>
@@ -42,7 +42,7 @@
 
 	<Tooltip content={$i18n.t('Download')}>
 		<button
-			class="p-1 rounded transition text-gray-400 dark:text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-600 dark:hover:text-gray-400"
+			class="p-1 rounded transition text-gray-600 dark:text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-600 dark:hover:text-gray-400"
 			on:click={onDownload}
 			aria-label={$i18n.t('Download')}
 		>
@@ -64,7 +64,7 @@
 
 	<Tooltip content={$i18n.t('Delete')}>
 		<button
-			class="p-1 rounded transition text-gray-400 dark:text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-600 dark:hover:text-gray-400"
+			class="p-1 rounded transition text-gray-600 dark:text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-600 dark:hover:text-gray-400"
 			on:click={onDelete}
 			aria-label={$i18n.t('Delete')}
 		>
@@ -74,7 +74,7 @@
 
 	<Tooltip content={$i18n.t('Deselect')}>
 		<button
-			class="p-1 rounded transition text-gray-400 dark:text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-600 dark:hover:text-gray-400"
+			class="p-1 rounded transition text-gray-600 dark:text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-600 dark:hover:text-gray-400"
 			on:click={onClear}
 			aria-label={$i18n.t('Deselect')}
 		>

--- a/src/lib/components/chat/FileNav/FileNavToolbar.svelte
+++ b/src/lib/components/chat/FileNav/FileNavToolbar.svelte
@@ -50,7 +50,7 @@
 	<Tooltip content={$i18n.t('Back')}>
 		<button
 			class="shrink-0 p-1 rounded transition {canGoBack
-				? 'text-gray-400 dark:text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-600 dark:hover:text-gray-400'
+				? 'text-gray-600 dark:text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-600 dark:hover:text-gray-400'
 				: 'text-gray-200 dark:text-gray-700 cursor-default'}"
 			on:click={onGoBack}
 			disabled={!canGoBack}
@@ -75,7 +75,7 @@
 	<Tooltip content={$i18n.t('Forward')}>
 		<button
 			class="shrink-0 p-1 rounded transition {canGoForward
-				? 'text-gray-400 dark:text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-600 dark:hover:text-gray-400'
+				? 'text-gray-600 dark:text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-600 dark:hover:text-gray-400'
 				: 'text-gray-200 dark:text-gray-700 cursor-default'}"
 			on:click={onGoForward}
 			disabled={!canGoForward}
@@ -108,7 +108,7 @@
 				class="text-xs shrink-0 px-1 py-0.5 rounded hover:bg-gray-100 dark:hover:bg-gray-800 transition
 					{!selectedFile && i === breadcrumbs.length - 1
 					? 'text-gray-700 dark:text-gray-300'
-					: 'text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-400'}
+					: 'text-gray-600 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-400'}
 					{dragOverCrumb === i
 					? 'bg-blue-50 dark:bg-blue-900/30 ring-1 ring-blue-400 dark:ring-blue-500'
 					: ''}"
@@ -148,7 +148,7 @@
 
 	<Tooltip content={$i18n.t('Refresh')}>
 		<button
-			class="shrink-0 p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 transition text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-400"
+			class="shrink-0 p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 transition text-gray-600 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-400"
 			on:click={onRefresh}
 			aria-label={$i18n.t('Refresh')}
 		>
@@ -171,7 +171,7 @@
 		<Dropdown align="end" sideOffset={4}>
 			<Tooltip content={$i18n.t('Sort')}>
 				<button
-					class="shrink-0 p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 transition text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-400"
+					class="shrink-0 p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 transition text-gray-600 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-400"
 					aria-label={$i18n.t('Sort')}
 				>
 					<svg
@@ -240,7 +240,7 @@
 		</Dropdown>
 		<Tooltip content={$i18n.t('New Folder')}>
 			<button
-				class="shrink-0 p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 transition text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-400"
+				class="shrink-0 p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 transition text-gray-600 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-400"
 				on:click={onNewFolder}
 				aria-label={$i18n.t('New Folder')}
 			>
@@ -249,7 +249,7 @@
 		</Tooltip>
 		<Tooltip content={$i18n.t('New File')}>
 			<button
-				class="shrink-0 p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 transition text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-400"
+				class="shrink-0 p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 transition text-gray-600 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-400"
 				on:click={onNewFile}
 				aria-label={$i18n.t('New File')}
 			>
@@ -258,7 +258,7 @@
 		</Tooltip>
 		<Tooltip content={$i18n.t('Download')}>
 			<button
-				class="shrink-0 p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 transition text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-400"
+				class="shrink-0 p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 transition text-gray-600 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-400"
 				on:click={onDownloadDir}
 				aria-label={$i18n.t('Download')}
 			>
@@ -279,7 +279,7 @@
 		</Tooltip>
 		<Tooltip content={$i18n.t('Upload')}>
 			<button
-				class="shrink-0 p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 transition text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-400"
+				class="shrink-0 p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 transition text-gray-600 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-400"
 				on:click={() => uploadInput?.click()}
 				aria-label={$i18n.t('Upload')}
 			>

--- a/src/lib/components/chat/FileNav/PortList.svelte
+++ b/src/lib/components/chat/FileNav/PortList.svelte
@@ -81,7 +81,7 @@
 			{/if}
 			<Tooltip content={$i18n.t('Refresh')}>
 				<button
-					class="p-0.5 rounded hover:bg-gray-100 dark:hover:bg-gray-800 transition text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-400"
+					class="p-0.5 rounded hover:bg-gray-100 dark:hover:bg-gray-800 transition text-gray-600 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-400"
 					on:click|stopPropagation={loadPorts}
 					aria-label={$i18n.t('Refresh')}
 				>
@@ -105,7 +105,7 @@
 	{#if expanded}
 		<div class="mt-1 space-y-0.5 max-h-[150px] overflow-y-auto">
 			{#if ports.length === 0}
-				<div class="text-xs text-gray-400 dark:text-gray-500 px-1 py-1">
+				<div class="text-xs text-gray-600 dark:text-gray-500 px-1 py-1">
 					{$i18n.t('No servers detected')}
 				</div>
 			{:else}
@@ -125,7 +125,7 @@
 							<span
 								role="button"
 								tabindex="-1"
-								class="text-gray-400 dark:text-gray-500 opacity-0 group-hover:opacity-100 transition shrink-0 p-0.5 rounded hover:bg-gray-200 dark:hover:bg-gray-700"
+								class="text-gray-600 dark:text-gray-500 opacity-0 group-hover:opacity-100 transition shrink-0 p-0.5 rounded hover:bg-gray-200 dark:hover:bg-gray-700"
 								on:click|stopPropagation={() => openPortExternal(port.port)}
 							>
 								<svg

--- a/src/lib/components/chat/FileNav/SqliteView.svelte
+++ b/src/lib/components/chat/FileNav/SqliteView.svelte
@@ -184,7 +184,7 @@
 							>{queryError}</span
 						>
 					{:else}
-						<span class="text-[0.6rem] text-gray-400 dark:text-gray-600 select-none">⌘+Enter</span>
+						<span class="text-[0.6rem] text-gray-600 dark:text-gray-400 select-none">⌘+Enter</span>
 					{/if}
 					<button
 						class="shrink-0 px-2.5 py-0.5 text-[0.65rem] font-normal rounded hover:bg-gray-200 dark:hover:bg-gray-800 transition text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300"

--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -1522,7 +1522,7 @@
 										<div class="flex min-h-4 items-center gap-3">
 											<span class="min-w-0 flex-1 truncate">Context usage</span>
 											<span
-												class="shrink-0 font-mono text-[0.625rem] text-gray-400 dark:text-gray-600"
+												class="shrink-0 font-mono text-[0.625rem] text-gray-600 dark:text-gray-400"
 											>
 												{contextValue}
 											</span>
@@ -1542,7 +1542,7 @@
 									{#if messageQueue.length}
 										<div class="flex min-h-5 items-center gap-3 text-gray-600 dark:text-gray-400">
 											<span class="min-w-0 flex-1 truncate">Queued messages</span>
-											<span class="font-mono text-[0.625rem] text-gray-400 dark:text-gray-600">
+											<span class="font-mono text-[0.625rem] text-gray-600 dark:text-gray-400">
 												{messageQueue.length}
 											</span>
 										</div>
@@ -1551,7 +1551,7 @@
 									{#if chatTasks.length}
 										<div class="flex min-h-5 items-center gap-3 text-gray-600 dark:text-gray-400">
 											<span class="min-w-0 flex-1 truncate">Tasks</span>
-											<span class="font-mono text-[0.625rem] text-gray-400 dark:text-gray-600">
+											<span class="font-mono text-[0.625rem] text-gray-600 dark:text-gray-400">
 												{chatTasks.length}
 											</span>
 										</div>
@@ -1568,7 +1568,7 @@
 												{copiedStatusChatId ? $i18n.t('Copied') : chatId}
 											</button>
 										{:else}
-											<span class="font-mono text-[0.625rem] text-gray-400 dark:text-gray-600">
+											<span class="font-mono text-[0.625rem] text-gray-600 dark:text-gray-400">
 												none
 											</span>
 										{/if}

--- a/src/lib/components/chat/MessageInput/QueuedMessageItem.svelte
+++ b/src/lib/components/chat/MessageInput/QueuedMessageItem.svelte
@@ -48,7 +48,7 @@
 		{#if content}
 			<p class="text-sm text-gray-600 dark:text-gray-300 truncate">{content}</p>
 		{:else if files.length === 0}
-			<p class="text-sm text-gray-400 dark:text-gray-500 truncate italic">
+			<p class="text-sm text-gray-600 dark:text-gray-500 truncate italic">
 				{$i18n.t('Empty message')}
 			</p>
 		{/if}

--- a/src/lib/components/chat/MessageInput/TerminalMenu.svelte
+++ b/src/lib/components/chat/MessageInput/TerminalMenu.svelte
@@ -116,7 +116,7 @@
 				{#if directTerminals.length > 0 && ($user?.role === 'admin' || ($user?.permissions?.features?.direct_tool_servers ?? true))}
 					<div class="flex items-center justify-between px-3 py-1">
 						<span
-							class="text-[10px] font-normal text-gray-400 dark:text-gray-500 uppercase tracking-wider"
+							class="text-[10px] font-normal text-gray-600 dark:text-gray-500 uppercase tracking-wider"
 						>
 							{$i18n.t('Direct')}
 						</span>
@@ -182,7 +182,7 @@
 				{#if systemTerminals.length > 0}
 					<div class="flex items-center justify-between px-3 py-1">
 						<span
-							class="text-[10px] font-normal text-gray-400 dark:text-gray-500 uppercase tracking-wider"
+							class="text-[10px] font-normal text-gray-600 dark:text-gray-500 uppercase tracking-wider"
 						>
 							{$i18n.t('System')}
 						</span>

--- a/src/lib/components/chat/Messages/Error.svelte
+++ b/src/lib/components/chat/Messages/Error.svelte
@@ -40,7 +40,7 @@
 <div
 	class="my-1.5 flex w-full items-start gap-2 rounded-2xl bg-black/[0.03] px-3 py-2 text-gray-500 dark:bg-white/[0.04] dark:text-gray-400"
 >
-	<Info className="mt-0.5 size-4 shrink-0 text-gray-400 dark:text-gray-500" strokeWidth="1.8" />
+	<Info className="mt-0.5 size-4 shrink-0 text-gray-600 dark:text-gray-500" strokeWidth="1.8" />
 
 	<div class="min-w-0 break-words text-[0.8125rem] leading-5">
 		{message}

--- a/src/lib/components/chat/Messages/Markdown/ConsecutiveDetailsGroup.svelte
+++ b/src/lib/components/chat/Messages/Markdown/ConsecutiveDetailsGroup.svelte
@@ -133,7 +133,7 @@
 					<CheckCircle className="size-4" strokeWidth="2" />
 				</div>
 			{:else}
-				<div class="text-gray-400 dark:text-gray-500">
+				<div class="text-gray-600 dark:text-gray-500">
 					<Sparkles className="size-3.5" />
 				</div>
 			{/if}
@@ -144,12 +144,12 @@
 					>{prefixText}</span
 				>
 				{#if summaryText}
-					<span class="text-gray-400 dark:text-gray-500">{summaryText}</span>
+					<span class="text-gray-600 dark:text-gray-500">{summaryText}</span>
 				{/if}
 			</div>
 
 			<!-- Chevron -->
-			<div class="flex shrink-0 self-center text-gray-400 dark:text-gray-500">
+			<div class="flex shrink-0 self-center text-gray-600 dark:text-gray-500">
 				{#if open}
 					<ChevronUp strokeWidth="3.5" className="size-3" />
 				{:else}

--- a/src/lib/components/chat/Messages/MultiResponseMessages.svelte
+++ b/src/lib/components/chat/Messages/MultiResponseMessages.svelte
@@ -441,7 +441,7 @@
 										>
 											<time
 												datetime={new Date(message.timestamp * 1000).toISOString()}
-												class="invisible group-hover:visible ml-1 shrink-0 whitespace-nowrap text-[0.6875rem] tabular-nums text-gray-400 dark:text-gray-600 select-none"
+												class="invisible group-hover:visible ml-1 shrink-0 whitespace-nowrap text-[0.6875rem] tabular-nums text-gray-600 dark:text-gray-400 select-none"
 											>
 												{formatMessageTimestamp(message.timestamp * 1000)}
 											</time>

--- a/src/lib/components/chat/Messages/OutputEditView.svelte
+++ b/src/lib/components/chat/Messages/OutputEditView.svelte
@@ -235,7 +235,7 @@
 				: $i18n.t('Switch to visual editor')}
 		>
 			<button
-				class="text-xs px-2 py-0.5 rounded-full transition-all text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 hover:bg-gray-200/50 dark:hover:bg-gray-700/50"
+				class="text-xs px-2 py-0.5 rounded-full transition-all text-gray-600 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 hover:bg-gray-200/50 dark:hover:bg-gray-700/50"
 				on:click={() => (viewMode === 'visual' ? switchToJson() : switchToVisual())}
 			>
 				{viewMode === 'visual' ? $i18n.t('Visual') : 'JSON'}
@@ -259,7 +259,7 @@
 					<!-- Role label -->
 					<div class="flex items-start pt-1.5">
 						<div
-							class="text-[11px] font-normal uppercase tracking-wide min-w-[4.5rem] text-gray-400 dark:text-gray-500"
+							class="text-[11px] font-normal uppercase tracking-wide min-w-[4.5rem] text-gray-600 dark:text-gray-500"
 						>
 							{getItemLabel(di)}
 						</div>
@@ -335,7 +335,7 @@
 					<!-- Delete -->
 					<div class="pt-1.5">
 						<button
-							class="invisible group-hover:visible p-1 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 transition rounded-lg"
+							class="invisible group-hover:visible p-1 text-gray-600 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 transition rounded-lg"
 							on:click={() => deleteIndices(di.indices)}
 						>
 							<svg
@@ -358,7 +358,7 @@
 			{/each}
 
 			{#if displayItems.length === 0}
-				<div class="text-sm text-gray-400 dark:text-gray-500 italic px-1">
+				<div class="text-sm text-gray-600 dark:text-gray-500 italic px-1">
 					{$i18n.t('No output items')}
 				</div>
 			{/if}

--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -905,7 +905,7 @@
 						>
 							<time
 								datetime={new Date(message.timestamp * 1000).toISOString()}
-								class="ml-1 shrink-0 whitespace-nowrap text-[0.6875rem] tabular-nums text-gray-400 dark:text-gray-600 select-none"
+								class="ml-1 shrink-0 whitespace-nowrap text-[0.6875rem] tabular-nums text-gray-600 dark:text-gray-400 select-none"
 							>
 								{formatMessageTimestamp(message.timestamp * 1000)}
 							</time>
@@ -1559,7 +1559,7 @@
 										>
 											<time
 												datetime={new Date(message.timestamp * 1000).toISOString()}
-												class="invisible group-hover:visible ml-1 shrink-0 whitespace-nowrap text-[0.6875rem] tabular-nums text-gray-400 dark:text-gray-600 select-none"
+												class="invisible group-hover:visible ml-1 shrink-0 whitespace-nowrap text-[0.6875rem] tabular-nums text-gray-600 dark:text-gray-400 select-none"
 											>
 												{formatMessageTimestamp(message.timestamp * 1000)}
 											</time>

--- a/src/lib/components/chat/Messages/ResponseMessage/TaskList.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage/TaskList.svelte
@@ -51,7 +51,7 @@
 			<div class="px-3.5 pb-2.5 space-y-0.5" transition:slide={{ duration: 150 }}>
 				{#each tasks as task, idx (task.id)}
 					<div class="flex items-start gap-2 py-0.5 text-xs">
-						<span class="flex-shrink-0 mt-0.5 text-gray-400 dark:text-gray-500">
+						<span class="flex-shrink-0 mt-0.5 text-gray-600 dark:text-gray-500">
 							{#if task.status === 'completed'}
 								<svg
 									class="w-3.5 h-3.5"
@@ -96,9 +96,9 @@
 						</span>
 						<span
 							class="line-clamp-2 {task.status === 'completed'
-								? 'line-through text-gray-400 dark:text-gray-500'
+								? 'line-through text-gray-600 dark:text-gray-500'
 								: task.status === 'cancelled'
-									? 'line-through text-gray-400 dark:text-gray-600'
+									? 'line-through text-gray-600 dark:text-gray-400'
 									: 'text-gray-700 dark:text-gray-300'}"
 						>
 							{idx + 1}. {task.content}

--- a/src/lib/components/chat/Messages/SubagentResultRow.svelte
+++ b/src/lib/components/chat/Messages/SubagentResultRow.svelte
@@ -45,13 +45,13 @@
 		{/if}
 		{#if delegationLabel}
 			<span
-				class="hidden sm:inline text-[0.6875rem] font-mono text-gray-400 dark:text-gray-600 shrink-0"
+				class="hidden sm:inline text-[0.6875rem] font-mono text-gray-600 dark:text-gray-400 shrink-0"
 			>
 				{delegationLabel}
 			</span>
 		{/if}
 		<ChevronDown
-			className="size-3 text-gray-400 dark:text-gray-600 shrink-0 transition-transform duration-150 {expanded
+			className="size-3 text-gray-600 dark:text-gray-400 shrink-0 transition-transform duration-150 {expanded
 				? 'rotate-180'
 				: ''}"
 		/>

--- a/src/lib/components/chat/Messages/UserMessage.svelte
+++ b/src/lib/components/chat/Messages/UserMessage.svelte
@@ -421,7 +421,7 @@
 									? ''
 									: 'invisible group-hover:visible'} {($settings?.chatBubble ?? true)
 									? 'mr-1'
-									: 'ml-1 shrink-0 whitespace-nowrap'} text-[0.6875rem] tabular-nums text-gray-400 dark:text-gray-600 select-none"
+									: 'ml-1 shrink-0 whitespace-nowrap'} text-[0.6875rem] tabular-nums text-gray-600 dark:text-gray-400 select-none"
 							>
 								{formatMessageTimestamp(message.timestamp * 1000)}
 							</time>

--- a/src/lib/components/chat/Placeholder.svelte
+++ b/src/lib/components/chat/Placeholder.svelte
@@ -191,7 +191,7 @@
 							</Tooltip>
 
 							{#if models[selectedModelIdx]?.info?.meta?.user}
-								<div class="mt-0.5 text-sm font-normal text-gray-400 dark:text-gray-500">
+								<div class="mt-0.5 text-sm font-normal text-gray-600 dark:text-gray-500">
 									By
 									{#if models[selectedModelIdx]?.info?.meta?.user.community}
 										<a

--- a/src/lib/components/chat/PyodideFileNav.svelte
+++ b/src/lib/components/chat/PyodideFileNav.svelte
@@ -373,7 +373,7 @@
 				fill="none"
 				stroke="currentColor"
 				stroke-width="1.5"
-				class="size-5 text-gray-400 dark:text-gray-500"
+				class="size-5 text-gray-600 dark:text-gray-500"
 			>
 				<path
 					stroke-linecap="round"
@@ -381,7 +381,7 @@
 					d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5m-13.5-9L12 3m0 0 4.5 4.5M12 3v13.5"
 				/>
 			</svg>
-			<span class="text-xs text-gray-400 dark:text-gray-500">{$i18n.t('Drop files here')}</span>
+			<span class="text-xs text-gray-600 dark:text-gray-500">{$i18n.t('Drop files here')}</span>
 		</div>
 	{/if}
 
@@ -417,7 +417,7 @@
 	>
 		<!-- File action buttons when a file is selected (slot content) -->
 		<button
-			class="shrink-0 p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 transition text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-400"
+			class="shrink-0 p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 transition text-gray-600 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-400"
 			on:click={() => selectedFile && downloadFile(selectedFile)}
 			aria-label={$i18n.t('Download')}
 		>
@@ -452,7 +452,7 @@
 		{:else if entries.length === 0 && !creatingFolder && !creatingFile}
 			<div class="flex flex-col items-center justify-center flex-1 p-6 text-center gap-2">
 				<Folder className="size-5 text-gray-300 dark:text-gray-600" />
-				<div class="text-xs text-gray-400 dark:text-gray-500">
+				<div class="text-xs text-gray-600 dark:text-gray-500">
 					{$i18n.t('No files yet. Upload files or run Python code to create them.')}
 				</div>
 			</div>
@@ -480,7 +480,7 @@
 			{/if}
 			{#if creatingFile}
 				<div class="flex items-center gap-2 px-3 py-1.5">
-					<Document className="size-4 shrink-0 text-gray-400 dark:text-gray-500" />
+					<Document className="size-4 shrink-0 text-gray-600 dark:text-gray-500" />
 					<input
 						bind:this={newFileInput}
 						bind:value={newFileName}

--- a/src/lib/components/chat/Settings/About.svelte
+++ b/src/lib/components/chat/Settings/About.svelte
@@ -118,7 +118,7 @@
 					<span class="capitalize">{$config?.license_metadata?.organization_name}</span>
 				</div>
 			{:else}
-				<div class="flex flex-wrap gap-x-3 gap-y-1 text-xs text-gray-400 dark:text-gray-600">
+				<div class="flex flex-wrap gap-x-3 gap-y-1 text-xs text-gray-600 dark:text-gray-400">
 					<a
 						class="hover:text-gray-700 dark:hover:text-gray-400"
 						href="https://discord.gg/5rJgQTnV4s"
@@ -137,13 +137,13 @@
 				</div>
 			{/if}
 
-			<div class="text-xs text-gray-400 dark:text-gray-500">
+			<div class="text-xs text-gray-600 dark:text-gray-500">
 				Emoji graphics provided by
 				<a href="https://github.com/jdecked/twemoji" target="_blank">Twemoji</a>, licensed under
 				<a href="https://creativecommons.org/licenses/by/4.0/" target="_blank">CC-BY 4.0</a>.
 			</div>
 
-			<div class="text-xs text-gray-400 dark:text-gray-500">
+			<div class="text-xs text-gray-600 dark:text-gray-500">
 				Copyright (c) {new Date().getFullYear()}
 				<a href="https://openwebui.com" target="_blank" class="underline">Open WebUI Inc.</a>
 				<a href="https://github.com/open-webui/open-webui/blob/main/LICENSE" target="_blank"
@@ -151,7 +151,7 @@
 				>
 			</div>
 
-			<div class="text-xs text-gray-400 dark:text-gray-500">
+			<div class="text-xs text-gray-600 dark:text-gray-500">
 				{$i18n.t('Created by')}
 				<a class="text-gray-500 dark:text-gray-400" href="https://github.com/tjbck" target="_blank"
 					>Tim J. Baek</a

--- a/src/lib/components/chat/Settings/Account.svelte
+++ b/src/lib/components/chat/Settings/Account.svelte
@@ -307,7 +307,7 @@
 			>
 				<div class="flex min-w-0 items-center gap-1.5">
 					{$i18n.t('User Variables')}
-					<span class="text-gray-400 dark:text-gray-600">{variableRows.length}</span>
+					<span class="text-gray-600 dark:text-gray-400">{variableRows.length}</span>
 				</div>
 				<button class={actionButtonClass} type="button" on:click={() => openVariableModal()}>
 					{$i18n.t('Add')}
@@ -329,13 +329,13 @@
 				{/each}
 
 				{#if variableRows.length === 0}
-					<div class="text-xs text-gray-400 dark:text-gray-600">
+					<div class="text-xs text-gray-600 dark:text-gray-400">
 						{$i18n.t('No user variables configured.')}
 					</div>
 				{/if}
 			</div>
 
-			<div class="text-[0.6875rem] text-gray-400 dark:text-gray-600">
+			<div class="text-[0.6875rem] text-gray-600 dark:text-gray-400">
 				{$i18n.t('Use these in model system prompts as {{example}}.', {
 					example: '{{user.variables.key_name}}'
 				})}
@@ -540,7 +540,7 @@
 			{variableFormIndex === null ? $i18n.t('Add User Variable') : $i18n.t('Edit User Variable')}
 		</h2>
 
-		<div class="mb-1 text-[0.625rem] text-gray-400 dark:text-gray-600">
+		<div class="mb-1 text-[0.625rem] text-gray-600 dark:text-gray-400">
 			{$i18n.t('Key')}
 		</div>
 		<input
@@ -553,7 +553,7 @@
 			spellcheck="false"
 		/>
 
-		<div class="mb-1 mt-3 text-[0.625rem] text-gray-400 dark:text-gray-600">
+		<div class="mb-1 mt-3 text-[0.625rem] text-gray-600 dark:text-gray-400">
 			{$i18n.t('Value')}
 		</div>
 		<Textarea

--- a/src/lib/components/chat/Settings/Account/UpdatePassword.svelte
+++ b/src/lib/components/chat/Settings/Account/UpdatePassword.svelte
@@ -55,7 +55,7 @@
 			}}>{show ? $i18n.t('Hide') : $i18n.t('Show')}</button
 		>
 	</div>
-	<p class="mt-0.5 text-[0.6875rem] text-gray-400 dark:text-gray-600">
+	<p class="mt-0.5 text-[0.6875rem] text-gray-600 dark:text-gray-400">
 		{$i18n.t('Update the password used for email and password sign-in.')}
 	</p>
 

--- a/src/lib/components/chat/Settings/ArchivedChats.svelte
+++ b/src/lib/components/chat/Settings/ArchivedChats.svelte
@@ -194,7 +194,7 @@
 
 	<div class="flex h-7 shrink-0 items-center w-full gap-2">
 		<div class="flex min-w-0 flex-1 items-center gap-2">
-			<Search className="size-3.5 shrink-0 text-gray-400 dark:text-gray-600" />
+			<Search className="size-3.5 shrink-0 text-gray-600 dark:text-gray-400" />
 			<input
 				data-settings-search
 				class="min-w-0 flex-1 bg-transparent py-0.5 text-xs text-gray-700 outline-hidden placeholder:text-gray-300 dark:text-gray-300 dark:placeholder:text-gray-700"
@@ -275,7 +275,7 @@
 				{$i18n.t('You have no archived conversations.')}
 			</div>
 		{:else}
-			<div class="flex items-center px-1 text-xs text-gray-400 dark:text-gray-600">
+			<div class="flex items-center px-1 text-xs text-gray-600 dark:text-gray-400">
 				<button
 					class="flex flex-1 items-center gap-1 py-0.5 text-left"
 					type="button"
@@ -322,7 +322,7 @@
 							{chat?.title}
 						</a>
 						<div
-							class="hidden w-24 shrink-0 self-center justify-end text-gray-400 dark:text-gray-600 sm:flex"
+							class="hidden w-24 shrink-0 self-center justify-end text-gray-600 dark:text-gray-400 sm:flex"
 						>
 							{$i18n.t(
 								dayjs(chat?.updated_at * 1000).calendar(null, {

--- a/src/lib/components/chat/Settings/Audio.svelte
+++ b/src/lib/components/chat/Settings/Audio.svelte
@@ -290,7 +290,7 @@
 				label={$i18n.t('Speech Playback Speed')}
 				description={$i18n.t('Adjust how quickly spoken responses are played.')}
 			>
-				<div class="relative flex items-center gap-1.5 text-xs text-gray-400 dark:text-gray-600">
+				<div class="relative flex items-center gap-1.5 text-xs text-gray-600 dark:text-gray-400">
 					<input
 						type="number"
 						min="0"
@@ -339,7 +339,7 @@
 						</div>
 					</div>
 
-					<div class="text-[0.6875rem] text-gray-400 dark:text-gray-600">
+					<div class="text-[0.6875rem] text-gray-600 dark:text-gray-400">
 						{$i18n.t('Please do not close the settings page while loading the model.')}
 					</div>
 				</UserSettingSection>

--- a/src/lib/components/chat/Settings/Connections.svelte
+++ b/src/lib/components/chat/Settings/Connections.svelte
@@ -79,7 +79,7 @@
 		{#if config !== null}
 			<UserSettingSection title={$i18n.t('Manage Direct Connections')} first>
 				<div class="flex items-center justify-between gap-2.5">
-					<div class="min-w-0 text-[0.6875rem] text-gray-400 dark:text-gray-600">
+					<div class="min-w-0 text-[0.6875rem] text-gray-600 dark:text-gray-400">
 						{$i18n.t('Connect to your own OpenAI compatible API endpoints.')}
 					</div>
 
@@ -124,7 +124,7 @@
 					{/each}
 				</div>
 
-				<div class="text-[0.6875rem] text-gray-400 dark:text-gray-600">
+				<div class="text-[0.6875rem] text-gray-600 dark:text-gray-400">
 					{$i18n.t(
 						'CORS must be properly configured by the provider to allow requests from Open WebUI.'
 					)}

--- a/src/lib/components/chat/Settings/General.svelte
+++ b/src/lib/components/chat/Settings/General.svelte
@@ -239,10 +239,10 @@
 				</SettingsSelect>
 			</UserSettingRow>
 			{#if $i18n.language === 'en-US' && !($config?.license_metadata ?? false)}
-				<div class="-mt-1 text-[0.6875rem] text-gray-400 dark:text-gray-600">
+				<div class="-mt-1 text-[0.6875rem] text-gray-600 dark:text-gray-400">
 					Couldn't find your language?
 					<a
-						class="font-normal underline text-gray-400 dark:text-gray-600"
+						class="font-normal underline text-gray-600 dark:text-gray-400"
 						href="https://github.com/open-webui/open-webui/blob/main/docs/CONTRIBUTING.md#-translations-and-internationalization"
 						target="_blank"
 					>

--- a/src/lib/components/chat/Settings/Integrations.svelte
+++ b/src/lib/components/chat/Settings/Integrations.svelte
@@ -35,7 +35,7 @@
 	let servers: ToolServerConnection[] | null = null;
 	let terminalServerConfigs: TerminalServerConfig[] = [];
 	let showConnectionModal = false;
-	const helpTextClass = 'text-[0.6875rem] text-gray-400 dark:text-gray-600';
+	const helpTextClass = 'text-[0.6875rem] text-gray-600 dark:text-gray-400';
 
 	const addConnectionHandler = async (server: ToolServerConnection) => {
 		servers = [...(servers ?? []), server];

--- a/src/lib/components/chat/Settings/Integrations/Terminals.svelte
+++ b/src/lib/components/chat/Settings/Integrations/Terminals.svelte
@@ -86,7 +86,7 @@
 	</div>
 
 	{#if servers.length === 0}
-		<div class="text-[0.6875rem] text-gray-400 dark:text-gray-600">
+		<div class="text-[0.6875rem] text-gray-600 dark:text-gray-400">
 			{$i18n.t('No terminal connections configured.')}
 		</div>
 	{/if}

--- a/src/lib/components/chat/Settings/Interface.svelte
+++ b/src/lib/components/chat/Settings/Interface.svelte
@@ -107,9 +107,9 @@
 	const settingRowClass = 'flex items-center justify-between gap-2.5';
 	const settingLabelClass = 'min-w-0 text-xs text-gray-600 dark:text-gray-400';
 	const settingControlClass = 'flex shrink-0 items-center justify-end gap-1.5';
-	const sectionHeadingClass = 'mt-4 text-xs text-gray-400 dark:text-gray-600';
-	const firstSectionHeadingClass = 'text-xs text-gray-400 dark:text-gray-600';
-	const settingDescriptionClass = 'mt-1.5 text-[0.6875rem] text-gray-400 dark:text-gray-600';
+	const sectionHeadingClass = 'mt-4 text-xs text-gray-600 dark:text-gray-400';
+	const firstSectionHeadingClass = 'text-xs text-gray-600 dark:text-gray-400';
+	const settingDescriptionClass = 'mt-1.5 text-[0.6875rem] text-gray-600 dark:text-gray-400';
 	const actionButtonClass =
 		'text-xs text-gray-500 transition-colors hover:text-gray-900 dark:text-gray-500 dark:hover:text-white';
 

--- a/src/lib/components/chat/Settings/Notifications.svelte
+++ b/src/lib/components/chat/Settings/Notifications.svelte
@@ -202,7 +202,7 @@
 					on:change={toggleNotifications}
 				/>
 			</label>
-			<p class="-mt-1 text-[0.6875rem] text-gray-400 dark:text-gray-600">
+			<p class="-mt-1 text-[0.6875rem] text-gray-600 dark:text-gray-400">
 				{$i18n.t('Allow browser notifications for completed responses.')}
 			</p>
 
@@ -236,9 +236,9 @@
 				</div>
 
 				{#if loadingTargets}
-					<p class="text-[0.6875rem] text-gray-400 dark:text-gray-600">{$i18n.t('Loading...')}</p>
+					<p class="text-[0.6875rem] text-gray-600 dark:text-gray-400">{$i18n.t('Loading...')}</p>
 				{:else if !targets.length}
-					<p class="text-[0.6875rem] text-gray-400 dark:text-gray-600">
+					<p class="text-[0.6875rem] text-gray-600 dark:text-gray-400">
 						{$i18n.t('No notification targets configured.')}
 					</p>
 				{:else}
@@ -254,22 +254,22 @@
 										<span class="truncate text-[0.71875rem] text-gray-700 dark:text-gray-300">
 											{target.id}
 										</span>
-										<span class="shrink-0 text-[0.625rem] text-gray-400 dark:text-gray-600">
+										<span class="shrink-0 text-[0.625rem] text-gray-600 dark:text-gray-400">
 											{$i18n.t('Webhook')}
 										</span>
 										{#if target.is_default}
-											<span class="shrink-0 text-[0.625rem] text-gray-400 dark:text-gray-600">
+											<span class="shrink-0 text-[0.625rem] text-gray-600 dark:text-gray-400">
 												{$i18n.t('Default')}
 											</span>
 										{/if}
 									</div>
 									<div
-										class="truncate text-[0.625rem] leading-tight text-gray-400 dark:text-gray-600"
+										class="truncate text-[0.625rem] leading-tight text-gray-600 dark:text-gray-400"
 									>
 										{target.config?.url_masked}
 									</div>
 									<div
-										class="truncate text-[0.625rem] leading-tight text-gray-400 dark:text-gray-600"
+										class="truncate text-[0.625rem] leading-tight text-gray-600 dark:text-gray-400"
 									>
 										{alertLabels || $i18n.t('No chat alerts')}
 										{#if target.events.length}
@@ -344,7 +344,7 @@
 			{editingId ? $i18n.t('Edit') : $i18n.t('Add Notification Target')}
 		</h2>
 
-		<div class="text-[0.625rem] text-gray-400 dark:text-gray-600">
+		<div class="text-[0.625rem] text-gray-600 dark:text-gray-400">
 			{$i18n.t('Target ID for notify')}
 		</div>
 		<input
@@ -355,7 +355,7 @@
 			class="block w-full bg-transparent py-0.5 font-mono text-[0.8125rem] text-gray-700 outline-none placeholder:text-gray-300 dark:text-gray-300 dark:placeholder:text-gray-700"
 		/>
 
-		<div class="mt-2 text-[0.625rem] text-gray-400 dark:text-gray-600">
+		<div class="mt-2 text-[0.625rem] text-gray-600 dark:text-gray-400">
 			{$i18n.t('Webhook')}
 		</div>
 		<input
@@ -369,7 +369,7 @@
 			class="block w-full bg-transparent py-0.5 font-mono text-[0.8125rem] text-gray-700 outline-none placeholder:text-gray-300 dark:text-gray-300 dark:placeholder:text-gray-700"
 		/>
 
-		<div class="mt-3 mb-1 text-[0.625rem] text-gray-400 dark:text-gray-600">
+		<div class="mt-3 mb-1 text-[0.625rem] text-gray-600 dark:text-gray-400">
 			{$i18n.t('Automatic Events')}
 		</div>
 		<div class="flex flex-wrap gap-1">
@@ -389,7 +389,7 @@
 		</div>
 
 		{#if form.events.length}
-			<div class="mt-3 mb-1 text-[0.625rem] text-gray-400 dark:text-gray-600">
+			<div class="mt-3 mb-1 text-[0.625rem] text-gray-600 dark:text-gray-400">
 				{$i18n.t('Automatic Delivery')}
 			</div>
 			<div class="flex gap-1">
@@ -407,7 +407,7 @@
 			</div>
 		{/if}
 
-		<p class="mt-3 text-[0.625rem] text-gray-400 dark:text-gray-600">
+		<p class="mt-3 text-[0.625rem] text-gray-600 dark:text-gray-400">
 			{$i18n.t(
 				'The notify tool always sends to an enabled target, regardless of automatic event settings.'
 			)}

--- a/src/lib/components/chat/Settings/Personalization.svelte
+++ b/src/lib/components/chat/Settings/Personalization.svelte
@@ -129,7 +129,7 @@
 				>
 					<div class="flex items-center gap-2">
 						{$i18n.t('Memory')}
-						<span class="text-[0.625rem] uppercase text-gray-400 dark:text-gray-600"
+						<span class="text-[0.625rem] uppercase text-gray-600 dark:text-gray-400"
 							>{$i18n.t('Experimental')}</span
 						>
 					</div>
@@ -149,7 +149,7 @@
 						<div class="text-xs text-gray-600 dark:text-gray-400">
 							{$i18n.t('Saved Memories')}
 							{#if !loadingMemories}
-								<span class="ml-1 text-gray-400 dark:text-gray-600">{memories.length}</span>
+								<span class="ml-1 text-gray-600 dark:text-gray-400">{memories.length}</span>
 							{/if}
 						</div>
 					</div>
@@ -162,7 +162,7 @@
 						<div class="mb-2 flex min-w-0 items-center justify-between gap-3">
 							{#if memories.length > 0}
 								<div class="flex min-w-0 flex-1 items-center gap-2">
-									<Search className="size-3.5 shrink-0 text-gray-400 dark:text-gray-600" />
+									<Search className="size-3.5 shrink-0 text-gray-600 dark:text-gray-400" />
 									<input
 										data-settings-search
 										class="min-w-0 flex-1 bg-transparent py-0.5 text-xs text-gray-700 outline-hidden placeholder:text-gray-300 dark:text-gray-300 dark:placeholder:text-gray-700"
@@ -231,7 +231,7 @@
 						</div>
 
 						{#if sortedMemories.length === 0}
-							<div class="min-h-16 text-[0.6875rem] text-gray-400 dark:text-gray-600">
+							<div class="min-h-16 text-[0.6875rem] text-gray-600 dark:text-gray-400">
 								{#if memories.length === 0}
 									{$i18n.t('Memories accessible by LLMs will be shown here.')}
 								{:else}

--- a/src/lib/components/chat/Settings/Shortcuts.svelte
+++ b/src/lib/components/chat/Settings/Shortcuts.svelte
@@ -137,24 +137,24 @@
 				/>
 			</div>
 		</div>
-		<p class="mt-1.5 text-[0.6875rem] text-gray-400 dark:text-gray-600">
+		<p class="mt-1.5 text-[0.6875rem] text-gray-600 dark:text-gray-400">
 			{$i18n.t('When disabled, keyboard shortcuts will not trigger any actions.')}
 		</p>
 	</div>
 
 	<div class="flex-1 min-h-0 overflow-y-auto scrollbar-hover pr-1.5">
 		<div class="flex items-center gap-2 px-1 pb-1">
-			<span class="flex-1 text-[0.625rem] text-gray-400 dark:text-gray-600">
+			<span class="flex-1 text-[0.625rem] text-gray-600 dark:text-gray-400">
 				{$i18n.t('Command')}
 			</span>
-			<span class="w-[9.5rem] shrink-0 text-right text-[0.625rem] text-gray-400 dark:text-gray-600">
+			<span class="w-[9.5rem] shrink-0 text-right text-[0.625rem] text-gray-600 dark:text-gray-400">
 				{$i18n.t('Key')}
 			</span>
 		</div>
 
 		{#each Object.entries(categorizedShortcuts) as [category, items], categoryIndex}
 			<div class={categoryIndex > 0 ? 'mt-3' : ''}>
-				<div class="px-1 pb-0.5 pt-1 text-xs text-gray-400 dark:text-gray-600">
+				<div class="px-1 pb-0.5 pt-1 text-xs text-gray-600 dark:text-gray-400">
 					{$i18n.t(category)}
 				</div>
 				<div class="divide-y divide-gray-100/70 dark:divide-white/[0.03]">
@@ -223,7 +223,7 @@
 										</button>
 									{:else}
 										<button
-											class="text-[0.625rem] text-gray-500 transition hover:text-gray-400 dark:text-gray-600"
+											class="text-[0.625rem] text-gray-600 transition hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-200"
 											on:click={() => (recordingShortcut = id)}
 										>
 											{$i18n.t('Unassigned')}

--- a/src/lib/components/chat/Settings/Usage.svelte
+++ b/src/lib/components/chat/Settings/Usage.svelte
@@ -290,7 +290,7 @@
 						<div class="text-sm font-medium text-gray-900 dark:text-white">
 							{formatNumber(usage.totals.lifetime_tokens)}
 						</div>
-						<div class="mt-0.5 text-[0.6875rem] text-gray-400 dark:text-gray-600">
+						<div class="mt-0.5 text-[0.6875rem] text-gray-600 dark:text-gray-400">
 							{$i18n.t('Lifetime tokens')}
 						</div>
 					</div>
@@ -298,7 +298,7 @@
 						<div class="text-sm font-medium text-gray-900 dark:text-white">
 							{formatNumber(usage.totals.peak_daily_tokens)}
 						</div>
-						<div class="mt-0.5 text-[0.6875rem] text-gray-400 dark:text-gray-600">
+						<div class="mt-0.5 text-[0.6875rem] text-gray-600 dark:text-gray-400">
 							{$i18n.t('Peak tokens')}
 						</div>
 					</div>
@@ -306,7 +306,7 @@
 						<div class="text-sm font-medium text-gray-900 dark:text-white">
 							{formatDuration(usage.totals.longest_chat_seconds)}
 						</div>
-						<div class="mt-0.5 text-[0.6875rem] text-gray-400 dark:text-gray-600">
+						<div class="mt-0.5 text-[0.6875rem] text-gray-600 dark:text-gray-400">
 							{$i18n.t('Longest active chat')}
 						</div>
 					</div>
@@ -314,7 +314,7 @@
 						<div class="text-sm font-medium text-gray-900 dark:text-white">
 							{usage.totals.current_streak.toLocaleString()}
 						</div>
-						<div class="mt-0.5 text-[0.6875rem] text-gray-400 dark:text-gray-600">
+						<div class="mt-0.5 text-[0.6875rem] text-gray-600 dark:text-gray-400">
 							{$i18n.t('Current streak')}
 						</div>
 					</div>
@@ -322,7 +322,7 @@
 						<div class="text-sm font-medium text-gray-900 dark:text-white">
 							{usage.totals.longest_streak.toLocaleString()}
 						</div>
-						<div class="mt-0.5 text-[0.6875rem] text-gray-400 dark:text-gray-600">
+						<div class="mt-0.5 text-[0.6875rem] text-gray-600 dark:text-gray-400">
 							{$i18n.t('Longest streak')}
 						</div>
 					</div>
@@ -331,7 +331,7 @@
 
 			<section class="mt-4 w-full">
 				<div class="mb-2 flex min-w-0 items-center justify-between gap-3">
-					<h3 class="min-w-0 shrink truncate text-xs text-gray-400 dark:text-gray-600">
+					<h3 class="min-w-0 shrink truncate text-xs text-gray-600 dark:text-gray-400">
 						{$i18n.t('Token activity')}
 					</h3>
 					<div
@@ -378,7 +378,7 @@
 						</div>
 
 						<div
-							class="mx-auto mt-2 grid text-[0.6875rem] leading-none text-gray-400 dark:text-gray-600"
+							class="mx-auto mt-2 grid text-[0.6875rem] leading-none text-gray-600 dark:text-gray-400"
 							style="width: min(100%, {heatmapGridWidth}); column-gap: {HEATMAP_GAP_PX}px; grid-template-columns: repeat({heatmapColumns}, minmax(0, 1fr));"
 						>
 							{#each monthLabels as month}
@@ -391,7 +391,7 @@
 
 					{#if usage.top_models.length > 0}
 						<div
-							class="mt-2 flex flex-wrap gap-x-3 gap-y-1 text-[0.6875rem] text-gray-400 dark:text-gray-600"
+							class="mt-2 flex flex-wrap gap-x-3 gap-y-1 text-[0.6875rem] text-gray-600 dark:text-gray-400"
 						>
 							{#each usage.top_models.slice(0, 6) as model}
 								<div class="flex min-w-0 items-center gap-1.5">
@@ -477,7 +477,7 @@
 				{/if}
 			{/if}
 
-			<div class="mt-4 text-right text-[0.6875rem] text-gray-400 dark:text-gray-600">
+			<div class="mt-4 text-right text-[0.6875rem] text-gray-600 dark:text-gray-400">
 				{$i18n.t('Token counts are estimates and may not reflect actual API usage')}
 			</div>
 		</div>

--- a/src/lib/components/chat/Settings/UserSettingField.svelte
+++ b/src/lib/components/chat/Settings/UserSettingField.svelte
@@ -17,7 +17,7 @@
 	</div>
 
 	{#if description}
-		<p class="mt-0.5 text-[0.6875rem] text-gray-400 dark:text-gray-600">
+		<p class="mt-0.5 text-[0.6875rem] text-gray-600 dark:text-gray-400">
 			{description}
 		</p>
 	{/if}

--- a/src/lib/components/chat/Settings/UserSettingRow.svelte
+++ b/src/lib/components/chat/Settings/UserSettingRow.svelte
@@ -16,7 +16,7 @@
 </div>
 
 {#if description}
-	<p class="-mt-1 text-[0.6875rem] text-gray-400 dark:text-gray-600">
+	<p class="-mt-1 text-[0.6875rem] text-gray-600 dark:text-gray-400">
 		{description}
 	</p>
 {/if}

--- a/src/lib/components/chat/SettingsModal.svelte
+++ b/src/lib/components/chat/SettingsModal.svelte
@@ -138,7 +138,7 @@
 	const shouldShowSettingGroup = (tabIds: string[], index: number) =>
 		index === 0 || settingGroupTitle(tabIds[index]) !== settingGroupTitle(tabIds[index - 1]);
 	const settingGroupHeadingClass = (first: boolean) =>
-		`hidden md:block shrink-0 text-[0.625rem] text-gray-400 dark:text-gray-600 px-2 ${
+		`hidden md:block shrink-0 text-[0.625rem] text-gray-600 dark:text-gray-400 px-2 ${
 			first ? 'mt-0.5' : 'mt-2'
 		} mb-0.5`;
 
@@ -894,7 +894,7 @@
 		class="shrink-0 min-w-0 md:min-h-0 flex md:flex-col border-b md:border-b-0 md:border-r border-gray-100/30 dark:border-white/[0.02] md:w-[15rem]"
 	>
 		<button
-			class="flex items-center gap-1.5 h-7 px-2 m-1 md:mb-0 md:w-[calc(100%-0.5rem)] shrink-0 rounded-lg text-xs text-gray-400 dark:text-gray-600 hover:text-gray-700 dark:hover:text-gray-300 transition-colors duration-75"
+			class="flex items-center gap-1.5 h-7 px-2 m-1 md:mb-0 md:w-[calc(100%-0.5rem)] shrink-0 rounded-lg text-xs text-gray-600 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 transition-colors duration-75"
 			type="button"
 			on:click={() => {
 				show = false;
@@ -925,7 +925,7 @@
 			class="tabs scrollbar-none flex min-w-0 flex-1 min-h-0 overflow-x-auto md:overflow-x-hidden md:overflow-y-auto md:flex-col p-1 pl-0 md:pl-1 gap-px"
 		>
 			<span
-				class="hidden md:block text-[0.625rem] text-gray-400 dark:text-gray-600 px-2 mt-1.5 mb-0.5"
+				class="hidden md:block text-[0.625rem] text-gray-600 dark:text-gray-400 px-2 mt-1.5 mb-0.5"
 			>
 				{$i18n.t('Personal')}
 			</span>
@@ -1119,7 +1119,7 @@
 				<div
 					class="hidden md:block shrink-0 self-stretch h-px mx-1 my-2 bg-gray-100/40 dark:bg-white/[0.025]"
 				></div>
-				<span class="hidden md:block text-[0.625rem] text-gray-400 dark:text-gray-600 px-2 mb-0.5">
+				<span class="hidden md:block text-[0.625rem] text-gray-600 dark:text-gray-400 px-2 mb-0.5">
 					{$i18n.t('Admin')}
 				</span>
 
@@ -1149,7 +1149,7 @@
 			{/if}
 
 			{#if filteredSettings.length === 0}
-				<div class="px-2 py-1 text-xs text-gray-400 dark:text-gray-600">
+				<div class="px-2 py-1 text-xs text-gray-600 dark:text-gray-400">
 					{$i18n.t('No matches')}
 				</div>
 			{/if}

--- a/src/lib/components/chat/ShortcutItem.svelte
+++ b/src/lib/components/chat/ShortcutItem.svelte
@@ -124,7 +124,7 @@
 				<Tooltip content={$i18n.t(shortcut.tooltip)}>
 					<span class="inline-flex max-w-full items-baseline gap-1">
 						<span class="truncate whitespace-pre-line">{$i18n.t(shortcut.name)}</span>
-						<span class="text-[0.625rem] text-gray-400 dark:text-gray-600">*</span>
+						<span class="text-[0.625rem] text-gray-600 dark:text-gray-400">*</span>
 					</span>
 				</Tooltip>
 			{:else}

--- a/src/lib/components/common/HotkeyHint.svelte
+++ b/src/lib/components/common/HotkeyHint.svelte
@@ -39,7 +39,7 @@
 
 {#if mounted && isVisible}
 	<div
-		class="hidden md:flex items-center self-center text-xs text-gray-400 dark:text-gray-600 {className}"
+		class="hidden md:flex items-center self-center text-xs text-gray-600 dark:text-gray-400 {className}"
 	>
 		<span>{displayKeys()}</span>
 	</div>

--- a/src/lib/components/common/SettingsSelect.svelte
+++ b/src/lib/components/common/SettingsSelect.svelte
@@ -28,7 +28,7 @@
 		<slot />
 	</select>
 	<ChevronDown
-		className="pointer-events-none absolute end-2 top-1/2 size-3.5 -translate-y-1/2 text-gray-400 dark:text-gray-500"
+		className="pointer-events-none absolute end-2 top-1/2 size-3.5 -translate-y-1/2 text-gray-600 dark:text-gray-500"
 		strokeWidth="2"
 	/>
 </div>

--- a/src/lib/components/common/ToolCallDisplay.svelte
+++ b/src/lib/components/common/ToolCallDisplay.svelte
@@ -141,7 +141,7 @@
 						<CheckCircle className="size-4" strokeWidth="2" />
 					</div>
 				{:else}
-					<div class="text-gray-400 dark:text-gray-500">
+					<div class="text-gray-600 dark:text-gray-500">
 						<WrenchSolid className="size-3.5" />
 					</div>
 				{/if}
@@ -180,7 +180,7 @@
 					{#if args}
 						<div>
 							<div
-								class="text-[10px] uppercase tracking-wider font-normal text-gray-400 dark:text-gray-500 mb-1.5 px-1"
+								class="text-[10px] uppercase tracking-wider font-normal text-gray-600 dark:text-gray-500 mb-1.5 px-1"
 							>
 								{$i18n.t('Input')}
 							</div>
@@ -213,7 +213,7 @@
 					{#if isDone && result}
 						<div>
 							<div
-								class="text-[10px] uppercase tracking-wider font-normal text-gray-400 dark:text-gray-500 mb-1.5 px-1"
+								class="text-[10px] uppercase tracking-wider font-normal text-gray-600 dark:text-gray-500 mb-1.5 px-1"
 							>
 								{$i18n.t('Output')}
 							</div>

--- a/src/lib/components/layout/Sidebar/ChatItem.svelte
+++ b/src/lib/components/layout/Sidebar/ChatItem.svelte
@@ -581,7 +581,7 @@
 
 				<!-- Time ago indicator -->
 				{#if (updatedAt ?? createdAt) && !showInlineActions}
-					<div class="shrink-0 self-center text-[10px] text-gray-400 dark:text-gray-500 pl-2">
+					<div class="shrink-0 self-center text-[10px] text-gray-600 dark:text-gray-500 pl-2">
 						{formatTimeAgo((updatedAt ?? createdAt) as number)}
 					</div>
 				{/if}

--- a/src/lib/components/layout/Sidebar/Folders.svelte
+++ b/src/lib/components/layout/Sidebar/Folders.svelte
@@ -76,7 +76,7 @@
 {/each}
 
 {#if sharedList.length > 0}
-	<div class="w-full pl-2.5 text-[11px] text-gray-400 dark:text-gray-600 pt-2 pb-0.5">
+	<div class="w-full pl-2.5 text-[11px] text-gray-600 dark:text-gray-400 pt-2 pb-0.5">
 		{$i18n.t('Shared')}
 	</div>
 	{#each sharedList as folderId (folderId)}

--- a/src/lib/components/layout/Sidebar/SharedFolderItem.svelte
+++ b/src/lib/components/layout/Sidebar/SharedFolderItem.svelte
@@ -92,13 +92,13 @@
 			</div>
 
 			{#if folder.owner_name}
-				<div class="shrink-0 text-[10px] text-gray-400 dark:text-gray-600 pr-1">
+				<div class="shrink-0 text-[10px] text-gray-600 dark:text-gray-400 pr-1">
 					{folder.owner_name}
 				</div>
 			{/if}
 
 			{#if !isWritable}
-				<div class="shrink-0 text-[10px] text-gray-400 dark:text-gray-600" title="Read only">
+				<div class="shrink-0 text-[10px] text-gray-600 dark:text-gray-400" title="Read only">
 					<Eye className="size-3" />
 				</div>
 			{/if}
@@ -158,7 +158,7 @@
 				{/if}
 
 				{#if chats.length === 0 && children.length === 0 && !hasMoreChats}
-					<div class="text-[11px] text-gray-400 dark:text-gray-600 py-1 px-2">
+					<div class="text-[11px] text-gray-600 dark:text-gray-400 py-1 px-2">
 						{$i18n.t('Empty')}
 					</div>
 				{/if}

--- a/src/lib/components/notes/Notes.svelte
+++ b/src/lib/components/notes/Notes.svelte
@@ -531,7 +531,7 @@
 						<div>
 							{#if displayOption === null}
 								<div
-									class="flex w-full items-center gap-2 px-2 pb-2 text-xs text-gray-400 dark:text-gray-600"
+									class="flex w-full items-center gap-2 px-2 pb-2 text-xs text-gray-600 dark:text-gray-400"
 								>
 									<div class="flex min-w-0 flex-1 items-center">
 										<button
@@ -601,7 +601,7 @@
 
 													<Tooltip content={dayjs(note.updated_at / 1000000).format('LLLL')}>
 														<div
-															class="shrink-0 truncate text-[11px] leading-5 text-gray-400 dark:text-gray-600"
+															class="shrink-0 truncate text-[11px] leading-5 text-gray-600 dark:text-gray-400"
 														>
 															{dayjs(note.updated_at / 1000000).fromNow()}
 														</div>

--- a/src/lib/components/playground/Images.svelte
+++ b/src/lib/components/playground/Images.svelte
@@ -164,7 +164,7 @@
 							</div>
 						{:else}
 							<div
-								class="h-full flex items-center justify-center text-gray-400 dark:text-gray-600 text-sm"
+								class="h-full flex items-center justify-center text-gray-600 dark:text-gray-400 text-sm"
 							>
 								{$i18n.t('Generated images will appear here')}
 							</div>

--- a/src/lib/components/workspace/Knowledge.svelte
+++ b/src/lib/components/workspace/Knowledge.svelte
@@ -353,7 +353,7 @@
 			{#if (items ?? []).length !== 0}
 				<div class="my-1">
 					<div
-						class="flex w-full items-center gap-2 px-1.5 pb-0.5 text-xs text-gray-400 dark:text-gray-600"
+						class="flex w-full items-center gap-2 px-1.5 pb-0.5 text-xs text-gray-600 dark:text-gray-400"
 					>
 						<div class="flex min-w-0 flex-1 items-center gap-1 py-0.5 text-left">
 							{$i18n.t('Title')}
@@ -415,7 +415,7 @@
 
 												<Tooltip content={dayjs(item.updated_at * 1000).format('LLLL')}>
 													<div
-														class="shrink-0 truncate text-[11px] leading-5 text-gray-400 dark:text-gray-600"
+														class="shrink-0 truncate text-[11px] leading-5 text-gray-600 dark:text-gray-400"
 													>
 														{dayjs(item.updated_at * 1000).fromNow()}
 													</div>
@@ -426,7 +426,7 @@
 										{#if metaPreview}
 											<Tooltip content={metaPreview} className="min-w-0" placement="top-start">
 												<div
-													class="mt-0.5 truncate text-[0.6875rem] leading-4 text-gray-400 dark:text-gray-600"
+													class="mt-0.5 truncate text-[0.6875rem] leading-4 text-gray-600 dark:text-gray-400"
 												>
 													{metaPreview}
 												</div>

--- a/src/lib/components/workspace/Knowledge/KnowledgeBase/KnowledgeBreadcrumbs.svelte
+++ b/src/lib/components/workspace/Knowledge/KnowledgeBase/KnowledgeBreadcrumbs.svelte
@@ -60,7 +60,7 @@
 		class="text-xs shrink-0 py-0.5 hover:underline transition
 			{breadcrumbs.length === 0
 			? 'text-gray-700 dark:text-gray-300'
-			: 'text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-400'}
+			: 'text-gray-600 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-400'}
 			{dragOverCrumb === -1 ? 'bg-gray-100 dark:bg-gray-800 rounded-lg' : ''}"
 		on:click={() => onNavigate(null)}
 		on:dragover={(e) => handleDragOver(e, -1)}
@@ -76,7 +76,7 @@
 			class="text-xs shrink-0 py-0.5 hover:underline transition
 				{i === breadcrumbs.length - 1
 				? 'text-gray-700 dark:text-gray-300'
-				: 'text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-400'}
+				: 'text-gray-600 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-400'}
 				{dragOverCrumb === i ? 'bg-gray-100 dark:bg-gray-800 rounded-lg' : ''}"
 			on:click={() => onNavigate(crumb.id)}
 			on:dragover={(e) => handleDragOver(e, i)}

--- a/src/lib/components/workspace/Models.svelte
+++ b/src/lib/components/workspace/Models.svelte
@@ -643,7 +643,7 @@
 			{#if (models ?? []).length !== 0}
 				<div class="my-1" id="model-list">
 					<div
-						class="flex w-full items-center gap-2 px-1.5 pb-0.5 text-xs text-gray-400 dark:text-gray-600"
+						class="flex w-full items-center gap-2 px-1.5 pb-0.5 text-xs text-gray-600 dark:text-gray-400"
 					>
 						<button
 							class="flex min-w-0 flex-1 items-center gap-1 py-0.5 text-left"
@@ -735,7 +735,7 @@
 
 												<Tooltip content={dayjs(model.updated_at * 1000).format('LLLL')}>
 													<div
-														class="shrink-0 truncate text-[11px] leading-5 text-gray-400 dark:text-gray-600"
+														class="shrink-0 truncate text-[11px] leading-5 text-gray-600 dark:text-gray-400"
 													>
 														{dayjs(model.updated_at * 1000).fromNow()}
 													</div>
@@ -755,7 +755,7 @@
 											placement="top-start"
 										>
 											<div
-												class="truncate text-[0.6875rem] leading-4 text-gray-400 dark:text-gray-600"
+												class="truncate text-[0.6875rem] leading-4 text-gray-600 dark:text-gray-400"
 											>
 												{(model?.meta?.description ?? '').trim() ||
 													model.base_model_id ||

--- a/src/lib/components/workspace/Models/BuiltinTools.svelte
+++ b/src/lib/components/workspace/Models/BuiltinTools.svelte
@@ -71,7 +71,7 @@
 </script>
 
 <div>
-	<div class="mb-1.5 text-xs text-gray-400 dark:text-gray-600">{$i18n.t('Builtin Tools')}</div>
+	<div class="mb-1.5 text-xs text-gray-600 dark:text-gray-400">{$i18n.t('Builtin Tools')}</div>
 	<div class="grid grid-cols-1 gap-x-5 gap-y-1 sm:grid-cols-2 lg:grid-cols-3">
 		{#each allTools as tool}
 			<div class="flex min-h-6 items-center justify-between gap-2.5">

--- a/src/lib/components/workspace/Models/Capabilities.svelte
+++ b/src/lib/components/workspace/Models/Capabilities.svelte
@@ -83,7 +83,7 @@
 </script>
 
 <div>
-	<div class="mb-1.5 text-xs text-gray-400 dark:text-gray-600">{$i18n.t('Capabilities')}</div>
+	<div class="mb-1.5 text-xs text-gray-600 dark:text-gray-400">{$i18n.t('Capabilities')}</div>
 	<div class="grid grid-cols-1 gap-x-5 gap-y-1 sm:grid-cols-2 lg:grid-cols-3">
 		{#each visibleCapabilities as capability}
 			<div class="flex min-h-6 items-center justify-between gap-2.5">

--- a/src/lib/components/workspace/Models/DefaultFeatures.svelte
+++ b/src/lib/components/workspace/Models/DefaultFeatures.svelte
@@ -26,7 +26,7 @@
 </script>
 
 <div>
-	<div class="mb-1.5 text-xs text-gray-400 dark:text-gray-600">{$i18n.t('Default Features')}</div>
+	<div class="mb-1.5 text-xs text-gray-600 dark:text-gray-400">{$i18n.t('Default Features')}</div>
 	<div class="grid grid-cols-1 gap-x-5 gap-y-1 sm:grid-cols-2 lg:grid-cols-3">
 		{#each availableFeatures as feature}
 			<div class="flex min-h-6 items-center justify-between gap-2.5">

--- a/src/lib/components/workspace/Models/Knowledge.svelte
+++ b/src/lib/components/workspace/Models/Knowledge.svelte
@@ -243,14 +243,14 @@
 							</div>
 
 							{#if file.status === 'uploading'}
-								<div class="shrink-0 text-gray-400 dark:text-gray-500">
+								<div class="shrink-0 text-gray-600 dark:text-gray-500">
 									{$i18n.t('Uploading')}
 								</div>
 							{/if}
 
 							<button
 								type="button"
-								class="flex size-4 shrink-0 items-center justify-center text-gray-400 dark:text-gray-500"
+								class="flex size-4 shrink-0 items-center justify-center text-gray-600 dark:text-gray-500"
 								aria-label={$i18n.t('Remove File')}
 								on:click={() => {
 									selectedItems = selectedItems.filter((_, idx) => idx !== fileIdx);

--- a/src/lib/components/workspace/Models/ModelEditor.svelte
+++ b/src/lib/components/workspace/Models/ModelEditor.svelte
@@ -683,7 +683,7 @@
 
 							{#if preset}
 								<div>
-									<div class="mb-1 text-xs text-gray-400 dark:text-gray-600">
+									<div class="mb-1 text-xs text-gray-600 dark:text-gray-400">
 										{$i18n.t('Base Model (From)')}
 									</div>
 
@@ -702,7 +702,7 @@
 
 							<div>
 								<div class="mb-1 flex w-full items-center justify-between">
-									<div class="self-center text-xs text-gray-400 dark:text-gray-600">
+									<div class="self-center text-xs text-gray-600 dark:text-gray-400">
 										{$i18n.t('Description')}
 									</div>
 
@@ -756,7 +756,7 @@
 						</div>
 
 						<section class="mt-2.5">
-							<div class="mb-2 text-xs text-gray-400 dark:text-gray-600">
+							<div class="mb-2 text-xs text-gray-600 dark:text-gray-400">
 								{$i18n.t('Model Params')}
 							</div>
 
@@ -783,7 +783,7 @@
 													{$i18n.t('Detected Variables')}
 												</div>
 												{#if chatVariablesPreview.fields.length + chatVariablesPreview.userFields.length > 0}
-													<div class="text-[0.6875rem] text-gray-400 dark:text-gray-600">
+													<div class="text-[0.6875rem] text-gray-600 dark:text-gray-400">
 														{chatVariablesPreview.fields.length +
 															chatVariablesPreview.userFields.length}
 													</div>
@@ -791,14 +791,14 @@
 											</div>
 
 											{#if chatVariablesPreview.fields.length > 0}
-												<div class="mb-1 text-[0.6875rem] text-gray-400 dark:text-gray-600">
+												<div class="mb-1 text-[0.6875rem] text-gray-600 dark:text-gray-400">
 													{$i18n.t('Chat Variables')}
 												</div>
 												<div class="flex flex-wrap gap-x-3 gap-y-1.5 text-xs">
 													{#each chatVariablesPreview.fields as field}
 														<div class="flex items-center gap-1 text-gray-600 dark:text-gray-300">
 															<span class="font-medium">{field.key}</span>
-															<span class="text-gray-400 dark:text-gray-600">{field.type}</span>
+															<span class="text-gray-600 dark:text-gray-400">{field.type}</span>
 															{#if field.required}
 																<span class="text-amber-600 dark:text-amber-400">required</span>
 															{/if}
@@ -808,7 +808,7 @@
 											{/if}
 
 											{#if chatVariablesPreview.userFields.length > 0}
-												<div class="mb-1 mt-2 text-[0.6875rem] text-gray-400 dark:text-gray-600">
+												<div class="mb-1 mt-2 text-[0.6875rem] text-gray-600 dark:text-gray-400">
 													{$i18n.t('User Variables')}
 												</div>
 												<div class="flex flex-wrap gap-x-3 gap-y-1.5 text-xs">
@@ -865,7 +865,7 @@
 
 						<section class="my-2.5">
 							<div class="flex w-full items-center justify-between">
-								<div class="self-center text-xs text-gray-400 dark:text-gray-600">
+								<div class="self-center text-xs text-gray-600 dark:text-gray-400">
 									{$i18n.t('Prompts')}
 								</div>
 

--- a/src/lib/components/workspace/Prompts.svelte
+++ b/src/lib/components/workspace/Prompts.svelte
@@ -504,7 +504,7 @@
 		{:else if (prompts ?? []).length !== 0}
 			<div class="my-1">
 				<div
-					class="flex w-full items-center gap-2 px-1.5 pb-0.5 text-xs text-gray-400 dark:text-gray-600"
+					class="flex w-full items-center gap-2 px-1.5 pb-0.5 text-xs text-gray-600 dark:text-gray-400"
 				>
 					<button
 						class="flex min-w-0 flex-1 items-center gap-1 py-0.5 text-left"
@@ -581,7 +581,7 @@
 												)}
 											>
 												<div
-													class="shrink-0 truncate text-[11px] leading-5 text-gray-400 dark:text-gray-600"
+													class="shrink-0 truncate text-[11px] leading-5 text-gray-600 dark:text-gray-400"
 												>
 													{dayjs((prompt.updated_at ?? prompt.created_at) * 1000).fromNow()}
 												</div>
@@ -596,7 +596,7 @@
 									{#if prompt.content}
 										<Tooltip content={prompt.content} className="min-w-0" placement="top-start">
 											<div
-												class="mt-0.5 truncate text-[0.6875rem] leading-4 text-gray-400 dark:text-gray-600"
+												class="mt-0.5 truncate text-[0.6875rem] leading-4 text-gray-600 dark:text-gray-400"
 											>
 												{prompt.content}
 											</div>

--- a/src/lib/components/workspace/Prompts/PromptEditor.svelte
+++ b/src/lib/components/workspace/Prompts/PromptEditor.svelte
@@ -492,7 +492,7 @@
 					{#if selectedHistoryEntry && !disabled}
 						<div class="flex items-center gap-2">
 							{#if selectedHistoryEntry.id === prompt?.version_id}
-								<span class="inline-flex items-center text-xs text-gray-400 dark:text-gray-500">
+								<span class="inline-flex items-center text-xs text-gray-600 dark:text-gray-500">
 									{$i18n.t('Live')}
 								</span>
 							{:else}
@@ -625,7 +625,7 @@
 							required
 						/>
 					{/if}
-					<div class="text-xs text-gray-400 dark:text-gray-500">
+					<div class="text-xs text-gray-600 dark:text-gray-500">
 						ⓘ {$i18n.t('Use')}
 						<span class="font-normal text-gray-600 dark:text-gray-300"
 							>{'{{'}{$i18n.t('variable')}{'}}'}</span
@@ -696,14 +696,14 @@
 							</div>
 							{#if entry.id === prompt?.version_id}
 								<span
-									class="inline-flex shrink-0 items-center text-xs text-gray-400 dark:text-gray-500"
+									class="inline-flex shrink-0 items-center text-xs text-gray-600 dark:text-gray-500"
 								>
 									{$i18n.t('Live')}
 								</span>
 							{/if}
 						</div>
 
-						<div class="flex items-center gap-1 text-xs text-gray-400 dark:text-gray-500">
+						<div class="flex items-center gap-1 text-xs text-gray-600 dark:text-gray-500">
 							{#if entry.user}
 								<img
 									src={`/api/v1/users/${entry.user.id}/profile/image`}

--- a/src/lib/components/workspace/Skills.svelte
+++ b/src/lib/components/workspace/Skills.svelte
@@ -382,7 +382,7 @@
 		{:else if (filteredItems ?? []).length !== 0}
 			<div class="my-1">
 				<div
-					class="flex w-full items-center gap-2 px-1.5 pb-0.5 text-xs text-gray-400 dark:text-gray-600"
+					class="flex w-full items-center gap-2 px-1.5 pb-0.5 text-xs text-gray-600 dark:text-gray-400"
 				>
 					<button
 						class="flex min-w-0 flex-1 items-center gap-1 py-0.5 text-left"
@@ -459,7 +459,7 @@
 												)}
 											>
 												<div
-													class="shrink-0 truncate text-[11px] leading-5 text-gray-400 dark:text-gray-600"
+													class="shrink-0 truncate text-[11px] leading-5 text-gray-600 dark:text-gray-400"
 												>
 													{dayjs((skill.updated_at ?? skill.created_at) * 1000).fromNow()}
 												</div>
@@ -478,7 +478,7 @@
 									{#if skill.description}
 										<Tooltip content={skill.description} className="min-w-0" placement="top-start">
 											<div
-												class="mt-0.5 truncate text-[0.6875rem] leading-4 text-gray-400 dark:text-gray-600"
+												class="mt-0.5 truncate text-[0.6875rem] leading-4 text-gray-600 dark:text-gray-400"
 											>
 												{skill.description}
 											</div>

--- a/src/lib/components/workspace/Tools.svelte
+++ b/src/lib/components/workspace/Tools.svelte
@@ -372,7 +372,7 @@
 		{#if (filteredItems ?? []).length !== 0}
 			<div class="my-1">
 				<div
-					class="flex w-full items-center gap-2 px-1.5 pb-0.5 text-xs text-gray-400 dark:text-gray-600"
+					class="flex w-full items-center gap-2 px-1.5 pb-0.5 text-xs text-gray-600 dark:text-gray-400"
 				>
 					<button
 						class="flex min-w-0 flex-1 items-center gap-1 py-0.5 text-left"
@@ -449,7 +449,7 @@
 
 											<Tooltip content={dayjs(tool.updated_at * 1000).format('LLLL')}>
 												<div
-													class="shrink-0 truncate text-[11px] leading-5 text-gray-400 dark:text-gray-600"
+													class="shrink-0 truncate text-[11px] leading-5 text-gray-600 dark:text-gray-400"
 												>
 													{dayjs(tool.updated_at * 1000).fromNow()}
 												</div>
@@ -468,7 +468,7 @@
 											placement="top-start"
 										>
 											<div
-												class="mt-0.5 truncate text-[0.6875rem] leading-4 text-gray-400 dark:text-gray-600"
+												class="mt-0.5 truncate text-[0.6875rem] leading-4 text-gray-600 dark:text-gray-400"
 											>
 												{tool?.meta?.description}
 											</div>

--- a/src/lib/components/workspace/common/CommunityDiscover.svelte
+++ b/src/lib/components/workspace/common/CommunityDiscover.svelte
@@ -11,7 +11,7 @@
 </script>
 
 <div class="mt-6 px-2 pb-8">
-	<div class="mb-0.5 text-[11px] font-normal text-gray-400 dark:text-gray-600">
+	<div class="mb-0.5 text-[11px] font-normal text-gray-600 dark:text-gray-400">
 		{$i18n.t('Made by Open WebUI Community')}
 	</div>
 
@@ -29,6 +29,6 @@
 			</div>
 		</div>
 
-		<ChevronRight className="size-3.5 shrink-0 text-gray-400 dark:text-gray-600" />
+		<ChevronRight className="size-3.5 shrink-0 text-gray-600 dark:text-gray-400" />
 	</a>
 </div>

--- a/src/routes/(app)/automations/+page.svelte
+++ b/src/routes/(app)/automations/+page.svelte
@@ -552,7 +552,7 @@
 													: $i18n.t('Never')}
 											>
 												<div
-													class="shrink-0 truncate text-[11px] leading-5 text-gray-400 dark:text-gray-600"
+													class="shrink-0 truncate text-[11px] leading-5 text-gray-600 dark:text-gray-400"
 												>
 													{formatLastRun(automation)}
 												</div>


### PR DESCRIPTION
On latest `dev`, muted UI text is written as `text-gray-400 dark:text-gray-600` and `text-gray-400 dark:text-gray-500`. The grey scale in `src/tailwind.css` is achromatic `oklch(L 0 0)`, so relative luminance is exactly `L³` and the ratios are:

| | light (on `#fff`) | dark (on `#171717`) |
|---|---|---|
| `text-gray-400` | **2.07:1** | 8.65:1 |
| `dark:text-gray-600` | 5.75:1 | **3.12:1** |
| `dark:text-gray-500` | 2.77:1 | 6.46:1 |

The pair is effectively inverted: the light variant is a light grey and the dark variant is a dark grey. `text-gray-400 dark:text-gray-600` therefore fails in **both** themes, at 2.07:1 and 3.12:1 against a 4.5:1 requirement, and the light value also fails the 3:1 required of icons. `text-gray-400 dark:text-gray-500` fails in light mode at the same 2.07:1.

This is the text used for every settings and admin section heading, every field description, sidebar section labels, timestamps and counters. All of it is 10px to 12px, so the large-text exemption does not apply.

Breaks WCAG 1.4.3 Contrast (Minimum) (Level AA) for the text, and 1.4.11 Non-text Contrast (Level AA) for the four sites where this pair is passed to an icon component as `className`.

Fix: `text-gray-400` becomes `text-gray-600` (5.75:1) in light mode, and `dark:text-gray-600` becomes `dark:text-gray-400` (8.65:1) in dark mode. `dark:text-gray-500` already passes at 6.46:1 and is left alone. Both failing pairs are converted together so components do not end up with two different greys side by side.

Three sites are hand fixed rather than pattern matched:

- `chat/Settings/Shortcuts.svelte` — here the literal string only appears as a substring spanning `hover:text-gray-400` and a separate `dark:text-gray-600`. A blind replace would have produced an unprefixed `hover:text-gray-600`, which applies in both themes and would have made the control **dimmer** on hover in dark mode, dropping it to 3.12:1. This is the only occurrence of that trap in the codebase.
- `admin/Settings/Audio.svelte` — the body text moving to `gray-600` would have made the nested links exactly the same colour as the surrounding prose, 1.00:1, with no resting underline. The link colour moves to `gray-900` so links stay distinguishable, which would otherwise have been a new WCAG 1.4.1 Use of Color failure.
- `chat/Messages/ResponseMessage/TaskList.svelte` — the completed and cancelled branches use different pairs. Both are converted so the completed / cancelled / active hierarchy is preserved rather than inverted.

Not covered here, and left for separate PRs: `text-gray-500 dark:text-gray-400` (140 sites, 2.77:1 in light), and the global `input::placeholder` colour in `src/tailwind.css` which has the same 2.07:1 problem.

Severity: Serious, and the most widely visible accessibility defect in the current light theme.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact. Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA. -->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.

<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->