### PR TITLE
feat: cap kb_exec output and make the knowledge tool limits configurable

### DIFF
--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -1044,6 +1044,29 @@ SENTENCE_TRANSFORMERS_CROSS_ENCODER_SIGMOID_ACTIVATION_FUNCTION = (
 )
 
 ####################################
+# KNOWLEDGE TOOLS
+####################################
+
+
+def _int_env(name: str, default: int) -> int:
+    try:
+        return max(int(os.getenv(name) or default), 1)
+    except (ValueError, TypeError):
+        return default
+
+
+# Total output of a single kb_exec call, whatever the command.
+KB_EXEC_MAX_OUTPUT_CHARS = _int_env('KB_EXEC_MAX_OUTPUT_CHARS', 30_000)
+# Files a single kb_exec grep may scan before it asks for a narrower scope.
+KB_EXEC_MAX_GREP_FILES = _int_env('KB_EXEC_MAX_GREP_FILES', 200)
+# Matching lines returned by kb_exec grep and grep_knowledge_files.
+KNOWLEDGE_GREP_MAX_MATCHES = _int_env('KNOWLEDGE_GREP_MAX_MATCHES', 50)
+# Characters returned by view_file / view_knowledge_file.
+VIEW_FILE_MAX_CHARS = _int_env('VIEW_FILE_MAX_CHARS', 100_000)
+VIEW_FILE_DEFAULT_MAX_CHARS = _int_env('VIEW_FILE_DEFAULT_MAX_CHARS', 10_000)
+
+
+####################################
 # TOOLS/FUNCTIONS PIP OPTIONS
 ####################################
 

--- a/backend/open_webui/tools/builtin.py
+++ b/backend/open_webui/tools/builtin.py
@@ -16,6 +16,11 @@ from typing import Literal, Optional
 
 from fastapi import Request
 
+from open_webui.env import (
+    KNOWLEDGE_GREP_MAX_MATCHES,
+    VIEW_FILE_DEFAULT_MAX_CHARS,
+    VIEW_FILE_MAX_CHARS,
+)
 from open_webui.models.channels import Channel, ChannelMember, Channels
 from open_webui.models.chats import Chats
 from open_webui.models.config import Config
@@ -2155,12 +2160,6 @@ async def search_knowledge_files(
         return json.dumps({'error': str(e)})
 
 
-# Hard cap for view_file / view_knowledge_file output
-MAX_VIEW_FILE_CHARS = 100_000
-DEFAULT_VIEW_FILE_MAX_CHARS = 10_000
-MAX_GREP_RESULTS = 50
-
-
 async def grep_knowledge_files(
     pattern: str,
     file_id: Optional[str] = None,
@@ -2298,7 +2297,7 @@ async def grep_knowledge_files(
                 if _matches(line):
                     file_matches += 1
                     total_matches += 1
-                    if not count_only and len(results) < MAX_GREP_RESULTS:
+                    if not count_only and len(results) < KNOWLEDGE_GREP_MAX_MATCHES:
                         results.append(f'{file.id}  {file.filename}:{i}: {line}')
 
             if file_matches > 0 and count_only:
@@ -2313,8 +2312,8 @@ async def grep_knowledge_files(
             return f'No matches for "{pattern}"'
 
         output = '\n'.join(results)
-        if total_matches > MAX_GREP_RESULTS:
-            output += f'\n[{MAX_GREP_RESULTS} of {total_matches} matches shown — use file_id to narrow]'
+        if total_matches > KNOWLEDGE_GREP_MAX_MATCHES:
+            output += f'\n[{KNOWLEDGE_GREP_MAX_MATCHES} of {total_matches} matches shown — use file_id to narrow]'
         return output
 
     except Exception as e:
@@ -2325,7 +2324,7 @@ async def grep_knowledge_files(
 async def view_file(
     file_id: str,
     offset: int = 0,
-    max_chars: int = DEFAULT_VIEW_FILE_MAX_CHARS,
+    max_chars: int = VIEW_FILE_DEFAULT_MAX_CHARS,
     line_numbers: bool = False,
     start_line: Optional[int] = None,
     end_line: Optional[int] = None,
@@ -2338,7 +2337,7 @@ async def view_file(
 
     :param file_id: The ID of the file to retrieve
     :param offset: Character offset to start reading from (default: 0)
-    :param max_chars: Maximum characters to return (default: 10000, hard cap: 100000)
+    :param max_chars: Maximum characters to return (a server-side hard cap applies)
     :param line_numbers: If true, prefix each line with its 1-indexed line number
     :param start_line: Optional 1-indexed start line (overrides offset/max_chars when set)
     :param end_line: Optional 1-indexed end line (inclusive)
@@ -2360,10 +2359,10 @@ async def view_file(
         try:
             max_chars = int(max_chars)
         except ValueError:
-            max_chars = DEFAULT_VIEW_FILE_MAX_CHARS
+            max_chars = VIEW_FILE_DEFAULT_MAX_CHARS
 
     # Enforce hard cap
-    max_chars = min(max(max_chars, 1), MAX_VIEW_FILE_CHARS)
+    max_chars = min(max(max_chars, 1), VIEW_FILE_MAX_CHARS)
     offset = max(offset, 0)
 
     try:
@@ -2441,7 +2440,7 @@ async def view_file(
 async def view_knowledge_file(
     file_id: str,
     offset: int = 0,
-    max_chars: int = DEFAULT_VIEW_FILE_MAX_CHARS,
+    max_chars: int = VIEW_FILE_DEFAULT_MAX_CHARS,
     line_numbers: bool = False,
     start_line: Optional[int] = None,
     end_line: Optional[int] = None,
@@ -2453,7 +2452,7 @@ async def view_knowledge_file(
 
     :param file_id: The ID of the file to retrieve
     :param offset: Character offset to start reading from (default: 0)
-    :param max_chars: Maximum characters to return (default: 10000, hard cap: 100000)
+    :param max_chars: Maximum characters to return (a server-side hard cap applies)
     :param line_numbers: If true, prefix each line with its 1-indexed line number
     :param start_line: Optional 1-indexed start line (overrides offset/max_chars when set)
     :param end_line: Optional 1-indexed end line (inclusive)
@@ -2475,10 +2474,10 @@ async def view_knowledge_file(
         try:
             max_chars = int(max_chars)
         except ValueError:
-            max_chars = DEFAULT_VIEW_FILE_MAX_CHARS
+            max_chars = VIEW_FILE_DEFAULT_MAX_CHARS
 
     # Enforce hard cap
-    max_chars = min(max(max_chars, 1), MAX_VIEW_FILE_CHARS)
+    max_chars = min(max(max_chars, 1), VIEW_FILE_MAX_CHARS)
     offset = max(offset, 0)
 
     try:

--- a/backend/open_webui/tools/knowledge_fs.py
+++ b/backend/open_webui/tools/knowledge_fs.py
@@ -16,15 +16,16 @@ from typing import Optional
 
 from fastapi import Request
 
+from open_webui.env import (
+    KB_EXEC_MAX_GREP_FILES,
+    KB_EXEC_MAX_OUTPUT_CHARS,
+    KNOWLEDGE_GREP_MAX_MATCHES,
+)
+
 log = logging.getLogger(__name__)
 
-# Limits
-MAX_CAT_CHARS = 100_000
-DEFAULT_CAT_CHARS = 10_000
-MAX_GREP_FILES = 200
 DEFAULT_HEAD_LINES = 10
 DEFAULT_TAIL_LINES = 10
-MAX_GREP_MATCHES = 50
 
 
 # =============================================================================
@@ -579,20 +580,10 @@ async def _kb_cat(args: list[str], flags: set[str], user: dict, model_knowledge:
         return resolved['error']
 
     content = resolved['content']
-    show_numbers = 'n' in flags
 
-    if len(content) > MAX_CAT_CHARS:
-        content = content[:MAX_CAT_CHARS]
-        truncated = True
-    else:
-        truncated = False
-
-    if show_numbers:
+    if 'n' in flags:
         lines = content.split('\n')
         content = '\n'.join(f'{i}: {line}' for i, line in enumerate(lines, 1))
-
-    if truncated:
-        content += f'\n[truncated at {MAX_CAT_CHARS:,} chars — use head/tail/sed/grep to navigate]'
 
     return content
 
@@ -742,7 +733,7 @@ async def _kb_grep(
     if ext_filter:
         accessible = [f for f in accessible if f['filename'].endswith(f'.{ext_filter}')]
 
-    if len(accessible) > MAX_GREP_FILES:
+    if len(accessible) > KB_EXEC_MAX_GREP_FILES:
         return f'Too many files ({len(accessible)}). Scope your search: grep "{pattern}" docs/ or grep "{pattern}" *.py'
 
     from open_webui.models.files import Files
@@ -774,7 +765,7 @@ async def _kb_grep(
 
             if not count_only and not filenames_only:
                 for line_num, line_text in file_matches:
-                    if len(results) < MAX_GREP_MATCHES:
+                    if len(results) < KNOWLEDGE_GREP_MAX_MATCHES:
                         results.append(f'{file_info["id"]}  {file_info["filename"]}:{line_num}: {line_text.rstrip()}')
 
     if count_only:
@@ -793,8 +784,8 @@ async def _kb_grep(
         return f'No matches for "{pattern}" across {len(accessible)} files'
 
     output = '\n'.join(results)
-    if total_matches > MAX_GREP_MATCHES:
-        output += f'\n[showing {MAX_GREP_MATCHES} of {total_matches} matches]'
+    if total_matches > KNOWLEDGE_GREP_MAX_MATCHES:
+        output += f'\n[showing {KNOWLEDGE_GREP_MAX_MATCHES} of {total_matches} matches]'
     return output
 
 
@@ -1131,7 +1122,13 @@ async def kb_exec(
         if not segments:
             return 'Could not parse command. Run kb_exec("ls") to start.'
 
-        return await _execute_pipeline(segments, __user__, __model_knowledge__)
+        output = await _execute_pipeline(segments, __user__, __model_knowledge__)
+        if len(output) > KB_EXEC_MAX_OUTPUT_CHARS:
+            output = output[:KB_EXEC_MAX_OUTPUT_CHARS] + (
+                f'\n[output truncated at {KB_EXEC_MAX_OUTPUT_CHARS:,} chars'
+                ' — narrow the command with a path, glob, head/tail/sed or grep]'
+            )
+        return output
     except Exception as e:
         log.exception(f'kb_exec error: {e}')
         return f'Error: {e}'


### PR DESCRIPTION
`kb_exec` had no bound on how much text it could hand back to the model. Only `cat` and `grep` were limited, so `ls`, `ls -a`, `tree`, `find`, `stat`, `wc` and `grep -l` / `grep -c` returned everything they found: a single `ls` on a large knowledge base could burn 100k+ tokens of context in one tool call. The limits that did exist were module constants, so an operator could neither lower them to protect context nor raise them to fit a bigger knowledge base.

Every `kb_exec` command and pipeline returns through one place, so the output cap goes there and covers all of them, including any command added later. The per-command `cat` truncation is dropped in favour of that single cap; as a side effect `cat big.md | grep x` now searches the whole file instead of only its first 100k chars, since only the final output is trimmed.

The remaining limits move to environment variables, with the same defaults as before:

- `KB_EXEC_MAX_OUTPUT_CHARS` (30000, new): total output of a single `kb_exec` call.
- `KB_EXEC_MAX_GREP_FILES` (200): files a `kb_exec` grep may scan before it asks for a narrower scope. Raising this is what a knowledge base of a few thousand documents needs (#27327).
- `KNOWLEDGE_GREP_MAX_MATCHES` (50): matching lines returned, shared by `kb_exec` grep and `grep_knowledge_files`, replacing the two separate constants that meant the same thing.
- `VIEW_FILE_MAX_CHARS` (100000) and `VIEW_FILE_DEFAULT_MAX_CHARS` (10000): `view_file` / `view_knowledge_file` output.

Values below 1 are clamped and unparseable values fall back to the default, so a typo in a compose file cannot stop the server from booting. `view_file`'s `:param max_chars:` no longer states the cap as a literal number, since that number is now operator-defined and the default already reaches the model through the tool schema.

`DEFAULT_HEAD_LINES` and `DEFAULT_TAIL_LINES` stay hardcoded on purpose: the model overrides them per call with `head -N` / `tail -N`, and their output is bounded by the global cap anyway, so a knob would have nothing to do.

Fixes #26139

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
