### PR TITLE
fix: sidebar folder chat list flashes/collapses when clicking a folder title

### DIFF
--- a/src/lib/components/layout/Sidebar/RecursiveFolder.svelte
+++ b/src/lib/components/layout/Sidebar/RecursiveFolder.svelte
@@ -420,7 +420,7 @@
 			} finally {
 				chatsLoading = false;
 			}
-		} else {
+		} else if (!open) {
 			chats = null;
 			chatsPage = 1;
 			hasMoreChats = false;


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27533 — sidebar folder chat list flashes/collapses when clicking a folder title
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable — no user-facing documentation changes.
- [ ] **Dependencies:** No new dependencies.
- [x] **Testing:** Manual tests have been performed to verify the fix works correctly and does not introduce regressions.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Local state is used for ephemeral UI logic; no new settings introduced.
- [x] **Git Hygiene:** The PR is atomic (one logical change), based on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

Clicking a folder title in the sidebar makes expanded folders visibly flash: their chat list disappears for a moment (replaced by the loading dots) and then pops back in, looking like a collapse/re-expand. This PR fixes the root cause with a one-line change in `RecursiveFolder.svelte`.

**Problem → Root Cause → Fix**

- **Problem:** Selecting a folder (clicking its title) momentarily wipes the visible chat list of expanded folders in the sidebar tree.
- **Root Cause:** A title click triggers a burst of overlapping `setFolderItems()` calls on every folder — the click handler sets `selectedFolder`, the folder route's `onMount` sets it again, `Sidebar.svelte`'s `$: if ($selectedFolder) initFolders();` rebuilds `folders` on each write, and `Folders.svelte`'s `$: if (folders || ($selectedFolder && $chatId)) loadFolderItems();` re-runs on every one of those changes. Inside `setFolderItems()`, the state-reset branch intended for collapsed folders also runs when the folder is *open but a fetch is already in flight* (`open && chatsLoading`), setting `chats = null` — instantly emptying the visible list — without refetching. When the in-flight fetch resolves, the chats reappear, producing the flash.
- **Fix:** Restrict the reset branch to actually-collapsed folders. A redundant refresh that arrives while a fetch is in flight is now a no-op: the visible list stays on screen and is replaced in place when the in-flight fetch lands (the `{#each}` is keyed by `chat.id`, so unchanged items don't re-render).

```diff
 			} finally {
 				chatsLoading = false;
 			}
-		} else {
+		} else if (!open) {
 			chats = null;
 			chatsPage = 1;
 			hasMoreChats = false;
```

Behavior is otherwise unchanged: collapsing a folder still resets its chat state, the first expand still shows the loading indicator, and data freshness is no worse than before — the old `else` branch didn't refetch in that case either; it only wiped the list.

### Fixed

- Fixed the sidebar folder chat list momentarily disappearing (collapse/re-expand flash) when clicking a folder title, caused by overlapping refresh calls wiping the list while a fetch was in flight.

---

### Additional Information

- One title click still triggers redundant refetches (`initFolders()` runs twice and `loadFolderItems()` sweeps all folders several times). This PR deliberately does not touch those reactive triggers — they have a much wider blast radius, and the visual bug is fully explained and resolved by correcting the reset guard. The redundancy is noted in #27533 for context.
- This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Manual Verification Performed

1. Expanded a sidebar folder containing several chats, then clicked the folder's title — the chat list stays on screen with no flash while navigating to the folder page.
2. Clicked the titles of other folders (both collapsed and expanded, including a nested subfolder) — no expanded folder's contents flicker.
3. Verified chevron expand/collapse still works, including the loading indicator on first expand.
4. Verified folder contents still refresh correctly after moving a chat into a folder.

### Screenshots or Videos

#### Before

[Screencast from 2026-07-26 15-02-47.webm](https://github.com/user-attachments/assets/2787ff0d-b8d1-4d6d-bed8-1fdbec776852)

#### After

[Screencast from 2026-07-26 15-02-01.webm](https://github.com/user-attachments/assets/a6008ff1-8c06-4ed0-b6db-26646fe82ebd)

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
