### PR TITLE
fix: skip pointless DNS lookups when filtering web search results

### DIFF
--- a/backend/open_webui/retrieval/web/main.py
+++ b/backend/open_webui/retrieval/web/main.py
@@ -1,16 +1,33 @@
 from __future__ import annotations
 
+import ipaddress
 from urllib.parse import urlparse
 
 import validators
 from open_webui.retrieval.web.utils import resolve_hostname
-from open_webui.utils.misc import is_host_allowed
+from open_webui.utils.misc import get_allow_block_lists, is_host_allowed
 from pydantic import BaseModel
+
+
+def _filter_list_has_ip_entry(filter_list) -> bool:
+    allow_list, block_list = get_allow_block_lists(filter_list)
+
+    for entry in allow_list + block_list:
+        try:
+            ipaddress.ip_address(entry)
+        except ValueError:
+            continue
+        return True
+
+    return False
 
 
 def get_filtered_results(results, filter_list):
     if not filter_list:
         return results
+
+    # A resolved IP can only ever match an IP filter entry, so skip the blocking lookup otherwise.
+    resolve_ips = _filter_list_has_ip_entry(filter_list)
 
     filtered_results = []
 
@@ -25,12 +42,13 @@ def get_filtered_results(results, filter_list):
 
         hostnames = [domain]
 
-        try:
-            ipv4_addresses, ipv6_addresses = resolve_hostname(domain)
-            hostnames.extend(ipv4_addresses)
-            hostnames.extend(ipv6_addresses)
-        except Exception:
-            pass
+        if resolve_ips:
+            try:
+                ipv4_addresses, ipv6_addresses = resolve_hostname(domain)
+                hostnames.extend(ipv4_addresses)
+                hostnames.extend(ipv6_addresses)
+            except Exception:
+                pass
 
         if is_host_allowed(hostnames, filter_list):
             filtered_results.append(result)


### PR DESCRIPTION
`get_filtered_results` resolved every search result's hostname to IP addresses before matching it against `WEB_SEARCH_DOMAIN_FILTER_LIST`, on the assumption that a resolved address could match a filter entry. It cannot, unless the list actually contains an IP: `is_host_allowed` matches on DNS label boundaries, so `142.250.185.78` is neither equal to nor a subdomain of `google.com`. For a domain-only filter list, which is what essentially every deployment configures, that is one blocking `socket.getaddrinfo` call per search result that can never change the outcome.

The cost is severe when the resolver is slow or the hostname does not resolve, because each lookup then runs to its full timeout. The reporter measured a 3 second SearXNG query turning into a 35 second `search_web` call. SearXNG is also the one provider awaited natively instead of being offloaded with `asyncio.to_thread`, so there the lookups block the event loop and stall unrelated requests too.

Resolution is now performed only when the filter list contains at least one IP literal, the only case where it can affect the outcome. Filtering behaviour is unchanged for every filter-list shape: domain entries, `!`-prefixed block entries, quoted entries from env, IPv4 and IPv6 literals, and mixed lists. Entry parsing goes through the existing `get_allow_block_lists` helper so quoting and `!` prefixes are handled the same way the matcher handles them.

Fixes #26920

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
