### PR TITLE
fix: warn instead of logging a traceback when a webhook URL is rejected

### DIFF
--- a/backend/open_webui/utils/webhook.py
+++ b/backend/open_webui/utils/webhook.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import logging
+from urllib.parse import urlparse
 
 from open_webui.config import WEBUI_FAVICON_URL
 from open_webui.env import (
@@ -11,6 +12,14 @@ from open_webui.env import (
 from open_webui.retrieval.web.utils import get_ssrf_safe_session, validate_url
 
 log = logging.getLogger(__name__)
+
+
+# Log the host only, webhook URLs carry secrets in the path; urlparse itself raises on malformed URLs.
+def _host(url: str) -> str:
+    try:
+        return urlparse(url).hostname or 'unknown'
+    except ValueError:
+        return 'unknown'
 
 
 # Let this message reach those for whom it was written, and
@@ -28,12 +37,18 @@ def _event_text(message: str, description: str | None = None, event_data: dict |
 
 
 async def post_webhook(name: str, url: str, message: str, event_data: dict, description: str | None = None) -> bool:
+    log.debug(f'post_webhook: {url}, {message}, {event_data}')
+    # Block private-IP / loopback / cloud-metadata targets — the URL is
+    # caller-controlled (user notification settings under
+    # ENABLE_USER_WEBHOOKS, automation notification triggers).
     try:
-        log.debug(f'post_webhook: {url}, {message}, {event_data}')
-        # Block private-IP / loopback / cloud-metadata targets — the URL is
-        # caller-controlled (user notification settings under
-        # ENABLE_USER_WEBHOOKS, automation notification triggers).
         await asyncio.to_thread(validate_url, url)
+    except Exception:
+        # Rejected target, not a fault: warn without a traceback.
+        log.warning(f'Webhook skipped, URL invalid or not publicly resolvable: {_host(url)}')
+        return False
+
+    try:
         payload = {}
 
         # Slack and Google Chat Webhooks


### PR DESCRIPTION
post_webhook validates the target with validate_url and let the resulting ValueError fall into the generic handler at the end of the function, which reports it with log.exception. A stored webhook URL pointing at an internal host (a Docker Compose service name, an RFC1918 address) therefore produced an ERROR line plus a full Python traceback on every dispatch, including the startup events, which reads like the worker crashing on boot. Delivery was already skipped and nothing propagated, but the log said otherwise.

Validation now runs in its own try block and a rejected target is reported as a single warning, carrying the hostname only so that the URL path (which holds the webhook secret for Slack, Discord and Teams) never reaches the logs. Genuine delivery failures keep the traceback they had. The hostname goes through a small helper because urlparse raises on exactly the malformed URLs this path is reached with, for example http://[abc.

This does not change which targets are allowed: a webhook pointing at a private address stays blocked, and a dotless internal hostname such as http://n8n:5678/hook is rejected by validators.url before the ENABLE_LOCAL_WEB_FETCH branch is reached, so that setting does not restore it either.

Refs #26975

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
