### PR TITLE
fix/a11y: let dropdown submenus open on activation, not only hover

### DIFF
--- a/src/lib/components/common/DropdownSub.svelte
+++ b/src/lib/components/common/DropdownSub.svelte
@@ -71,12 +71,33 @@
 		contentEl.style.top = `${top}px`;
 	}
 
-	async function handleMouseEnter() {
+	const FOCUSABLE =
+		'button:not([disabled]), [href], input:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+	async function openSub() {
 		open = true;
 		await tick();
 		positionContent();
 		// Re-position after transition starts rendering real dimensions
 		setTimeout(positionContent, 50);
+	}
+
+	async function handleMouseEnter() {
+		await openSub();
+	}
+
+	async function handleTriggerClick() {
+		await openSub();
+		contentEl?.querySelector(FOCUSABLE)?.focus();
+	}
+
+	function handleKeydown(event) {
+		if (event.key === 'Escape' && open) {
+			// keep the parent menu open
+			event.stopPropagation();
+			open = false;
+			triggerEl?.firstElementChild?.focus();
+		}
 	}
 
 	function handleMouseLeave(event) {
@@ -112,6 +133,10 @@
 	class="w-full"
 	on:mouseenter={handleMouseEnter}
 	on:mouseleave={handleMouseLeave}
+	on:click={handleTriggerClick}
+	on:keydown={handleKeydown}
+	aria-haspopup="true"
+	aria-expanded={open}
 >
 	<slot name="trigger" />
 </div>
@@ -119,7 +144,12 @@
 {#if open}
 	<!-- svelte-ignore a11y-no-static-element-interactions -->
 	<!-- Outer wrapper: positioned flush with trigger, invisible padding bridges the gap -->
-	<div use:portal bind:this={contentEl} on:mouseleave={handleContentMouseLeave}>
+	<div
+		use:portal
+		bind:this={contentEl}
+		on:mouseleave={handleContentMouseLeave}
+		on:keydown={handleKeydown}
+	>
 		<!-- Inner content: visual styles and transition -->
 		<div transition:flyAndScale>
 			<DropdownMenu className={contentClass} style="max-width: {maxWidth}px;">


### PR DESCRIPTION
On latest `dev`, `DropdownSub` opens **only** on `mouseenter`. There is no click handler, no keydown handler, and `open` is module private with no binding, so there is no way to open the submenu other than moving a pointer over it.

The slotted trigger is a real `<button>`, so it takes focus. Pressing Enter on it does nothing at all.

What this locks out:

- `layout/Sidebar/ChatMenu.svelte` — **Move**, which is the only non drag way to file a chat into a folder.
- `layout/Sidebar/ChatMenu.svelte` — **Download**, so Export as JSON, plain text and PDF.
- `layout/Navbar/Menu.svelte`, `notes/Notes/NoteMenu.svelte`, `playground/Chat.svelte` — same component, same defect.

Breaks WCAG 2.1.1 Keyboard (Level A). Also 1.4.13 Content on Hover or Focus (Level AA) on two counts: the content is not focus triggerable, and it was not dismissible, since the file had no keydown handling at all.

Fix: open the submenu on activation as well as on hover, move focus to the first item so the opened content is actually reachable, and close on Escape. Escape stops propagation so it closes the submenu and leaves the parent menu open, and returns focus to the trigger. The keydown handler is bound to both wrappers because the content is portaled to `document.body` and is therefore not a DOM descendant of the trigger.

Activation deliberately **opens** rather than toggles. On touch devices the compatibility `mouseenter` fires before `click`, so a toggle would open and then immediately close the submenu on every tap, making it unopenable by touch. Closing stays with the existing mouseleave handlers and the new Escape.

`aria-haspopup` and `aria-expanded` are added because this change introduces a programmatic focus move, and without them a screen reader announces a plain button and then focus lands somewhere unannounced.

The focusable selector excludes disabled controls, since the first item of the `playground/Chat.svelte` submenu is disabled when there are no messages and focus would otherwise be dropped.

Scope note: this makes the submenu respond to activation. It does not make the whole menu system keyboard complete. The parent `common/Dropdown.svelte` still never moves focus into its own portaled content, and `layout/Sidebar/ChatItem.svelte` renders the menu container as `invisible group-hover:visible` with no focus-within, so for non active chats the trigger is still not reachable. Both need their own fixes.

Arrow key navigation and menu roles are not added here.

Severity: Critical for the affected paths. Filing a chat into a folder currently has no keyboard route at all.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact. Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA. -->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.

<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->