### PR TITLE
fix: meet 4.5:1 contrast for gray-500 muted text in light theme (WCAG 1.4.3, 1.4.11)

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -659,7 +659,7 @@ input[type='number'] {
 
 /* Table styling for tiptap editors */
 .tiptap table {
-	@apply w-full text-sm text-start text-gray-500 dark:text-gray-400 max-w-full;
+	@apply w-full text-sm text-start text-gray-600 dark:text-gray-400 max-w-full;
 }
 
 .tiptap thead {

--- a/src/lib/components/AddConnectionModal.svelte
+++ b/src/lib/components/AddConnectionModal.svelte
@@ -476,7 +476,7 @@
 						<div class="flex items-center justify-between">
 							<button
 								type="button"
-								class="flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition mt-2"
+								class="flex items-center gap-1 text-xs text-gray-600 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition mt-2"
 								on:click={() => (showAdvanced = !showAdvanced)}
 							>
 								<svg
@@ -741,7 +741,7 @@
 						<div>
 							{#if edit}
 								<button
-									class="px-1 py-1.5 text-sm font-medium text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 hover:underline transition"
+									class="px-1 py-1.5 text-sm font-medium text-gray-600 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 hover:underline transition"
 									type="button"
 									on:click={() => {
 										showDeleteConfirmDialog = true;

--- a/src/lib/components/AddTerminalServerModal.svelte
+++ b/src/lib/components/AddTerminalServerModal.svelte
@@ -651,7 +651,7 @@
 										</div>
 										<button
 											type="button"
-											class="text-xs text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition"
+											class="text-xs text-gray-600 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition"
 											on:click={() =>
 												(policyEnvPairs = [...policyEnvPairs, { key: '', value: '' }])}
 										>
@@ -703,7 +703,7 @@
 							</div>
 
 							<div class="flex flex-wrap items-center justify-between gap-2 mt-2">
-								<div class="flex items-center gap-3 text-xs text-gray-500 dark:text-gray-400">
+								<div class="flex items-center gap-3 text-xs text-gray-600 dark:text-gray-400">
 									<label class="flex items-center gap-1.5">
 										<input type="checkbox" bind:checked={refreshOnlyIdle} />
 										<span>{$i18n.t('Idle only')}</span>
@@ -713,7 +713,7 @@
 										<span>{$i18n.t('Reset persisted files')}</span>
 									</label>
 								</div>
-								<div class="mt-2 text-xs text-gray-500 dark:text-gray-400">
+								<div class="mt-2 text-xs text-gray-600 dark:text-gray-400">
 									{$i18n.t(
 										'Policy changes apply to newly provisioned terminals. Refresh matching terminals to apply them to existing terminals.'
 									)}
@@ -732,7 +732,7 @@
 						<div class="flex items-center justify-between">
 							<button
 								type="button"
-								class="flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition mt-2"
+								class="flex items-center gap-1 text-xs text-gray-600 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition mt-2"
 								on:click={() => (showAdvanced = !showAdvanced)}
 							>
 								<svg
@@ -852,7 +852,7 @@
 							<div>
 								{#if edit}
 									<button
-										class="px-1 py-1.5 text-sm font-medium text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 hover:underline transition"
+										class="px-1 py-1.5 text-sm font-medium text-gray-600 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 hover:underline transition"
 										type="button"
 										on:click={() => {
 											showDeleteConfirmDialog = true;

--- a/src/lib/components/AddToolServerModal.svelte
+++ b/src/lib/components/AddToolServerModal.svelte
@@ -768,7 +768,7 @@
 						<div class="flex items-center justify-between">
 							<button
 								type="button"
-								class="flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition mt-2"
+								class="flex items-center gap-1 text-xs text-gray-600 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition mt-2"
 								on:click={() => (showAdvanced = !showAdvanced)}
 							>
 								<svg
@@ -978,7 +978,7 @@
 						<div>
 							{#if edit}
 								<button
-									class="px-1 py-1.5 text-sm font-medium text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 hover:underline transition"
+									class="px-1 py-1.5 text-sm font-medium text-gray-600 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 hover:underline transition"
 									type="button"
 									on:click={() => {
 										showDeleteConfirmDialog = true;

--- a/src/lib/components/ChangelogModal.svelte
+++ b/src/lib/components/ChangelogModal.svelte
@@ -97,7 +97,7 @@
 					{$i18n.t("What's New in")}
 					{$WEBUI_NAME}
 				</h2>
-				<div class="mt-1 flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
+				<div class="mt-1 flex items-center gap-2 text-xs text-gray-600 dark:text-gray-400">
 					<span>{$i18n.t('Release Notes')}</span>
 					<span class="h-1 w-1 rounded-full bg-gray-300 dark:bg-gray-700"></span>
 					<span>v{WEBUI_VERSION}</span>
@@ -139,7 +139,7 @@
 													? 'text-yellow-700 dark:text-yellow-300'
 													: section === 'removed'
 														? 'text-red-600 dark:text-red-300'
-														: 'text-gray-500 dark:text-gray-400'}"
+														: 'text-gray-600 dark:text-gray-400'}"
 									>
 										{section}
 									</div>
@@ -166,7 +166,7 @@
 				</div>
 			{:else if error}
 				<div class="flex flex-col items-center justify-center gap-3 py-16 text-center">
-					<p class="text-sm text-gray-500 dark:text-gray-400">
+					<p class="text-sm text-gray-600 dark:text-gray-400">
 						{$i18n.t('Could not load release notes.')}
 					</p>
 					<button

--- a/src/lib/components/ImportModal.svelte
+++ b/src/lib/components/ImportModal.svelte
@@ -66,7 +66,7 @@
 		<div class=" flex justify-between dark:text-gray-300 px-4 pt-3 pb-1">
 			<div class=" text-sm font-medium self-center">{$i18n.t('Import')}</div>
 			<button
-				class="self-center rounded-lg p-1 text-gray-500 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+				class="self-center rounded-lg p-1 text-gray-600 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
 				aria-label={$i18n.t('Close')}
 				on:click={() => {
 					show = false;

--- a/src/lib/components/NotificationToast.svelte
+++ b/src/lib/components/NotificationToast.svelte
@@ -101,7 +101,7 @@
 	<!-- Close button (visible on hover) -->
 	<button
 		bind:this={closeButtonElement}
-		class="absolute -top-0.5 -left-0.5 p-0.5 rounded-full opacity-0 group-hover:opacity-100 bg-gray-50 dark:bg-gray-800 hover:bg-gray-100 dark:hover:bg-gray-700 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-opacity z-10"
+		class="absolute -top-0.5 -left-0.5 p-0.5 rounded-full opacity-0 group-hover:opacity-100 bg-gray-50 dark:bg-gray-800 hover:bg-gray-100 dark:hover:bg-gray-700 text-gray-600 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-opacity z-10"
 		on:click|stopPropagation={closeHandler}
 		aria-label="Dismiss notification"
 	>

--- a/src/lib/components/admin/Analytics/AnalyticsModelModal.svelte
+++ b/src/lib/components/admin/Analytics/AnalyticsModelModal.svelte
@@ -185,7 +185,7 @@
 				</div>
 			</Tooltip>
 			<button
-				class="self-center rounded-lg p-1 text-gray-500 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+				class="self-center rounded-lg p-1 text-gray-600 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
 				on:click={close}
 				aria-label="Close"
 			>
@@ -236,7 +236,7 @@
 									class="rounded-full transition-all duration-200 px-2.5 py-0.5 text-xs font-normal {selectedRange ===
 									range.key
 										? 'bg-white text-gray-900 shadow-sm dark:bg-gray-700 dark:text-white'
-										: 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200'}"
+										: 'text-gray-600 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200'}"
 									on:click={() => selectRange(range.key)}
 								>
 									{range.label}

--- a/src/lib/components/admin/Analytics/Dashboard.svelte
+++ b/src/lib/components/admin/Analytics/Dashboard.svelte
@@ -282,7 +282,7 @@
 
 <!-- Summary stats -->
 {#if !loading}
-	<div class="flex gap-3 text-xs text-gray-500 dark:text-gray-400 px-0.5 pb-2">
+	<div class="flex gap-3 text-xs text-gray-600 dark:text-gray-400 px-0.5 pb-2">
 		<span
 			><span class="font-normal text-gray-900 dark:text-gray-300"
 				>{summary.total_messages.toLocaleString()}</span
@@ -351,7 +351,7 @@
 				{$i18n.t('Model Usage')}
 			</div>
 			<div class="scrollbar-hidden relative whitespace-nowrap overflow-x-auto max-w-full">
-				<table class="w-full text-sm text-left text-gray-500 dark:text-gray-400 table-auto">
+				<table class="w-full text-sm text-left text-gray-600 dark:text-gray-400 table-auto">
 					<thead class="text-xs text-gray-800 uppercase bg-transparent dark:text-gray-200">
 						<tr class="border-b-[1.5px] border-gray-50 dark:border-gray-850/30">
 							<th scope="col" class="px-2.5 py-2 w-8">#</th>
@@ -519,7 +519,7 @@
 				{$i18n.t('User Activity')}
 			</div>
 			<div class="scrollbar-hidden relative whitespace-nowrap overflow-x-auto max-w-full">
-				<table class="w-full text-sm text-left text-gray-500 dark:text-gray-400 table-auto">
+				<table class="w-full text-sm text-left text-gray-600 dark:text-gray-400 table-auto">
 					<thead class="text-xs text-gray-800 uppercase bg-transparent dark:text-gray-200">
 						<tr class="border-b-[1.5px] border-gray-50 dark:border-gray-850/30">
 							<th scope="col" class="px-2.5 py-2 w-8">#</th>

--- a/src/lib/components/admin/Analytics/ModelUsage.svelte
+++ b/src/lib/components/admin/Analytics/ModelUsage.svelte
@@ -75,7 +75,7 @@
 		<div class="text-center text-xs text-gray-500 py-1">{$i18n.t('No data found')}</div>
 	{:else if modelStats.length}
 		<table
-			class="w-full text-sm text-left text-gray-500 dark:text-gray-400 {loading
+			class="w-full text-sm text-left text-gray-600 dark:text-gray-400 {loading
 				? 'opacity-20'
 				: ''}"
 		>

--- a/src/lib/components/admin/Analytics/UserUsage.svelte
+++ b/src/lib/components/admin/Analytics/UserUsage.svelte
@@ -70,7 +70,7 @@
 		<div class="text-center text-xs text-gray-500 py-1">{$i18n.t('No data found')}</div>
 	{:else if userStats.length}
 		<table
-			class="w-full text-sm text-left text-gray-500 dark:text-gray-400 {loading
+			class="w-full text-sm text-left text-gray-600 dark:text-gray-400 {loading
 				? 'opacity-20'
 				: ''}"
 		>

--- a/src/lib/components/admin/Evaluations/FeedbackModal.svelte
+++ b/src/lib/components/admin/Evaluations/FeedbackModal.svelte
@@ -47,7 +47,7 @@
 					{$i18n.t('Feedback Details')}
 				</div>
 				<button
-					class="self-center rounded-lg p-1 text-gray-500 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+					class="self-center rounded-lg p-1 text-gray-600 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
 					on:click={close}
 					aria-label="Close"
 				>

--- a/src/lib/components/admin/Evaluations/Leaderboard.svelte
+++ b/src/lib/components/admin/Evaluations/Leaderboard.svelte
@@ -168,7 +168,7 @@
 			<div class="text-center text-xs text-gray-500 py-1">{$i18n.t('No models found')}</div>
 		{:else if rankedModels.length}
 			<table
-				class="w-full text-sm text-left text-gray-500 dark:text-gray-400 {loading
+				class="w-full text-sm text-left text-gray-600 dark:text-gray-400 {loading
 					? 'opacity-20'
 					: ''}"
 			>

--- a/src/lib/components/admin/Evaluations/LeaderboardModal.svelte
+++ b/src/lib/components/admin/Evaluations/LeaderboardModal.svelte
@@ -68,7 +68,7 @@
 				</div>
 			</Tooltip>
 			<button
-				class="self-center rounded-lg p-1 text-gray-500 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+				class="self-center rounded-lg p-1 text-gray-600 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
 				on:click={close}
 				aria-label="Close"
 			>
@@ -91,7 +91,7 @@
 								class="rounded-full transition-all duration-200 px-2.5 py-0.5 text-xs font-normal {selectedRange ===
 								range.key
 									? 'bg-white text-gray-900 shadow-sm dark:bg-gray-700 dark:text-white'
-									: 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200'}"
+									: 'text-gray-600 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200'}"
 								on:click={() => selectRange(range.key)}
 							>
 								{range.label}

--- a/src/lib/components/admin/Functions.svelte
+++ b/src/lib/components/admin/Functions.svelte
@@ -342,7 +342,7 @@
 							{$i18n.t('Functions')}
 						</div>
 
-						<div class="text-sm font-normal text-gray-500 dark:text-gray-500 opacity-60">
+						<div class="text-sm font-normal text-gray-600 dark:text-gray-500">
 							{filteredItems.length}
 						</div>
 					</div>
@@ -555,7 +555,7 @@
 								</div>
 
 								<div
-									class="hidden max-w-44 shrink-0 self-center truncate text-right text-[11px] leading-5 text-gray-500 dark:text-gray-500 md:block"
+									class="hidden max-w-44 shrink-0 self-center truncate text-right text-[11px] leading-5 text-gray-600 dark:text-gray-500 md:block"
 								>
 									<Tooltip
 										content={func?.user?.email ?? $i18n.t('Deleted User')}

--- a/src/lib/components/admin/Settings/Audio.svelte
+++ b/src/lib/components/admin/Settings/Audio.svelte
@@ -430,7 +430,7 @@
 							bind:value={STT_WHISPER_MODEL}
 						/>
 						<button
-							class="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg text-gray-500 transition-colors hover:bg-black/5 hover:text-gray-900 disabled:opacity-50 dark:text-gray-500 dark:hover:bg-white/5 dark:hover:text-white"
+							class="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg text-gray-600 transition-colors hover:bg-black/5 hover:text-gray-900 disabled:opacity-50 dark:text-gray-500 dark:hover:bg-white/5 dark:hover:text-white"
 							type="button"
 							on:click={() => {
 								sttModelUpdateHandler();

--- a/src/lib/components/admin/Settings/Connections/ManageOllamaModal.svelte
+++ b/src/lib/components/admin/Settings/Connections/ManageOllamaModal.svelte
@@ -20,7 +20,7 @@
 				</div>
 			</div>
 			<button
-				class="self-center rounded-lg p-1 text-gray-500 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+				class="self-center rounded-lg p-1 text-gray-600 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
 				on:click={() => {
 					show = false;
 				}}

--- a/src/lib/components/admin/Settings/Database.svelte
+++ b/src/lib/components/admin/Settings/Database.svelte
@@ -18,7 +18,7 @@
 
 	let configImportInputElement: HTMLInputElement;
 	const actionButtonClass =
-		'text-xs text-gray-500 transition-colors hover:text-gray-900 dark:text-gray-500 dark:hover:text-white';
+		'text-xs text-gray-600 transition-colors hover:text-gray-900 dark:text-gray-500 dark:hover:text-white';
 
 	const exportAllUserChats = async () => {
 		let blob = new Blob([JSON.stringify(await getAllUserChats(localStorage.token))], {

--- a/src/lib/components/admin/Settings/Documents.svelte
+++ b/src/lib/components/admin/Settings/Documents.svelte
@@ -73,7 +73,7 @@
 	const inputClass =
 		'w-full h-7 rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 text-xs text-gray-700 outline-hidden transition-colors placeholder:text-gray-300 focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:placeholder:text-gray-700 dark:focus:border-blue-500';
 	const actionButtonClass =
-		'shrink-0 text-xs text-gray-500 transition-colors hover:text-gray-900 dark:text-gray-500 dark:hover:text-white';
+		'shrink-0 text-xs text-gray-600 transition-colors hover:text-gray-900 dark:text-gray-500 dark:hover:text-white';
 	const textareaClass =
 		'w-full rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 py-1.5 text-xs text-gray-700 outline-hidden transition-colors placeholder:text-gray-300 focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:placeholder:text-gray-700 dark:focus:border-blue-500';
 
@@ -570,7 +570,7 @@
 							{$i18n.t('Header variables')}
 						</button>
 						{#if showExternalDocumentLoaderHeadersHint}
-							<div class="mt-1 text-[0.6875rem] leading-5 text-gray-500 dark:text-gray-400">
+							<div class="mt-1 text-[0.6875rem] leading-5 text-gray-600 dark:text-gray-400">
 								<div>{$i18n.t('No additional headers are sent unless configured.')}</div>
 								<div>
 									{$i18n.t('Example')}:
@@ -1041,7 +1041,7 @@
 
 							{#if RAG_EMBEDDING_ENGINE === ''}
 								<button
-									class="flex size-7 shrink-0 items-center justify-center rounded-lg text-gray-500 transition-colors hover:bg-black/5 hover:text-gray-900 dark:text-gray-500 dark:hover:bg-white/5 dark:hover:text-white"
+									class="flex size-7 shrink-0 items-center justify-center rounded-lg text-gray-600 transition-colors hover:bg-black/5 hover:text-gray-900 dark:text-gray-500 dark:hover:bg-white/5 dark:hover:text-white"
 									type="button"
 									on:click={() => {
 										embeddingModelUpdateHandler();

--- a/src/lib/components/admin/Settings/Events.svelte
+++ b/src/lib/components/admin/Settings/Events.svelte
@@ -401,7 +401,7 @@
 			</h1>
 
 			<button
-				class="self-center rounded-lg p-1 text-gray-500 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+				class="self-center rounded-lg p-1 text-gray-600 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
 				aria-label={$i18n.t('Close')}
 				type="button"
 				on:click={resetForm}
@@ -654,7 +654,7 @@
 					<div>
 						{#if editing}
 							<button
-								class="px-1 py-1.5 text-sm font-normal text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 hover:underline transition"
+								class="px-1 py-1.5 text-sm font-normal text-gray-600 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 hover:underline transition"
 								type="button"
 								on:click={() => {
 									showDeleteConfirmDialog = true;

--- a/src/lib/components/admin/Settings/ExternalKnowledge.svelte
+++ b/src/lib/components/admin/Settings/ExternalKnowledge.svelte
@@ -417,7 +417,7 @@
 			</h1>
 
 			<button
-				class="self-center rounded-lg p-1 text-gray-500 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+				class="self-center rounded-lg p-1 text-gray-600 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
 				aria-label={$i18n.t('Close')}
 				type="button"
 				on:click={() => {

--- a/src/lib/components/admin/Settings/General.svelte
+++ b/src/lib/components/admin/Settings/General.svelte
@@ -100,7 +100,7 @@
 								<a
 									href="https://github.com/open-webui/open-webui/releases/tag/v{version.latest}"
 									target="_blank"
-									class="text-gray-500 hover:text-gray-700 dark:text-gray-500 dark:hover:text-gray-300"
+									class="text-gray-600 hover:text-gray-700 dark:text-gray-500 dark:hover:text-gray-300"
 								>
 									{updateAvailable === null
 										? $i18n.t('Checking for updates...')
@@ -124,7 +124,7 @@
 
 					{#if $config?.features?.enable_version_update_check}
 						<button
-							class="shrink-0 text-xs text-gray-500 transition-colors hover:text-gray-900 dark:text-gray-500 dark:hover:text-white"
+							class="shrink-0 text-xs text-gray-600 transition-colors hover:text-gray-900 dark:text-gray-500 dark:hover:text-white"
 							type="button"
 							on:click={() => {
 								checkForVersionUpdates();
@@ -145,7 +145,7 @@
 						</div>
 
 						<a
-							class="shrink-0 text-gray-500 transition-colors hover:text-gray-900 dark:text-gray-500 dark:hover:text-white"
+							class="shrink-0 text-gray-600 transition-colors hover:text-gray-900 dark:text-gray-500 dark:hover:text-white"
 							href="https://docs.openwebui.com/"
 							target="_blank"
 						>
@@ -257,7 +257,6 @@
 					<AdminSettingRow
 						label={$i18n.t('Memory System Context')}
 						description={$i18n.t('Include saved memories in the system context.')}
-						labelClassName="text-gray-500 dark:text-gray-500"
 					>
 						<Switch bind:state={adminConfig.ENABLE_MEMORY_SYSTEM_CONTEXT} />
 					</AdminSettingRow>

--- a/src/lib/components/admin/Settings/Images.svelte
+++ b/src/lib/components/admin/Settings/Images.svelte
@@ -565,7 +565,7 @@
 								<div class="flex items-center justify-end gap-2">
 									{#if config.COMFYUI_WORKFLOW}
 										<button
-											class="text-xs text-gray-500 transition-colors hover:text-gray-900 hover:underline dark:text-gray-500 dark:hover:text-white"
+											class="text-xs text-gray-600 transition-colors hover:text-gray-900 hover:underline dark:text-gray-500 dark:hover:text-white"
 											type="button"
 											aria-label={$i18n.t('Edit workflow.json content')}
 											on:click={() => {
@@ -579,7 +579,7 @@
 
 									<Tooltip content={$i18n.t('Click here to upload a workflow.json file.')}>
 										<button
-											class="text-xs text-gray-500 transition-colors hover:text-gray-900 hover:underline dark:text-gray-500 dark:hover:text-white"
+											class="text-xs text-gray-600 transition-colors hover:text-gray-900 hover:underline dark:text-gray-500 dark:hover:text-white"
 											type="button"
 											aria-label={$i18n.t('Click here to upload a workflow.json file.')}
 											on:click={() => {
@@ -862,7 +862,7 @@
 								<div class="flex items-center justify-end gap-2">
 									{#if config.IMAGES_EDIT_COMFYUI_WORKFLOW}
 										<button
-											class="text-xs text-gray-500 transition-colors hover:text-gray-900 hover:underline dark:text-gray-500 dark:hover:text-white"
+											class="text-xs text-gray-600 transition-colors hover:text-gray-900 hover:underline dark:text-gray-500 dark:hover:text-white"
 											type="button"
 											aria-label={$i18n.t('Edit workflow.json content')}
 											on:click={() => {
@@ -876,7 +876,7 @@
 
 									<Tooltip content={$i18n.t('Click here to upload a workflow.json file.')}>
 										<button
-											class="text-xs text-gray-500 transition-colors hover:text-gray-900 hover:underline dark:text-gray-500 dark:hover:text-white"
+											class="text-xs text-gray-600 transition-colors hover:text-gray-900 hover:underline dark:text-gray-500 dark:hover:text-white"
 											type="button"
 											aria-label={$i18n.t('Click here to upload a workflow.json file.')}
 											on:click={() => {

--- a/src/lib/components/admin/Settings/Integrations.svelte
+++ b/src/lib/components/admin/Settings/Integrations.svelte
@@ -301,7 +301,7 @@
 						)}
 					</div>
 					<a
-						class="mt-0.5 block text-[0.6875rem] text-gray-500 underline hover:text-gray-700 dark:text-gray-500 dark:hover:text-gray-300"
+						class="mt-0.5 block text-[0.6875rem] text-gray-600 underline hover:text-gray-700 dark:text-gray-500 dark:hover:text-gray-300"
 						href="https://github.com/open-webui/open-terminal"
 						target="_blank">{$i18n.t('Learn more about Open Terminal')} ↗</a
 					>

--- a/src/lib/components/admin/Settings/Models.svelte
+++ b/src/lib/components/admin/Settings/Models.svelte
@@ -129,7 +129,7 @@
 		if (isSharedModel(model)) {
 			return 'text-[#4f6f93] dark:text-[#8ba6c6]';
 		}
-		return 'text-gray-500 dark:text-gray-400';
+		return 'text-gray-600 dark:text-gray-400';
 	};
 
 	$: defaultModelIdSet = new Set(defaultModelIds);
@@ -677,7 +677,7 @@
 			<div class="mb-2 flex items-center justify-between">
 				<h2 class="text-sm font-medium text-gray-900 dark:text-white">
 					{$i18n.t('Models')}
-					<span class="ml-2 font-normal text-gray-500 dark:text-gray-500">
+					<span class="ml-2 font-normal text-gray-600 dark:text-gray-500">
 						{filteredModels.length}
 					</span>
 				</h2>
@@ -984,7 +984,7 @@
 
 												{#if defaultModelIdSet.has(model.id)}
 													<span
-														class="shrink-0 text-[11px] font-normal leading-4 text-gray-500 dark:text-gray-400"
+														class="shrink-0 text-[11px] font-normal leading-4 text-gray-600 dark:text-gray-400"
 													>
 														{$i18n.t('Selected')}
 													</span>
@@ -992,7 +992,7 @@
 
 												{#if defaultPinnedModelIdSet.has(model.id)}
 													<span
-														class="shrink-0 text-[11px] font-normal leading-4 text-gray-500 dark:text-gray-400"
+														class="shrink-0 text-[11px] font-normal leading-4 text-gray-600 dark:text-gray-400"
 													>
 														{$i18n.t('Pinned')}
 													</span>
@@ -1029,7 +1029,7 @@
 													model.id
 												)
 													? 'text-gray-900 dark:text-white'
-													: 'text-gray-500 dark:text-gray-400 dark:hover:text-white'}"
+													: 'text-gray-600 dark:text-gray-400 dark:hover:text-white'}"
 												type="button"
 												aria-label={defaultModelIdSet.has(model.id)
 													? $i18n.t('Remove Selected Model')
@@ -1052,7 +1052,7 @@
 													model.id
 												)
 													? 'text-gray-900 dark:text-white'
-													: 'text-gray-500 dark:text-gray-400 dark:hover:text-white'}"
+													: 'text-gray-600 dark:text-gray-400 dark:hover:text-white'}"
 												type="button"
 												aria-label={defaultPinnedModelIdSet.has(model.id)
 													? $i18n.t('Remove Pinned Model')
@@ -1075,7 +1075,7 @@
 												: $i18n.t('Make Public')}
 										>
 											<button
-												class="self-center w-fit text-sm p-1.5 rounded-xl text-gray-500 hover:bg-black/5 dark:text-gray-400 dark:hover:bg-white/5 dark:hover:text-white"
+												class="self-center w-fit text-sm p-1.5 rounded-xl text-gray-600 hover:bg-black/5 dark:text-gray-400 dark:hover:bg-white/5 dark:hover:text-white"
 												type="button"
 												aria-label={isPublicModel(model)
 													? $i18n.t('Make Private')

--- a/src/lib/components/admin/Settings/Models/ManageModelsModal.svelte
+++ b/src/lib/components/admin/Settings/Models/ManageModelsModal.svelte
@@ -44,7 +44,7 @@
 				{$i18n.t('Manage Models')}
 			</div>
 			<button
-				class="self-center rounded-lg p-1 text-gray-500 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+				class="self-center rounded-lg p-1 text-gray-600 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
 				on:click={() => {
 					show = false;
 				}}

--- a/src/lib/components/admin/Settings/Pipelines.svelte
+++ b/src/lib/components/admin/Settings/Pipelines.svelte
@@ -45,7 +45,7 @@
 	const inputClass =
 		'w-full h-7 rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 text-xs text-gray-700 outline-hidden transition-colors placeholder:text-gray-300 focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:placeholder:text-gray-700 dark:focus:border-blue-500';
 	const actionButtonClass =
-		'shrink-0 text-xs text-gray-500 transition-colors hover:text-gray-900 disabled:opacity-50 dark:text-gray-500 dark:hover:text-white';
+		'shrink-0 text-xs text-gray-600 transition-colors hover:text-gray-900 disabled:opacity-50 dark:text-gray-500 dark:hover:text-white';
 	const mutedMessageClass = 'text-xs text-gray-400 dark:text-gray-600';
 
 	const updateHandler = async () => {
@@ -299,7 +299,7 @@
 					>
 						<div class="flex gap-2">
 							<button
-								class="h-7 flex-1 rounded-lg border border-dashed border-gray-100/50 bg-transparent px-2 text-left text-xs text-gray-500 transition-colors hover:bg-black/5 hover:text-gray-900 dark:border-white/[0.04] dark:text-gray-500 dark:hover:bg-white/5 dark:hover:text-white"
+								class="h-7 flex-1 rounded-lg border border-dashed border-gray-100/50 bg-transparent px-2 text-left text-xs text-gray-600 transition-colors hover:bg-black/5 hover:text-gray-900 dark:border-white/[0.04] dark:text-gray-500 dark:hover:bg-white/5 dark:hover:text-white"
 								type="button"
 								on:click={() => {
 									document.getElementById('pipelines-upload-input')?.click();

--- a/src/lib/components/admin/Users/Groups.svelte
+++ b/src/lib/components/admin/Users/Groups.svelte
@@ -217,7 +217,7 @@
 					</div>
 
 					<div
-						class="shrink-0 px-1.5 text-xs text-gray-500 transition group-hover:text-gray-800 dark:text-gray-400 dark:group-hover:text-gray-200"
+						class="shrink-0 px-1.5 text-xs text-gray-600 transition group-hover:text-gray-800 dark:text-gray-400 dark:group-hover:text-gray-200"
 					>
 						{$i18n.t('Edit')}
 					</div>

--- a/src/lib/components/admin/Users/Groups/EditGroupModal.svelte
+++ b/src/lib/components/admin/Users/Groups/EditGroupModal.svelte
@@ -146,7 +146,7 @@
 				{/if}
 			</div>
 			<button
-				class="self-center rounded-lg p-1 text-gray-500 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+				class="self-center rounded-lg p-1 text-gray-600 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
 				on:click={() => {
 					show = false;
 				}}
@@ -298,7 +298,7 @@
 													: $i18n.t('Reset all permissions to their initial configuration values')}
 											>
 												<button
-													class="text-sm font-normal text-gray-500 hover:text-gray-700 dark:text-gray-500 dark:hover:text-gray-300 transition hover:underline"
+													class="text-sm font-normal text-gray-600 hover:text-gray-700 dark:text-gray-500 dark:hover:text-gray-300 transition hover:underline"
 													type="button"
 													on:click={() => {
 														showResetConfirmDialog = true;

--- a/src/lib/components/admin/Users/Groups/GroupItem.svelte
+++ b/src/lib/components/admin/Users/Groups/GroupItem.svelte
@@ -111,7 +111,7 @@
 			</div>
 
 			<div
-				class="shrink-0 px-1.5 text-xs text-gray-500 transition group-hover:text-gray-800 dark:text-gray-400 dark:group-hover:text-gray-200"
+				class="shrink-0 px-1.5 text-xs text-gray-600 transition group-hover:text-gray-800 dark:text-gray-400 dark:group-hover:text-gray-200"
 			>
 				{$i18n.t('Edit')}
 			</div>

--- a/src/lib/components/admin/Users/Groups/Users.svelte
+++ b/src/lib/components/admin/Users/Groups/Users.svelte
@@ -52,7 +52,7 @@
 		if (role === 'user') {
 			return 'text-[#4f7a5a] dark:text-[#8db395]';
 		}
-		return 'text-gray-500 dark:text-gray-400';
+		return 'text-gray-600 dark:text-gray-400';
 	};
 
 	const getUserList = async () => {
@@ -132,7 +132,7 @@
 		{#if users.length > 0}
 			<div class="scrollbar-hidden relative whitespace-nowrap overflow-x-auto max-w-full">
 				<table
-					class="w-full text-sm text-left text-gray-500 dark:text-gray-400 table-auto max-w-full"
+					class="w-full text-sm text-left text-gray-600 dark:text-gray-400 table-auto max-w-full"
 				>
 					<thead class="text-xs text-gray-800 uppercase bg-transparent dark:text-gray-200">
 						<tr class=" border-b-[1.5px] border-gray-50/50 dark:border-gray-800/10">

--- a/src/lib/components/admin/Users/UserList.svelte
+++ b/src/lib/components/admin/Users/UserList.svelte
@@ -88,7 +88,7 @@
 		if (role === 'user') {
 			return 'text-[#4f7a5a] dark:text-[#8db395]';
 		}
-		return 'text-gray-500 dark:text-gray-400';
+		return 'text-gray-600 dark:text-gray-400';
 	};
 
 	const getUserList = async () => {
@@ -218,7 +218,7 @@
 	</div>
 
 	<div class="scrollbar-hidden relative whitespace-nowrap overflow-x-auto max-w-full">
-		<table class="w-full text-sm text-left text-gray-500 dark:text-gray-400 table-auto max-w-full">
+		<table class="w-full text-sm text-left text-gray-600 dark:text-gray-400 table-auto max-w-full">
 			<thead class="text-xs text-gray-800 uppercase bg-transparent dark:text-gray-200">
 				<tr class=" border-b-[1.5px] border-gray-50 dark:border-gray-850/30">
 					<th
@@ -482,12 +482,12 @@
 							'You have more than 50 users, which often means this workspace is supporting organizational use. Open WebUI is free to use as-is, with no restrictions or hidden limits, and we want to keep it that way.'
 						)}
 					</p>
-					<p class="text-gray-500 dark:text-gray-400">
+					<p class="text-gray-600 dark:text-gray-400">
 						{$i18n.t(
 							'By supporting the project through sponsorship or an enterprise license, you help us stay independent, ship new features faster, improve stability, and grow Open WebUI for the long haul.'
 						)}
 					</p>
-					<p class="text-gray-500 dark:text-gray-400">
+					<p class="text-gray-600 dark:text-gray-400">
 						{$i18n.t(
 							'Enterprise licenses also include dedicated support, customization options, and more, at a fraction of the cost of building and maintaining this stack internally.'
 						)}
@@ -504,7 +504,7 @@
 						{$i18n.t('Enterprise licensing')}
 					</a>
 					<a
-						class="text-xs text-gray-500 underline transition hover:text-gray-900 dark:text-gray-500 dark:hover:text-gray-100"
+						class="text-xs text-gray-600 underline transition hover:text-gray-900 dark:text-gray-500 dark:hover:text-gray-100"
 						href="https://github.com/sponsors/open-webui"
 						target="_blank"
 						rel="noreferrer"

--- a/src/lib/components/admin/Users/UserList/AddUserModal.svelte
+++ b/src/lib/components/admin/Users/UserList/AddUserModal.svelte
@@ -146,7 +146,7 @@
 		<div class=" flex justify-between dark:text-gray-300 px-4 pt-3 pb-1">
 			<div class=" text-sm font-medium self-center">{$i18n.t('Add User')}</div>
 			<button
-				class="self-center rounded-lg p-1 text-gray-500 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+				class="self-center rounded-lg p-1 text-gray-600 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
 				aria-label={$i18n.t('Close')}
 				on:click={() => {
 					show = false;

--- a/src/lib/components/admin/Users/UserList/EditUserModal.svelte
+++ b/src/lib/components/admin/Users/UserList/EditUserModal.svelte
@@ -71,7 +71,7 @@
 		<div class=" flex justify-between dark:text-gray-300 px-4 pt-3 pb-1">
 			<div class=" text-sm font-medium self-center">{$i18n.t('Edit User')}</div>
 			<button
-				class="self-center rounded-lg p-1 text-gray-500 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+				class="self-center rounded-lg p-1 text-gray-600 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
 				aria-label={$i18n.t('Close')}
 				on:click={() => {
 					show = false;

--- a/src/lib/components/automations/AutomationEditor.svelte
+++ b/src/lib/components/automations/AutomationEditor.svelte
@@ -324,7 +324,7 @@
 									? 'bg-emerald-500'
 									: 'bg-red-400'}"
 							></span>
-							<span class="text-gray-500 dark:text-gray-400">{formatTime(run.created_at)}</span>
+							<span class="text-gray-600 dark:text-gray-400">{formatTime(run.created_at)}</span>
 							{#if run.chat_id}
 								<button
 									class="group flex items-center gap-1 text-[0.6875rem] text-gray-400"

--- a/src/lib/components/calendar/CalendarEventChip.svelte
+++ b/src/lib/components/calendar/CalendarEventChip.svelte
@@ -21,7 +21,7 @@
 			style="background-color: {event.color || calendarColor || '#3b82f6'};"
 		></span>
 		<span class="truncate">
-			{#if !event.all_day}<span class="text-gray-500 dark:text-gray-400"
+			{#if !event.all_day}<span class="text-gray-600 dark:text-gray-400"
 					>{new Date(event.start_at / 1_000_000)
 						.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })
 						.replace(' ', '')}</span

--- a/src/lib/components/calendar/CalendarView.svelte
+++ b/src/lib/components/calendar/CalendarView.svelte
@@ -172,7 +172,7 @@
 						<div class="flex justify-start px-0.5 mb-0.5">
 							<span
 								class="text-xs w-6 h-6 flex items-center justify-center rounded-full
-								{isToday(day) ? 'bg-blue-500 text-white' : 'text-gray-500 dark:text-gray-400'}"
+								{isToday(day) ? 'bg-blue-500 text-white' : 'text-gray-600 dark:text-gray-400'}"
 							>
 								{day.getDate()}
 							</span>

--- a/src/lib/components/channel/ChannelInfoModal.svelte
+++ b/src/lib/components/channel/ChannelInfoModal.svelte
@@ -95,7 +95,7 @@
 					</div>
 				</div>
 				<button
-					class="self-center rounded-lg p-1 text-gray-500 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+					class="self-center rounded-lg p-1 text-gray-600 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
 					on:click={() => {
 						show = false;
 					}}

--- a/src/lib/components/channel/ChannelInfoModal/AddMembersModal.svelte
+++ b/src/lib/components/channel/ChannelInfoModal/AddMembersModal.svelte
@@ -59,7 +59,7 @@
 					</div>
 				</div>
 				<button
-					class="self-center rounded-lg p-1 text-gray-500 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+					class="self-center rounded-lg p-1 text-gray-600 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
 					on:click={() => {
 						show = false;
 					}}

--- a/src/lib/components/channel/ChannelInfoModal/UserList.svelte
+++ b/src/lib/components/channel/ChannelInfoModal/UserList.svelte
@@ -153,7 +153,7 @@
 
 		{#if users.length > 0}
 			<div class="scrollbar-hidden relative whitespace-nowrap w-full max-w-full">
-				<div class=" text-sm text-left text-gray-500 dark:text-gray-400 w-full max-w-full">
+				<div class=" text-sm text-left text-gray-600 dark:text-gray-400 w-full max-w-full">
 					<!-- <div
 						class="text-xs text-gray-800 uppercase bg-transparent dark:text-gray-200 w-full mb-0.5"
 					>

--- a/src/lib/components/channel/Messages/Message.svelte
+++ b/src/lib/components/channel/Messages/Message.svelte
@@ -357,7 +357,7 @@
 								$i18n.t('Unknown User')}
 						</div>
 
-						<div class="italic text-sm text-gray-500 dark:text-gray-400 line-clamp-1 w-full flex-1">
+						<div class="italic text-sm text-gray-600 dark:text-gray-400 line-clamp-1 w-full flex-1">
 							<Markdown
 								id={`${renderedMessageId}-reply-to`}
 								content={message?.reply_to_message?.content}
@@ -595,7 +595,7 @@
 												<Emoji shortCode={reaction.name} />
 
 												{#if reaction.users.length > 0}
-													<div class="text-xs font-normal text-gray-500 dark:text-gray-400">
+													<div class="text-xs font-normal text-gray-600 dark:text-gray-400">
 														{reaction.users?.length}
 													</div>
 												{/if}
@@ -611,7 +611,7 @@
 										>
 											<Tooltip content={$i18n.t('Add Reaction')}>
 												<div
-													class="flex items-center gap-1.5 bg-gray-500/10 hover:outline hover:outline-gray-700/30 dark:hover:outline-gray-300/30 hover:outline-1 transition rounded-xl px-1 py-1 cursor-pointer text-gray-500 dark:text-gray-400"
+													class="flex items-center gap-1.5 bg-gray-500/10 hover:outline hover:outline-gray-700/30 dark:hover:outline-gray-300/30 hover:outline-1 transition rounded-xl px-1 py-1 cursor-pointer text-gray-600 dark:text-gray-400"
 												>
 													<FaceSmile />
 												</div>
@@ -625,7 +625,7 @@
 						{#if !thread && message.reply_count > 0}
 							<div class="flex items-center gap-1.5 -mt-0.5 mb-1.5">
 								<button
-									class="flex items-center text-xs py-1 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 transition"
+									class="flex items-center text-xs py-1 text-gray-600 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 transition"
 									on:click={() => {
 										onThread(message.id);
 									}}

--- a/src/lib/components/channel/PinnedMessagesModal.svelte
+++ b/src/lib/components/channel/PinnedMessagesModal.svelte
@@ -76,7 +76,7 @@
 					</div>
 				</div>
 				<button
-					class="self-center rounded-lg p-1 text-gray-500 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+					class="self-center rounded-lg p-1 text-gray-600 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
 					on:click={() => {
 						show = false;
 					}}
@@ -97,7 +97,7 @@
 								class="flex flex-col gap-2 max-h-[60vh] overflow-y-auto scrollbar-thin scrollbar-thumb-gray-300 dark:scrollbar-thumb-gray-700 scrollbar-track-transparent py-2"
 							>
 								{#if pinnedMessages.length === 0}
-									<div class=" text-center text-xs text-gray-500 dark:text-gray-400 py-6">
+									<div class=" text-center text-xs text-gray-600 dark:text-gray-400 py-6">
 										{$i18n.t('No pinned messages')}
 									</div>
 								{:else}

--- a/src/lib/components/channel/Thread.svelte
+++ b/src/lib/components/channel/Thread.svelte
@@ -178,7 +178,7 @@
 
 			<div>
 				<button
-					class="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300 p-2"
+					class="text-gray-600 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300 p-2"
 					on:click={() => {
 						onClose();
 					}}

--- a/src/lib/components/channel/WebhooksModal.svelte
+++ b/src/lib/components/channel/WebhooksModal.svelte
@@ -118,7 +118,7 @@
 				</div>
 
 				<button
-					class="self-center rounded-lg p-1 text-gray-500 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+					class="self-center rounded-lg p-1 text-gray-600 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
 					on:click={() => (show = false)}
 				>
 					<XMark className="size-4" />

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -3641,7 +3641,7 @@
 			<div class="flex justify-between px-4 pt-3 pb-1 dark:text-gray-300">
 				<div class="self-center text-sm font-medium">{$i18n.t('Chat Variables')}</div>
 				<button
-					class="self-center rounded-lg p-1 text-gray-500 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+					class="self-center rounded-lg p-1 text-gray-600 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
 					on:click={() => {
 						showChatVariablesModal = false;
 					}}
@@ -3651,14 +3651,14 @@
 			</div>
 
 			<div class="px-5 pb-4 text-sm text-gray-600 dark:text-gray-300">
-				<div class="mb-2 text-xs text-gray-500 dark:text-gray-400">
+				<div class="mb-2 text-xs text-gray-600 dark:text-gray-400">
 					{$i18n.t('Selected models define incompatible Chat Variables.')}
 				</div>
 				<div class="flex flex-col gap-1">
 					{#each getChatVariablesForm(selectedModelIds, chatVariables, $models).conflicts as conflict}
 						<div class="rounded-lg border border-red-200 px-3 py-2 text-xs dark:border-red-900/60">
 							<div class="font-medium text-red-600 dark:text-red-400">{conflict.key}</div>
-							<div class="mt-1 text-gray-500 dark:text-gray-400">
+							<div class="mt-1 text-gray-600 dark:text-gray-400">
 								{conflict.modelIds.join(', ')}
 							</div>
 						</div>
@@ -4014,7 +4014,7 @@
 												{#each suggestedPrompts as suggestion}
 													<button
 														type="button"
-														class="flex min-h-8 w-full items-center justify-between py-1 text-left text-[13px] leading-5 text-gray-500 transition hover:text-gray-700 dark:text-gray-500 dark:hover:text-gray-300"
+														class="flex min-h-8 w-full items-center justify-between py-1 text-left text-[13px] leading-5 text-gray-600 transition hover:text-gray-700 dark:text-gray-500 dark:hover:text-gray-300"
 														on:click={async () => {
 															await tick();
 															await submitHandler(withSelectedText(suggestion));

--- a/src/lib/components/chat/ChatControls.svelte
+++ b/src/lib/components/chat/ChatControls.svelte
@@ -311,7 +311,7 @@
 										class="px-2.5 py-1 text-sm rounded-lg transition whitespace-nowrap {activeTab ===
 										'controls'
 											? 'bg-gray-100/40 dark:bg-gray-800/25 font-normal text-gray-700 dark:text-gray-200'
-											: 'text-gray-500 dark:text-gray-400 hover:bg-gray-100/30 dark:hover:bg-gray-800/20 hover:text-gray-600 dark:hover:text-gray-300'}"
+											: 'text-gray-600 dark:text-gray-400 hover:bg-gray-100/30 dark:hover:bg-gray-800/20 hover:text-gray-600 dark:hover:text-gray-300'}"
 										on:click={() => (activeTab = 'controls')}
 									>
 										{$i18n.t('Controls')}
@@ -322,7 +322,7 @@
 										class="px-2.5 py-1 text-sm rounded-lg transition whitespace-nowrap {activeTab ===
 										'files'
 											? 'bg-gray-100/40 dark:bg-gray-800/25 font-normal text-gray-700 dark:text-gray-200'
-											: 'text-gray-500 dark:text-gray-400 hover:bg-gray-100/30 dark:hover:bg-gray-800/20 hover:text-gray-600 dark:hover:text-gray-300'}"
+											: 'text-gray-600 dark:text-gray-400 hover:bg-gray-100/30 dark:hover:bg-gray-800/20 hover:text-gray-600 dark:hover:text-gray-300'}"
 										on:click={() => (activeTab = 'files')}
 									>
 										{$i18n.t('Files')}
@@ -333,7 +333,7 @@
 										class="px-2.5 py-1 text-sm rounded-lg transition whitespace-nowrap {activeTab ===
 										'overview'
 											? 'bg-gray-100/40 dark:bg-gray-800/25 font-normal text-gray-700 dark:text-gray-200'
-											: 'text-gray-500 dark:text-gray-400 hover:bg-gray-100/30 dark:hover:bg-gray-800/20 hover:text-gray-600 dark:hover:text-gray-300'}"
+											: 'text-gray-600 dark:text-gray-400 hover:bg-gray-100/30 dark:hover:bg-gray-800/20 hover:text-gray-600 dark:hover:text-gray-300'}"
 										on:click={() => (activeTab = 'overview')}
 									>
 										{$i18n.t('Overview')}
@@ -341,7 +341,7 @@
 								{/if}
 							</div>
 							<button
-								class="p-1 rounded-lg text-gray-500 dark:text-gray-400"
+								class="p-1 rounded-lg text-gray-600 dark:text-gray-400"
 								on:click={() => showControls.set(false)}
 								aria-label={$i18n.t('Close')}
 							>
@@ -456,7 +456,7 @@
 											class="px-2.5 py-1 text-sm rounded-lg transition whitespace-nowrap {activeTab ===
 											'controls'
 												? 'bg-gray-100/40 dark:bg-gray-800/25 font-normal text-gray-700 dark:text-gray-200'
-												: 'text-gray-500 dark:text-gray-400 hover:bg-gray-100/30 dark:hover:bg-gray-800/20 hover:text-gray-600 dark:hover:text-gray-300'}"
+												: 'text-gray-600 dark:text-gray-400 hover:bg-gray-100/30 dark:hover:bg-gray-800/20 hover:text-gray-600 dark:hover:text-gray-300'}"
 											on:click={() => (activeTab = 'controls')}
 										>
 											{$i18n.t('Controls')}
@@ -467,7 +467,7 @@
 											class="px-2.5 py-1 text-sm rounded-lg transition whitespace-nowrap {activeTab ===
 											'files'
 												? 'bg-gray-100/40 dark:bg-gray-800/25 font-normal text-gray-700 dark:text-gray-200'
-												: 'text-gray-500 dark:text-gray-400 hover:bg-gray-100/30 dark:hover:bg-gray-800/20 hover:text-gray-600 dark:hover:text-gray-300'}"
+												: 'text-gray-600 dark:text-gray-400 hover:bg-gray-100/30 dark:hover:bg-gray-800/20 hover:text-gray-600 dark:hover:text-gray-300'}"
 											on:click={() => (activeTab = 'files')}
 										>
 											{$i18n.t('Files')}
@@ -478,7 +478,7 @@
 											class="px-2.5 py-1 text-sm rounded-lg transition whitespace-nowrap {activeTab ===
 											'overview'
 												? 'bg-gray-100/40 dark:bg-gray-800/25 font-normal text-gray-700 dark:text-gray-200'
-												: 'text-gray-500 dark:text-gray-400 hover:bg-gray-100/30 dark:hover:bg-gray-800/20 hover:text-gray-600 dark:hover:text-gray-300'}"
+												: 'text-gray-600 dark:text-gray-400 hover:bg-gray-100/30 dark:hover:bg-gray-800/20 hover:text-gray-600 dark:hover:text-gray-300'}"
 											on:click={() => (activeTab = 'overview')}
 										>
 											{$i18n.t('Overview')}
@@ -486,7 +486,7 @@
 									{/if}
 								</div>
 								<button
-									class="p-1 rounded-lg text-gray-500 dark:text-gray-400"
+									class="p-1 rounded-lg text-gray-600 dark:text-gray-400"
 									on:click={() => showControls.set(false)}
 									aria-label={$i18n.t('Close')}
 								>

--- a/src/lib/components/chat/ChatPlaceholder.svelte
+++ b/src/lib/components/chat/ChatPlaceholder.svelte
@@ -97,7 +97,7 @@
 				<div in:fade={{ duration: 200, delay: 200 }}>
 					{#if models[selectedModelIdx]?.info?.meta?.description ?? null}
 						<div
-							class="mt-0.5 text-base font-normal text-gray-500 dark:text-gray-400 line-clamp-3 markdown"
+							class="mt-0.5 text-base font-normal text-gray-600 dark:text-gray-400 line-clamp-3 markdown"
 						>
 							{@html DOMPurify.sanitize(
 								marked.parse(

--- a/src/lib/components/chat/Controls/Controls.svelte
+++ b/src/lib/components/chat/Controls/Controls.svelte
@@ -30,7 +30,7 @@
 	let showAdvancedParams = getOpen('advancedParams');
 
 	const compactSectionButtonClass =
-		'w-full py-1 text-xs font-normal text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100 transition cursor-pointer select-none';
+		'w-full py-1 text-xs font-normal text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100 transition cursor-pointer select-none';
 	const systemPromptTextareaClass =
 		'w-full resize-vertical rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 py-1.5 text-xs text-gray-700 outline-hidden transition-colors placeholder:text-gray-300 focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:placeholder:text-gray-700 dark:focus:border-blue-500';
 	const compactSystemPromptTextareaClass =

--- a/src/lib/components/chat/FileNav.svelte
+++ b/src/lib/components/chat/FileNav.svelte
@@ -952,7 +952,7 @@
 {#if !selectedTerminal}
 	<div class="flex-1 flex flex-col items-center justify-center p-6 text-center">
 		<Folder className="size-6 text-gray-300 dark:text-gray-600 mb-2" />
-		<div class="text-xs text-gray-500 dark:text-gray-400 mb-1">
+		<div class="text-xs text-gray-600 dark:text-gray-400 mb-1">
 			{$i18n.t('No Terminal connection configured.')}
 		</div>
 		<div class="text-[10px] text-gray-400 dark:text-gray-500">
@@ -1479,7 +1479,7 @@
 
 				<!-- Toggle header (full-width button) -->
 				<button
-					class="w-full flex items-center gap-2 px-3 py-1 mb-0.5 text-xs text-gray-500 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition"
+					class="w-full flex items-center gap-2 px-3 py-1 mb-0.5 text-xs text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition"
 					on:click={toggleTerminal}
 				>
 					<svg

--- a/src/lib/components/chat/FileNav/FileNavToolbar.svelte
+++ b/src/lib/components/chat/FileNav/FileNavToolbar.svelte
@@ -200,7 +200,7 @@
 								xmlns="http://www.w3.org/2000/svg"
 								viewBox="0 0 16 16"
 								fill="currentColor"
-								class="size-3 text-gray-500 dark:text-gray-400 transition-transform {sortAsc
+								class="size-3 text-gray-600 dark:text-gray-400 transition-transform {sortAsc
 									? ''
 									: 'rotate-180'}"
 							>
@@ -223,7 +223,7 @@
 								xmlns="http://www.w3.org/2000/svg"
 								viewBox="0 0 16 16"
 								fill="currentColor"
-								class="size-3 text-gray-500 dark:text-gray-400 transition-transform {sortAsc
+								class="size-3 text-gray-600 dark:text-gray-400 transition-transform {sortAsc
 									? ''
 									: 'rotate-180'}"
 							>

--- a/src/lib/components/chat/FileNav/FilePreview.svelte
+++ b/src/lib/components/chat/FileNav/FilePreview.svelte
@@ -320,7 +320,7 @@
 							class="shrink-0 px-3 py-1 text-xs rounded-md transition-colors
 								{selectedExcelSheet === sheet
 								? 'bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-200 font-normal'
-								: 'text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800'}"
+								: 'text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800'}"
 							on:click={() => onSheetChange?.(sheet)}
 						>
 							{sheet}

--- a/src/lib/components/chat/FileNav/PortList.svelte
+++ b/src/lib/components/chat/FileNav/PortList.svelte
@@ -55,7 +55,7 @@
 
 <div class="px-2 py-1">
 	<button
-		class="flex items-center gap-1 w-full text-xs font-normal text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 transition"
+		class="flex items-center gap-1 w-full text-xs font-normal text-gray-600 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 transition"
 		on:click={() => (expanded = !expanded)}
 	>
 		<svg
@@ -74,7 +74,7 @@
 		<span class="ml-auto flex items-center gap-1">
 			{#if ports.length > 0}
 				<span
-					class="text-[10px] px-1.5 py-0.5 rounded-full bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400"
+					class="text-[10px] px-1.5 py-0.5 rounded-full bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400"
 				>
 					{ports.length}
 				</span>
@@ -117,7 +117,7 @@
 						<span class="font-mono text-blue-500 dark:text-blue-400 shrink-0">
 							:{port.port}
 						</span>
-						<span class="text-gray-500 dark:text-gray-400 truncate flex-1 text-left">
+						<span class="text-gray-600 dark:text-gray-400 truncate flex-1 text-left">
 							{port.process ?? ''}
 						</span>
 						<Tooltip content={$i18n.t('Open in new tab')}>

--- a/src/lib/components/chat/FileNav/PortPreview.svelte
+++ b/src/lib/components/chat/FileNav/PortPreview.svelte
@@ -128,7 +128,7 @@
 		<Tooltip content={$i18n.t('Back')}>
 			<button
 				class="p-1 rounded transition {canGoBack
-					? 'text-gray-500 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-800 hover:text-gray-700 dark:hover:text-gray-300'
+					? 'text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-800 hover:text-gray-700 dark:hover:text-gray-300'
 					: 'text-gray-300 dark:text-gray-700 cursor-default'}"
 				on:click={goBack}
 				disabled={!canGoBack}
@@ -153,7 +153,7 @@
 		<Tooltip content={$i18n.t('Forward')}>
 			<button
 				class="p-1 rounded transition {canGoForward
-					? 'text-gray-500 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-800 hover:text-gray-700 dark:hover:text-gray-300'
+					? 'text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-800 hover:text-gray-700 dark:hover:text-gray-300'
 					: 'text-gray-300 dark:text-gray-700 cursor-default'}"
 				on:click={goForward}
 				disabled={!canGoForward}
@@ -177,7 +177,7 @@
 		<!-- Refresh -->
 		<Tooltip content={$i18n.t('Refresh')}>
 			<button
-				class="p-1 rounded text-gray-500 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-800 hover:text-gray-700 dark:hover:text-gray-300 transition"
+				class="p-1 rounded text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-800 hover:text-gray-700 dark:hover:text-gray-300 transition"
 				on:click={refresh}
 				aria-label={$i18n.t('Refresh')}
 			>
@@ -210,7 +210,7 @@
 		<!-- Open in new tab -->
 		<Tooltip content={$i18n.t('Open in new tab')}>
 			<button
-				class="p-1 rounded text-gray-500 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-800 hover:text-gray-700 dark:hover:text-gray-300 transition"
+				class="p-1 rounded text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-800 hover:text-gray-700 dark:hover:text-gray-300 transition"
 				on:click={openExternal}
 				aria-label={$i18n.t('Open in new tab')}
 			>
@@ -232,7 +232,7 @@
 		<!-- Close -->
 		<Tooltip content={$i18n.t('Close')}>
 			<button
-				class="p-1 rounded text-gray-500 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-800 hover:text-gray-700 dark:hover:text-gray-300 transition"
+				class="p-1 rounded text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-800 hover:text-gray-700 dark:hover:text-gray-300 transition"
 				on:click={onClose}
 				aria-label={$i18n.t('Close')}
 			>

--- a/src/lib/components/chat/FileNav/SqliteView.svelte
+++ b/src/lib/components/chat/FileNav/SqliteView.svelte
@@ -140,7 +140,7 @@
 					class="shrink-0 px-2 py-1 text-xs rounded-lg transition
 						{table === selectedTable && !queryMode
 						? 'bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-200 font-normal'
-						: 'text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800'}"
+						: 'text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800'}"
 					on:click={() => selectTable(table)}
 				>
 					{table}
@@ -151,7 +151,7 @@
 				class="shrink-0 px-2 py-1 text-xs rounded-lg transition font-mono
 					{queryMode
 					? 'bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-200 font-normal'
-					: 'text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800'}"
+					: 'text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800'}"
 				on:click={() => {
 					queryMode = !queryMode;
 				}}
@@ -187,7 +187,7 @@
 						<span class="text-[0.6rem] text-gray-400 dark:text-gray-600 select-none">⌘+Enter</span>
 					{/if}
 					<button
-						class="shrink-0 px-2.5 py-0.5 text-[0.65rem] font-normal rounded hover:bg-gray-200 dark:hover:bg-gray-800 transition text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300"
+						class="shrink-0 px-2.5 py-0.5 text-[0.65rem] font-normal rounded hover:bg-gray-200 dark:hover:bg-gray-800 transition text-gray-600 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300"
 						on:click={runQuery}
 					>
 						{$i18n.t('Run')}

--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -2246,7 +2246,7 @@
 											<button
 												type="button"
 												id="chat-variables-button"
-												class="flex size-[1.875rem] shrink-0 items-center justify-center rounded-full bg-transparent text-gray-500 transition-colors hover:text-gray-800 focus:outline-hidden dark:text-gray-400 dark:hover:text-gray-100"
+												class="flex size-[1.875rem] shrink-0 items-center justify-center rounded-full bg-transparent text-gray-600 transition-colors hover:text-gray-800 focus:outline-hidden dark:text-gray-400 dark:hover:text-gray-100"
 												aria-label={$i18n.t('Chat Variables')}
 												on:click={() => {
 													dispatch('chatVariables');

--- a/src/lib/components/chat/MessageInput/AttachWebpageModal.svelte
+++ b/src/lib/components/chat/MessageInput/AttachWebpageModal.svelte
@@ -44,7 +44,7 @@
 				{$i18n.t('Attach Webpage')}
 			</h1>
 			<button
-				class="self-center rounded-lg p-1 text-gray-500 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+				class="self-center rounded-lg p-1 text-gray-600 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
 				aria-label={$i18n.t('Close modal')}
 				on:click={() => {
 					show = false;

--- a/src/lib/components/chat/MessageInput/Commands/AtCommands.svelte
+++ b/src/lib/components/chat/MessageInput/Commands/AtCommands.svelte
@@ -168,7 +168,7 @@
 	{#each knowledgeResults as item, idx}
 		{@const itemIdx = idx}
 		{#if idx === 0 || item?.type !== knowledgeResults[idx - 1]?.type}
-			<div class="px-2 py-1 text-[11px] text-gray-500 dark:text-gray-400">
+			<div class="px-2 py-1 text-[11px] text-gray-600 dark:text-gray-400">
 				{#if item?.type === 'folder'}
 					{$i18n.t('Folders')}
 				{:else if item?.type === 'collection'}
@@ -232,7 +232,7 @@
 {/if}
 
 {#if filteredModels.length > 0}
-	<div class="px-2 py-1 text-[11px] text-gray-500 dark:text-gray-400">
+	<div class="px-2 py-1 text-[11px] text-gray-600 dark:text-gray-400">
 		{$i18n.t('Models')}
 	</div>
 

--- a/src/lib/components/chat/MessageInput/Commands/Emojis.svelte
+++ b/src/lib/components/chat/MessageInput/Commands/Emojis.svelte
@@ -64,7 +64,7 @@
 </script>
 
 {#if filteredItems.length > 0}
-	<div class="px-2 py-1 text-[11px] text-gray-500 dark:text-gray-400">
+	<div class="px-2 py-1 text-[11px] text-gray-600 dark:text-gray-400">
 		{$i18n.t('Emojis')}
 	</div>
 

--- a/src/lib/components/chat/MessageInput/Commands/Knowledge.svelte
+++ b/src/lib/components/chat/MessageInput/Commands/Knowledge.svelte
@@ -142,7 +142,7 @@
 {#if filteredItems.length > 0 || query.startsWith('http')}
 	{#each filteredItems as item, idx}
 		{#if idx === 0 || item?.type !== items[idx - 1]?.type}
-			<div class="px-2 py-1 text-[11px] text-gray-500 dark:text-gray-400">
+			<div class="px-2 py-1 text-[11px] text-gray-600 dark:text-gray-400">
 				{#if item?.type === 'folder'}
 					{$i18n.t('Folders')}
 				{:else if item?.type === 'collection'}

--- a/src/lib/components/chat/MessageInput/Commands/Models.svelte
+++ b/src/lib/components/chat/MessageInput/Commands/Models.svelte
@@ -60,7 +60,7 @@
 	};
 </script>
 
-<div class="px-2 py-1 text-[11px] text-gray-500 dark:text-gray-400">
+<div class="px-2 py-1 text-[11px] text-gray-600 dark:text-gray-400">
 	{$i18n.t('Models')}
 </div>
 

--- a/src/lib/components/chat/MessageInput/Commands/Prompts.svelte
+++ b/src/lib/components/chat/MessageInput/Commands/Prompts.svelte
@@ -57,7 +57,7 @@
 	};
 </script>
 
-<div class="px-2 py-1 text-[11px] text-gray-500 dark:text-gray-400">
+<div class="px-2 py-1 text-[11px] text-gray-600 dark:text-gray-400">
 	{$i18n.t('Prompts')}
 </div>
 
@@ -84,7 +84,7 @@
 						{promptItem.command}
 					</span>
 
-					<span class="min-w-0 truncate text-xs text-gray-500 dark:text-gray-400">
+					<span class="min-w-0 truncate text-xs text-gray-600 dark:text-gray-400">
 						{promptItem.name}
 					</span>
 				</button>

--- a/src/lib/components/chat/MessageInput/Commands/Skills.svelte
+++ b/src/lib/components/chat/MessageInput/Commands/Skills.svelte
@@ -69,7 +69,7 @@
 	};
 </script>
 
-<div class="px-2 py-1 text-[11px] text-gray-500 dark:text-gray-400">
+<div class="px-2 py-1 text-[11px] text-gray-600 dark:text-gray-400">
 	{$i18n.t('Skills')}
 </div>
 
@@ -102,7 +102,7 @@
 					<div class="truncate min-w-0 flex-1">
 						{skill.name}
 					</div>
-					<div class="ml-2 max-w-24 shrink-0 truncate text-xs text-gray-500 dark:text-gray-400">
+					<div class="ml-2 max-w-24 shrink-0 truncate text-xs text-gray-600 dark:text-gray-400">
 						{skill.id}
 					</div>
 				</div>

--- a/src/lib/components/chat/MessageInput/Commands/SlashCommands.svelte
+++ b/src/lib/components/chat/MessageInput/Commands/SlashCommands.svelte
@@ -271,7 +271,7 @@
 {/if}
 
 {#if filteredPrompts.length > 0}
-	<div class="px-2 py-1 text-[11px] text-gray-500 dark:text-gray-400">
+	<div class="px-2 py-1 text-[11px] text-gray-600 dark:text-gray-400">
 		{$i18n.t('Prompts')}
 	</div>
 
@@ -297,7 +297,7 @@
 					{promptItem.command}
 				</span>
 
-				<span class="min-w-0 truncate text-xs text-gray-500 dark:text-gray-400">
+				<span class="min-w-0 truncate text-xs text-gray-600 dark:text-gray-400">
 					{promptItem.name}
 				</span>
 			</button>
@@ -306,7 +306,7 @@
 {/if}
 
 {#if skills.length > 0}
-	<div class="px-2 py-1 text-[11px] text-gray-500 dark:text-gray-400">
+	<div class="px-2 py-1 text-[11px] text-gray-600 dark:text-gray-400">
 		{$i18n.t('Skills')}
 	</div>
 
@@ -339,7 +339,7 @@
 					<div class="truncate min-w-0 flex-1">
 						{skill.name}
 					</div>
-					<div class="ml-2 max-w-24 shrink-0 truncate text-xs text-gray-500 dark:text-gray-400">
+					<div class="ml-2 max-w-24 shrink-0 truncate text-xs text-gray-600 dark:text-gray-400">
 						{skill.id}
 					</div>
 				</div>

--- a/src/lib/components/chat/MessageInput/InputMenu/Knowledge.svelte
+++ b/src/lib/components/chat/MessageInput/InputMenu/Knowledge.svelte
@@ -192,7 +192,7 @@
 					<Spinner />
 				</div>
 			{:else if items.length === 0}
-				<div class="py-4 text-center text-sm text-gray-500 dark:text-gray-400">
+				<div class="py-4 text-center text-sm text-gray-600 dark:text-gray-400">
 					{$i18n.t('No knowledge bases found.')}
 				</div>
 			{:else}
@@ -267,7 +267,7 @@
 									<Spinner className="size-3" />
 								</div>
 							{:else if selectedFileItemsTotal === 0}
-								<div class=" text-xs text-gray-500 dark:text-gray-400 italic py-0.5 px-2">
+								<div class=" text-xs text-gray-600 dark:text-gray-400 italic py-0.5 px-2">
 									{$i18n.t('No files in this knowledge base.')}
 								</div>
 							{:else}

--- a/src/lib/components/chat/MessageInput/InputVariablesModal.svelte
+++ b/src/lib/components/chat/MessageInput/InputVariablesModal.svelte
@@ -84,7 +84,7 @@
 				{title}
 			</div>
 			<button
-				class="self-center rounded-lg p-1 text-gray-500 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+				class="self-center rounded-lg p-1 text-gray-600 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
 				on:click={() => {
 					show = false;
 				}}

--- a/src/lib/components/chat/MessageInput/QueuedMessageItem.svelte
+++ b/src/lib/components/chat/MessageInput/QueuedMessageItem.svelte
@@ -36,7 +36,7 @@
 						<Image src={fileUrl} alt="" imageClassName="size-6 rounded-md object-cover" />
 					{:else}
 						<div
-							class="flex items-center px-1.5 py-0.5 rounded-md bg-gray-100 dark:bg-gray-800 text-xs text-gray-500 dark:text-gray-400"
+							class="flex items-center px-1.5 py-0.5 rounded-md bg-gray-100 dark:bg-gray-800 text-xs text-gray-600 dark:text-gray-400"
 						>
 							<span class="max-w-[80px] truncate">{file.name ?? 'file'}</span>
 						</div>

--- a/src/lib/components/chat/Messages/Citations.svelte
+++ b/src/lib/components/chat/Messages/Citations.svelte
@@ -185,7 +185,7 @@
 					{/each}
 					{#if citations.length > 3}
 						<div
-							class="size-4 rounded-full shrink-0 border border-white dark:border-gray-850 bg-gray-100 dark:bg-gray-800 flex items-center justify-center text-[8px] font-normal text-gray-500 dark:text-gray-400 whitespace-nowrap tracking-tighter"
+							class="size-4 rounded-full shrink-0 border border-white dark:border-gray-850 bg-gray-100 dark:bg-gray-800 flex items-center justify-center text-[8px] font-normal text-gray-600 dark:text-gray-400 whitespace-nowrap tracking-tighter"
 							aria-hidden="true"
 						>
 							+{citations.length - Math.min(urlCitations.length, 3)}

--- a/src/lib/components/chat/Messages/Citations/CitationModal.svelte
+++ b/src/lib/components/chat/Messages/Citations/CitationModal.svelte
@@ -130,7 +130,7 @@
 				{/if}
 			</div>
 			<button
-				class="self-center rounded-lg p-1 text-gray-500 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+				class="self-center rounded-lg p-1 text-gray-600 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
 				aria-label={$i18n.t('Close citation modal')}
 				on:click={() => {
 					show = false;
@@ -196,7 +196,7 @@
 													</span>
 												{/if}
 											{:else if typeof document?.distance === 'number'}
-												<span class="text-gray-500 dark:text-gray-500">
+												<span class="text-gray-600 dark:text-gray-500">
 													({(document?.distance ?? 0).toFixed(4)})
 												</span>
 											{/if}
@@ -205,7 +205,7 @@
 								{/if}
 
 								{#if Number.isInteger(document?.metadata?.page)}
-									<span class="text-sm text-gray-500 dark:text-gray-400">
+									<span class="text-sm text-gray-600 dark:text-gray-400">
 										({$i18n.t('page')}
 										{document.metadata.page + 1})
 									</span>

--- a/src/lib/components/chat/Messages/Citations/CitationsModal.svelte
+++ b/src/lib/components/chat/Messages/Citations/CitationsModal.svelte
@@ -44,7 +44,7 @@
 				{$i18n.t('Citations')}
 			</div>
 			<button
-				class="self-center rounded-lg p-1 text-gray-500 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+				class="self-center rounded-lg p-1 text-gray-600 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
 				on:click={() => {
 					show = false;
 				}}

--- a/src/lib/components/chat/Messages/CodeExecutionModal.svelte
+++ b/src/lib/components/chat/Messages/CodeExecutionModal.svelte
@@ -44,7 +44,7 @@
 				</div>
 			</div>
 			<button
-				class="self-center rounded-lg p-1 text-gray-500 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+				class="self-center rounded-lg p-1 text-gray-600 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
 				on:click={() => {
 					show = false;
 					codeExecution = null;

--- a/src/lib/components/chat/Messages/Error.svelte
+++ b/src/lib/components/chat/Messages/Error.svelte
@@ -38,7 +38,7 @@
 </script>
 
 <div
-	class="my-1.5 flex w-full items-start gap-2 rounded-2xl bg-black/[0.03] px-3 py-2 text-gray-500 dark:bg-white/[0.04] dark:text-gray-400"
+	class="my-1.5 flex w-full items-start gap-2 rounded-2xl bg-black/[0.03] px-3 py-2 text-gray-600 dark:bg-white/[0.04] dark:text-gray-400"
 >
 	<Info className="mt-0.5 size-4 shrink-0 text-gray-400 dark:text-gray-500" strokeWidth="1.8" />
 

--- a/src/lib/components/chat/Messages/Markdown/ColonFenceBlock.svelte
+++ b/src/lib/components/chat/Messages/Markdown/ColonFenceBlock.svelte
@@ -36,7 +36,7 @@
 <div class="relative group my-2 rounded-2xl border border-gray-100 dark:border-gray-800 px-4 py-3">
 	<!-- Header row: type badge + copy button -->
 	<div class="flex items-center justify-between mb-2">
-		<span class="text-xs font-normal text-gray-500 dark:text-gray-400">
+		<span class="text-xs font-normal text-gray-600 dark:text-gray-400">
 			{label}
 		</span>
 

--- a/src/lib/components/chat/Messages/Markdown/HTMLToken.svelte
+++ b/src/lib/components/chat/Messages/Markdown/HTMLToken.svelte
@@ -92,7 +92,7 @@
 				<div
 					class="{statusDone === false
 						? 'shimmer'
-						: ''} text-gray-500 dark:text-gray-500 line-clamp-1 text-wrap"
+						: ''} text-gray-600 dark:text-gray-500 line-clamp-1 text-wrap"
 				>
 					{statusTitle}
 				</div>

--- a/src/lib/components/chat/Messages/Markdown/MarkdownTokens.svelte
+++ b/src/lib/components/chat/Messages/Markdown/MarkdownTokens.svelte
@@ -190,7 +190,7 @@
 		<div class="relative w-full group mb-2">
 			<div class="scrollbar-hidden relative overflow-x-auto max-w-full">
 				<table
-					class=" w-full text-sm text-start text-gray-500 dark:text-gray-400 max-w-full rounded-xl"
+					class=" w-full text-sm text-start text-gray-600 dark:text-gray-400 max-w-full rounded-xl"
 					dir="auto"
 				>
 					<thead

--- a/src/lib/components/chat/Messages/OutputEditView.svelte
+++ b/src/lib/components/chat/Messages/OutputEditView.svelte
@@ -282,7 +282,7 @@
 						{:else if di.type === 'reasoning'}
 							<textarea
 								use:fitContent
-								class="w-full bg-transparent outline-hidden resize-none overflow-hidden text-[0.9375rem] text-gray-500 dark:text-gray-400 p-1.5 rounded-lg"
+								class="w-full bg-transparent outline-hidden resize-none overflow-hidden text-[0.9375rem] text-gray-600 dark:text-gray-400 p-1.5 rounded-lg"
 								value={getReasoningText(di.item)}
 								on:input={(e) => {
 									updateReasoningText(di.indices[0], e.target.value);
@@ -292,7 +292,7 @@
 								rows="1"
 							/>
 						{:else if di.type === 'function_call'}
-							<div class="text-[0.9375rem] p-1.5 text-gray-500 dark:text-gray-400">
+							<div class="text-[0.9375rem] p-1.5 text-gray-600 dark:text-gray-400">
 								{#if di.item.arguments}
 									<pre
 										class="text-xs font-mono whitespace-pre-wrap overflow-x-auto pb-0.5">{formatArgs(
@@ -309,7 +309,7 @@
 								{/if}
 							</div>
 						{:else if di.type === 'code_interpreter'}
-							<div class="text-[0.9375rem] p-1.5 text-gray-500 dark:text-gray-400">
+							<div class="text-[0.9375rem] p-1.5 text-gray-600 dark:text-gray-400">
 								{#if di.item.code}
 									<pre class="text-xs font-mono whitespace-pre overflow-x-auto">{di.item.code}</pre>
 								{/if}
@@ -322,7 +322,7 @@
 								{/if}
 							</div>
 						{:else if di.type === 'openai_tool'}
-							<div class="text-[0.9375rem] p-1.5 text-gray-500 dark:text-gray-400">
+							<div class="text-[0.9375rem] p-1.5 text-gray-600 dark:text-gray-400">
 								{#if di.item.action?.queries || di.item.queries}
 									<span class="text-xs"
 										>{(di.item.action?.queries ?? di.item.queries ?? []).join(', ')}</span

--- a/src/lib/components/chat/Messages/ResponseMessage/FollowUps.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage/FollowUps.svelte
@@ -17,7 +17,7 @@
 		{#each followUps as followUp, idx (idx)}
 			<Tooltip content={followUp} placement="top-start" className="line-clamp-1">
 				<button
-					class=" py-1 bg-transparent text-left text-sm flex items-center gap-2 text-gray-500 dark:text-gray-400 hover:text-black dark:hover:text-white transition cursor-pointer w-full"
+					class=" py-1 bg-transparent text-left text-sm flex items-center gap-2 text-gray-600 dark:text-gray-400 hover:text-black dark:hover:text-white transition cursor-pointer w-full"
 					on:click={() => onClick(followUp)}
 					aria-label={$i18n.t('Follow up: {{question}}', { question: followUp })}
 				>

--- a/src/lib/components/chat/Messages/ResponseMessage/StatusHistory/StatusItem.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage/StatusHistory/StatusItem.svelte
@@ -41,7 +41,7 @@
 				<div
 					class="{(done || status?.done) === false
 						? 'shimmer'
-						: ''} text-gray-500 dark:text-gray-500 text-[0.9375rem] line-clamp-1 text-wrap"
+						: ''} text-gray-600 dark:text-gray-500 text-[0.9375rem] line-clamp-1 text-wrap"
 				>
 					{$i18n.t(`Searching Knowledge for "{{searchQuery}}"`, {
 						searchQuery: status.query
@@ -53,7 +53,7 @@
 				<div
 					class="{(done || status?.done) === false
 						? 'shimmer'
-						: ''} text-gray-500 dark:text-gray-500 text-[0.9375rem] line-clamp-1 text-wrap"
+						: ''} text-gray-600 dark:text-gray-500 text-[0.9375rem] line-clamp-1 text-wrap"
 				>
 					{$i18n.t(`Searching`)}
 				</div>
@@ -79,7 +79,7 @@
 				<div
 					class="{(done || status?.done) === false
 						? 'shimmer'
-						: ''} text-gray-500 dark:text-gray-500 text-[0.9375rem] line-clamp-1 text-wrap"
+						: ''} text-gray-600 dark:text-gray-500 text-[0.9375rem] line-clamp-1 text-wrap"
 				>
 					{$i18n.t(`Querying`)}
 				</div>
@@ -105,7 +105,7 @@
 				<div
 					class="{(done || status?.done) === false
 						? 'shimmer'
-						: ''} text-gray-500 dark:text-gray-500 text-[0.9375rem] line-clamp-1 text-wrap"
+						: ''} text-gray-600 dark:text-gray-500 text-[0.9375rem] line-clamp-1 text-wrap"
 				>
 					{#if status.count === 0}
 						{$i18n.t('No sources found')}
@@ -127,7 +127,7 @@
 				<div
 					class="{(done || status?.done) === false
 						? 'shimmer'
-						: ''} text-gray-500 dark:text-gray-500 text-[0.9375rem] line-clamp-1 text-wrap"
+						: ''} text-gray-600 dark:text-gray-500 text-[0.9375rem] line-clamp-1 text-wrap"
 				>
 					<!-- $i18n.t(`Searching "{{searchQuery}}"`) -->
 					{#if status?.description?.includes('{{searchQuery}}')}

--- a/src/lib/components/chat/Messages/SubagentResultRow.svelte
+++ b/src/lib/components/chat/Messages/SubagentResultRow.svelte
@@ -33,7 +33,7 @@
 <div class="w-full min-w-0 pb-1">
 	<button
 		type="button"
-		class="w-full min-w-0 flex items-center gap-2 text-left text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 transition-colors"
+		class="w-full min-w-0 flex items-center gap-2 text-left text-gray-600 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 transition-colors"
 		aria-expanded={expanded}
 		on:click={() => (expanded = !expanded)}
 	>

--- a/src/lib/components/chat/Messages/UserMessage.svelte
+++ b/src/lib/components/chat/Messages/UserMessage.svelte
@@ -337,7 +337,7 @@
 				<div class="w-full min-w-0">
 					<button
 						type="button"
-						class="flex w-full min-w-0 items-center gap-2 text-left text-gray-500 transition-colors hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300"
+						class="flex w-full min-w-0 items-center gap-2 text-left text-gray-600 transition-colors hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300"
 						aria-expanded={timerExpanded}
 						on:click={() => {
 							timerExpanded = !timerExpanded;

--- a/src/lib/components/chat/ModelSelector/ModelItem.svelte
+++ b/src/lib/components/chat/ModelSelector/ModelItem.svelte
@@ -118,7 +118,7 @@
 								}`}
 								className="self-end"
 							>
-								<span class="line-clamp-1 text-[11px] font-normal text-gray-500 dark:text-gray-400"
+								<span class="line-clamp-1 text-[11px] font-normal text-gray-600 dark:text-gray-400"
 									>{item.model.ollama?.details?.parameter_size ?? ''}</span
 								>
 							</Tooltip>

--- a/src/lib/components/chat/ModelSelector/Selector.svelte
+++ b/src/lib/components/chat/ModelSelector/Selector.svelte
@@ -813,7 +813,7 @@
 												type="button"
 												class="flex size-[1.375rem] shrink-0 items-center justify-center rounded-lg transition-colors duration-100 {compareEnabled
 													? 'bg-gray-50 text-gray-700 hover:bg-gray-50 dark:bg-gray-800/60 dark:text-gray-200 dark:hover:bg-gray-800/60'
-													: 'text-gray-500 hover:bg-gray-50/40 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800/40 dark:hover:text-gray-200'}"
+													: 'text-gray-600 hover:bg-gray-50/40 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800/40 dark:hover:text-gray-200'}"
 												aria-label={$i18n.t('Compare')}
 												aria-pressed={compareEnabled}
 												on:click={() => {
@@ -853,7 +853,7 @@
 									>
 										{$i18n.t('No models available')}
 									</div>
-									<div class="w-full text-[11px] leading-3.5 text-gray-500 dark:text-gray-400">
+									<div class="w-full text-[11px] leading-3.5 text-gray-600 dark:text-gray-400">
 										{$i18n.t('Connect to an AI provider to start chatting')}
 									</div>
 									<button
@@ -999,7 +999,7 @@
 						<div class="flex shrink-0 items-center justify-end px-2 py-1 leading-none">
 							<button
 								type="button"
-								class="text-[0.65rem] font-normal leading-none text-gray-500 underline-offset-2 transition-colors duration-100 hover:text-gray-700 hover:underline dark:text-gray-500 dark:hover:text-gray-300"
+								class="text-[0.65rem] font-normal leading-none text-gray-600 underline-offset-2 transition-colors duration-100 hover:text-gray-700 hover:underline dark:text-gray-500 dark:hover:text-gray-300"
 								on:click|stopPropagation={setDefaultHandler}
 							>
 								{$i18n.t('Set as default')}

--- a/src/lib/components/chat/Navbar.svelte
+++ b/src/lib/components/chat/Navbar.svelte
@@ -97,7 +97,7 @@
 						<Tooltip content={$showSidebar ? $i18n.t('Close Sidebar') : $i18n.t('Open Sidebar')}>
 							<button
 								id="sidebar-toggle-button"
-								class="flex cursor-pointer rounded-lg text-gray-500 transition hover:bg-gray-50/40 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800/40 dark:hover:text-gray-200"
+								class="flex cursor-pointer rounded-lg text-gray-600 transition hover:bg-gray-50/40 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800/40 dark:hover:text-gray-200"
 								on:click={() => {
 									showSidebar.set(!$showSidebar);
 								}}
@@ -140,7 +140,7 @@
 									{moveChatHandler}
 								>
 									<button
-										class="flex size-6 shrink-0 cursor-pointer items-center justify-center rounded-lg text-gray-500 transition hover:bg-gray-50/40 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800/40 dark:hover:text-gray-200"
+										class="flex size-6 shrink-0 cursor-pointer items-center justify-center rounded-lg text-gray-600 transition hover:bg-gray-50/40 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800/40 dark:hover:text-gray-200"
 										id="chat-context-menu-button"
 										aria-label={$i18n.t('Chat actions')}
 									>
@@ -167,7 +167,7 @@
 						{#if !chat?.id}
 							<Tooltip content={$i18n.t(`Temporary Chat`)}>
 								<button
-									class="flex size-6 cursor-pointer items-center justify-center rounded-lg text-gray-500 transition hover:bg-gray-50/40 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800/40 dark:hover:text-gray-200"
+									class="flex size-6 cursor-pointer items-center justify-center rounded-lg text-gray-600 transition hover:bg-gray-50/40 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800/40 dark:hover:text-gray-200"
 									id="temporary-chat-button"
 									on:click={async () => {
 										if (($settings?.temporaryChatByDefault ?? false) && $temporaryChatEnabled) {
@@ -200,7 +200,7 @@
 						{:else if $temporaryChatEnabled}
 							<Tooltip content={$i18n.t(`Save Chat`)}>
 								<button
-									class="flex size-6 cursor-pointer items-center justify-center rounded-lg text-gray-500 transition hover:bg-gray-50/40 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800/40 dark:hover:text-gray-200"
+									class="flex size-6 cursor-pointer items-center justify-center rounded-lg text-gray-600 transition hover:bg-gray-50/40 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800/40 dark:hover:text-gray-200"
 									id="save-temporary-chat-button"
 									on:click={async () => {
 										onSaveTempChat();
@@ -218,7 +218,7 @@
 							<button
 								class="flex size-6 {$showSidebar
 									? 'md:hidden'
-									: ''} cursor-pointer items-center justify-center rounded-lg text-gray-500 transition hover:bg-gray-50/40 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800/40 dark:hover:text-gray-200"
+									: ''} cursor-pointer items-center justify-center rounded-lg text-gray-600 transition hover:bg-gray-50/40 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800/40 dark:hover:text-gray-200"
 								on:click={() => {
 									initNewChat();
 								}}
@@ -232,7 +232,7 @@
 					{#if $user?.role === 'admin' || ($user?.permissions.chat?.controls ?? true)}
 						<Tooltip content={$i18n.t('Controls')}>
 							<button
-								class="flex size-6 cursor-pointer items-center justify-center rounded-lg text-gray-500 transition hover:bg-gray-50/40 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800/40 dark:hover:text-gray-200"
+								class="flex size-6 cursor-pointer items-center justify-center rounded-lg text-gray-600 transition hover:bg-gray-50/40 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800/40 dark:hover:text-gray-200"
 								on:click={async () => {
 									await showControls.set(!$showControls);
 								}}

--- a/src/lib/components/chat/Placeholder/ChatList.svelte
+++ b/src/lib/components/chat/Placeholder/ChatList.svelte
@@ -131,7 +131,7 @@
 	<div class="text-left text-sm w-full mb-3">
 		{#if chatList.length === 0}
 			<div
-				class="text-xs text-gray-500 dark:text-gray-400 text-center px-5 min-h-20 w-full h-full flex justify-center items-center"
+				class="text-xs text-gray-600 dark:text-gray-400 text-center px-5 min-h-20 w-full h-full flex justify-center items-center"
 			>
 				{$i18n.t('No chats found')}
 			</div>
@@ -140,7 +140,7 @@
 		{#each chatList as chat, idx (chat.id)}
 			{#if (idx === 0 || (idx > 0 && chat.time_range !== chatList[idx - 1].time_range)) && chat?.time_range}
 				<div
-					class="w-full text-xs text-gray-500 dark:text-gray-500 font-normal {idx === 0
+					class="w-full text-xs text-gray-600 dark:text-gray-500 font-normal {idx === 0
 						? ''
 						: 'pt-5'} pb-2 px-2"
 				>
@@ -176,7 +176,7 @@
 				</div>
 
 				<div class="hidden sm:flex sm:basis-2/5 items-center justify-end gap-2">
-					<div class=" text-gray-500 dark:text-gray-400 text-xs">
+					<div class=" text-gray-600 dark:text-gray-400 text-xs">
 						{dayjs(chat?.updated_at * 1000).calendar()}
 					</div>
 
@@ -196,7 +196,7 @@
 		{#if totalPages > 1}
 			<div class="flex items-center justify-center gap-1.5 pt-2">
 				<button
-					class="inline-flex size-7 items-center justify-center rounded-lg text-xs font-medium text-gray-500 transition hover:bg-gray-50 hover:text-gray-700 disabled:cursor-not-allowed disabled:opacity-25 dark:text-gray-500 dark:hover:bg-gray-850 dark:hover:text-gray-300"
+					class="inline-flex size-7 items-center justify-center rounded-lg text-xs font-medium text-gray-600 transition hover:bg-gray-50 hover:text-gray-700 disabled:cursor-not-allowed disabled:opacity-25 dark:text-gray-500 dark:hover:bg-gray-850 dark:hover:text-gray-300"
 					disabled={chatListLoading || page <= 1}
 					aria-label={$i18n.t('Previous page')}
 					on:click={() => onPageChange(page - 1)}
@@ -227,7 +227,7 @@
 				{/each}
 
 				<button
-					class="inline-flex size-7 items-center justify-center rounded-lg text-xs font-medium text-gray-500 transition hover:bg-gray-50 hover:text-gray-700 disabled:cursor-not-allowed disabled:opacity-25 dark:text-gray-500 dark:hover:bg-gray-850 dark:hover:text-gray-300"
+					class="inline-flex size-7 items-center justify-center rounded-lg text-xs font-medium text-gray-600 transition hover:bg-gray-50 hover:text-gray-700 disabled:cursor-not-allowed disabled:opacity-25 dark:text-gray-500 dark:hover:bg-gray-850 dark:hover:text-gray-300"
 					disabled={chatListLoading || page >= totalPages}
 					aria-label={$i18n.t('Next page')}
 					on:click={() => onPageChange(page + 1)}

--- a/src/lib/components/chat/Settings/About.svelte
+++ b/src/lib/components/chat/Settings/About.svelte
@@ -20,7 +20,7 @@
 		latest: ''
 	};
 	const actionButtonClass =
-		'text-xs text-gray-500 transition-colors hover:text-gray-900 dark:text-gray-500 dark:hover:text-white';
+		'text-xs text-gray-600 transition-colors hover:text-gray-900 dark:text-gray-500 dark:hover:text-white';
 
 	const checkForVersionUpdates = async () => {
 		updateAvailable = null;
@@ -153,7 +153,7 @@
 
 			<div class="text-xs text-gray-400 dark:text-gray-500">
 				{$i18n.t('Created by')}
-				<a class="text-gray-500 dark:text-gray-400" href="https://github.com/tjbck" target="_blank"
+				<a class="text-gray-600 dark:text-gray-400" href="https://github.com/tjbck" target="_blank"
 					>Tim J. Baek</a
 				>
 			</div>

--- a/src/lib/components/chat/Settings/Account.svelte
+++ b/src/lib/components/chat/Settings/Account.svelte
@@ -53,7 +53,7 @@
 	const variableValueClass =
 		'w-full resize-none rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 py-1.5 text-xs text-gray-700 outline-hidden transition-colors placeholder:text-gray-300 focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:placeholder:text-gray-700 dark:focus:border-blue-500';
 	const actionButtonClass =
-		'text-xs text-gray-500 transition-colors hover:text-gray-900 dark:text-gray-500 dark:hover:text-white';
+		'text-xs text-gray-600 transition-colors hover:text-gray-900 dark:text-gray-500 dark:hover:text-white';
 	const variableRowClass = 'flex w-full items-center gap-1.5';
 	const variableKeyRegex = /^[a-z][a-z0-9_]*$/;
 
@@ -319,7 +319,7 @@
 						<div class="min-w-0 truncate font-mono text-xs text-gray-700 dark:text-gray-300">
 							{row.key || $i18n.t('key_name')}
 						</div>
-						<div class="min-w-0 flex-1 truncate text-xs text-gray-500 dark:text-gray-500">
+						<div class="min-w-0 flex-1 truncate text-xs text-gray-600 dark:text-gray-500">
 							{row.value || $i18n.t('Empty')}
 						</div>
 						<button class={actionButtonClass} type="button" on:click={() => openVariableModal(idx)}>
@@ -569,7 +569,7 @@
 			<div>
 				{#if variableFormIndex !== null}
 					<button
-						class="text-xs text-gray-500 transition-colors hover:text-gray-900 dark:text-gray-500 dark:hover:text-white"
+						class="text-xs text-gray-600 transition-colors hover:text-gray-900 dark:text-gray-500 dark:hover:text-white"
 						type="button"
 						on:click={deleteVariableForm}
 					>
@@ -580,7 +580,7 @@
 
 			<div class="flex items-center gap-3">
 				<button
-					class="text-xs text-gray-500 transition-colors hover:text-gray-900 dark:text-gray-500 dark:hover:text-white"
+					class="text-xs text-gray-600 transition-colors hover:text-gray-900 dark:text-gray-500 dark:hover:text-white"
 					type="button"
 					on:click={() => {
 						variableModalOpen = false;

--- a/src/lib/components/chat/Settings/Account/UpdatePassword.svelte
+++ b/src/lib/components/chat/Settings/Account/UpdatePassword.svelte
@@ -11,7 +11,7 @@
 	let newPassword = '';
 	let newPasswordConfirm = '';
 	const actionButtonClass =
-		'text-xs text-gray-500 transition-colors hover:text-gray-900 dark:text-gray-500 dark:hover:text-white';
+		'text-xs text-gray-600 transition-colors hover:text-gray-900 dark:text-gray-500 dark:hover:text-white';
 
 	const updatePasswordHandler = async () => {
 		if (newPassword === newPasswordConfirm) {

--- a/src/lib/components/chat/Settings/Account/UserProfileImage.svelte
+++ b/src/lib/components/chat/Settings/Account/UserProfileImage.svelte
@@ -125,7 +125,7 @@
 			<span class="text-xs text-gray-600 dark:text-gray-400">{displayName || user?.name}</span>
 			<div class="flex flex-wrap items-center gap-2">
 				<button
-					class="text-[0.6875rem] text-gray-500 transition-colors duration-100 hover:text-gray-700 dark:text-gray-500 dark:hover:text-gray-300"
+					class="text-[0.6875rem] text-gray-600 transition-colors duration-100 hover:text-gray-700 dark:text-gray-500 dark:hover:text-gray-300"
 					type="button"
 					on:click={() => {
 						profileImageInputElement.click();
@@ -133,7 +133,7 @@
 				>
 				<span class="text-[0.6875rem] text-gray-300 dark:text-gray-700">·</span>
 				<button
-					class="text-[0.6875rem] text-gray-500 transition-colors duration-100 hover:text-gray-700 dark:text-gray-500 dark:hover:text-gray-300"
+					class="text-[0.6875rem] text-gray-600 transition-colors duration-100 hover:text-gray-700 dark:text-gray-500 dark:hover:text-gray-300"
 					type="button"
 					on:click={async () => {
 						profileImageUrl = `${WEBUI_BASE_URL}/user.png`;
@@ -141,7 +141,7 @@
 				>
 				<span class="text-[0.6875rem] text-gray-300 dark:text-gray-700">·</span>
 				<button
-					class="text-[0.6875rem] text-gray-500 transition-colors duration-100 hover:text-gray-700 dark:text-gray-500 dark:hover:text-gray-300"
+					class="text-[0.6875rem] text-gray-600 transition-colors duration-100 hover:text-gray-700 dark:text-gray-500 dark:hover:text-gray-300"
 					type="button"
 					on:click={async () => {
 						if (canvasPixelTest()) {
@@ -160,7 +160,7 @@
 				>
 				<span class="text-[0.6875rem] text-gray-300 dark:text-gray-700">·</span>
 				<button
-					class="text-[0.6875rem] text-gray-500 transition-colors duration-100 hover:text-gray-700 dark:text-gray-500 dark:hover:text-gray-300"
+					class="text-[0.6875rem] text-gray-600 transition-colors duration-100 hover:text-gray-700 dark:text-gray-500 dark:hover:text-gray-300"
 					type="button"
 					on:click={async () => {
 						const url = await getGravatarUrl(localStorage.token, user?.email);

--- a/src/lib/components/chat/Settings/ArchivedChats.svelte
+++ b/src/lib/components/chat/Settings/ArchivedChats.svelte
@@ -185,7 +185,7 @@
 		<h2 class="text-sm font-medium text-gray-900 dark:text-white">
 			{$i18n.t('Archived Chats')}
 			{#if chatCount !== null}
-				<span class="ml-2 font-normal text-gray-500 dark:text-gray-500">
+				<span class="ml-2 font-normal text-gray-600 dark:text-gray-500">
 					{formatNumber(chatCount)}
 				</span>
 			{/if}
@@ -223,7 +223,7 @@
 		<Dropdown align="end">
 			<Tooltip content={$i18n.t('Actions')}>
 				<button
-					class="flex h-7 items-center gap-1.5 rounded-lg bg-transparent px-1.5 text-xs text-gray-500 transition-colors hover:text-gray-900 dark:text-gray-500 dark:hover:text-white"
+					class="flex h-7 items-center gap-1.5 rounded-lg bg-transparent px-1.5 text-xs text-gray-600 transition-colors hover:text-gray-900 dark:text-gray-500 dark:hover:text-white"
 					type="button"
 				>
 					<span>{$i18n.t('Actions')}</span>
@@ -270,7 +270,7 @@
 			</div>
 		{:else if chatList.length === 0}
 			<div
-				class="flex min-h-20 items-center justify-center px-4 text-center text-xs text-gray-500 dark:text-gray-400"
+				class="flex min-h-20 items-center justify-center px-4 text-center text-xs text-gray-600 dark:text-gray-400"
 			>
 				{$i18n.t('You have no archived conversations.')}
 			</div>
@@ -335,7 +335,7 @@
 								})
 							)}
 						</div>
-						<div class="flex shrink-0 items-center justify-end text-gray-500 dark:text-gray-500">
+						<div class="flex shrink-0 items-center justify-end text-gray-600 dark:text-gray-500">
 							<Tooltip content={$i18n.t('Unarchive Chat')}>
 								<button
 									class="rounded-lg p-1 text-gray-400 transition-colors hover:text-gray-700 dark:text-gray-600 dark:hover:text-gray-300"

--- a/src/lib/components/chat/Settings/DataControls.svelte
+++ b/src/lib/components/chat/Settings/DataControls.svelte
@@ -30,7 +30,7 @@
 
 	let chatImportInputElement: HTMLInputElement;
 	const actionButtonClass =
-		'text-xs text-gray-500 transition-colors hover:text-gray-900 dark:text-gray-500 dark:hover:text-white';
+		'text-xs text-gray-600 transition-colors hover:text-gray-900 dark:text-gray-500 dark:hover:text-white';
 
 	$: if (importFiles) {
 		console.log(importFiles);

--- a/src/lib/components/chat/Settings/General.svelte
+++ b/src/lib/components/chat/Settings/General.svelte
@@ -29,7 +29,7 @@
 	const systemPromptTextareaClass =
 		'w-full resize-y rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 py-1.5 text-xs text-gray-700 outline-hidden transition-colors placeholder:text-gray-300 focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:placeholder:text-gray-700 dark:focus:border-blue-500';
 	const actionButtonClass =
-		'text-xs text-gray-500 transition-colors hover:text-gray-900 dark:text-gray-500 dark:hover:text-white';
+		'text-xs text-gray-600 transition-colors hover:text-gray-900 dark:text-gray-500 dark:hover:text-white';
 
 	let params = {
 		// Advanced

--- a/src/lib/components/chat/Settings/Integrations.svelte
+++ b/src/lib/components/chat/Settings/Integrations.svelte
@@ -146,7 +146,7 @@
 							'CORS must be properly configured by the provider to allow requests from Open WebUI.'
 						)}
 						<a
-							class="ml-1 text-gray-500 underline hover:text-gray-700 dark:text-gray-500 dark:hover:text-gray-300"
+							class="ml-1 text-gray-600 underline hover:text-gray-700 dark:text-gray-500 dark:hover:text-gray-300"
 							href="https://github.com/open-webui/openapi-servers"
 							target="_blank">{$i18n.t('Learn more about OpenAPI tool servers.')} ↗</a
 						>
@@ -163,7 +163,7 @@
 					)}
 				</div>
 				<a
-					class="mt-0.5 block text-[0.6875rem] text-gray-500 underline hover:text-gray-700 dark:text-gray-500 dark:hover:text-gray-300"
+					class="mt-0.5 block text-[0.6875rem] text-gray-600 underline hover:text-gray-700 dark:text-gray-500 dark:hover:text-gray-300"
 					href="https://github.com/open-webui/open-terminal"
 					target="_blank">{$i18n.t('Learn more about Open Terminal')} ↗</a
 				>

--- a/src/lib/components/chat/Settings/Interface.svelte
+++ b/src/lib/components/chat/Settings/Interface.svelte
@@ -111,7 +111,7 @@
 	const firstSectionHeadingClass = 'text-xs text-gray-400 dark:text-gray-600';
 	const settingDescriptionClass = 'mt-1.5 text-[0.6875rem] text-gray-400 dark:text-gray-600';
 	const actionButtonClass =
-		'text-xs text-gray-500 transition-colors hover:text-gray-900 dark:text-gray-500 dark:hover:text-white';
+		'text-xs text-gray-600 transition-colors hover:text-gray-900 dark:text-gray-500 dark:hover:text-white';
 
 	const toggleLandingPageMode = async () => {
 		landingPageMode = landingPageMode === '' ? 'chat' : '';

--- a/src/lib/components/chat/Settings/Interface/ManageFloatingActionButtonsModal.svelte
+++ b/src/lib/components/chat/Settings/Interface/ManageFloatingActionButtonsModal.svelte
@@ -35,7 +35,7 @@
 				{$i18n.t('Quick Actions')}
 			</h1>
 			<button
-				class="self-center rounded-lg p-1 text-gray-500 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+				class="self-center rounded-lg p-1 text-gray-600 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
 				aria-label={$i18n.t('Close modal')}
 				on:click={() => {
 					show = false;
@@ -60,7 +60,7 @@
 						<div class="text-xs flex items-center justify-between mb-2">
 							<div class="font-normal">{$i18n.t('Actions')}</div>
 
-							<div class="flex items-center gap-2 text-gray-500 dark:text-gray-500">
+							<div class="flex items-center gap-2 text-gray-600 dark:text-gray-500">
 								<button
 									type="button"
 									on:click={() => {
@@ -122,7 +122,7 @@
 						</div>
 
 						{#if floatingActionButtons === null || floatingActionButtons.length === 0}
-							<div class="text-gray-500 dark:text-gray-400 text-xs w-full text-center py-5">
+							<div class="text-gray-600 dark:text-gray-400 text-xs w-full text-center py-5">
 								{$i18n.t('Default action buttons will be used.')}
 							</div>
 						{:else}

--- a/src/lib/components/chat/Settings/Interface/ManageImageCompressionModal.svelte
+++ b/src/lib/components/chat/Settings/Interface/ManageImageCompressionModal.svelte
@@ -31,7 +31,7 @@
 				{$i18n.t('Manage')}
 			</h1>
 			<button
-				class="self-center rounded-lg p-1 text-gray-500 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+				class="self-center rounded-lg p-1 text-gray-600 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
 				aria-label={$i18n.t('Close modal')}
 				on:click={() => {
 					show = false;
@@ -77,7 +77,7 @@
 										/>
 									</div>
 
-									<div class="self-center text-gray-500 dark:text-gray-400">
+									<div class="self-center text-gray-600 dark:text-gray-400">
 										<XMark />
 									</div>
 

--- a/src/lib/components/chat/Settings/Personalization.svelte
+++ b/src/lib/components/chat/Settings/Personalization.svelte
@@ -37,7 +37,7 @@
 	let showDeleteConfirm = false;
 	let query = '';
 	const actionButtonClass =
-		'shrink-0 text-xs text-gray-500 transition-colors hover:text-gray-900 dark:text-gray-500 dark:hover:text-white';
+		'shrink-0 text-xs text-gray-600 transition-colors hover:text-gray-900 dark:text-gray-500 dark:hover:text-white';
 
 	type Memory = {
 		id: string;
@@ -192,7 +192,7 @@
 							<Dropdown align="end">
 								<Tooltip content={$i18n.t('Actions')}>
 									<button
-										class="flex h-7 items-center gap-1.5 rounded-lg bg-transparent px-1.5 text-xs text-gray-500 transition-colors hover:text-gray-900 dark:text-gray-500 dark:hover:text-white"
+										class="flex h-7 items-center gap-1.5 rounded-lg bg-transparent px-1.5 text-xs text-gray-600 transition-colors hover:text-gray-900 dark:text-gray-500 dark:hover:text-white"
 										type="button"
 									>
 										<span>{$i18n.t('Actions')}</span>

--- a/src/lib/components/chat/Settings/Shortcuts.svelte
+++ b/src/lib/components/chat/Settings/Shortcuts.svelte
@@ -110,7 +110,7 @@
 		</h2>
 
 		<button
-			class="text-xs text-gray-500 transition-colors hover:text-gray-900 dark:text-gray-500 dark:hover:text-white"
+			class="text-xs text-gray-600 transition-colors hover:text-gray-900 dark:text-gray-500 dark:hover:text-white"
 			on:click={resetBindings}
 		>
 			{$i18n.t('Reset Defaults')}
@@ -209,13 +209,13 @@
 								{#if configurable}
 									{#if recordingShortcut === id}
 										<span
-											class="inline-flex min-h-[1.125rem] items-center rounded-full bg-gray-100 px-[0.4375rem] py-0.5 text-[0.625rem] font-medium leading-none text-gray-500 dark:bg-white/6 dark:text-gray-400"
+											class="inline-flex min-h-[1.125rem] items-center rounded-full bg-gray-100 px-[0.4375rem] py-0.5 text-[0.625rem] font-medium leading-none text-gray-600 dark:bg-white/6 dark:text-gray-400"
 										>
 											{$i18n.t('Press keys...')}
 										</span>
 									{:else if chord}
 										<button
-											class="inline-flex min-h-[1.125rem] items-center rounded-full bg-gray-100 px-[0.4375rem] py-0.5 text-center text-[0.625rem] font-medium leading-none text-gray-500 dark:bg-white/6 dark:text-gray-400"
+											class="inline-flex min-h-[1.125rem] items-center rounded-full bg-gray-100 px-[0.4375rem] py-0.5 text-center text-[0.625rem] font-medium leading-none text-gray-600 dark:bg-white/6 dark:text-gray-400"
 											title={$i18n.t('Click to rebind')}
 											on:click={() => (recordingShortcut = id)}
 										>

--- a/src/lib/components/chat/Settings/SyncStatsModal.svelte
+++ b/src/lib/components/chat/Settings/SyncStatsModal.svelte
@@ -358,7 +358,7 @@
 			<div class="flex justify-between px-4 pt-3 pb-1">
 				<div class="text-sm font-medium self-center">{$i18n.t('Sync Usage Stats')}</div>
 				<button
-					class="self-center rounded-lg p-1 text-gray-500 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+					class="self-center rounded-lg p-1 text-gray-600 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
 					aria-label={$i18n.t('Close modal')}
 					on:click={() => {
 						show = false;
@@ -370,7 +370,7 @@
 			</div>
 
 			<div class="px-5 pt-2 pb-5">
-				<div class="text-sm text-gray-500 dark:text-gray-400">
+				<div class="text-sm text-gray-600 dark:text-gray-400">
 					{$i18n.t('Do you want to sync your usage stats with Open WebUI Community?')}
 				</div>
 
@@ -380,7 +380,7 @@
 					)}
 				</div>
 
-				<div class="mt-3 text-xs text-gray-500">
+				<div class="mt-3 text-xs text-gray-600">
 					<div class="mb-1 font-normal text-gray-600 dark:text-gray-400">
 						{$i18n.t('What is shared:')}
 					</div>

--- a/src/lib/components/chat/Settings/Usage.svelte
+++ b/src/lib/components/chat/Settings/Usage.svelte
@@ -407,7 +407,7 @@
 
 			{#if !hasUsage}
 				<UserSettingSection title={$i18n.t('Activity')}>
-					<div class="text-xs text-gray-500 dark:text-gray-400">
+					<div class="text-xs text-gray-600 dark:text-gray-400">
 						{$i18n.t('No usage data found')}
 					</div>
 				</UserSettingSection>
@@ -448,13 +448,13 @@
 
 				<UserSettingSection title={$i18n.t('Top models')}>
 					{#if usage.top_models.length === 0}
-						<div class="text-xs text-gray-500 dark:text-gray-400">
+						<div class="text-xs text-gray-600 dark:text-gray-400">
 							{$i18n.t('No model usage found')}
 						</div>
 					{:else}
 						{#each usage.top_models as model}
 							<UserSettingRow label={modelName(model.model_id)}>
-								<span class="text-xs text-gray-500 dark:text-gray-400">
+								<span class="text-xs text-gray-600 dark:text-gray-400">
 									{model.messages.toLocaleString()}
 									{$i18n.t('messages')} · {formatNumber(model.total_tokens)}
 								</span>
@@ -467,7 +467,7 @@
 					<UserSettingSection title={$i18n.t('Most used tools')}>
 						{#each usage.top_tools as tool}
 							<UserSettingRow label={tool.name}>
-								<span class="text-xs text-gray-500 dark:text-gray-400">
+								<span class="text-xs text-gray-600 dark:text-gray-400">
 									{tool.count.toLocaleString()}
 									{$i18n.t('runs')}
 								</span>

--- a/src/lib/components/chat/ShareChatModal.svelte
+++ b/src/lib/components/chat/ShareChatModal.svelte
@@ -114,7 +114,7 @@
 		<div class=" flex justify-between dark:text-gray-300 px-4 pt-3 pb-1">
 			<div class=" text-sm font-medium self-center">{$i18n.t('Share Chat')}</div>
 			<button
-				class="self-center rounded-lg p-1 text-gray-500 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+				class="self-center rounded-lg p-1 text-gray-600 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
 				aria-label={$i18n.t('Close')}
 				on:click={() => {
 					show = false;

--- a/src/lib/components/chat/ShortcutItem.svelte
+++ b/src/lib/components/chat/ShortcutItem.svelte
@@ -105,7 +105,7 @@
 
 {#if keysOnly}
 	<span
-		class="inline-flex min-h-[1.125rem] max-w-[9.5rem] shrink-0 items-center justify-center rounded-full bg-gray-100 px-[0.4375rem] py-0.5 text-center text-[0.625rem] font-medium leading-none text-gray-500 dark:bg-white/6 dark:text-gray-400"
+		class="inline-flex min-h-[1.125rem] max-w-[9.5rem] shrink-0 items-center justify-center rounded-full bg-gray-100 px-[0.4375rem] py-0.5 text-center text-[0.625rem] font-medium leading-none text-gray-600 dark:bg-white/6 dark:text-gray-400"
 	>
 		{displayKeys()}
 	</span>
@@ -133,7 +133,7 @@
 		</div>
 		{#if !compact}
 			<span
-				class="inline-flex min-h-[1.125rem] max-w-[9.5rem] shrink-0 items-center justify-center rounded-full bg-gray-100 px-[0.4375rem] py-0.5 text-center text-[0.625rem] font-medium leading-none text-gray-500 dark:bg-white/6 dark:text-gray-400"
+				class="inline-flex min-h-[1.125rem] max-w-[9.5rem] shrink-0 items-center justify-center rounded-full bg-gray-100 px-[0.4375rem] py-0.5 text-center text-[0.625rem] font-medium leading-none text-gray-600 dark:bg-white/6 dark:text-gray-400"
 			>
 				{displayKeys()}
 			</span>

--- a/src/lib/components/chat/SkillsModal.svelte
+++ b/src/lib/components/chat/SkillsModal.svelte
@@ -21,7 +21,7 @@
 		<div class=" flex justify-between dark:text-gray-300 px-4 pt-3 pb-1">
 			<div class=" text-sm font-medium self-center">{$i18n.t('Available Skills')}</div>
 			<button
-				class="self-center rounded-lg p-1 text-gray-500 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+				class="self-center rounded-lg p-1 text-gray-600 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
 				aria-label={$i18n.t('Close')}
 				on:click={() => {
 					show = false;

--- a/src/lib/components/chat/ToolServersModal.svelte
+++ b/src/lib/components/chat/ToolServersModal.svelte
@@ -36,7 +36,7 @@
 		<div class=" flex justify-between dark:text-gray-300 px-4 pt-3 pb-1">
 			<div class=" text-sm font-medium self-center">{$i18n.t('Available Tools')}</div>
 			<button
-				class="self-center rounded-lg p-1 text-gray-500 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+				class="self-center rounded-lg p-1 text-gray-600 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
 				aria-label={$i18n.t('Close')}
 				on:click={() => {
 					show = false;
@@ -73,7 +73,7 @@
 									{/if}
 									{#if toolSpecs.length > 0}
 										<span
-											class="inline-flex min-w-3 items-center justify-center text-center text-[11px] leading-none text-gray-500 dark:text-gray-400 shrink-0"
+											class="inline-flex min-w-3 items-center justify-center text-center text-[11px] leading-none text-gray-600 dark:text-gray-400 shrink-0"
 										>
 											{toolSpecs.length}
 										</span>
@@ -90,7 +90,7 @@
 								{/if}
 							</div>
 
-							<div slot="content" class="pl-4 pr-2 pb-2 text-xs text-gray-500 dark:text-gray-400">
+							<div slot="content" class="pl-4 pr-2 pb-2 text-xs text-gray-600 dark:text-gray-400">
 								{#if toolSpecs.length > 0}
 									{#each toolSpecs as toolSpec}
 										<div class="mt-1 truncate">

--- a/src/lib/components/common/ChatList.svelte
+++ b/src/lib/components/common/ChatList.svelte
@@ -126,7 +126,7 @@
 			{#each chatList as chat, idx (chat.id)}
 				{#if chat.time_range && (idx === 0 || chat.time_range !== chatList[idx - 1]?.time_range)}
 					<div
-						class="w-full text-xs text-gray-500 dark:text-gray-500 font-normal {idx === 0
+						class="w-full text-xs text-gray-600 dark:text-gray-500 font-normal {idx === 0
 							? ''
 							: 'pt-5'} pb-2 px-2"
 					>
@@ -160,7 +160,7 @@
 					</a>
 
 					<div class="{showUserInfo ? 'w-28' : 'basis-2/5'} flex items-center justify-end">
-						<div class="hidden sm:flex text-gray-500 dark:text-gray-400 text-xs">
+						<div class="hidden sm:flex text-gray-600 dark:text-gray-400 text-xs">
 							{dayjs(chat.updated_at * 1000).calendar(null, {
 								sameDay: '[Today] h:mm A',
 								lastDay: '[Yesterday] h:mm A',

--- a/src/lib/components/common/DropdownOptions.svelte
+++ b/src/lib/components/common/DropdownOptions.svelte
@@ -42,7 +42,7 @@
 	</svelte:fragment>
 
 	<svelte:fragment slot="item" let:item let:selected>
-		<span class={`min-w-0 truncate ${selected ? '' : 'text-gray-500 dark:text-gray-400'}`}
+		<span class={`min-w-0 truncate ${selected ? '' : 'text-gray-600 dark:text-gray-400'}`}
 			>{item.label}</span
 		>
 	</svelte:fragment>

--- a/src/lib/components/common/EmojiPicker.svelte
+++ b/src/lib/components/common/EmojiPicker.svelte
@@ -180,7 +180,7 @@
 			<!-- Virtualized Emoji List -->
 			<div class="w-full flex justify-start h-96 overflow-y-auto px-2.5 pb-2.5 text-[13px]">
 				{#if emojiRows.length === 0}
-					<div class="text-center text-xs text-gray-500 dark:text-gray-400">
+					<div class="text-center text-xs text-gray-600 dark:text-gray-400">
 						{$i18n.t('No results')}
 					</div>
 				{:else}
@@ -189,7 +189,7 @@
 							<div class="w-full mb-2.5">
 								{#if item.length === 1 && item[0].type === 'group'}
 									<!-- Render group header -->
-									<div class="text-xs font-normal -mb-1 text-gray-500 dark:text-gray-400">
+									<div class="text-xs font-normal -mb-1 text-gray-600 dark:text-gray-400">
 										{item[0].label}
 									</div>
 								{:else}

--- a/src/lib/components/common/FileItemModal.svelte
+++ b/src/lib/components/common/FileItemModal.svelte
@@ -422,7 +422,7 @@
 						<div class="absolute top-2 right-2 z-10">
 							<Tooltip content={$i18n.t('Reset view')}>
 								<button
-									class="p-1.5 rounded-lg bg-white/80 dark:bg-gray-850/80 backdrop-blur-sm shadow-sm hover:bg-gray-100 dark:hover:bg-gray-800 transition text-gray-500 dark:text-gray-400"
+									class="p-1.5 rounded-lg bg-white/80 dark:bg-gray-850/80 backdrop-blur-sm shadow-sm hover:bg-gray-100 dark:hover:bg-gray-800 transition text-gray-600 dark:text-gray-400"
 									on:click={resetImageView}
 								>
 									<Reset className="size-4" />

--- a/src/lib/components/common/PDFViewer.svelte
+++ b/src/lib/components/common/PDFViewer.svelte
@@ -289,7 +289,7 @@
 			class="absolute bottom-3 left-1/2 -translate-x-1/2 z-10 flex items-center gap-0.5 rounded-lg bg-white/90 dark:bg-gray-850/90 backdrop-blur-sm shadow-lg border border-gray-200/60 dark:border-gray-700/60 px-1 py-0.5"
 		>
 			<button
-				class="p-1.5 rounded-md hover:bg-gray-100 dark:hover:bg-gray-800 transition text-gray-500 dark:text-gray-400"
+				class="p-1.5 rounded-md hover:bg-gray-100 dark:hover:bg-gray-800 transition text-gray-600 dark:text-gray-400"
 				on:click={zoomOut}
 				aria-label="Zoom out"
 			>
@@ -307,14 +307,14 @@
 				</svg>
 			</button>
 			<button
-				class="px-1.5 py-1 min-w-[3rem] text-center text-[11px] font-normal text-gray-500 dark:text-gray-400 rounded-md hover:bg-gray-100 dark:hover:bg-gray-800 transition tabular-nums"
+				class="px-1.5 py-1 min-w-[3rem] text-center text-[11px] font-normal text-gray-600 dark:text-gray-400 rounded-md hover:bg-gray-100 dark:hover:bg-gray-800 transition tabular-nums"
 				on:click={resetView}
 				aria-label="Reset zoom"
 			>
 				{Math.round(zoomLevel * 100)}%
 			</button>
 			<button
-				class="p-1.5 rounded-md hover:bg-gray-100 dark:hover:bg-gray-800 transition text-gray-500 dark:text-gray-400"
+				class="p-1.5 rounded-md hover:bg-gray-100 dark:hover:bg-gray-800 transition text-gray-600 dark:text-gray-400"
 				on:click={zoomIn}
 				aria-label="Zoom in"
 			>

--- a/src/lib/components/common/Valves.svelte
+++ b/src/lib/components/common/Valves.svelte
@@ -204,7 +204,7 @@
 			{/if}
 
 			{#if (valvesSpec.properties[property]?.description ?? null) !== null}
-				<div class="markdown-prose-xs max-w-full text-gray-500 dark:text-gray-400">
+				<div class="markdown-prose-xs max-w-full text-gray-600 dark:text-gray-400">
 					<!-- eslint-disable-next-line svelte/no-at-html-tags -->
 					{@html DOMPurify.sanitize(
 						marked.parse(valvesSpec.properties[property].description ?? '', { async: false })

--- a/src/lib/components/layout/ChatsModal.svelte
+++ b/src/lib/components/layout/ChatsModal.svelte
@@ -97,17 +97,17 @@
 			<div class="flex items-center gap-2 text-sm font-medium self-center">
 				<div>{title}</div>
 				{#if count !== null}
-					<div class="text-sm font-medium text-gray-500 dark:text-gray-500">
+					<div class="text-sm font-medium text-gray-600 dark:text-gray-500">
 						{formatNumber(count)}
 					</div>
 				{:else if chatList}
-					<div class="text-sm font-medium text-gray-500 dark:text-gray-500">
+					<div class="text-sm font-medium text-gray-600 dark:text-gray-500">
 						{formatNumber(chatList.length)}
 					</div>
 				{/if}
 			</div>
 			<button
-				class="self-center rounded-lg p-1 text-gray-500 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+				class="self-center rounded-lg p-1 text-gray-600 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
 				on:click={() => {
 					show = false;
 				}}
@@ -232,7 +232,7 @@
 						<div class="text-left text-sm w-full mb-3 max-h-[22rem] overflow-y-scroll">
 							{#if chatList.length === 0}
 								<div
-									class="text-xs text-gray-500 dark:text-gray-400 text-center px-5 min-h-20 w-full h-full flex justify-center items-center"
+									class="text-xs text-gray-600 dark:text-gray-400 text-center px-5 min-h-20 w-full h-full flex justify-center items-center"
 								>
 									{$i18n.t('No results found')}
 								</div>
@@ -241,7 +241,7 @@
 							{#each chatList as chat, idx (chat.id)}
 								{#if (idx === 0 || (idx > 0 && chat.time_range !== chatList[idx - 1].time_range)) && chat?.time_range}
 									<div
-										class="w-full text-xs text-gray-500 dark:text-gray-500 font-normal {idx === 0
+										class="w-full text-xs text-gray-600 dark:text-gray-500 font-normal {idx === 0
 											? ''
 											: 'pt-5'} pb-2 px-2"
 									>
@@ -294,7 +294,7 @@
 									</a>
 
 									<div class="{showUserInfo ? 'w-28' : 'basis-2/5'} flex items-center justify-end">
-										<div class="hidden sm:flex text-gray-500 dark:text-gray-400 text-xs">
+										<div class="hidden sm:flex text-gray-600 dark:text-gray-400 text-xs">
 											{$i18n.t(
 												dayjs(chat?.updated_at * 1000).calendar(null, {
 													sameDay: '[Today]',

--- a/src/lib/components/layout/FilesModal.svelte
+++ b/src/lib/components/layout/FilesModal.svelte
@@ -206,17 +206,17 @@
 			<div class="flex items-center gap-2 text-sm font-medium self-center">
 				<div>{$i18n.t('Files')}</div>
 				{#if query && files}
-					<div class="text-sm font-medium text-gray-500 dark:text-gray-500">
+					<div class="text-sm font-medium text-gray-600 dark:text-gray-500">
 						{files.length}
 					</div>
 				{:else if fileCount !== null}
-					<div class="text-sm font-medium text-gray-500 dark:text-gray-500">
+					<div class="text-sm font-medium text-gray-600 dark:text-gray-500">
 						{fileCount}
 					</div>
 				{/if}
 			</div>
 			<button
-				class="self-center rounded-lg p-1 text-gray-500 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+				class="self-center rounded-lg p-1 text-gray-600 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
 				on:click={() => {
 					show = false;
 				}}
@@ -330,7 +330,7 @@
 						<div class="text-left text-sm w-full mb-3 max-h-[32rem] overflow-y-scroll">
 							{#if files.length === 0}
 								<div
-									class="text-xs text-gray-500 dark:text-gray-400 text-center px-5 min-h-20 w-full h-full flex justify-center items-center"
+									class="text-xs text-gray-600 dark:text-gray-400 text-center px-5 min-h-20 w-full h-full flex justify-center items-center"
 								>
 									{$i18n.t('No files found')}
 								</div>
@@ -349,7 +349,7 @@
 									</div>
 
 									<div class="basis-2/5 flex items-center justify-end">
-										<div class="hidden sm:flex text-gray-500 dark:text-gray-400 text-xs">
+										<div class="hidden sm:flex text-gray-600 dark:text-gray-400 text-xs">
 											{dayjs(file.created_at * 1000).format('MMM D, YYYY')}
 										</div>
 

--- a/src/lib/components/layout/SearchModal.svelte
+++ b/src/lib/components/layout/SearchModal.svelte
@@ -600,7 +600,7 @@
 			<div
 				class="flex flex-col overflow-y-auto h-96 md:h-[40rem] max-h-full scrollbar-hidden w-full flex-1 pr-2"
 			>
-				<div class="w-full text-xs text-gray-500 dark:text-gray-500 font-normal pb-2 px-2">
+				<div class="w-full text-xs text-gray-600 dark:text-gray-500 font-normal pb-2 px-2">
 					{$i18n.t('Actions')}
 				</div>
 
@@ -634,7 +634,7 @@
 					<div aria-hidden="true" class="h-px my-3" />
 
 					{#if chatList.length === 0}
-						<div class="text-xs text-gray-500 dark:text-gray-400 text-center px-5 py-4">
+						<div class="text-xs text-gray-600 dark:text-gray-400 text-center px-5 py-4">
 							{$i18n.t('No results found')}
 						</div>
 					{/if}
@@ -642,7 +642,7 @@
 					{#each chatList as chat, idx (chat.id)}
 						{#if idx === 0 || (idx > 0 && chat.time_range !== chatList[idx - 1].time_range)}
 							<div
-								class="w-full text-xs text-gray-500 dark:text-gray-500 font-normal {idx === 0
+								class="w-full text-xs text-gray-600 dark:text-gray-500 font-normal {idx === 0
 									? ''
 									: 'pt-4'} pb-1.5 px-2"
 							>
@@ -738,7 +738,7 @@
 										{chat?.title}
 									</div>
 									{#if chat?.snippet}
-										<div class="text-xs text-gray-500 dark:text-gray-400 line-clamp-2 mt-0.5">
+										<div class="text-xs text-gray-600 dark:text-gray-400 line-clamp-2 mt-0.5">
 											{#each getHighlightedSnippet(chat.snippet, query) as part}
 												{#if part.highlight}
 													<mark
@@ -758,7 +758,7 @@
 							<div
 								class="absolute right-3 top-1/2 -translate-y-1/2 flex items-center gap-3 pl-6 shrink-0"
 							>
-								<div class="text-gray-500 dark:text-gray-400 text-xs">
+								<div class="text-gray-600 dark:text-gray-400 text-xs">
 									{$i18n.t(
 										dayjs(chat?.updated_at * 1000).calendar(null, {
 											sameDay: '[Today]',
@@ -877,7 +877,7 @@
 			>
 				{#if messages === null}
 					<div
-						class="w-full h-full flex justify-center items-center text-gray-500 dark:text-gray-400 text-sm"
+						class="w-full h-full flex justify-center items-center text-gray-600 dark:text-gray-400 text-sm"
 					>
 						{$i18n.t('Select a conversation to preview')}
 					</div>

--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -1440,7 +1440,7 @@
 								{#each $chats as chat, idx (`chat-${chat?.id ?? idx}`)}
 									{#if idx === 0 || (idx > 0 && chat.time_range !== $chats[idx - 1].time_range)}
 										<div
-											class="w-full pl-2.5 text-xs text-gray-500 dark:text-gray-500 font-normal {idx ===
+											class="w-full pl-2.5 text-xs text-gray-600 dark:text-gray-500 font-normal {idx ===
 											0
 												? ''
 												: 'pt-4'} pb-1"

--- a/src/lib/components/layout/Sidebar/ChannelModal.svelte
+++ b/src/lib/components/layout/Sidebar/ChannelModal.svelte
@@ -149,7 +149,7 @@
 				{/if}
 			</div>
 			<button
-				class="self-center rounded-lg p-1 text-gray-500 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+				class="self-center rounded-lg p-1 text-gray-600 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
 				on:click={() => {
 					show = false;
 				}}

--- a/src/lib/components/layout/Sidebar/ChatHoverPreview.svelte
+++ b/src/lib/components/layout/Sidebar/ChatHoverPreview.svelte
@@ -111,13 +111,13 @@
 			>
 				{#if loading}
 					<div
-						class="flex w-full items-center justify-center py-8 text-gray-500 dark:text-gray-400"
+						class="flex w-full items-center justify-center py-8 text-gray-600 dark:text-gray-400"
 					>
 						<Spinner className="size-5" />
 					</div>
 				{:else if error}
 					<div
-						class="flex w-full items-center justify-center px-6 py-6 text-center text-sm text-gray-500 dark:text-gray-400"
+						class="flex w-full items-center justify-center px-6 py-6 text-center text-sm text-gray-600 dark:text-gray-400"
 					>
 						{error}
 					</div>

--- a/src/lib/components/layout/Sidebar/Folders/FolderModal.svelte
+++ b/src/lib/components/layout/Sidebar/Folders/FolderModal.svelte
@@ -119,7 +119,7 @@
 				{/if}
 			</div>
 			<button
-				class="self-center rounded-lg p-1 text-gray-500 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+				class="self-center rounded-lg p-1 text-gray-600 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
 				on:click={() => {
 					show = false;
 				}}

--- a/src/lib/components/layout/Sidebar/Folders/FolderShareModal.svelte
+++ b/src/lib/components/layout/Sidebar/Folders/FolderShareModal.svelte
@@ -61,7 +61,7 @@
 				{$i18n.t('Share')}: {folder?.name ?? ''}
 			</div>
 			<button
-				class="self-center rounded-lg p-1 text-gray-500 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+				class="self-center rounded-lg p-1 text-gray-600 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
 				on:click={() => {
 					show = false;
 				}}

--- a/src/lib/components/layout/Sidebar/Section.svelte
+++ b/src/lib/components/layout/Sidebar/Section.svelte
@@ -130,7 +130,7 @@
 				<div class="flex items-center justify-between h-6 w-full pl-3.5 pr-1.5 shrink-0">
 					<button
 						type="button"
-						class="group flex flex-1 h-full items-center gap-1 text-left text-xs text-gray-400 hover:text-gray-500 dark:text-gray-500 dark:hover:text-gray-400 transition-colors duration-100 {buttonClassName}"
+						class="group flex flex-1 h-full items-center gap-1 text-left text-xs text-gray-600 hover:text-gray-800 dark:text-gray-500 dark:hover:text-gray-400 transition-colors duration-100 {buttonClassName}"
 						aria-expanded={open}
 						aria-controls="{id}-content"
 					>

--- a/src/lib/components/layout/Sidebar/UserMenu.svelte
+++ b/src/lib/components/layout/Sidebar/UserMenu.svelte
@@ -146,7 +146,7 @@
 									: $i18n.t('Active Users')}
 							>
 								<div
-									class="ml-auto flex shrink-0 items-center justify-end gap-1 rounded-full px-1.5 py-0.5 text-[11px] leading-none text-gray-500 dark:text-gray-400"
+									class="ml-auto flex shrink-0 items-center justify-end gap-1 rounded-full px-1.5 py-0.5 text-[11px] leading-none text-gray-600 dark:text-gray-400"
 									on:mouseenter={() => {
 										if ($config?.features?.enable_public_active_users_count || role === 'admin') {
 											getUsageInfo();

--- a/src/lib/components/layout/Sidebar/UserStatusModal.svelte
+++ b/src/lib/components/layout/Sidebar/UserStatusModal.svelte
@@ -81,7 +81,7 @@
 				{$i18n.t('Set your status')}
 			</div>
 			<button
-				class="self-center rounded-lg p-1 text-gray-500 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+				class="self-center rounded-lg p-1 text-gray-600 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
 				on:click={() => {
 					show = false;
 				}}

--- a/src/lib/components/notes/NoteEditor.svelte
+++ b/src/lib/components/notes/NoteEditor.svelte
@@ -1260,7 +1260,7 @@ ${content}
 							}}
 						>
 							<div
-								class="flex gap-0.5 items-center text-xs font-normal text-gray-500 dark:text-gray-500 w-fit"
+								class="flex gap-0.5 items-center text-xs font-normal text-gray-600 dark:text-gray-500 w-fit"
 							>
 								<button class=" flex items-center gap-1 w-fit py-1 px-1.5 rounded-lg min-w-fit">
 									<!-- check for same date, yesterday, last week, and other -->

--- a/src/lib/components/notes/Notes.svelte
+++ b/src/lib/components/notes/Notes.svelte
@@ -406,7 +406,7 @@
 			<div class="flex w-full items-center">
 				<div class="flex items-center gap-1 py-1 min-w-0">
 					<span class="min-w-fit px-1 text-sm select-none">{$i18n.t('Notes')}</span>
-					<span class="text-sm text-gray-500 dark:text-gray-500">
+					<span class="text-sm text-gray-600 dark:text-gray-500">
 						{total === null ? '' : formatNumber(total)}
 					</span>
 				</div>
@@ -572,7 +572,7 @@
 							{/if}
 
 							{#each groupedNotes as [timeRange, notesList], idx}
-								<div class="w-full px-2 pb-1 text-xs text-gray-500 dark:text-gray-500">
+								<div class="w-full px-2 pb-1 text-xs text-gray-600 dark:text-gray-500">
 									{$i18n.t(timeRange)}
 								</div>
 
@@ -610,7 +610,7 @@
 
 												<div class="ml-2 flex shrink-0 items-center justify-end gap-2">
 													<div
-														class="hidden max-w-44 shrink-0 truncate text-right text-[11px] leading-5 text-gray-500 dark:text-gray-500 md:block"
+														class="hidden max-w-44 shrink-0 truncate text-right text-[11px] leading-5 text-gray-600 dark:text-gray-500 md:block"
 													>
 														<Tooltip
 															content={note?.user?.email ?? $i18n.t('Deleted User')}
@@ -737,7 +737,7 @@
 
 												<a href={`/notes/${note.id}`} class="mt-1 flex min-h-0 flex-1 flex-col">
 													<div
-														class="line-clamp-3 text-xs leading-5 text-gray-500 dark:text-gray-500"
+														class="line-clamp-3 text-xs leading-5 text-gray-600 dark:text-gray-500"
 													>
 														{#if note.data?.content?.md}
 															{note.data?.content?.md}
@@ -747,7 +747,7 @@
 													</div>
 
 													<div
-														class="mt-auto flex w-full items-center justify-between gap-2 pt-3 text-[11px] leading-4 text-gray-500 dark:text-gray-500"
+														class="mt-auto flex w-full items-center justify-between gap-2 pt-3 text-[11px] leading-4 text-gray-600 dark:text-gray-500"
 													>
 														<Tooltip
 															content={note?.user?.email ?? $i18n.t('Deleted User')}

--- a/src/lib/components/playground/Chat.svelte
+++ b/src/lib/components/playground/Chat.svelte
@@ -323,7 +323,7 @@
 		<div class="flex justify-between px-4 pt-3 pb-1">
 			<div class="text-sm font-medium self-center">{$i18n.t('Controls')}</div>
 			<button
-				class="self-center rounded-lg p-1 text-gray-500 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+				class="self-center rounded-lg p-1 text-gray-600 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
 				aria-label={$i18n.t('Close')}
 				on:click={() => {
 					showControls = false;
@@ -388,7 +388,7 @@
 
 				<Dropdown>
 					<button
-						class="p-1.5 text-sm font-normal bg-transparent hover:bg-gray-100 dark:hover:bg-gray-800 text-gray-500 dark:text-gray-400 transition rounded-lg"
+						class="p-1.5 text-sm font-normal bg-transparent hover:bg-gray-100 dark:hover:bg-gray-800 text-gray-600 dark:text-gray-400 transition rounded-lg"
 						aria-label={$i18n.t('More options')}
 					>
 						<EllipsisHorizontal className="size-3.5" />
@@ -510,7 +510,7 @@
 							<button
 								class="p-1.5 text-sm font-normal bg-transparent hover:bg-gray-100 dark:hover:bg-gray-800 transition rounded-lg {showControls
 									? 'text-black dark:text-white'
-									: 'text-gray-500 dark:text-gray-400'}"
+									: 'text-gray-600 dark:text-gray-400'}"
 								aria-label={$i18n.t('Controls')}
 								id="playground-controls-toggle"
 								on:click={() => {

--- a/src/lib/components/workspace/Knowledge.svelte
+++ b/src/lib/components/workspace/Knowledge.svelte
@@ -436,7 +436,7 @@
 								</div>
 
 								<div
-									class="hidden max-w-44 shrink-0 self-center truncate text-right text-[11px] leading-5 text-gray-500 dark:text-gray-500 md:block"
+									class="hidden max-w-44 shrink-0 self-center truncate text-right text-[11px] leading-5 text-gray-600 dark:text-gray-500 md:block"
 								>
 									<Tooltip
 										content={item?.user?.email ?? $i18n.t('Deleted User')}

--- a/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
+++ b/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
@@ -1545,7 +1545,7 @@
 							class="flex items-center gap-2 rounded-xl py-1.5 px-2.5 bg-gray-50 dark:bg-gray-850"
 						>
 							<Spinner className="size-3.5 shrink-0" />
-							<div class="text-xs text-gray-500 dark:text-gray-400 truncate">
+							<div class="text-xs text-gray-600 dark:text-gray-400 truncate">
 								{syncing}
 							</div>
 						</div>

--- a/src/lib/components/workspace/Models.svelte
+++ b/src/lib/components/workspace/Models.svelte
@@ -766,7 +766,7 @@
 								</div>
 
 								<div
-									class="hidden max-w-44 shrink-0 self-center truncate text-right text-[11px] leading-5 text-gray-500 dark:text-gray-500 md:block"
+									class="hidden max-w-44 shrink-0 self-center truncate text-right text-[11px] leading-5 text-gray-600 dark:text-gray-500 md:block"
 								>
 									<Tooltip
 										content={model?.user?.email ?? $i18n.t('Deleted User')}

--- a/src/lib/components/workspace/Models/Knowledge.svelte
+++ b/src/lib/components/workspace/Models/Knowledge.svelte
@@ -190,7 +190,7 @@
 							}}
 						>
 							<div
-								class="flex min-w-0 items-center bg-transparent text-xs text-gray-500 outline-hidden hover:underline dark:text-gray-400"
+								class="flex min-w-0 items-center bg-transparent text-xs text-gray-600 outline-hidden hover:underline dark:text-gray-400"
 							>
 								<span class="truncate">{$i18n.t('Select Knowledge')}</span>
 							</div>
@@ -199,7 +199,7 @@
 
 					{#if $user?.role === 'admin' || $user?.permissions?.chat?.file_upload}
 						<button
-							class="self-center bg-transparent text-xs text-gray-500 hover:underline dark:text-gray-400"
+							class="self-center bg-transparent text-xs text-gray-600 hover:underline dark:text-gray-400"
 							type="button"
 							aria-label={$i18n.t('Upload Files')}
 							on:click={() => {
@@ -222,7 +222,7 @@
 						<div
 							class="flex max-w-56 items-center gap-1.5 py-0.5 pr-2 text-xs text-gray-700 dark:text-gray-200"
 						>
-							<div class="shrink-0 text-gray-500 dark:text-gray-400">
+							<div class="shrink-0 text-gray-600 dark:text-gray-400">
 								{#if file.status === 'uploading'}
 									<Spinner className="size-3.5" />
 								{:else if file.type === 'collection'}

--- a/src/lib/components/workspace/Models/Knowledge/KnowledgeSelector.svelte
+++ b/src/lib/components/workspace/Models/Knowledge/KnowledgeSelector.svelte
@@ -137,7 +137,7 @@
 
 			<div class="max-h-56 overflow-y-scroll gap-0.5 flex flex-col">
 				{#if items.length === 0}
-					<div class="text-center text-xs text-gray-500 dark:text-gray-400 pt-4 pb-6">
+					<div class="text-center text-xs text-gray-600 dark:text-gray-400 pt-4 pb-6">
 						{$i18n.t('No knowledge found')}
 					</div>
 				{:else}

--- a/src/lib/components/workspace/Models/ModelEditor.svelte
+++ b/src/lib/components/workspace/Models/ModelEditor.svelte
@@ -671,7 +671,7 @@
 										</div>
 
 										<input
-											class="block w-full bg-transparent py-0.5 text-xs text-gray-500 outline-hidden placeholder:text-gray-300 dark:text-gray-500 dark:placeholder:text-gray-700"
+											class="block w-full bg-transparent py-0.5 text-xs text-gray-600 outline-hidden placeholder:text-gray-300 dark:text-gray-500 dark:placeholder:text-gray-700"
 											placeholder={$i18n.t('Model ID')}
 											bind:value={id}
 											disabled={edit}
@@ -779,7 +779,7 @@
 									{#if chatVariablesPreview.fields.length > 0 || chatVariablesPreview.userFields.length > 0 || chatVariablesPreview.warnings.length > 0}
 										<div class="mt-2 border-t border-gray-100/60 pt-2 dark:border-gray-850/60">
 											<div class="mb-1.5 flex items-center justify-between gap-2">
-												<div class="text-xs text-gray-500 dark:text-gray-400">
+												<div class="text-xs text-gray-600 dark:text-gray-400">
 													{$i18n.t('Detected Variables')}
 												</div>
 												{#if chatVariablesPreview.fields.length + chatVariablesPreview.userFields.length > 0}

--- a/src/lib/components/workspace/Models/PromptSuggestions.svelte
+++ b/src/lib/components/workspace/Models/PromptSuggestions.svelte
@@ -46,7 +46,7 @@
 
 <div class="space-y-2">
 	<div class="mb-1 flex h-6 w-full items-center justify-between">
-		<div class="min-w-0 flex-1 self-center text-xs text-gray-500 dark:text-gray-400">
+		<div class="min-w-0 flex-1 self-center text-xs text-gray-600 dark:text-gray-400">
 			{$i18n.t('Default Prompt Suggestions')}
 		</div>
 
@@ -93,7 +93,7 @@
 			/>
 
 			<button
-				class="flex items-center rounded-xl bg-transparent px-1 py-0.5 text-xs text-gray-500 transition hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+				class="flex items-center rounded-xl bg-transparent px-1 py-0.5 text-xs text-gray-600 transition hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
 				type="button"
 				on:click={() => {
 					const input = document.getElementById('prompt-suggestions-import-input');
@@ -109,7 +109,7 @@
 
 			{#if promptSuggestions.length}
 				<button
-					class="flex items-center rounded-xl bg-transparent px-1 py-0.5 text-xs text-gray-500 transition hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+					class="flex items-center rounded-xl bg-transparent px-1 py-0.5 text-xs text-gray-600 transition hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
 					type="button"
 					on:click={async () => {
 						let blob = new Blob([JSON.stringify(promptSuggestions)], {
@@ -125,7 +125,7 @@
 			{/if}
 
 			<button
-				class="flex size-6 items-center justify-center text-gray-500 transition hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+				class="flex size-6 items-center justify-center text-gray-600 transition hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
 				type="button"
 				aria-label={$i18n.t('Add prompt suggestion')}
 				on:click={() => {
@@ -158,7 +158,7 @@
 
 							<Tooltip content={$i18n.t('e.g. about the Roman Empire')} placement="top-start">
 								<input
-									class="w-full bg-transparent text-[13px] leading-5 text-gray-500 outline-hidden placeholder:text-gray-300 dark:text-gray-500 dark:placeholder:text-gray-700"
+									class="w-full bg-transparent text-[13px] leading-5 text-gray-600 outline-hidden placeholder:text-gray-300 dark:text-gray-500 dark:placeholder:text-gray-700"
 									placeholder={$i18n.t('Subtitle')}
 									aria-label={$i18n.t('Subtitle')}
 									bind:value={prompt.title[1]}

--- a/src/lib/components/workspace/Models/TTSVoiceInput.svelte
+++ b/src/lib/components/workspace/Models/TTSVoiceInput.svelte
@@ -172,11 +172,11 @@
 			>
 				<span class="truncate">{voice.id}</span>
 				{#if voice.name && voice.name !== voice.id}
-					<span class="truncate text-gray-500 dark:text-gray-400">{voice.name}</span>
+					<span class="truncate text-gray-600 dark:text-gray-400">{voice.name}</span>
 				{/if}
 				{#if selectedIds !== null && selectedIds.includes(voice.id)}
 					<svg
-						class="h-3.5 w-3.5 shrink-0 text-gray-500 dark:text-gray-400"
+						class="h-3.5 w-3.5 shrink-0 text-gray-600 dark:text-gray-400"
 						aria-hidden="true"
 						xmlns="http://www.w3.org/2000/svg"
 						fill="none"

--- a/src/lib/components/workspace/Models/TypeaheadSelector.svelte
+++ b/src/lib/components/workspace/Models/TypeaheadSelector.svelte
@@ -68,7 +68,7 @@
 		}}
 	>
 		<div
-			class="flex min-w-0 items-center bg-transparent text-xs text-gray-500 outline-hidden hover:underline dark:text-gray-400"
+			class="flex min-w-0 items-center bg-transparent text-xs text-gray-600 outline-hidden hover:underline dark:text-gray-400"
 		>
 			<span class="truncate">{triggerLabel || placeholder}</span>
 		</div>
@@ -106,7 +106,7 @@
 					{/if}
 
 					{#if matchedItems.length === 0}
-						<div class="pt-4 pb-6 text-center text-xs text-gray-500 dark:text-gray-400">
+						<div class="pt-4 pb-6 text-center text-xs text-gray-600 dark:text-gray-400">
 							{emptyLabel || placeholder}
 						</div>
 					{:else}
@@ -122,7 +122,7 @@
 								<span class="min-w-0 flex-1 truncate">{item.name || item.id}</span>
 								{#if selectedIds !== null && selectedIds.includes(item.id)}
 									<svg
-										class="size-3.5 shrink-0 text-gray-500 dark:text-gray-400"
+										class="size-3.5 shrink-0 text-gray-600 dark:text-gray-400"
 										aria-hidden="true"
 										xmlns="http://www.w3.org/2000/svg"
 										fill="none"

--- a/src/lib/components/workspace/Prompts.svelte
+++ b/src/lib/components/workspace/Prompts.svelte
@@ -606,7 +606,7 @@
 							</div>
 
 							<div
-								class="hidden max-w-44 shrink-0 self-center truncate text-right text-[11px] leading-5 text-gray-500 dark:text-gray-500 md:block"
+								class="hidden max-w-44 shrink-0 self-center truncate text-right text-[11px] leading-5 text-gray-600 dark:text-gray-500 md:block"
 							>
 								<Tooltip
 									content={prompt?.user?.email ?? $i18n.t('Deleted User')}

--- a/src/lib/components/workspace/Prompts/PromptEditor.svelte
+++ b/src/lib/components/workspace/Prompts/PromptEditor.svelte
@@ -311,7 +311,7 @@
 		<div class="flex justify-between items-center mb-2 dark:text-gray-100">
 			<div class="text-xs">{$i18n.t('Edit Prompt')}</div>
 			<button
-				class="rounded-lg p-1 text-gray-500 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+				class="rounded-lg p-1 text-gray-600 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
 				aria-label={$i18n.t('Close')}
 				on:click={() => (showEditModal = false)}
 			>
@@ -363,7 +363,7 @@
 				<div>
 					<button
 						class="px-3 py-1.5 text-xs transition rounded-full {loading
-							? 'cursor-not-allowed bg-gray-200 text-gray-500 dark:bg-gray-700 dark:text-gray-400'
+							? 'cursor-not-allowed bg-gray-200 text-gray-600 dark:bg-gray-700 dark:text-gray-400'
 							: 'bg-black hover:bg-gray-900 text-white dark:bg-white dark:hover:bg-gray-100 dark:text-black'} flex justify-center"
 						type="submit"
 						disabled={loading}
@@ -680,7 +680,7 @@
 						class="group relative w-full px-1.5 py-1.5 pl-3 text-left transition {selectedHistoryEntry?.id ===
 						entry.id
 							? 'text-gray-900 dark:text-white'
-							: 'text-gray-500 hover:text-gray-900 dark:text-gray-500 dark:hover:text-gray-200'}"
+							: 'text-gray-600 hover:text-gray-900 dark:text-gray-500 dark:hover:text-gray-200'}"
 						on:click={() => (selectedHistoryEntry = entry)}
 					>
 						<span

--- a/src/lib/components/workspace/Skills.svelte
+++ b/src/lib/components/workspace/Skills.svelte
@@ -488,7 +488,7 @@
 							</div>
 
 							<div
-								class="hidden max-w-44 shrink-0 self-center truncate text-right text-[11px] leading-5 text-gray-500 dark:text-gray-500 md:block"
+								class="hidden max-w-44 shrink-0 self-center truncate text-right text-[11px] leading-5 text-gray-600 dark:text-gray-500 md:block"
 							>
 								<Tooltip
 									content={skill?.user?.email ?? $i18n.t('Deleted User')}

--- a/src/lib/components/workspace/Tools.svelte
+++ b/src/lib/components/workspace/Tools.svelte
@@ -478,7 +478,7 @@
 							</div>
 
 							<div
-								class="hidden max-w-44 shrink-0 self-center truncate text-right text-[11px] leading-5 text-gray-500 dark:text-gray-500 md:block"
+								class="hidden max-w-44 shrink-0 self-center truncate text-right text-[11px] leading-5 text-gray-600 dark:text-gray-500 md:block"
 							>
 								<Tooltip
 									content={tool?.user?.email ?? $i18n.t('Deleted User')}

--- a/src/lib/components/workspace/common/AccessControlModal.svelte
+++ b/src/lib/components/workspace/common/AccessControlModal.svelte
@@ -32,7 +32,7 @@
 				{$i18n.t('Access Control')}
 			</div>
 			<button
-				class="self-center rounded-lg p-1 text-gray-500 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+				class="self-center rounded-lg p-1 text-gray-600 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
 				on:click={() => {
 					show = false;
 				}}

--- a/src/lib/components/workspace/common/AddAccessModal.svelte
+++ b/src/lib/components/workspace/common/AddAccessModal.svelte
@@ -36,7 +36,7 @@
 				</div>
 			</div>
 			<button
-				class="self-center rounded-lg p-1 text-gray-500 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+				class="self-center rounded-lg p-1 text-gray-600 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
 				on:click={() => {
 					show = false;
 				}}

--- a/src/lib/components/workspace/common/CommunityDiscover.svelte
+++ b/src/lib/components/workspace/common/CommunityDiscover.svelte
@@ -24,7 +24,7 @@
 			<div class="line-clamp-1 text-[13px] font-normal text-gray-700 dark:text-gray-200">
 				{title}
 			</div>
-			<div class="line-clamp-1 text-xs text-gray-500 dark:text-gray-500">
+			<div class="line-clamp-1 text-xs text-gray-600 dark:text-gray-500">
 				{description}
 			</div>
 		</div>

--- a/src/lib/components/workspace/common/ManifestModal.svelte
+++ b/src/lib/components/workspace/common/ManifestModal.svelte
@@ -18,7 +18,7 @@
 		<div class=" flex justify-between dark:text-gray-300 px-4 pt-3 pb-1">
 			<div class=" text-sm font-medium self-center">{$i18n.t('Show your support!')}</div>
 			<button
-				class="self-center rounded-lg p-1 text-gray-500 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+				class="self-center rounded-lg p-1 text-gray-600 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
 				on:click={() => {
 					show = false;
 				}}

--- a/src/lib/components/workspace/common/MemberSelector.svelte
+++ b/src/lib/components/workspace/common/MemberSelector.svelte
@@ -197,7 +197,7 @@
 
 		{#if users.length > 0 || filteredGroups.length > 0}
 			<div class="scrollbar-hidden relative whitespace-nowrap w-full max-w-full">
-				<div class=" text-sm text-left text-gray-500 dark:text-gray-400 w-full max-w-full">
+				<div class=" text-sm text-left text-gray-600 dark:text-gray-400 w-full max-w-full">
 					<div class="w-full max-h-96 overflow-y-auto rounded-lg">
 						{#if includeGroups && filteredGroups.length > 0}
 							<div class="text-xs text-gray-500 mb-1 mx-1">

--- a/src/lib/components/workspace/common/ValvesModal.svelte
+++ b/src/lib/components/workspace/common/ValvesModal.svelte
@@ -157,7 +157,7 @@
 		<div class="flex justify-between dark:text-gray-100 px-4 pt-3 pb-1">
 			<div class="self-center text-sm font-medium">{$i18n.t('Valves')}</div>
 			<button
-				class="self-center rounded-lg p-1 text-gray-500 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+				class="self-center rounded-lg p-1 text-gray-600 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
 				on:click={() => {
 					show = false;
 				}}

--- a/src/routes/(app)/automations/+layout.svelte
+++ b/src/routes/(app)/automations/+layout.svelte
@@ -106,7 +106,7 @@
 						{:else}
 							<span class="min-w-fit px-1 text-sm select-none">{$i18n.t('Automations')}</span>
 						{/if}
-						<span class="text-sm text-gray-500 dark:text-gray-500">
+						<span class="text-sm text-gray-600 dark:text-gray-500">
 							{$total === null ? '' : formatNumber($total)}
 						</span>
 						{#if itemName}

--- a/src/routes/(app)/automations/+page.svelte
+++ b/src/routes/(app)/automations/+page.svelte
@@ -563,7 +563,7 @@
 							</div>
 
 							<div
-								class="hidden max-w-44 shrink-0 self-center truncate text-right text-[11px] leading-5 text-gray-500 dark:text-gray-500 md:block"
+								class="hidden max-w-44 shrink-0 self-center truncate text-right text-[11px] leading-5 text-gray-600 dark:text-gray-500 md:block"
 							>
 								<Tooltip content={formatRRule(automation.data.rrule)} className="min-w-0">
 									<div class="truncate">


### PR DESCRIPTION
Follow up to the `text-gray-400` contrast fix, covering the other failing muted token.

The grey scale in `src/tailwind.css` is achromatic `oklch(L 0 0)`, so relative luminance is exactly `L³`:

| | on `#fff` (light) | on `#171717` (dark) |
|---|---|---|
| `text-gray-500` | **2.77:1** | 6.46:1 |
| `text-gray-600` | **5.75:1** | 3.12:1 |
| `dark:text-gray-400` | | 8.65:1 |

`text-gray-500` paired with a dark variant fails Level AA in light mode at 2.77:1, against 4.5:1 for text and 3:1 for icon buttons. The dark halves already pass and are deliberately left alone, so only the light value moves.

Scope: an unprefixed `text-gray-500` becomes `text-gray-600` **whenever the same class string also carries an unprefixed `dark:text-gray-400` or `dark:text-gray-500`**. The rule is deliberately "same class string" rather than "adjacent tokens", because adjacency is an accident of how the class list was typed, not a property of the design. Matching on adjacency alone would have left 113 identical sites behind, 38 of them inside components this PR already touches, producing two different greys in the same row (for example the tool count and tool description in `chat/ToolServersModal.svelte`, or the table text and its empty state in `admin/Analytics/ModelUsage.svelte`).

Prefixed variants (`hover:`, `group-hover:`, `dark:`) are excluded by a negative lookbehind, so hover ramps keep their existing relationships.

Three sites are hand fixed rather than pattern matched:

- `layout/Sidebar/Section.svelte` — the sidebar "Chats" / "Folders" / "Pinned" label. Its tokens are `text-gray-400 hover:text-gray-500 dark:text-gray-500 dark:hover:text-gray-400`, which no pattern can see as one unit. The resting colour was **2.07:1** and the hover was **2.77:1**, so both failed. Now gray-600 resting, gray-800 on hover, matching the house convention of a two step ramp.
- `admin/Functions.svelte` — carried `opacity-60`, which composites before contrast, so even at gray-600 it would only reach 2.52:1. The opacity is dropped so the item counter actually passes.
- `admin/Settings/General.svelte` — `labelClassName="text-gray-500 dark:text-gray-500"` was a dead override. `AdminSettingRow` already renders `text-gray-600 dark:text-gray-400`, and because gray-600 sits later in the scale it already won. The conflicting override is removed rather than rewritten.

Not covered here: roughly 458 sites where `text-gray-500` has **no** dark sibling at all, so the same value serves both themes. Those need a per site judgement about which dark value to add, and belong in their own PR.

Formatting was only re-run where the file was already Prettier clean on `dev`, so no unrelated reflow is included.

Severity: Serious, and together with the `text-gray-400` fix this is the bulk of the light theme contrast problem.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact. Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA. -->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.

<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->