### PR TITLE
fix: make sidebar hover and selection states perceivable

### DIFF
--- a/src/lib/components/common/Folder.svelte
+++ b/src/lib/components/common/Folder.svelte
@@ -154,7 +154,7 @@
 				<!-- svelte-ignore a11y-no-static-element-interactions -->
 				<div
 					id="sidebar-folder-button"
-					class=" w-full group rounded-xl relative flex items-center justify-between hover:bg-gray-100 dark:hover:bg-gray-900 transition {buttonClassName}"
+					class=" w-full group rounded-xl relative flex items-center justify-between hover:bg-gray-100 dark:hover:bg-white/[0.06] transition {buttonClassName}"
 				>
 					<button class="w-full py-1.5 pl-2 flex items-center gap-1.5 text-xs font-normal">
 						{#if chevron}

--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -835,7 +835,7 @@
 						aria-label={$showSidebar ? $i18n.t('Close Sidebar') : $i18n.t('Open Sidebar')}
 					>
 						<div
-							class=" self-center flex size-[30px] items-center justify-center rounded-lg transition group-hover:bg-gray-50 dark:group-hover:bg-gray-900"
+							class=" self-center flex size-[30px] items-center justify-center rounded-lg transition group-hover:bg-gray-100 dark:group-hover:bg-white/[0.06]"
 						>
 							<img
 								src="{WEBUI_BASE_URL}/static/favicon.png"
@@ -866,7 +866,7 @@
 							aria-label={$i18n.t('New Chat')}
 						>
 							<div
-								class=" self-center flex size-[30px] items-center justify-center rounded-lg transition group-hover:bg-gray-50 dark:group-hover:bg-gray-900"
+								class=" self-center flex size-[30px] items-center justify-center rounded-lg transition group-hover:bg-gray-100 dark:group-hover:bg-white/[0.06]"
 							>
 								<EditPencilIcon className="size-4" strokeWidth="1.5" />
 							</div>
@@ -888,7 +888,7 @@
 							aria-label={$i18n.t('Search')}
 						>
 							<div
-								class=" self-center flex size-[30px] items-center justify-center rounded-lg transition group-hover:bg-gray-50 dark:group-hover:bg-gray-900"
+								class=" self-center flex size-[30px] items-center justify-center rounded-lg transition group-hover:bg-gray-100 dark:group-hover:bg-white/[0.06]"
 							>
 								<SearchIcon className="size-4" strokeWidth="1.5" />
 							</div>
@@ -917,9 +917,9 @@
 										class=" self-center flex size-[30px] items-center justify-center rounded-lg transition {itemId ===
 										activeMenuItemId
 											? ($settings?.highContrastMode ?? false)
-												? 'bg-black/[0.035] dark:bg-white/[0.06]'
-												: 'bg-black/[0.035] dark:bg-white/[0.045]'
-											: 'group-hover:bg-gray-50 dark:group-hover:bg-gray-900'}"
+												? 'bg-black/[0.08] dark:bg-white/[0.08] outline outline-1 -outline-offset-1 outline-gray-700 dark:outline-gray-300'
+												: 'bg-black/[0.08] dark:bg-white/[0.08]'
+											: 'group-hover:bg-gray-100 dark:group-hover:bg-white/[0.06]'}"
 									>
 										{#if itemId === 'notes'}
 											<NotesIcon className="size-4" strokeWidth="1.5" />
@@ -952,7 +952,7 @@
 								aria-label={$i18n.t('User menu')}
 							>
 								<div
-									class="self-center relative flex size-[30px] items-center justify-center rounded-lg transition group-hover:bg-gray-50 dark:group-hover:bg-gray-900"
+									class="self-center relative flex size-[30px] items-center justify-center rounded-lg transition group-hover:bg-gray-100 dark:group-hover:bg-white/[0.06]"
 								>
 									<img
 										src={`${WEBUI_API_BASE_URL}/users/${$user?.id}/profile/image`}
@@ -1007,7 +1007,7 @@
 				class="sidebar px-1 pt-1.5 pb-1 flex justify-between space-x-1 text-gray-600 dark:text-gray-400 sticky top-0 z-10 -mb-2"
 			>
 				<a
-					class="flex items-center rounded-xl size-8.5 h-full justify-center hover:bg-gray-50 dark:hover:bg-gray-900 transition no-drag-region"
+					class="flex items-center rounded-xl size-8.5 h-full justify-center hover:bg-gray-100 dark:hover:bg-white/[0.06] transition no-drag-region"
 					href="/"
 					draggable="false"
 					on:click={newChatHandler}
@@ -1033,7 +1033,7 @@
 					placement="bottom"
 				>
 					<button
-						class="flex size-[30px] justify-center items-center rounded-lg hover:bg-gray-50 dark:hover:bg-gray-900 transition {isWindows
+						class="flex size-[30px] justify-center items-center rounded-lg hover:bg-gray-100 dark:hover:bg-white/[0.06] transition {isWindows
 							? 'cursor-pointer'
 							: 'cursor-[w-resize]'}"
 						on:click={() => {
@@ -1068,7 +1068,7 @@
 					<div class="px-1 flex justify-center text-gray-700 dark:text-gray-300">
 						<a
 							id="sidebar-new-chat-button"
-							class="group grow flex items-center space-x-2 rounded-xl px-2 py-1.5 hover:bg-gray-50 dark:hover:bg-gray-900 transition outline-none"
+							class="group grow flex items-center space-x-2 rounded-xl px-2 py-1.5 hover:bg-gray-100 dark:hover:bg-white/[0.06] transition outline-none"
 							href="/"
 							draggable="false"
 							on:click={newChatHandler}
@@ -1089,7 +1089,7 @@
 					<div class="px-1 flex justify-center text-gray-700 dark:text-gray-300">
 						<button
 							id="sidebar-search-button"
-							class="group grow flex items-center space-x-2 rounded-xl px-2 py-1.5 hover:bg-gray-50 dark:hover:bg-gray-900 transition outline-none"
+							class="group grow flex items-center space-x-2 rounded-xl px-2 py-1.5 hover:bg-gray-100 dark:hover:bg-white/[0.06] transition outline-none"
 							on:click={() => {
 								showSearch.set(true);
 							}}
@@ -1120,9 +1120,9 @@
 										class="grow flex items-center space-x-2 rounded-xl px-2 py-1.5 transition {itemId ===
 										activeMenuItemId
 											? ($settings?.highContrastMode ?? false)
-												? 'bg-black/[0.035] dark:bg-white/[0.06]'
-												: 'bg-black/[0.035] dark:bg-white/[0.045]'
-											: 'hover:bg-gray-50 dark:hover:bg-gray-900'}"
+												? 'bg-black/[0.08] dark:bg-white/[0.08] outline outline-1 -outline-offset-1 outline-gray-700 dark:outline-gray-300'
+												: 'bg-black/[0.08] dark:bg-white/[0.08]'
+											: 'hover:bg-gray-100 dark:hover:bg-white/[0.06]'}"
 										href={meta.href}
 										on:click={itemClickHandler}
 										draggable="false"
@@ -1535,7 +1535,7 @@
 						>
 							<button
 								type="button"
-								class=" flex items-center rounded-xl py-1.5 px-1.5 w-full hover:bg-gray-50 dark:hover:bg-gray-900 transition"
+								class=" flex items-center rounded-xl py-1.5 px-1.5 w-full hover:bg-gray-100 dark:hover:bg-white/[0.06] transition"
 								aria-label={$i18n.t('User menu')}
 							>
 								<div class=" self-center mr-3 relative flex-shrink-0">

--- a/src/lib/components/layout/Sidebar/ChannelItem.svelte
+++ b/src/lib/components/layout/Sidebar/ChannelItem.svelte
@@ -74,9 +74,9 @@
 <div
 	id="sidebar-channel-item"
 	bind:this={itemElement}
-	class=" w-full {className} rounded-xl flex relative group hover:bg-gray-100 dark:hover:bg-gray-900 {$page
+	class=" w-full {className} rounded-xl flex relative group hover:bg-gray-100 dark:hover:bg-white/[0.06] {$page
 		.url.pathname === `/channels/${channel.id}`
-		? 'bg-gray-100 dark:bg-gray-900 selected'
+		? 'bg-black/[0.08] dark:bg-white/[0.08] selected'
 		: ''} {channel?.type === 'dm' ? 'px-1 py-[3px]' : 'p-1'}  {channel?.unread_count > 0
 		? 'font-normal dark:text-white text-black'
 		: ' dark:text-gray-400 text-gray-600'} cursor-pointer select-none"

--- a/src/lib/components/layout/Sidebar/ChatItem.svelte
+++ b/src/lib/components/layout/Sidebar/ChatItem.svelte
@@ -465,15 +465,13 @@
 	{#if confirmEdit}
 		<div
 			id="sidebar-chat-item"
-			class=" w-full flex justify-between rounded-xl px-2 py-[6px] {id === $chatId || confirmEdit
+			class=" w-full flex justify-between rounded-xl px-2 py-[6px] {id === $chatId ||
+			confirmEdit ||
+			selected
 				? ($settings?.highContrastMode ?? false)
-					? 'bg-black/[0.035] dark:bg-white/[0.06] selected'
-					: 'bg-black/[0.035] dark:bg-white/[0.045] selected'
-				: selected
-					? ($settings?.highContrastMode ?? false)
-						? 'bg-black/[0.035] dark:bg-white/[0.055] selected'
-						: 'bg-black/[0.035] dark:bg-white/[0.045] selected'
-					: 'hover:bg-gray-50 dark:hover:bg-gray-900 group-hover:bg-gray-50 dark:group-hover:bg-gray-900'}  whitespace-nowrap text-ellipsis relative transition {generating
+					? 'bg-black/[0.08] dark:bg-white/[0.08] outline outline-1 -outline-offset-1 outline-gray-700 dark:outline-gray-300 selected'
+					: 'bg-black/[0.08] dark:bg-white/[0.08] selected'
+				: 'hover:bg-gray-100 dark:hover:bg-white/[0.06] group-hover:bg-gray-100 dark:group-hover:bg-white/[0.06]'}  whitespace-nowrap text-ellipsis relative transition {generating
 				? 'cursor-not-allowed'
 				: ''}"
 		>
@@ -510,15 +508,13 @@
 		>
 			<LinkPreview.Trigger
 				id="sidebar-chat-item"
-				class=" w-full flex justify-between rounded-xl px-2 py-[6px] {id === $chatId || confirmEdit
+				class=" w-full flex justify-between rounded-xl px-2 py-[6px] {id === $chatId ||
+				confirmEdit ||
+				selected
 					? ($settings?.highContrastMode ?? false)
-						? 'bg-black/[0.035] dark:bg-white/[0.06] selected'
-						: 'bg-black/[0.035] dark:bg-white/[0.045] selected'
-					: selected
-						? ($settings?.highContrastMode ?? false)
-							? 'bg-black/[0.035] dark:bg-white/[0.055] selected'
-							: 'bg-black/[0.035] dark:bg-white/[0.045] selected'
-						: ' hover:bg-gray-50 dark:hover:bg-gray-900 group-hover:bg-gray-50 dark:group-hover:bg-gray-900'}  whitespace-nowrap text-ellipsis transition"
+						? 'bg-black/[0.08] dark:bg-white/[0.08] outline outline-1 -outline-offset-1 outline-gray-700 dark:outline-gray-300 selected'
+						: 'bg-black/[0.08] dark:bg-white/[0.08] selected'
+					: 'hover:bg-gray-100 dark:hover:bg-white/[0.06] group-hover:bg-gray-100 dark:group-hover:bg-white/[0.06]'}  whitespace-nowrap text-ellipsis transition"
 				href="/c/{id}"
 				onclick={() => {
 					openPreview = false;

--- a/src/lib/components/layout/Sidebar/PinnedModelItem.svelte
+++ b/src/lib/components/layout/Sidebar/PinnedModelItem.svelte
@@ -29,7 +29,7 @@
 		}}
 	>
 		<a
-			class="grow flex items-center space-x-2 rounded-xl px-2 py-[7px] group-hover:bg-gray-100 dark:group-hover:bg-gray-900 transition"
+			class="grow flex items-center space-x-2 rounded-xl px-2 py-[7px] group-hover:bg-gray-100 dark:group-hover:bg-white/[0.06] transition"
 			href="/?model={model?.id}"
 			on:click={onClick}
 			draggable="false"

--- a/src/lib/components/layout/Sidebar/PinnedNoteList.svelte
+++ b/src/lib/components/layout/Sidebar/PinnedNoteList.svelte
@@ -63,7 +63,7 @@
 	{#each sortedPinnedNotes as note (note.id)}
 		<!-- svelte-ignore a11y-no-static-element-interactions -->
 		<div
-			class="flex items-center text-gray-800 dark:text-gray-200 cursor-grab relative group rounded-xl px-2 py-1.5 hover:bg-gray-100 dark:hover:bg-gray-900 transition"
+			class="flex items-center text-gray-800 dark:text-gray-200 cursor-grab relative group rounded-xl px-2 py-1.5 hover:bg-gray-100 dark:hover:bg-white/[0.06] transition"
 			data-id={note.id}
 		>
 			<a

--- a/src/lib/components/layout/Sidebar/RecursiveFolder.svelte
+++ b/src/lib/components/layout/Sidebar/RecursiveFolder.svelte
@@ -556,9 +556,9 @@
 		<div class="w-full group">
 			<div
 				id="folder-{folderId}-button"
-				class="relative w-full py-1 px-1.5 rounded-xl flex items-center gap-1.5 hover:bg-gray-50/40 dark:hover:bg-gray-800/40 transition {$selectedFolder?.id ===
+				class="relative w-full py-1 px-1.5 rounded-xl flex items-center gap-1.5 hover:bg-gray-100 dark:hover:bg-white/[0.06] transition {$selectedFolder?.id ===
 				folderId
-					? 'bg-gray-100/80 dark:bg-gray-850/50 selected'
+					? 'bg-black/[0.08] dark:bg-white/[0.08] selected'
 					: ''}"
 				on:dblclick={(e) => {
 					if (folders[folderId]?.shared && folders[folderId]?.permission !== 'write') return;

--- a/src/lib/components/layout/Sidebar/SearchInput.svelte
+++ b/src/lib/components/layout/Sidebar/SearchInput.svelte
@@ -293,7 +293,7 @@
 		{#if showClearButton && value}
 			<div class="self-center pl-1.5 translate-y-[0.5px] rounded-l-xl bg-transparent">
 				<button
-					class="p-0.5 rounded-full hover:bg-gray-100 dark:hover:bg-gray-900 transition"
+					class="p-0.5 rounded-full hover:bg-gray-100 dark:hover:bg-white/[0.06] transition"
 					on:click={clearSearchInput}
 				>
 					<XMark className="size-3" strokeWidth="1.5" />
@@ -326,7 +326,7 @@
 					<div class="max-h-60 overflow-auto">
 						{#each filteredItems as item, itemIdx}
 							<button
-								class=" px-1.5 py-0.5 flex gap-1 hover:bg-gray-100 dark:hover:bg-gray-900 w-full rounded {selectedIdx ===
+								class=" px-1.5 py-0.5 flex gap-1 hover:bg-gray-100 dark:hover:bg-white/[0.06] w-full rounded {selectedIdx ===
 								itemIdx
 									? 'bg-gray-100 dark:bg-gray-900'
 									: ''}"
@@ -362,7 +362,7 @@
 					<div class=" max-h-60 overflow-auto">
 						{#each filteredOptions as option, optionIdx}
 							<button
-								class=" px-1.5 py-0.5 flex gap-1 hover:bg-gray-100 dark:hover:bg-gray-900 w-full rounded {selectedIdx ===
+								class=" px-1.5 py-0.5 flex gap-1 hover:bg-gray-100 dark:hover:bg-white/[0.06] w-full rounded {selectedIdx ===
 								optionIdx
 									? 'bg-gray-100 dark:bg-gray-900'
 									: ''}"


### PR DESCRIPTION
The sidebar surface is `bg-gray-50/70 dark:bg-gray-950/70`, which composites to about `#fafafa` and `#101010`, so the row tints have to be measured against **that**, not against the page background. Measured there:

| state | current | ratio |
|---|---|---|
| hover, light | `hover:bg-gray-50` on `#fafafa` | **1.02:1** | | hover, light, **mobile** | `hover:bg-gray-50` on opaque `bg-gray-50` | **1.00:1** | | hover, dark | `dark:hover:bg-gray-900` | 1.05:1 | | selected, light | `bg-black/[0.035]` | 1.08:1 |
| selected, dark | `dark:bg-white/[0.045]` | 1.10:1 |

On mobile in light mode the hover class is **the same colour as the surface**, so there is no hover state at all. On desktop it is 1.02:1, which is indistinguishable in practice. This is what users have been reporting as "the background only differs on barely nothing".

Separately, all four selected branches in `ChatItem.svelte` used the **same** light value, and the pinned menu rows in `Sidebar.svelte` did too, so turning on **High Contrast Mode changed nothing whatsoever in light mode**.

After this change: hover 1.15 light / 1.15 dark, selected 1.20 / 1.21, and hover stays below selected in both themes so the row you are on always outranks the row you are pointing at.

High Contrast Mode now adds an **outline** rather than a heavier fill. That is not a stylistic preference: past `bg-black/[0.08]` the 10px timestamp in each row drops below 4.5:1 against its own background, so in light mode there is simply no room to strengthen the fill without introducing a WCAG 1.4.3 text failure inside the setting meant to help. An outline at `gray-700` / `gray-300` is far above 3:1 against the fill and costs the text nothing.

Also fixed in the same pass, because they share the surface and would otherwise end up inconsistent with the rows around them:

- `ChannelItem.svelte` used `bg-gray-100 dark:bg-gray-900` for selected and the same token family for hover, so raising hover alone would have made a hovered channel more prominent than the channel you are actually in.
- `RecursiveFolder.svelte` folder rows were `hover:bg-gray-50/40` at **1.01:1** light, worse than anything else here, and their selected state would have read as less selected than the chats nested inside them.
- `SearchInput.svelte` clear button hover.
- The now redundant nested ternary in `ChatItem.svelte` is collapsed: with the values unified, `id === $chatId`, `confirmEdit` and `selected` produced identical output.

Scope is deliberately limited to components that sit on the sidebar surface. The same `dark:hover:bg-gray-900` token appears in about 16 other files on different surfaces where it behaves differently, and those are not touched.

Not a WCAG conformance claim. A row hover tint is not in scope for 1.4.11, and although the selected state arguably is, none of these values reaches 3:1 either before or after. This is a legibility fix; the accessible marking of the current chat is handled separately by adding `aria-current`.

All eight files compile with no new warnings and are Prettier clean.

Severity: Serious usability regression, most visible in light mode.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact. Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA. -->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.

<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->