### PR TITLE
fix: add a global keyboard focus indicator (WCAG 2.4.7, 1.4.11)

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -399,6 +399,13 @@ input[type='number'] {
 	outline: none;
 }
 
+/* unlayered, so it beats the outline-none utilities used across the app */
+:focus-visible,
+.ProseMirror:focus-visible {
+	outline: 2px solid theme(--color-blue-500);
+	outline-offset: 2px;
+}
+
 .ProseMirror p.is-editor-empty:first-child::before {
 	content: attr(data-placeholder);
 	float: left;

--- a/src/lib/components/common/Switch.svelte
+++ b/src/lib/components/common/Switch.svelte
@@ -32,10 +32,8 @@
 		aria-label={ariaLabel || undefined}
 		class="relative h-4 min-h-4 w-7 shrink-0 cursor-pointer rounded-full mx-[1px] transition-colors duration-150 {($settings?.highContrastMode ??
 		false)
-			? 'focus:outline focus:outline-2 focus:outline-gray-800 focus:dark:outline-gray-200'
-			: 'focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-400 dark:focus-visible:outline-gray-500'} {state
-			? 'bg-gray-900 dark:bg-white'
-			: 'bg-gray-300 dark:bg-gray-700'}"
+			? 'focus:outline focus:outline-2 focus:outline-gray-800! focus:dark:outline-gray-200!'
+			: ''} {state ? 'bg-gray-900 dark:bg-white' : 'bg-gray-300 dark:bg-gray-700'}"
 		onCheckedChange={async () => {
 			await tick();
 			dispatch('change', state);


### PR DESCRIPTION
On latest `dev` there are **431** `outline-hidden` / `outline-none` usages across `src/` and effectively no focus styling to replace them. Both utilities compile to `outline-style: none`, so for a keyboard user the focus position is simply invisible across most of the application.

Breaks WCAG 2.4.7 Focus Visible (Level AA), and 1.4.11 Non-text Contrast (Level AA) for the few places that do draw something.

Fix: one unlayered rule in `src/app.css`. `app.css` only `@reference`s the Tailwind entry, so it emits no cascade layer, while Tailwind utilities land in `@layer utilities`. Unlayered normal declarations beat layered ones regardless of specificity, so a single rule overrides all 431 suppressions without touching a single component, and without `!important`. Verified in a browser that `.outline-none` and `.outline-hidden` elements both take the ring.

`:focus-visible` rather than `:focus`, so mouse clicks stay clean and only keyboard focus draws the ring. On browsers without support the result is what exists today, no ring, so nothing regresses.

`.ProseMirror:focus-visible` is included in the same rule because `.ProseMirror:focus { outline: none }` in this file is more specific than the global selector and would otherwise keep the chat composer unstyled.

Indicator contrast, computed against every surface the ring can sit on: white 3.68:1, `gray-50` 3.47:1, `gray-100` 3.08:1, dark body `#171717` 4.87:1, `gray-850` 4.10:1, `gray-900` 4.92:1, `gray-950` 5.28:1, OLED `#000` 5.71:1. All clear the 3:1 required of a focus indicator. Because `outline-offset` paints the ring outside the border box, the adjacent colour is always the parent surface, so a focused element with its own blue background does not hide the ring.

`common/Switch.svelte` is updated in the same change because it is the only component in the repo with its own `focus-visible:` styling, and the new rule would otherwise silently override it. Two consequences were handled:

- With **High Contrast Mode** on, its ring was `gray-800` on white (12.69:1) and `gray-200` on `gray-900` (14.29:1). The global rule would have replaced those with 3.68:1 and 4.92:1, weakening the setting whose entire purpose is contrast, and only for keyboard users. Those two utilities are now marked important so the high contrast ring still wins.
- With the setting off, its ring was `gray-400`, which is **2.07:1 on white** and fails 1.4.11 today. That branch is removed rather than kept, since the global rule replaces it with a passing value.

Deliberately out of scope, because each has its own higher specificity `outline: none` that needs separate handling: the CodeMirror editors (`.cm-editor.cm-focused` here, plus CodeMirror's own base theme on `.cm-content`) and the two scoped textareas in `chat/FileNav/NotebookView.svelte`.

Worth a look on review: the composer's ring is drawn around the inner contenteditable, inside `#chat-input-container`, which is `overflow-auto` with only 4px of horizontal and 2px of bottom padding, so the ring may sit flush against or be partially clipped by that edge. Moving the indicator to the container with `focus-within` would be the visually cleaner treatment and can follow.

Severity: Critical. Keyboard navigation is currently untrackable across most of the application.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact. Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA. -->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.

<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->