### PR TITLE
fix: move focus into dropdown content and restore it on close (WCAG 2.4.3)

### DIFF
--- a/src/lib/components/common/Dropdown.svelte
+++ b/src/lib/components/common/Dropdown.svelte
@@ -31,6 +31,7 @@
 
 	let triggerEl: HTMLElement | null = null;
 	let contentEl: HTMLElement | null = null;
+	let previouslyFocused: HTMLElement | null = null;
 	let positionFrame: number | undefined;
 	let settleTimers: number[] = [];
 	let resolvedMaxHeight = maxHeight;
@@ -201,31 +202,51 @@
 		}
 	}
 
-	async function toggleOpen() {
-		show = !show;
-		onOpenChange(show);
-		if (show) {
-			await tick();
-			positionContent();
-			// Re-check after transition renders real dimensions
-			if (visualViewportAware) {
-				scheduleSettledPositionUpdates();
-			} else {
-				setTimeout(positionContent, 50);
-			}
+	const FOCUSABLE =
+		'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+	async function afterOpen() {
+		previouslyFocused = document.activeElement as HTMLElement | null;
+
+		await tick();
+		positionContent();
+		// the content is portaled to the end of <body>, so Tab would skip past it
+		contentEl?.querySelector<HTMLElement>(FOCUSABLE)?.focus();
+
+		// Re-check after transition renders real dimensions
+		if (visualViewportAware) {
+			scheduleSettledPositionUpdates();
+		} else {
+			setTimeout(positionContent, 50);
 		}
 	}
 
-	// React to external show changes (e.g. bind:show toggled by parent component)
+	function closeDropdown() {
+		// only take focus back if the dropdown still holds it
+		const restoreFocus = !!contentEl?.contains(document.activeElement);
+
+		show = false;
+		onOpenChange(false);
+
+		if (restoreFocus) {
+			previouslyFocused?.focus();
+		}
+		previouslyFocused = null;
+	}
+
+	function toggleOpen() {
+		if (show) {
+			closeDropdown();
+			return;
+		}
+
+		show = true;
+		onOpenChange(true);
+	}
+
+	// Also covers external show changes (e.g. bind:show toggled by parent component)
 	$: if (show) {
-		tick().then(() => {
-			positionContent();
-			if (visualViewportAware) {
-				scheduleSettledPositionUpdates();
-			} else {
-				setTimeout(positionContent, 50);
-			}
-		});
+		afterOpen();
 	}
 
 	function handleWindowPointerDown(event: PointerEvent) {
@@ -233,21 +254,18 @@
 		if (!(event.target instanceof Node)) return;
 		if (triggerEl?.contains(event.target)) return;
 		if (contentEl?.contains(event.target)) return;
-		show = false;
-		onOpenChange(false);
+		closeDropdown();
 	}
 
 	function handleKeydown(event: KeyboardEvent) {
 		if (event.key === 'Escape' && show) {
-			show = false;
-			onOpenChange(false);
+			closeDropdown();
 		}
 	}
 
 	/** Close the dropdown programmatically */
 	export function close() {
-		show = false;
-		onOpenChange(false);
+		closeDropdown();
 	}
 
 	import { onMount, onDestroy } from 'svelte';
@@ -297,7 +315,6 @@
 		use:portal
 		bind:this={contentEl}
 		class={contentClass}
-		role="menu"
 		tabindex="-1"
 		style:max-height={resolvedMaxHeight}
 		style:overflow-y="auto"


### PR DESCRIPTION
On latest `dev`, `common/Dropdown.svelte` does no focus management at all. The content is portaled to the end of `<body>` while the trigger sits mid document, so opening a menu leaves focus on the trigger and the next Tab goes to the **next sidebar element**, not into the menu. Reaching a menu item means tabbing through the entire rest of the document to the portal at the end of `<body>`.

Breaks WCAG 2.4.3 Focus Order (Level A): the focus order does not preserve meaning, because the menu's DOM position no longer matches its visual position.

This component has 49 consumers, including the chat item menu, the user menu and the model selector.

Fix: move focus to the first item when the dropdown opens, and restore it when the dropdown closes.

Focus restoration is placed at a single `closeDropdown()` chokepoint used by Escape, outside click and the exported `close()`. Putting it only on Escape would have left the two commonest paths, clicking a menu item and clicking away, dropping focus to `<body>` and resetting the keyboard user's position to the top of the document, which is worse than the current behaviour.

Restoration is conditional on the dropdown still holding focus. On an outside click focus has already moved to whatever the user clicked, and restoring it there would steal focus back.

The element to restore to is captured as `document.activeElement` at open time rather than read from `triggerEl`. `triggerEl` is guessed as `node.firstElementChild`, and at call sites that wrap the trigger in a `Tooltip` (which renders a plain `<div>`) that is not a focusable element, so `triggerEl.focus()` would silently do nothing.

Opening is consolidated into the reactive block so consumers that open the dropdown externally with `bind:show` behave the same as consumers that use the trigger.

`role="menu"` is removed. The content's children are plain `<button>`s with no `role="menuitem"`, no roving tabindex and no arrow key handling. Moving focus into a `role="menu"` is exactly when screen readers switch to application mode and hand arrow keys to the widget, so keeping the role while moving focus into it would turn an unreachable menu into a reachable dead end. Without the role, ordinary Tab semantics apply and match what the component actually implements. Implementing the full menu pattern is a separate change.

Known limitation: for a dropdown rendered inside `common/Modal.svelte`, the modal's focus trap only pauses on a pointerdown outside the modal, so it pulls focus back out of the portaled content. Dropdowns inside modals are therefore unchanged by this PR and still need the trap to account for portaled content.

Severity: Serious. Menus open but their contents are effectively unreachable in sequence.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact. Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA. -->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.

<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->