### PR TITLE
fix: meet 4.5:1 contrast for input placeholders (WCAG 1.4.3)

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -402,12 +402,9 @@ input[type='number'] {
 .ProseMirror p.is-editor-empty:first-child::before {
 	content: attr(data-placeholder);
 	float: left;
-	/* Below color is from tailwind, and has the proper contrast
-	text-gray-600 from: https://tailwindcss.com/docs/color */
-	color: #676767;
 	pointer-events: none;
 
-	@apply line-clamp-1 absolute;
+	@apply line-clamp-1 absolute text-gray-600 dark:text-gray-500;
 }
 
 .tiptap ul[data-type='taskList'] {
@@ -566,12 +563,6 @@ input[type='number'] {
 				align-items: initial;
 			}
 		}
-	}
-}
-
-@media (prefers-color-scheme: dark) {
-	.ProseMirror p.is-editor-empty:first-child::before {
-		color: #757575;
 	}
 }
 

--- a/src/lib/components/AddConnectionModal.svelte
+++ b/src/lib/components/AddConnectionModal.svelte
@@ -60,10 +60,8 @@
 	let showDeleteConfirmDialog = false;
 	let showAdvanced = false;
 
-	const inputClass =
-		'bg-transparent outline-hidden placeholder:text-gray-300 dark:placeholder:text-gray-700';
-	const selectClass =
-		'dark:bg-gray-900 bg-transparent pr-5 outline-hidden placeholder:text-gray-300 dark:placeholder:text-gray-700';
+	const inputClass = 'bg-transparent outline-hidden';
+	const selectClass = 'dark:bg-gray-900 bg-transparent pr-5 outline-hidden';
 
 	const parsePassthroughParams = (value: string) =>
 		value

--- a/src/lib/components/AddTerminalServerModal.svelte
+++ b/src/lib/components/AddTerminalServerModal.svelte
@@ -59,10 +59,8 @@
 	let loadingPolicy = false;
 	let policyLoadError = '';
 
-	const inputClass =
-		'bg-transparent outline-hidden placeholder:text-gray-300 dark:placeholder:text-gray-700';
-	const selectClass =
-		'dark:bg-gray-900 bg-transparent pr-5 outline-hidden placeholder:text-gray-300 dark:placeholder:text-gray-700';
+	const inputClass = 'bg-transparent outline-hidden';
+	const selectClass = 'dark:bg-gray-900 bg-transparent pr-5 outline-hidden';
 
 	const stringifyJson = (value: object | null | undefined) => {
 		return JSON.stringify(value && Object.keys(value).length ? value : {}, null, 2);

--- a/src/lib/components/AddToolServerModal.svelte
+++ b/src/lib/components/AddToolServerModal.svelte
@@ -69,10 +69,8 @@
 	let showAccessControlModal = false;
 	let showDeleteConfirmDialog = false;
 
-	const inputClass =
-		'bg-transparent outline-hidden placeholder:text-gray-300 dark:placeholder:text-gray-700';
-	const selectClass =
-		'dark:bg-gray-900 bg-transparent pr-5 outline-hidden placeholder:text-gray-300 dark:placeholder:text-gray-700';
+	const inputClass = 'bg-transparent outline-hidden';
+	const selectClass = 'dark:bg-gray-900 bg-transparent pr-5 outline-hidden';
 
 	const registerOAuthClientHandler = async () => {
 		if (url === '') {

--- a/src/lib/components/AutomationModal.svelte
+++ b/src/lib/components/AutomationModal.svelte
@@ -112,7 +112,7 @@
 		<!-- Header -->
 		<div class="flex justify-between dark:text-gray-100 px-4 pt-3 pb-1">
 			<input
-				class="w-full text-sm font-medium bg-transparent outline-hidden placeholder:text-gray-300 dark:placeholder:text-gray-700"
+				class="w-full text-sm font-medium bg-transparent outline-hidden"
 				type="text"
 				bind:value={name}
 				placeholder={$i18n.t('Automation title')}
@@ -130,7 +130,7 @@
 		<div class="px-5 pb-2">
 			<div class="mb-1 text-xs text-gray-500">{$i18n.t('Instructions')}</div>
 			<textarea
-				class="w-full text-sm bg-transparent outline-hidden placeholder:text-gray-300 dark:placeholder:text-gray-700 resize-none min-h-[12rem]"
+				class="w-full text-sm bg-transparent outline-hidden resize-none min-h-[12rem]"
 				bind:value={prompt}
 				rows={8}
 				placeholder={$i18n.t('Enter prompt here.')}

--- a/src/lib/components/admin/Evaluations/Feedbacks.svelte
+++ b/src/lib/components/admin/Evaluations/Feedbacks.svelte
@@ -248,7 +248,7 @@
 							>
 								<svelte:fragment slot="trigger" let:selectedLabel>
 									<span
-										class="inline-flex h-input px-0.5 w-full outline-hidden bg-transparent truncate placeholder-gray-400 focus:outline-hidden"
+										class="inline-flex h-input px-0.5 w-full outline-hidden bg-transparent truncate focus:outline-hidden"
 									>
 										{selectedLabel}
 									</span>

--- a/src/lib/components/admin/Settings/Audio.svelte
+++ b/src/lib/components/admin/Settings/Audio.svelte
@@ -79,9 +79,9 @@
 	let providerVoices: Voice[] = [];
 	let models: Awaited<ReturnType<typeof _getModels>>['models'] = [];
 	const inputClass =
-		'w-full h-7 rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 text-xs text-gray-700 outline-hidden transition-colors placeholder:text-gray-300 focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:placeholder:text-gray-700 dark:focus:border-blue-500';
+		'w-full h-7 rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 text-xs text-gray-700 outline-hidden transition-colors focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:focus:border-blue-500';
 	const textareaClass =
-		'w-full rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 py-1.5 text-xs text-gray-700 outline-hidden transition-colors placeholder:text-gray-300 focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:placeholder:text-gray-700 dark:focus:border-blue-500';
+		'w-full rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 py-1.5 text-xs text-gray-700 outline-hidden transition-colors focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:focus:border-blue-500';
 	const linkedHelpClass =
 		'text-[0.6875rem] text-gray-400 dark:text-gray-600 [&_a]:text-gray-600 [&_a]:hover:underline dark:[&_a]:text-gray-300';
 

--- a/src/lib/components/admin/Settings/Authentication.svelte
+++ b/src/lib/components/admin/Settings/Authentication.svelte
@@ -50,9 +50,9 @@
 
 	let oauthConfig: any = null;
 	const inputClass =
-		'w-full h-7 rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 text-xs text-gray-700 outline-hidden transition-colors placeholder:text-gray-300 focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:placeholder:text-gray-700 dark:focus:border-blue-500';
+		'w-full h-7 rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 text-xs text-gray-700 outline-hidden transition-colors focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:focus:border-blue-500';
 	const textareaClass =
-		'w-full rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 py-1.5 text-xs text-gray-700 outline-hidden transition-colors placeholder:text-gray-300 focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:placeholder:text-gray-700 dark:focus:border-blue-500';
+		'w-full rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 py-1.5 text-xs text-gray-700 outline-hidden transition-colors focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:focus:border-blue-500';
 
 	const updateLdapServerHandler = async () => {
 		await updateLdapConfig(localStorage.token, ENABLE_LDAP);

--- a/src/lib/components/admin/Settings/CodeExecution.svelte
+++ b/src/lib/components/admin/Settings/CodeExecution.svelte
@@ -19,9 +19,9 @@
 
 	let engines = ['pyodide', 'jupyter'];
 	const inputClass =
-		'w-full h-7 rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 text-xs text-gray-700 outline-hidden transition-colors placeholder:text-gray-300 focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:placeholder:text-gray-700 dark:focus:border-blue-500';
+		'w-full h-7 rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 text-xs text-gray-700 outline-hidden transition-colors focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:focus:border-blue-500';
 	const textareaClass =
-		'w-full rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 py-1.5 text-xs text-gray-700 outline-hidden transition-colors placeholder:text-gray-300 focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:placeholder:text-gray-700 dark:focus:border-blue-500';
+		'w-full rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 py-1.5 text-xs text-gray-700 outline-hidden transition-colors focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:focus:border-blue-500';
 
 	const submitHandler = async () => {
 		const res = await setCodeExecutionConfig(localStorage.token, config);

--- a/src/lib/components/admin/Settings/Documents.svelte
+++ b/src/lib/components/admin/Settings/Documents.svelte
@@ -71,11 +71,11 @@
 
 	let RAGConfig = null;
 	const inputClass =
-		'w-full h-7 rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 text-xs text-gray-700 outline-hidden transition-colors placeholder:text-gray-300 focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:placeholder:text-gray-700 dark:focus:border-blue-500';
+		'w-full h-7 rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 text-xs text-gray-700 outline-hidden transition-colors focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:focus:border-blue-500';
 	const actionButtonClass =
 		'shrink-0 text-xs text-gray-500 transition-colors hover:text-gray-900 dark:text-gray-500 dark:hover:text-white';
 	const textareaClass =
-		'w-full rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 py-1.5 text-xs text-gray-700 outline-hidden transition-colors placeholder:text-gray-300 focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:placeholder:text-gray-700 dark:focus:border-blue-500';
+		'w-full rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 py-1.5 text-xs text-gray-700 outline-hidden transition-colors focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:focus:border-blue-500';
 
 	const embeddingModelUpdateHandler = async () => {
 		if (RAG_EMBEDDING_ENGINE === '' && RAG_EMBEDDING_MODEL.split('/').length - 1 > 1) {

--- a/src/lib/components/admin/Settings/Evaluations/ArenaModelModal.svelte
+++ b/src/lib/components/admin/Settings/Evaluations/ArenaModelModal.svelte
@@ -249,7 +249,7 @@
 
 								<div class="flex-1">
 									<input
-										class="w-full text-sm bg-transparent placeholder:text-gray-300 dark:placeholder:text-gray-700 outline-hidden"
+										class="w-full text-sm bg-transparent outline-hidden"
 										type="text"
 										bind:value={name}
 										placeholder={$i18n.t('Model Name')}
@@ -264,7 +264,7 @@
 
 								<div class="flex-1">
 									<input
-										class="w-full text-sm bg-transparent placeholder:text-gray-300 dark:placeholder:text-gray-700 outline-hidden"
+										class="w-full text-sm bg-transparent outline-hidden"
 										type="text"
 										bind:value={id}
 										placeholder={$i18n.t('Model ID')}
@@ -281,7 +281,7 @@
 
 							<div class="flex-1">
 								<input
-									class="w-full text-sm bg-transparent placeholder:text-gray-300 dark:placeholder:text-gray-700 outline-hidden"
+									class="w-full text-sm bg-transparent outline-hidden"
 									type="text"
 									bind:value={description}
 									placeholder={$i18n.t('Enter description')}
@@ -352,7 +352,7 @@
 							<select
 								class="w-full py-1 text-sm rounded-lg bg-transparent {selectedModelId
 									? ''
-									: 'text-gray-500'} placeholder:text-gray-300 dark:placeholder:text-gray-700 outline-hidden"
+									: 'text-gray-500'} outline-hidden"
 								bind:value={selectedModelId}
 							>
 								<option value="">{$i18n.t('Select a model')}</option>

--- a/src/lib/components/admin/Settings/Events.svelte
+++ b/src/lib/components/admin/Settings/Events.svelte
@@ -53,7 +53,7 @@
 	};
 
 	const inputClass =
-		'rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 py-1.5 text-gray-700 outline-hidden transition-colors placeholder:text-gray-300 focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:placeholder:text-gray-700 dark:focus:border-blue-500';
+		'rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 py-1.5 text-gray-700 outline-hidden transition-colors focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:focus:border-blue-500';
 
 	$: events = eventItems.map((item) => item.event);
 	$: eventDetails = Object.fromEntries(eventItems.map((item) => [item.event, item]));

--- a/src/lib/components/admin/Settings/ExternalKnowledge.svelte
+++ b/src/lib/components/admin/Settings/ExternalKnowledge.svelte
@@ -443,7 +443,7 @@
 								<div class="flex flex-1 items-center">
 									<input
 										id="external-source-name"
-										class="w-full flex-1 text-sm bg-transparent outline-hidden placeholder:text-gray-300 dark:placeholder:text-gray-700"
+										class="w-full flex-1 text-sm bg-transparent outline-hidden"
 										bind:value={sourceForm.name}
 										on:input={markUntested}
 										placeholder={$i18n.t('Research Knowledge')}
@@ -480,7 +480,7 @@
 							>
 							<textarea
 								id="external-source-description"
-								class="w-full text-sm bg-transparent outline-hidden resize-none placeholder:text-gray-300 dark:placeholder:text-gray-700"
+								class="w-full text-sm bg-transparent outline-hidden resize-none"
 								rows="2"
 								bind:value={sourceForm.description}
 							></textarea>
@@ -496,7 +496,7 @@
 								<div class="flex flex-1 items-center">
 									<input
 										id="external-source-endpoint"
-										class="w-full flex-1 text-sm bg-transparent outline-hidden placeholder:text-gray-300 dark:placeholder:text-gray-700"
+										class="w-full flex-1 text-sm bg-transparent outline-hidden"
 										bind:value={sourceForm.endpoint}
 										on:input={markUntested}
 										placeholder={endpointPlaceholder()}
@@ -534,7 +534,7 @@
 									<div class="flex flex-1 items-center">
 										<input
 											id="external-source-api-key"
-											class="w-full text-sm bg-transparent outline-hidden placeholder:text-gray-300 dark:placeholder:text-gray-700"
+											class="w-full text-sm bg-transparent outline-hidden"
 											type="password"
 											bind:value={sourceForm.apiKey}
 											on:input={markUntested}
@@ -578,7 +578,7 @@
 								<div class="flex flex-1 items-center">
 									<input
 										id="external-source-collection"
-										class="w-full text-sm bg-transparent outline-hidden placeholder:text-gray-300 dark:placeholder:text-gray-700"
+										class="w-full text-sm bg-transparent outline-hidden"
 										bind:value={sourceForm.sourceName}
 										on:input={markUntested}
 										placeholder="research-docs"
@@ -599,7 +599,7 @@
 									<div class="flex flex-1 items-center">
 										<input
 											id="external-source-table"
-											class="w-full text-sm bg-transparent outline-hidden placeholder:text-gray-300 dark:placeholder:text-gray-700"
+											class="w-full text-sm bg-transparent outline-hidden"
 											bind:value={sourceForm.tableName}
 											on:input={markUntested}
 											placeholder="document_chunk"
@@ -617,7 +617,7 @@
 									<div class="flex flex-1 items-center">
 										<input
 											id="external-source-collection-field"
-											class="w-full text-sm bg-transparent outline-hidden placeholder:text-gray-300 dark:placeholder:text-gray-700"
+											class="w-full text-sm bg-transparent outline-hidden"
 											bind:value={sourceForm.collectionField}
 											on:input={markUntested}
 											placeholder="collection_name"
@@ -638,7 +638,7 @@
 								<div class="flex flex-1 items-center">
 									<input
 										id="external-source-content-field"
-										class="w-full text-sm bg-transparent outline-hidden placeholder:text-gray-300 dark:placeholder:text-gray-700"
+										class="w-full text-sm bg-transparent outline-hidden"
 										bind:value={sourceForm.contentField}
 										on:input={markUntested}
 										placeholder={sourceForm.provider === 'pgvector' ? 'text' : 'payload.text'}
@@ -656,7 +656,7 @@
 								<div class="flex flex-1 items-center">
 									<input
 										id="external-source-vector-field"
-										class="w-full text-sm bg-transparent outline-hidden placeholder:text-gray-300 dark:placeholder:text-gray-700"
+										class="w-full text-sm bg-transparent outline-hidden"
 										bind:value={sourceForm.vectorField}
 										on:input={markUntested}
 										placeholder={sourceForm.provider === 'qdrant' ? $i18n.t('Default') : 'vector'}
@@ -676,7 +676,7 @@
 								<div class="flex flex-1 items-center">
 									<input
 										id="external-source-metadata-field"
-										class="w-full text-sm bg-transparent outline-hidden placeholder:text-gray-300 dark:placeholder:text-gray-700"
+										class="w-full text-sm bg-transparent outline-hidden"
 										bind:value={sourceForm.metadataField}
 										on:input={markUntested}
 										placeholder={sourceForm.provider === 'pgvector'
@@ -695,7 +695,7 @@
 								<div class="flex flex-1 items-center">
 									<input
 										id="external-source-document-id-field"
-										class="w-full text-sm bg-transparent outline-hidden placeholder:text-gray-300 dark:placeholder:text-gray-700"
+										class="w-full text-sm bg-transparent outline-hidden"
 										bind:value={sourceForm.documentIdField}
 										on:input={markUntested}
 										placeholder="id"
@@ -714,7 +714,7 @@
 								<div class="flex flex-1 items-center">
 									<input
 										id="external-source-test-query"
-										class="w-full flex-1 text-sm bg-transparent outline-hidden placeholder:text-gray-300 dark:placeholder:text-gray-700"
+										class="w-full flex-1 text-sm bg-transparent outline-hidden"
 										bind:value={sourceForm.testQuery}
 										on:input={markUntested}
 										placeholder={$i18n.t('Ask a test question')}

--- a/src/lib/components/admin/Settings/General.svelte
+++ b/src/lib/components/admin/Settings/General.svelte
@@ -35,9 +35,9 @@
 
 	let banners: Banner[] = [];
 	const inputClass =
-		'w-full h-7 rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 text-xs text-gray-700 outline-hidden transition-colors placeholder:text-gray-300 focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:placeholder:text-gray-700 dark:focus:border-blue-500';
+		'w-full h-7 rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 text-xs text-gray-700 outline-hidden transition-colors focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:focus:border-blue-500';
 	const textareaClass =
-		'w-full rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 py-1.5 text-xs text-gray-700 outline-hidden transition-colors placeholder:text-gray-300 focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:placeholder:text-gray-700 dark:focus:border-blue-500';
+		'w-full rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 py-1.5 text-xs text-gray-700 outline-hidden transition-colors focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:focus:border-blue-500';
 
 	const checkForVersionUpdates = async () => {
 		updateAvailable = null;

--- a/src/lib/components/admin/Settings/Images.svelte
+++ b/src/lib/components/admin/Settings/Images.svelte
@@ -33,9 +33,9 @@
 	let models = null;
 	let config = null;
 	const inputClass =
-		'w-full h-7 rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 text-xs text-gray-700 outline-hidden transition-colors placeholder:text-gray-300 focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:placeholder:text-gray-700 dark:focus:border-blue-500';
+		'w-full h-7 rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 text-xs text-gray-700 outline-hidden transition-colors focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:focus:border-blue-500';
 	const textareaClass =
-		'w-full rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 py-1.5 text-xs text-gray-700 outline-hidden transition-colors placeholder:text-gray-300 focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:placeholder:text-gray-700 dark:focus:border-blue-500';
+		'w-full rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 py-1.5 text-xs text-gray-700 outline-hidden transition-colors focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:focus:border-blue-500';
 
 	let showComfyUIWorkflowEditor = false;
 	let REQUIRED_WORKFLOW_NODES = [
@@ -606,7 +606,7 @@
 								/>
 								<!-- {#if config.COMFYUI_WORKFLOW}
 								<Textarea
-									className="my-1 w-full resize-none rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 py-1.5 text-xs text-gray-700 outline-hidden transition-colors placeholder:text-gray-300 focus:border-blue-400 disabled:text-gray-600 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:placeholder:text-gray-700 dark:focus:border-blue-500"
+									className="my-1 w-full resize-none rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 py-1.5 text-xs text-gray-700 outline-hidden transition-colors focus:border-blue-400 disabled:text-gray-600 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:focus:border-blue-500"
 									rows="10"
 										bind:value={config.COMFYUI_WORKFLOW}
 									required

--- a/src/lib/components/admin/Settings/Interface.svelte
+++ b/src/lib/components/admin/Settings/Interface.svelte
@@ -72,9 +72,9 @@
 	let models: any[] | null = null;
 	$: modelOptions = models ?? [];
 	const inputClass =
-		'w-full h-7 rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 text-xs text-gray-700 outline-hidden transition-colors placeholder:text-gray-300 focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:placeholder:text-gray-700 dark:focus:border-blue-500';
+		'w-full h-7 rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 text-xs text-gray-700 outline-hidden transition-colors focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:focus:border-blue-500';
 	const textareaClass =
-		'w-full rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 py-1.5 text-xs text-gray-700 outline-hidden transition-colors placeholder:text-gray-300 focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:placeholder:text-gray-700 dark:focus:border-blue-500';
+		'w-full rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 py-1.5 text-xs text-gray-700 outline-hidden transition-colors focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:focus:border-blue-500';
 
 	const init = async () => {
 		try {

--- a/src/lib/components/admin/Settings/Models/AdminViewSelector.svelte
+++ b/src/lib/components/admin/Settings/Models/AdminViewSelector.svelte
@@ -31,12 +31,12 @@
 	{placeholder}
 	{align}
 	triggerClass="relative h-8 w-full flex items-center gap-0.5 px-1.5 py-1.5 bg-transparent rounded-xl text-[13px] font-normal text-gray-700 transition hover:text-gray-900 dark:text-gray-200 dark:hover:text-gray-100"
-	labelClass="inline-flex h-input w-full outline-hidden bg-transparent truncate placeholder-gray-400 focus:outline-hidden"
+	labelClass="inline-flex h-input w-full outline-hidden bg-transparent truncate focus:outline-hidden"
 	onChange={() => onChange(value)}
 >
 	<svelte:fragment slot="trigger" let:selectedLabel>
 		<span
-			class="inline-flex h-input w-full outline-hidden bg-transparent truncate placeholder-gray-400 focus:outline-hidden"
+			class="inline-flex h-input w-full outline-hidden bg-transparent truncate focus:outline-hidden"
 		>
 			{selectedLabel}
 		</span>

--- a/src/lib/components/admin/Settings/Pipelines.svelte
+++ b/src/lib/components/admin/Settings/Pipelines.svelte
@@ -43,7 +43,7 @@
 
 	let pipelineDownloadUrl = '';
 	const inputClass =
-		'w-full h-7 rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 text-xs text-gray-700 outline-hidden transition-colors placeholder:text-gray-300 focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:placeholder:text-gray-700 dark:focus:border-blue-500';
+		'w-full h-7 rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 text-xs text-gray-700 outline-hidden transition-colors focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:focus:border-blue-500';
 	const actionButtonClass =
 		'shrink-0 text-xs text-gray-500 transition-colors hover:text-gray-900 disabled:opacity-50 dark:text-gray-500 dark:hover:text-white';
 	const mutedMessageClass = 'text-xs text-gray-400 dark:text-gray-600';

--- a/src/lib/components/admin/Settings/WebSearch.svelte
+++ b/src/lib/components/admin/Settings/WebSearch.svelte
@@ -52,9 +52,9 @@
 
 	let webConfig: any = null;
 	const inputClass =
-		'w-full rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 py-1.5 text-xs text-gray-700 outline-hidden transition-colors placeholder:text-gray-300 focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:placeholder:text-gray-700 dark:focus:border-blue-500';
+		'w-full rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 py-1.5 text-xs text-gray-700 outline-hidden transition-colors focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:focus:border-blue-500';
 	const textareaClass =
-		'w-full rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 py-1.5 text-xs text-gray-700 outline-hidden transition-colors placeholder:text-gray-300 focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:placeholder:text-gray-700 dark:focus:border-blue-500';
+		'w-full rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 py-1.5 text-xs text-gray-700 outline-hidden transition-colors focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:focus:border-blue-500';
 
 	const submitHandler = async () => {
 		// Convert domain filter string to array before sending

--- a/src/lib/components/admin/Users/Groups.svelte
+++ b/src/lib/components/admin/Users/Groups.svelte
@@ -143,12 +143,12 @@
 					items={sortItems}
 					placeholder={$i18n.t('Sort')}
 					triggerClass="relative h-8 shrink-0 flex items-center gap-1 px-1.5 py-1.5 bg-transparent rounded-xl text-[13px] font-normal text-gray-700 transition hover:text-gray-900 dark:text-gray-200 dark:hover:text-gray-100"
-					labelClass="inline-flex h-input outline-hidden bg-transparent truncate placeholder-gray-400 focus:outline-hidden"
+					labelClass="inline-flex h-input outline-hidden bg-transparent truncate focus:outline-hidden"
 					align="end"
 				>
 					<svelte:fragment slot="trigger" let:selectedLabel>
 						<span
-							class="inline-flex h-input outline-hidden bg-transparent truncate placeholder-gray-400 focus:outline-hidden"
+							class="inline-flex h-input outline-hidden bg-transparent truncate focus:outline-hidden"
 						>
 							{selectedLabel}
 						</span>

--- a/src/lib/components/admin/Users/Groups/General.svelte
+++ b/src/lib/components/admin/Users/Groups/General.svelte
@@ -20,7 +20,7 @@
 
 		<div class="flex-1">
 			<input
-				class="w-full text-sm bg-transparent placeholder:text-gray-300 dark:placeholder:text-gray-700 outline-hidden"
+				class="w-full text-sm bg-transparent outline-hidden"
 				type="text"
 				bind:value={name}
 				placeholder={$i18n.t('Group Name')}
@@ -40,7 +40,7 @@
 				<div class="text-gray-500">#</div>
 
 				<input
-					class="w-full text-sm bg-transparent placeholder:text-gray-300 dark:placeholder:text-gray-700 outline-hidden"
+					class="w-full text-sm bg-transparent outline-hidden"
 					type="text"
 					bind:value={color}
 					placeholder={$i18n.t('Hex Color')}
@@ -56,7 +56,7 @@
 
 	<div class="flex-1">
 		<Textarea
-			className="w-full text-sm bg-transparent placeholder:text-gray-300 dark:placeholder:text-gray-700 outline-hidden resize-none"
+			className="w-full text-sm bg-transparent outline-hidden resize-none"
 			rows={4}
 			bind:value={description}
 			placeholder={$i18n.t('Group Description')}

--- a/src/lib/components/automations/ScheduleDropdown.svelte
+++ b/src/lib/components/automations/ScheduleDropdown.svelte
@@ -217,7 +217,7 @@
 					type="text"
 					bind:value={customRrule}
 					placeholder="RRULE:FREQ=DAILY;BYHOUR=9;BYMINUTE=0"
-					class="w-full bg-transparent outline-hidden text-[13px] placeholder:text-gray-400 dark:placeholder:text-gray-600"
+					class="w-full bg-transparent outline-hidden text-[13px]"
 					on:click={(e) => e.stopPropagation()}
 					on:input={onChange}
 				/>

--- a/src/lib/components/automations/TerminalDropdown.svelte
+++ b/src/lib/components/automations/TerminalDropdown.svelte
@@ -106,7 +106,7 @@
 							type="text"
 							bind:value={terminalCwd}
 							placeholder="/home/user/project"
-							class="w-full bg-transparent outline-hidden text-[13px] py-1 placeholder:text-gray-400 dark:placeholder:text-gray-600"
+							class="w-full bg-transparent outline-hidden text-[13px] py-1"
 							on:click={(e) => e.stopPropagation()}
 							on:input={onChange}
 						/>

--- a/src/lib/components/calendar/CalendarEventModal.svelte
+++ b/src/lib/components/calendar/CalendarEventModal.svelte
@@ -189,7 +189,7 @@
 	<div>
 		<div class="dark:text-gray-100 px-4 pt-3 pb-1">
 			<input
-				class="w-full text-base bg-transparent outline-hidden placeholder:text-gray-300 dark:placeholder:text-gray-700"
+				class="w-full text-base bg-transparent outline-hidden"
 				type="text"
 				bind:value={title}
 				placeholder={$i18n.t('Event title')}
@@ -231,7 +231,7 @@
 			<div>
 				<div class="mb-1 text-xs text-gray-500">{$i18n.t('Location')}</div>
 				<input
-					class="w-full text-sm bg-transparent outline-hidden placeholder:text-gray-300 dark:placeholder:text-gray-700"
+					class="w-full text-sm bg-transparent outline-hidden"
 					placeholder={$i18n.t('Add location')}
 					bind:value={location}
 				/>
@@ -274,7 +274,7 @@
 			<div>
 				<div class="mb-1 text-xs text-gray-500">{$i18n.t('Description')}</div>
 				<textarea
-					class="w-full text-sm bg-transparent outline-hidden placeholder:text-gray-300 dark:placeholder:text-gray-700 resize-none min-h-[4rem]"
+					class="w-full text-sm bg-transparent outline-hidden resize-none min-h-[4rem]"
 					placeholder={$i18n.t('Add description')}
 					bind:value={description}
 					rows="3"

--- a/src/lib/components/calendar/CreateCalendarModal.svelte
+++ b/src/lib/components/calendar/CreateCalendarModal.svelte
@@ -81,7 +81,7 @@
 			<div>
 				<div class="mb-1 text-xs text-gray-500">{$i18n.t('Name')}</div>
 				<input
-					class="w-full text-sm bg-transparent outline-hidden placeholder:text-gray-300 dark:placeholder:text-gray-700"
+					class="w-full text-sm bg-transparent outline-hidden"
 					type="text"
 					bind:value={name}
 					placeholder={$i18n.t('Calendar name')}

--- a/src/lib/components/channel/WebhookItem.svelte
+++ b/src/lib/components/channel/WebhookItem.svelte
@@ -133,7 +133,7 @@
 					<div class=" text-gray-500 text-xs">{$i18n.t('Name')}</div>
 					<input
 						type="text"
-						class="w-full text-sm bg-transparent outline-none placeholder:text-gray-300 dark:placeholder:text-gray-700"
+						class="w-full text-sm bg-transparent outline-none"
 						bind:value={name}
 						placeholder={$i18n.t('Webhook Name')}
 					/>

--- a/src/lib/components/chat/Controls/Controls.svelte
+++ b/src/lib/components/chat/Controls/Controls.svelte
@@ -32,7 +32,7 @@
 	const compactSectionButtonClass =
 		'w-full py-1 text-xs font-normal text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100 transition cursor-pointer select-none';
 	const systemPromptTextareaClass =
-		'w-full resize-vertical rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 py-1.5 text-xs text-gray-700 outline-hidden transition-colors placeholder:text-gray-300 focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:placeholder:text-gray-700 dark:focus:border-blue-500';
+		'w-full resize-vertical rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 py-1.5 text-xs text-gray-700 outline-hidden transition-colors focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:focus:border-blue-500';
 	const compactSystemPromptTextareaClass =
 		'w-full resize-vertical appearance-none bg-transparent py-1 text-xs outline-hidden focus:bg-transparent disabled:bg-transparent';
 </script>

--- a/src/lib/components/chat/MessageInput/AttachWebpageModal.svelte
+++ b/src/lib/components/chat/MessageInput/AttachWebpageModal.svelte
@@ -15,7 +15,7 @@
 	let url = '';
 
 	const highContrastInputClass =
-		'rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 py-1.5 text-gray-700 outline-hidden transition-colors placeholder:text-gray-300 focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:placeholder:text-gray-700 dark:focus:border-blue-500';
+		'rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 py-1.5 text-gray-700 outline-hidden transition-colors focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:focus:border-blue-500';
 
 	const submitHandler = () => {
 		let urls = url
@@ -71,7 +71,7 @@
 
 				<textarea
 					id="webpage-url"
-					class={`w-full flex-1 text-sm ${($settings?.highContrastMode ?? false) ? highContrastInputClass : 'bg-transparent outline-hidden placeholder:text-gray-300 dark:placeholder:text-gray-700'}`}
+					class={`w-full flex-1 text-sm ${($settings?.highContrastMode ?? false) ? highContrastInputClass : 'bg-transparent outline-hidden'}`}
 					type="text"
 					bind:value={url}
 					rows="3"

--- a/src/lib/components/chat/MessageInput/InputMenu/SearchInput.svelte
+++ b/src/lib/components/chat/MessageInput/InputMenu/SearchInput.svelte
@@ -14,7 +14,7 @@
 
 	<input
 		bind:value
-		class="w-full bg-transparent text-[13px] font-normal outline-hidden placeholder:text-gray-400 dark:placeholder:text-gray-500"
+		class="w-full bg-transparent text-[13px] font-normal outline-hidden dark:placeholder:text-gray-500"
 		{placeholder}
 		autocomplete="off"
 		aria-label={placeholder}

--- a/src/lib/components/chat/ModelSelector/Selector.svelte
+++ b/src/lib/components/chat/ModelSelector/Selector.svelte
@@ -741,7 +741,7 @@
 			class="flex w-full min-w-0 text-left px-0.5 bg-transparent {triggerClassName} justify-between {($settings?.highContrastMode ??
 			false)
 				? 'dark:placeholder-gray-100 placeholder-gray-800'
-				: 'placeholder-gray-400'}"
+				: ''}"
 			on:mouseenter={async () => {
 				models.set(
 					await getModels(
@@ -777,7 +777,7 @@
 							<input
 								id="model-search-input"
 								bind:value={searchValue}
-								class="w-full bg-transparent text-[13px] font-normal outline-hidden placeholder:text-gray-400 dark:placeholder:text-gray-500"
+								class="w-full bg-transparent text-[13px] font-normal outline-hidden dark:placeholder:text-gray-500"
 								placeholder={searchPlaceholder}
 								autocomplete="off"
 								aria-label={$i18n.t('Search In Models')}

--- a/src/lib/components/chat/Settings/Account.svelte
+++ b/src/lib/components/chat/Settings/Account.svelte
@@ -47,11 +47,11 @@
 	let variableFormValue = '';
 
 	const textareaClass =
-		'w-full resize-y rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 py-1.5 text-xs text-gray-700 outline-hidden transition-colors placeholder:text-gray-300 focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:placeholder:text-gray-700 dark:focus:border-blue-500';
+		'w-full resize-y rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 py-1.5 text-xs text-gray-700 outline-hidden transition-colors focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:focus:border-blue-500';
 	const inputClass =
-		'h-7 w-full rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 text-xs text-gray-700 outline-hidden transition-colors placeholder:text-gray-300 focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:placeholder:text-gray-700 dark:focus:border-blue-500';
+		'h-7 w-full rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 text-xs text-gray-700 outline-hidden transition-colors focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:focus:border-blue-500';
 	const variableValueClass =
-		'w-full resize-none rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 py-1.5 text-xs text-gray-700 outline-hidden transition-colors placeholder:text-gray-300 focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:placeholder:text-gray-700 dark:focus:border-blue-500';
+		'w-full resize-none rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 py-1.5 text-xs text-gray-700 outline-hidden transition-colors focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:focus:border-blue-500';
 	const actionButtonClass =
 		'text-xs text-gray-500 transition-colors hover:text-gray-900 dark:text-gray-500 dark:hover:text-white';
 	const variableRowClass = 'flex w-full items-center gap-1.5';

--- a/src/lib/components/chat/Settings/ArchivedChats.svelte
+++ b/src/lib/components/chat/Settings/ArchivedChats.svelte
@@ -197,7 +197,7 @@
 			<Search className="size-3.5 shrink-0 text-gray-400 dark:text-gray-600" />
 			<input
 				data-settings-search
-				class="min-w-0 flex-1 bg-transparent py-0.5 text-xs text-gray-700 outline-hidden placeholder:text-gray-300 dark:text-gray-300 dark:placeholder:text-gray-700"
+				class="min-w-0 flex-1 bg-transparent py-0.5 text-xs text-gray-700 outline-hidden dark:text-gray-300"
 				bind:value={query}
 				on:input={searchHandler}
 				placeholder={$i18n.t('Search')}

--- a/src/lib/components/chat/Settings/Audio.svelte
+++ b/src/lib/components/chat/Settings/Audio.svelte
@@ -40,7 +40,7 @@
 	// Audio speed control
 	let playbackRate = 1;
 	const inputClass =
-		'h-7 w-full rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 text-xs text-gray-700 outline-hidden transition-colors placeholder:text-gray-300 focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:placeholder:text-gray-700 dark:focus:border-blue-500';
+		'h-7 w-full rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 text-xs text-gray-700 outline-hidden transition-colors focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:focus:border-blue-500';
 
 	const getVoices = async () => {
 		if (TTSEngine === 'browser-kokoro') {
@@ -217,7 +217,7 @@
 							bind:value={STTLanguage}
 							aria-label={$i18n.t('Speech-to-Text Language')}
 							placeholder={$i18n.t('e.g. en')}
-							class="h-7 w-24 rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 text-right text-xs text-gray-700 outline-hidden transition-colors placeholder:text-gray-300 focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:placeholder:text-gray-700 dark:focus:border-blue-500"
+							class="h-7 w-24 rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 text-right text-xs text-gray-700 outline-hidden transition-colors focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:focus:border-blue-500"
 						/>
 					</Tooltip>
 				</UserSettingRow>

--- a/src/lib/components/chat/Settings/Connections/Connection.svelte
+++ b/src/lib/components/chat/Settings/Connections/Connection.svelte
@@ -56,7 +56,7 @@
 		<div class="flex w-full gap-2">
 			<div class="flex-1 relative">
 				<input
-					class={`h-7 w-full rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 text-xs text-gray-700 outline-hidden transition-colors placeholder:text-gray-300 focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:placeholder:text-gray-700 dark:focus:border-blue-500 ${pipeline ? 'pr-8' : ''}`}
+					class={`h-7 w-full rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 text-xs text-gray-700 outline-hidden transition-colors focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:focus:border-blue-500 ${pipeline ? 'pr-8' : ''}`}
 					placeholder={$i18n.t('API Base URL')}
 					bind:value={url}
 					autocomplete="off"

--- a/src/lib/components/chat/Settings/General.svelte
+++ b/src/lib/components/chat/Settings/General.svelte
@@ -27,7 +27,7 @@
 	let showAdvanced = false;
 
 	const systemPromptTextareaClass =
-		'w-full resize-y rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 py-1.5 text-xs text-gray-700 outline-hidden transition-colors placeholder:text-gray-300 focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:placeholder:text-gray-700 dark:focus:border-blue-500';
+		'w-full resize-y rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 py-1.5 text-xs text-gray-700 outline-hidden transition-colors focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:focus:border-blue-500';
 	const actionButtonClass =
 		'text-xs text-gray-500 transition-colors hover:text-gray-900 dark:text-gray-500 dark:hover:text-white';
 

--- a/src/lib/components/chat/Settings/Interface/ManageImageCompressionModal.svelte
+++ b/src/lib/components/chat/Settings/Interface/ManageImageCompressionModal.svelte
@@ -71,7 +71,7 @@
 											id="image-comp-width"
 											bind:value={size.width}
 											type="number"
-											class="h-7 w-full rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 text-center text-xs text-gray-700 outline-hidden transition-colors placeholder:text-gray-300 focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:placeholder:text-gray-700 dark:focus:border-blue-500"
+											class="h-7 w-full rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 text-center text-xs text-gray-700 outline-hidden transition-colors focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:focus:border-blue-500"
 											min="0"
 											placeholder={$i18n.t('Width')}
 										/>
@@ -89,7 +89,7 @@
 											id="image-comp-height"
 											bind:value={size.height}
 											type="number"
-											class="h-7 w-full rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 text-center text-xs text-gray-700 outline-hidden transition-colors placeholder:text-gray-300 focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:placeholder:text-gray-700 dark:focus:border-blue-500"
+											class="h-7 w-full rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 text-center text-xs text-gray-700 outline-hidden transition-colors focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:focus:border-blue-500"
 											min="0"
 											placeholder={$i18n.t('Height')}
 										/>

--- a/src/lib/components/chat/Settings/Notifications.svelte
+++ b/src/lib/components/chat/Settings/Notifications.svelte
@@ -352,7 +352,7 @@
 			placeholder={$i18n.t('Target ID')}
 			autocomplete="off"
 			spellcheck="false"
-			class="block w-full bg-transparent py-0.5 font-mono text-[0.8125rem] text-gray-700 outline-none placeholder:text-gray-300 dark:text-gray-300 dark:placeholder:text-gray-700"
+			class="block w-full bg-transparent py-0.5 font-mono text-[0.8125rem] text-gray-700 outline-none dark:text-gray-300"
 		/>
 
 		<div class="mt-2 text-[0.625rem] text-gray-400 dark:text-gray-600">
@@ -366,7 +366,7 @@
 				: 'https://hooks.slack.com/services/...'}
 			autocomplete="off"
 			spellcheck="false"
-			class="block w-full bg-transparent py-0.5 font-mono text-[0.8125rem] text-gray-700 outline-none placeholder:text-gray-300 dark:text-gray-300 dark:placeholder:text-gray-700"
+			class="block w-full bg-transparent py-0.5 font-mono text-[0.8125rem] text-gray-700 outline-none dark:text-gray-300"
 		/>
 
 		<div class="mt-3 mb-1 text-[0.625rem] text-gray-400 dark:text-gray-600">

--- a/src/lib/components/chat/Settings/Personalization.svelte
+++ b/src/lib/components/chat/Settings/Personalization.svelte
@@ -165,7 +165,7 @@
 									<Search className="size-3.5 shrink-0 text-gray-400 dark:text-gray-600" />
 									<input
 										data-settings-search
-										class="min-w-0 flex-1 bg-transparent py-0.5 text-xs text-gray-700 outline-hidden placeholder:text-gray-300 dark:text-gray-300 dark:placeholder:text-gray-700"
+										class="min-w-0 flex-1 bg-transparent py-0.5 text-xs text-gray-700 outline-hidden dark:text-gray-300"
 										bind:value={query}
 										placeholder={$i18n.t('Search Memories')}
 										maxlength="500"

--- a/src/lib/components/chat/Settings/Personalization/MemoryModal.svelte
+++ b/src/lib/components/chat/Settings/Personalization/MemoryModal.svelte
@@ -90,7 +90,7 @@
 
 						<textarea
 							bind:value={content}
-							class="bg-transparent w-full text-sm outline-hidden placeholder:text-gray-300 dark:placeholder:text-gray-700"
+							class="bg-transparent w-full text-sm outline-hidden"
 							rows="6"
 							style="resize: vertical;"
 							placeholder={type === 'user'
@@ -107,7 +107,7 @@
 							<input
 								id="memory-path"
 								bind:value={path}
-								class="w-full text-sm bg-transparent outline-hidden placeholder:text-gray-300 dark:placeholder:text-gray-700"
+								class="w-full text-sm bg-transparent outline-hidden"
 								placeholder={$i18n.t('Path')}
 								autocomplete="off"
 							/>

--- a/src/lib/components/common/DropdownOptions.svelte
+++ b/src/lib/components/common/DropdownOptions.svelte
@@ -30,7 +30,7 @@
 	{align}
 	triggerClass={className
 		? className
-		: 'flex h-8 shrink-0 items-center gap-1.5 rounded-xl bg-transparent px-1.5 text-[13px] font-normal text-gray-700 transition placeholder-gray-400 outline-hidden hover:text-gray-900 focus:outline-hidden dark:text-gray-200 dark:hover:text-gray-100'}
+		: 'flex h-8 shrink-0 items-center gap-1.5 rounded-xl bg-transparent px-1.5 text-[13px] font-normal text-gray-700 transition outline-hidden hover:text-gray-900 focus:outline-hidden dark:text-gray-200 dark:hover:text-gray-100'}
 	itemClass="flex h-[1.6875rem] w-full cursor-pointer items-center gap-2 rounded-xl bg-transparent px-2 text-[13px] hover:bg-gray-50/40 hover:text-gray-900 dark:hover:bg-gray-800/40 dark:hover:text-gray-100"
 	onChange={(v) => {
 		onChange(v);

--- a/src/lib/components/common/Selector.svelte
+++ b/src/lib/components/common/Selector.svelte
@@ -38,7 +38,7 @@
 >
 	<svelte:fragment slot="trigger" let:selectedLabel>
 		<span
-			class="inline-flex h-input px-0.5 w-full outline-hidden bg-transparent truncate text-lg font-normal placeholder-gray-400 focus:outline-hidden"
+			class="inline-flex h-input px-0.5 w-full outline-hidden bg-transparent truncate text-lg font-normal focus:outline-hidden"
 		>
 			{selectedLabel}
 		</span>

--- a/src/lib/components/common/SensitiveInput.svelte
+++ b/src/lib/components/common/SensitiveInput.svelte
@@ -25,7 +25,7 @@
 			: outerClassName;
 	$: inputBaseClass =
 		variant === 'settings'
-			? 'min-w-0 flex-1 bg-transparent text-xs text-gray-700 outline-hidden placeholder:text-gray-300 disabled:text-gray-500 dark:text-gray-300 dark:placeholder:text-gray-700'
+			? 'min-w-0 flex-1 bg-transparent text-xs text-gray-700 outline-hidden disabled:text-gray-500 dark:text-gray-300'
 			: 'w-full bg-transparent py-0.5 text-sm outline-hidden';
 	$: resolvedInputClass = `${inputBaseClass} ${variant === 'plain' ? className : ''} ${inputClassName} ${
 		show ? '' : 'password'

--- a/src/lib/components/common/Tags.svelte
+++ b/src/lib/components/common/Tags.svelte
@@ -92,7 +92,7 @@
 				bind:value={inputValue}
 				class="w-full {tags.length > 0
 					? 'px-0.5'
-					: ''} text-xs bg-transparent outline-hidden placeholder:text-gray-400 dark:placeholder:text-gray-500"
+					: ''} text-xs bg-transparent outline-hidden dark:placeholder:text-gray-500"
 				placeholder={$i18n.t('Add a tag...')}
 				role="combobox"
 				aria-autocomplete="list"

--- a/src/lib/components/common/Tags/TagInput.svelte
+++ b/src/lib/components/common/Tags/TagInput.svelte
@@ -39,7 +39,7 @@
 		<input
 			bind:this={inputElement}
 			bind:value={tagName}
-			class="w-20 text-sm bg-transparent outline-hidden text-gray-700 dark:text-blue-400 placeholder:text-gray-400 dark:placeholder:text-blue-400/50"
+			class="w-20 text-sm bg-transparent outline-hidden text-gray-700 dark:text-blue-400 dark:placeholder:text-blue-400/50"
 			placeholder={$i18n.t('Add tag')}
 			aria-label={$i18n.t('Add a tag')}
 			list="tagOptions"

--- a/src/lib/components/layout/Sidebar/ChannelModal.svelte
+++ b/src/lib/components/layout/Sidebar/ChannelModal.svelte
@@ -181,10 +181,7 @@
 												)}
 									placement="top-start"
 								>
-									<select
-										class="w-full text-sm bg-transparent placeholder:text-gray-300 dark:placeholder:text-gray-700 outline-hidden"
-										bind:value={type}
-									>
+									<select class="w-full text-sm bg-transparent outline-hidden" bind:value={type}>
 										{#each channelTypes as channelType, channelTypeIdx (channelType)}
 											<option value={channelType} selected={channelTypeIdx === 0}>
 												{#if channelType === 'group'}
@@ -222,7 +219,7 @@
 
 						<div class="flex-1">
 							<input
-								class="w-full text-sm bg-transparent placeholder:text-gray-300 dark:placeholder:text-gray-700 outline-hidden"
+								class="w-full text-sm bg-transparent outline-hidden"
 								type="text"
 								bind:value={name}
 								placeholder={`${$i18n.t('new-channel')}`}
@@ -264,7 +261,7 @@
 							<div class="text-xs text-gray-500">{$i18n.t('Webhooks')}</div>
 
 							<button
-								class="text-xs bg-transparent placeholder:text-gray-300 dark:placeholder:text-gray-700 outline-hidden text-left"
+								class="text-xs bg-transparent outline-hidden text-left"
 								type="button"
 								on:click={() => {
 									showWebhooksModal = true;

--- a/src/lib/components/layout/Sidebar/Folders/FolderModal.svelte
+++ b/src/lib/components/layout/Sidebar/Folders/FolderModal.svelte
@@ -142,7 +142,7 @@
 						<div class="flex-1">
 							<input
 								id="folder-name"
-								class="w-full text-sm bg-transparent placeholder:text-gray-300 dark:placeholder:text-gray-700 outline-hidden"
+								class="w-full text-sm bg-transparent outline-hidden"
 								type="text"
 								bind:value={name}
 								placeholder={$i18n.t('Enter folder name')}

--- a/src/lib/components/layout/Sidebar/UserStatusModal.svelte
+++ b/src/lib/components/layout/Sidebar/UserStatusModal.svelte
@@ -25,7 +25,7 @@
 	let loading = false;
 
 	const highContrastInputClass =
-		'rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 py-1.5 text-gray-700 outline-hidden transition-colors placeholder:text-gray-300 focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:placeholder:text-gray-700 dark:focus:border-blue-500';
+		'rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 py-1.5 text-gray-700 outline-hidden transition-colors focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:focus:border-blue-500';
 
 	const submitHandler = async () => {
 		loading = true;
@@ -126,7 +126,7 @@
 								id="status-message"
 								type="text"
 								bind:value={message}
-								class={`w-full flex-1 text-sm ${($settings?.highContrastMode ?? false) ? highContrastInputClass : 'bg-transparent outline-hidden placeholder:text-gray-300 dark:placeholder:text-gray-700'}`}
+								class={`w-full flex-1 text-sm ${($settings?.highContrastMode ?? false) ? highContrastInputClass : 'bg-transparent outline-hidden'}`}
 								placeholder={$i18n.t("What's on your mind?")}
 								autocomplete="off"
 								required

--- a/src/lib/components/workspace/Knowledge/CreateKnowledgeBase.svelte
+++ b/src/lib/components/workspace/Knowledge/CreateKnowledgeBase.svelte
@@ -113,7 +113,7 @@
 					<div class="w-full mt-1">
 						<input
 							class={modal
-								? 'w-full text-sm bg-transparent outline-hidden placeholder:text-gray-300 dark:placeholder:text-gray-700'
+								? 'w-full text-sm bg-transparent outline-hidden'
 								: 'w-full rounded-lg py-2 px-4 text-sm bg-gray-50 dark:text-gray-300 dark:bg-gray-850 outline-hidden'}
 							type="text"
 							bind:value={name}
@@ -131,7 +131,7 @@
 					<div class="w-full mt-1">
 						<textarea
 							class={modal
-								? 'w-full resize-none text-sm bg-transparent outline-hidden placeholder:text-gray-300 dark:placeholder:text-gray-700'
+								? 'w-full resize-none text-sm bg-transparent outline-hidden'
 								: 'w-full resize-none rounded-lg py-2 px-4 text-sm bg-gray-50 dark:text-gray-300 dark:bg-gray-850 outline-hidden'}
 							rows={modal ? 6 : 4}
 							bind:value={description}

--- a/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
+++ b/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
@@ -1486,7 +1486,7 @@
 						>
 							<DropdownOptions
 								align="end"
-								className="flex h-8 shrink-0 items-center gap-1.5 rounded-xl bg-transparent px-1.5 text-xs text-gray-700 transition placeholder-gray-400 outline-hidden hover:text-gray-900 focus:outline-hidden dark:text-gray-200 dark:hover:text-gray-100"
+								className="flex h-8 shrink-0 items-center gap-1.5 rounded-xl bg-transparent px-1.5 text-xs text-gray-700 transition outline-hidden hover:text-gray-900 focus:outline-hidden dark:text-gray-200 dark:hover:text-gray-100"
 								bind:value={viewOption}
 								items={[
 									{ value: null, label: $i18n.t('All') },

--- a/src/lib/components/workspace/Knowledge/KnowledgeBase/AddTextContentModal.svelte
+++ b/src/lib/components/workspace/Knowledge/KnowledgeBase/AddTextContentModal.svelte
@@ -67,7 +67,7 @@
 
 					<div class=" flex-1 w-full h-full">
 						<textarea
-							class="w-full h-full min-h-[200px] bg-transparent outline-none resize-none text-base leading-relaxed placeholder:text-gray-300 dark:placeholder:text-gray-600"
+							class="w-full h-full min-h-[200px] bg-transparent outline-none resize-none text-base leading-relaxed"
 							bind:value={content}
 							placeholder={$i18n.t('Write something...')}
 						/>

--- a/src/lib/components/workspace/Knowledge/KnowledgeBase/NewDirectoryModal.svelte
+++ b/src/lib/components/workspace/Knowledge/KnowledgeBase/NewDirectoryModal.svelte
@@ -47,7 +47,7 @@
 			<div>
 				<div class="mb-1 text-xs text-gray-500">{$i18n.t('Name')}</div>
 				<input
-					class="w-full text-sm bg-transparent outline-hidden placeholder:text-gray-300 dark:placeholder:text-gray-700"
+					class="w-full text-sm bg-transparent outline-hidden"
 					type="text"
 					bind:value={name}
 					placeholder={$i18n.t('Directory name')}

--- a/src/lib/components/workspace/Models/ModelEditor.svelte
+++ b/src/lib/components/workspace/Models/ModelEditor.svelte
@@ -657,7 +657,7 @@
 									<div class="min-w-0 flex-1">
 										<div class="flex min-w-0 items-center gap-2">
 											<input
-												class="min-w-0 flex-1 bg-transparent text-base leading-tight text-gray-900 outline-hidden placeholder:text-gray-300 dark:text-white dark:placeholder:text-gray-700 md:text-lg"
+												class="min-w-0 flex-1 bg-transparent text-base leading-tight text-gray-900 outline-hidden dark:text-white md:text-lg"
 												placeholder={$i18n.t('Model Name')}
 												bind:value={name}
 												required
@@ -671,7 +671,7 @@
 										</div>
 
 										<input
-											class="block w-full bg-transparent py-0.5 text-xs text-gray-500 outline-hidden placeholder:text-gray-300 dark:text-gray-500 dark:placeholder:text-gray-700"
+											class="block w-full bg-transparent py-0.5 text-xs text-gray-500 outline-hidden dark:text-gray-500"
 											placeholder={$i18n.t('Model ID')}
 											bind:value={id}
 											disabled={edit}
@@ -727,7 +727,7 @@
 
 								{#if enableDescription}
 									<Textarea
-										className="w-full resize-none overflow-y-hidden bg-transparent py-1 text-[0.8125rem] text-gray-700 outline-hidden placeholder:text-gray-300 dark:text-gray-300 dark:placeholder:text-gray-700"
+										className="w-full resize-none overflow-y-hidden bg-transparent py-1 text-[0.8125rem] text-gray-700 outline-hidden dark:text-gray-300"
 										placeholder={$i18n.t('Add a short description about what this model does')}
 										minSize={32}
 										bind:value={info.meta.description}
@@ -767,7 +767,7 @@
 									</div>
 									<div>
 										<Textarea
-											className="min-h-12 w-full resize-none overflow-y-hidden bg-transparent py-1 text-[0.8125rem] text-gray-700 outline-hidden placeholder:text-gray-300 dark:text-gray-300 dark:placeholder:text-gray-700"
+											className="min-h-12 w-full resize-none overflow-y-hidden bg-transparent py-1 text-[0.8125rem] text-gray-700 outline-hidden dark:text-gray-300"
 											placeholder={$i18n.t(
 												'Write your model system prompt content here\ne.g.) You are Mario from Super Mario Bros, acting as an assistant.'
 											)}

--- a/src/lib/components/workspace/Models/PromptSuggestions.svelte
+++ b/src/lib/components/workspace/Models/PromptSuggestions.svelte
@@ -149,7 +149,7 @@
 						<div class="grid min-w-0 gap-1 md:grid-cols-2 md:gap-1.5">
 							<Tooltip content={$i18n.t('e.g. Tell me a fun fact')} placement="top-start">
 								<input
-									class="w-full bg-transparent text-[13px] leading-5 text-gray-700 outline-hidden placeholder:text-gray-300 dark:text-gray-200 dark:placeholder:text-gray-700"
+									class="w-full bg-transparent text-[13px] leading-5 text-gray-700 outline-hidden dark:text-gray-200"
 									placeholder={$i18n.t('Title')}
 									aria-label={$i18n.t('Title')}
 									bind:value={prompt.title[0]}
@@ -158,7 +158,7 @@
 
 							<Tooltip content={$i18n.t('e.g. about the Roman Empire')} placement="top-start">
 								<input
-									class="w-full bg-transparent text-[13px] leading-5 text-gray-500 outline-hidden placeholder:text-gray-300 dark:text-gray-500 dark:placeholder:text-gray-700"
+									class="w-full bg-transparent text-[13px] leading-5 text-gray-500 outline-hidden dark:text-gray-500"
 									placeholder={$i18n.t('Subtitle')}
 									aria-label={$i18n.t('Subtitle')}
 									bind:value={prompt.title[1]}
@@ -172,7 +172,7 @@
 							placement="top-start"
 						>
 							<textarea
-								class="min-h-5 w-full resize-none overflow-hidden bg-transparent text-[13px] leading-5 text-gray-700 outline-hidden placeholder:text-gray-300 dark:text-gray-200 dark:placeholder:text-gray-700"
+								class="min-h-5 w-full resize-none overflow-hidden bg-transparent text-[13px] leading-5 text-gray-700 outline-hidden dark:text-gray-200"
 								placeholder={$i18n.t('Content')}
 								aria-label={$i18n.t('Content')}
 								rows="1"

--- a/src/lib/components/workspace/Skills/SkillEditor.svelte
+++ b/src/lib/components/workspace/Skills/SkillEditor.svelte
@@ -182,7 +182,7 @@
 				</div>
 			{:else}
 				<textarea
-					class="h-full w-full resize-none bg-transparent px-3 py-2 font-mono text-[11px] leading-relaxed outline-hidden placeholder:text-gray-400 dark:placeholder:text-gray-600"
+					class="h-full w-full resize-none bg-transparent px-3 py-2 font-mono text-[11px] leading-relaxed outline-hidden"
 					bind:value={content}
 					on:input={handleContentInput}
 					placeholder={$i18n.t('Enter skill instructions in markdown...')}

--- a/src/lib/components/workspace/common/AccessControl.svelte
+++ b/src/lib/components/workspace/common/AccessControl.svelte
@@ -492,7 +492,7 @@
 				>
 					<select
 						id="models"
-						class="outline-none bg-transparent text-sm font-normal block w-fit pr-8 max-w-full placeholder-gray-400"
+						class="outline-none bg-transparent text-sm font-normal block w-fit pr-8 max-w-full"
 						value={!hasPublicReadGrant(accessGrants ?? []) ? 'private' : 'public'}
 						on:change={(e) => {
 							setPublic((e.target as HTMLSelectElement).value === 'public');

--- a/src/lib/components/workspace/common/TagSelector.svelte
+++ b/src/lib/components/workspace/common/TagSelector.svelte
@@ -33,7 +33,7 @@
 >
 	<svelte:fragment slot="trigger" let:selectedLabel>
 		<div
-			class="inline-flex h-input min-w-0 flex-1 outline-hidden bg-transparent truncate placeholder-gray-400 focus:outline-hidden capitalize"
+			class="inline-flex h-input min-w-0 flex-1 outline-hidden bg-transparent truncate focus:outline-hidden capitalize"
 		>
 			{#if value}
 				{selectedLabel}

--- a/src/lib/components/workspace/common/ViewSelector.svelte
+++ b/src/lib/components/workspace/common/ViewSelector.svelte
@@ -25,12 +25,12 @@
 	{placeholder}
 	{align}
 	triggerClass="relative h-8 w-full flex items-center gap-0.5 px-1.5 py-1.5 bg-transparent rounded-xl text-[13px] font-normal text-gray-700 transition hover:text-gray-900 dark:text-gray-200 dark:hover:text-gray-100"
-	labelClass="inline-flex h-input w-full outline-hidden bg-transparent truncate placeholder-gray-400 focus:outline-hidden"
+	labelClass="inline-flex h-input w-full outline-hidden bg-transparent truncate focus:outline-hidden"
 	onChange={() => onChange(value)}
 >
 	<svelte:fragment slot="trigger" let:selectedLabel>
 		<span
-			class="inline-flex h-input w-full outline-hidden bg-transparent truncate placeholder-gray-400 focus:outline-hidden"
+			class="inline-flex h-input w-full outline-hidden bg-transparent truncate focus:outline-hidden"
 		>
 			{selectedLabel}
 		</span>

--- a/src/lib/components/workspace/common/Visibility.svelte
+++ b/src/lib/components/workspace/common/Visibility.svelte
@@ -27,7 +27,7 @@
 			<div>
 				<select
 					id="models"
-					class="outline-hidden bg-transparent text-sm font-normal block w-fit pr-10 max-w-full placeholder-gray-400"
+					class="outline-hidden bg-transparent text-sm font-normal block w-fit pr-10 max-w-full"
 					value={state === 'private' ? 'private' : 'public'}
 					on:change={(e) => {
 						if (e.target.value === 'public') {

--- a/src/routes/(app)/automations/+page.svelte
+++ b/src/routes/(app)/automations/+page.svelte
@@ -448,7 +448,7 @@
 						>
 							<svelte:fragment slot="trigger" let:selectedLabel>
 								<span
-									class="inline-flex h-input w-full outline-hidden bg-transparent truncate placeholder-gray-400 focus:outline-hidden"
+									class="inline-flex h-input w-full outline-hidden bg-transparent truncate focus:outline-hidden"
 								>
 									{selectedLabel}
 								</span>

--- a/src/routes/auth/+page.svelte
+++ b/src/routes/auth/+page.svelte
@@ -285,7 +285,7 @@
 													bind:value={name}
 													type="text"
 													id="name"
-													class="my-0.5 w-full text-sm outline-hidden bg-transparent placeholder:text-gray-300 dark:placeholder:text-gray-600"
+													class="my-0.5 w-full text-sm outline-hidden bg-transparent"
 													autocomplete="name"
 													placeholder={$i18n.t('Enter Your Full Name')}
 													required
@@ -301,7 +301,7 @@
 												<input
 													bind:value={ldapUsername}
 													type="text"
-													class="my-0.5 w-full text-sm outline-hidden bg-transparent placeholder:text-gray-300 dark:placeholder:text-gray-600"
+													class="my-0.5 w-full text-sm outline-hidden bg-transparent"
 													autocomplete="username"
 													name="username"
 													id="username"
@@ -318,7 +318,7 @@
 													bind:value={email}
 													type="email"
 													id="email"
-													class="my-0.5 w-full text-sm outline-hidden bg-transparent placeholder:text-gray-300 dark:placeholder:text-gray-600"
+													class="my-0.5 w-full text-sm outline-hidden bg-transparent"
 													autocomplete="email"
 													name="email"
 													placeholder={$i18n.t('Enter Your Email')}
@@ -335,7 +335,7 @@
 												bind:value={password}
 												type="password"
 												id="password"
-												class="my-0.5 w-full text-sm outline-hidden bg-transparent placeholder:text-gray-300 dark:placeholder:text-gray-600"
+												class="my-0.5 w-full text-sm outline-hidden bg-transparent"
 												placeholder={$i18n.t('Enter Your Password')}
 												autocomplete={mode === 'signup' ? 'new-password' : 'current-password'}
 												name="password"

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -54,7 +54,12 @@
 
 	input::placeholder,
 	textarea::placeholder {
-		color: theme(--color-gray-400);
+		color: theme(--color-gray-600);
+	}
+
+	.dark input::placeholder,
+	.dark textarea::placeholder {
+		color: theme(--color-gray-500);
 	}
 
 	input[type='checkbox'] {


### PR DESCRIPTION
On latest `dev`, placeholder text is the lowest contrast text in the product. The grey scale in `src/tailwind.css` is achromatic `oklch(L 0 0)`, so relative luminance is exactly `L³`:

| | ratio |
|---|---|
| `placeholder:text-gray-300` on `#fff` | **1.58:1** | | `dark:placeholder:text-gray-700` on `#171717` | **2.12:1** | | `placeholder-gray-400` / `placeholder:text-gray-400` on `#fff` | **2.07:1** | | `dark:placeholder:text-gray-600` on `#171717` | **3.12:1** | | global `input::placeholder` rule, `--color-gray-400` on `#fff` | **2.07:1** |

Level AA requires 4.5:1. The large text exemption does not apply, the largest of these is `text-lg`. Placeholders are frequently the only format hint a field gives, for example `admin/Settings/General.svelte` uses `e.g.) "http://localhost:3000"`.

Fix, in three parts:

1. The global `input::placeholder` / `textarea::placeholder` rule had **no dark variant at all**, so one value served both themes. It now resolves to gray-600 in light (5.75:1) and gray-500 in dark (6.46:1).

2. The ~207 per component placeholder colour utilities are **removed** rather than rewritten, so they fall through to the corrected base rule. They encoded no per component intent, they were copy paste drift, and they duplicated a decision that now lives in one place. Removing them also fixes `placeholder-gray-400`, which is un-prefixed and therefore applied its light mode value in dark mode too: rewriting it to gray-600 would have taken dark mode from 8.65:1 down to 3.12:1, replacing one failure with another. The two genuinely intentional placeholder colours, in `ModelSelector/Selector.svelte` and `common/Tags/TagInput.svelte`, are left untouched.

3. The chat composer placeholder is a tiptap `::before`, so neither the base rule nor any utility reaches it. It was hardcoded `#676767` for both themes, which is 5.66:1 light but only **3.17:1** dark. Its dark override also keyed off `@media (prefers-color-scheme: dark)` while this app toggles dark mode with a **class**, so the colour followed the operating system rather than the selected theme. Both are replaced with `text-gray-600 dark:text-gray-500`, matching every other placeholder. The comment claiming the old value had "the proper contrast" is removed, since it was never true for dark mode.

Placeholders stay distinguishable from real input values, which are `text-gray-700` (8.46:1) in light and `dark:text-gray-300` (11.39:1) in dark.

Verified against the `oled-dark` theme (gray-500 on `#000` is 7.57:1) and the `dark:bg-white/[0.03]` input surface (6.01:1). Formatting was only re-run on files that were already Prettier clean on `dev`, so no unrelated reflow is included.

Severity: Serious. Affects every text input in the product, including the chat composer.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
