### PR TITLE
feat: configurable idle timeout for streaming model calls

### DIFF
--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -565,6 +565,14 @@ try:
 except (ValueError, TypeError):
     AIOHTTP_CLIENT_TIMEOUT = 300
 
+# Seconds a streaming model call may go without producing a chunk before it is
+# aborted. Unset = no idle cap, only AIOHTTP_CLIENT_TIMEOUT applies.
+_stream_idle_timeout_raw = os.getenv('AIOHTTP_CLIENT_TIMEOUT_STREAM_IDLE', '')
+try:
+    AIOHTTP_CLIENT_TIMEOUT_STREAM_IDLE = int(_stream_idle_timeout_raw) if _stream_idle_timeout_raw else None
+except (ValueError, TypeError):
+    AIOHTTP_CLIENT_TIMEOUT_STREAM_IDLE = None
+
 
 # SSL verification for general outbound requests (OpenAI, OAuth, etc.).
 # Accepts "True", "False", or a path to a CA bundle file.

--- a/backend/open_webui/routers/ollama.py
+++ b/backend/open_webui/routers/ollama.py
@@ -47,7 +47,12 @@ from open_webui.utils.payload import (
     apply_model_params_to_body_openai,
     apply_system_prompt_to_body,
 )
-from open_webui.utils.session_pool import cleanup_response, get_session, stream_wrapper
+from open_webui.utils.session_pool import (
+    cleanup_response,
+    get_client_timeout,
+    get_session,
+    stream_wrapper,
+)
 
 log = logging.getLogger(__name__)
 
@@ -99,6 +104,7 @@ async def send_request(
     key: str | None = None,
     user: UserModel = None,
     stream: bool = False,
+    inference: bool = False,
     content_type: str | None = None,
     metadata: dict | None = None,
     api_config: dict | None = None,
@@ -129,7 +135,7 @@ async def send_request(
             data=payload,
             headers=headers,
             ssl=AIOHTTP_CLIENT_SESSION_SSL,
-            timeout=aiohttp.ClientTimeout(total=AIOHTTP_CLIENT_TIMEOUT),
+            timeout=get_client_timeout(stream=stream and inference),
         )
 
         if not r.ok:
@@ -1012,6 +1018,7 @@ async def generate_completion(
         key=get_api_key(url_idx, url, api_configs),
         user=user,
         stream=True,
+        inference=True,
     )
 
 
@@ -1144,6 +1151,7 @@ async def generate_chat_completion(
         key=get_api_key(url_idx, url, api_configs),
         user=user,
         stream=form_data.stream,
+        inference=True,
         content_type='application/x-ndjson',
         metadata=metadata,
         api_config=api_config,
@@ -1241,6 +1249,7 @@ async def generate_openai_completion(
         key=get_api_key(url_idx, url, api_configs),
         user=user,
         stream=payload.get('stream', False),
+        inference=True,
         metadata=metadata,
         api_config=api_config,
         request=request,
@@ -1351,6 +1360,7 @@ async def generate_openai_chat_completion(
         key=get_api_key(url_idx, url, api_configs),
         user=user,
         stream=payload.get('stream', False),
+        inference=True,
         metadata=metadata,
         api_config=api_config,
         request=request,
@@ -1403,6 +1413,7 @@ async def generate_anthropic_messages(
         key=get_api_key(url_idx, url, api_configs),
         user=user,
         stream=payload.get('stream', False),
+        inference=True,
         content_type='text/event-stream' if payload.get('stream', False) else None,
         api_config=api_config,
         request=request,
@@ -1461,6 +1472,7 @@ async def generate_responses(
         key=get_api_key(url_idx, url, api_configs),
         user=user,
         stream=payload.get('stream', False),
+        inference=True,
         content_type='text/event-stream' if payload.get('stream', False) else None,
         api_config=api_config,
         request=request,

--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -54,6 +54,7 @@ from open_webui.utils.payload import (
 )
 from open_webui.utils.session_pool import (
     cleanup_response,
+    get_client_timeout,
     get_session,
     stream_wrapper,
 )
@@ -1345,6 +1346,7 @@ async def generate_chat_completion(
                     part.get('text', '') for part in message['content'] if part.get('type') in ('input_text', 'text')
                 )
 
+    requested_stream = bool(payload.get('stream'))
     payload = json.dumps(payload)
 
     r = None
@@ -1361,7 +1363,7 @@ async def generate_chat_completion(
             headers=headers,
             cookies=cookies,
             ssl=AIOHTTP_CLIENT_SESSION_SSL,
-            timeout=aiohttp.ClientTimeout(total=AIOHTTP_CLIENT_TIMEOUT),
+            timeout=get_client_timeout(stream=requested_stream),
         )
 
         # Check if response is SSE
@@ -1638,7 +1640,7 @@ async def responses(
             headers=headers,
             cookies=cookies,
             ssl=AIOHTTP_CLIENT_SESSION_SSL,
-            timeout=aiohttp.ClientTimeout(total=AIOHTTP_CLIENT_TIMEOUT),
+            timeout=get_client_timeout(stream=bool(payload.get('stream'))),
         )
 
         # Check if response is SSE

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -4048,6 +4048,20 @@ async def streaming_chat_response_handler(response, ctx):
                         },
                     )
 
+                async def emit_error(error_content):
+                    if not metadata.get('chat_id', '').startswith('channel:'):
+                        await Chats.upsert_message_to_chat_by_id_and_message_id(
+                            metadata['chat_id'],
+                            metadata['message_id'],
+                            {'error': {'content': error_content}},
+                        )
+                    await event_emitter(
+                        {
+                            'type': 'chat:message:error',
+                            'data': {'error': {'content': error_content}},
+                        }
+                    )
+
                 async def stream_body_handler(response, form_data):
                     nonlocal content_parts
                     nonlocal usage
@@ -5131,7 +5145,8 @@ async def streaming_chat_response_handler(response, ctx):
                         else:
                             break
                     except Exception as e:
-                        log.debug(e)
+                        log.exception('Tool-call continuation failed')
+                        await emit_error(f'Generation failed after tool execution: {e}')
                         break
 
                 if (
@@ -5140,19 +5155,7 @@ async def streaming_chat_response_handler(response, ctx):
                     and tool_call_iterations >= max_tool_call_iterations
                 ):
                     log.warning('Tool-call iteration limit reached (%s)', max_tool_call_iterations)
-                    error_content = f'Tool-call limit reached ({max_tool_call_iterations} iterations).'
-                    if not metadata.get('chat_id', '').startswith('channel:'):
-                        await Chats.upsert_message_to_chat_by_id_and_message_id(
-                            metadata['chat_id'],
-                            metadata['message_id'],
-                            {'error': {'content': error_content}},
-                        )
-                    await event_emitter(
-                        {
-                            'type': 'chat:message:error',
-                            'data': {'error': {'content': error_content}},
-                        }
-                    )
+                    await emit_error(f'Tool-call limit reached ({max_tool_call_iterations} iterations).')
 
                 if DETECT_CODE_INTERPRETER:
                     MAX_RETRIES = 5
@@ -5321,7 +5324,8 @@ async def streaming_chat_response_handler(response, ctx):
                             else:
                                 break
                         except Exception as e:
-                            log.debug(e)
+                            log.exception('Code-interpreter continuation failed')
+                            await emit_error(f'Generation failed after code execution: {e}')
                             break
 
                 # Mark all in-progress items as completed

--- a/backend/open_webui/utils/session_pool.py
+++ b/backend/open_webui/utils/session_pool.py
@@ -29,6 +29,7 @@ from typing import Optional
 import aiohttp
 from open_webui.env import (
     AIOHTTP_CLIENT_TIMEOUT,
+    AIOHTTP_CLIENT_TIMEOUT_STREAM_IDLE,
     AIOHTTP_POOL_CONNECTIONS,
     AIOHTTP_POOL_CONNECTIONS_PER_HOST,
     AIOHTTP_POOL_DNS_TTL,
@@ -78,6 +79,14 @@ async def close_session():
         await _session.close()
         log.info('Closed shared aiohttp session pool')
         _session = None
+
+
+def get_client_timeout(stream: bool) -> aiohttp.ClientTimeout:
+    """Whole-call cap, plus a between-chunks idle cap for streaming calls."""
+    return aiohttp.ClientTimeout(
+        total=AIOHTTP_CLIENT_TIMEOUT,
+        sock_read=AIOHTTP_CLIENT_TIMEOUT_STREAM_IDLE if stream else None,
+    )
 
 
 async def cleanup_response(


### PR DESCRIPTION
AIOHTTP_CLIENT_TIMEOUT bounds an entire assistant turn, so deployments that allow long tool-call and reasoning chains have to set it high (30 minutes is common). Nothing bounds the gap inside that turn: when an upstream provider accepts the connection and then streams nothing, the request sits there until the full client timeout expires before the user sees an error.

This adds AIOHTTP_CLIENT_TIMEOUT_STREAM_IDLE, the number of seconds a streaming model call may go without producing a chunk before it is aborted. It maps onto aiohttp's sock_read, so it covers both time to first token and stalls mid-stream, while a stream that is actively producing keeps resetting the timer. Unset by default, so existing deployments are unaffected.

It applies to streaming model calls only: OpenAI chat completions, the Responses API, and the Ollama inference endpoints. Non-streaming calls (embeddings, token counting, the passthrough proxy) and Ollama model management (/api/pull, /api/push, /api/create) keep the whole-call timeout on its own, because a long silent gap there is normal.

Tool-call and code-interpreter continuations swallowed every exception from the follow-up stream (log.debug(e); break), so a timeout on those turns would have surfaced as a silently truncated message instead of an error. Both now report the failure through the same emit_error helper the tool-call limit already used.

Fixes #27038

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
