### PR TITLE
fix: show notes shared with read-only access in the notes list

### DIFF
--- a/backend/open_webui/models/notes.py
+++ b/backend/open_webui/models/notes.py
@@ -194,16 +194,11 @@ class NoteTable:
                     stmt = stmt.filter(Note.user_id != user_id)
 
                 # Apply access control filtering
-                if 'permission' in filter:
-                    permission = filter['permission']
-                else:
-                    permission = 'write'
-
                 stmt = self._has_permission(
                     db,
                     stmt,
                     filter,
-                    permission=permission,
+                    permission=filter.get('permission', 'read'),
                 )
 
                 order_by = filter.get('order_by')

--- a/src/lib/components/notes/Notes.svelte
+++ b/src/lib/components/notes/Notes.svelte
@@ -498,7 +498,8 @@
 								align="end"
 								bind:value={permission}
 								items={[
-									{ value: null, label: $i18n.t('Write') },
+									{ value: null, label: $i18n.t('All') },
+									{ value: 'write', label: $i18n.t('Write') },
 									{ value: 'read_only', label: $i18n.t('Read Only') }
 								]}
 							/>


### PR DESCRIPTION
Notes shared read-only were invisible to the recipient. `Notes.search_notes` defaulted its access-control filter to the `write` permission whenever the request did not specify one, so the unfiltered notes list only ever returned notes the user could edit. A read-only share was only reachable by manually switching the permission dropdown to "Read Only", and the recipient had no indication the note existed.

Default to `read` instead, matching every other note path (`GET /notes/`, `GET /notes/pinned`, and the read gate on `GET /notes/{id}`) as well as the other resource types. The unfiltered list now returns exactly the notes the detail endpoint authorizes: own notes, direct user read grants, group read grants, write grants, and public notes.

The same default also affected the other two callers of `/notes/search`: the attach-note menu in the chat input made read-only notes disappear as soon as a search query was typed (it falls back to `GET /notes/` when the query is empty), and the knowledge selector in the model editor hid them entirely.

On the frontend the permission dropdown's default option is relabelled from "Write" to "All", since it no longer filters by write access, and an explicit "Write" option is added so the previous filter remains available.

Fixes #27487

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
