### PR TITLE
perf: dedupe folder refetches and chat-list sweeps when selecting a sidebar folder

### DIFF
--- a/src/lib/components/layout/Sidebar/Folders.svelte
+++ b/src/lib/components/layout/Sidebar/Folders.svelte
@@ -4,7 +4,7 @@
 	const dispatch = createEventDispatcher();
 
 	import RecursiveFolder from './RecursiveFolder.svelte';
-	import { chatId, selectedFolder } from '$lib/stores';
+	import { chatId } from '$lib/stores';
 
 	export let folderRegistry = {};
 
@@ -49,7 +49,7 @@
 		}
 	};
 
-	$: if (folders || ($selectedFolder && $chatId)) {
+	$: if (folders || $chatId) {
 		loadFolderItems();
 	}
 </script>

--- a/src/routes/(app)/folders/[folderId]/+page.svelte
+++ b/src/routes/(app)/folders/[folderId]/+page.svelte
@@ -18,17 +18,23 @@
 			return;
 		}
 
-		const folder = await getFolderById(localStorage.token, folderId).catch((error) => {
-			toast.error(`${error}`);
-			return null;
-		});
+		// The sidebar click handler already fetches the folder and sets
+		// `selectedFolder` before navigating here; refetching would duplicate
+		// the request and re-trigger the sidebar's folder refresh.
+		if ($selectedFolder?.id !== folderId) {
+			const folder = await getFolderById(localStorage.token, folderId).catch((error) => {
+				toast.error(`${error}`);
+				return null;
+			});
 
-		if (!folder) {
-			await goto('/');
-			return;
+			if (!folder) {
+				await goto('/');
+				return;
+			}
+
+			await selectedFolder.set(folder);
 		}
 
-		await selectedFolder.set(folder);
 		ready = true;
 	});
 


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27539 — clicking a sidebar folder title fires duplicate folder refetches and chat-list sweeps
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable — no user-facing documentation changes.
- [ ] **Dependencies:** No new dependencies.
- [x] **Testing:** Manual tests have been performed to verify the fix works correctly and does not introduce regressions, including instrumented per-request counting before/after.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new settings; existing refresh semantics are preserved — only provably duplicate triggers are removed.
- [x] **Git Hygiene:** The PR is atomic (one logical change), based on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `perf`

# Changelog Entry

### Description

A single click on a sidebar folder title currently triggers a burst of redundant requests: `getFolderById` twice, a full folder-tree refetch (`getFolders` + `getSharedFolders`) twice, and 3–4 `setFolderItems()` sweeps that refetch every expanded folder's chat list. This PR removes the two duplicate triggers so each resource is fetched exactly once per selection.

**Problem → Root Cause → Fix**

- **Problem:** One folder selection produces 2× folder fetches, 2× folder-tree refetches, and 3–4× chat-list fetches per expanded folder.
- **Root Cause:** Two compounding redundancies. (1) The sidebar click handler fetches the folder and sets `selectedFolder` before navigating, and the folder route's `onMount` then unconditionally fetches and sets it again — and every `selectedFolder` write triggers `Sidebar.svelte`'s `$: if ($selectedFolder) initFolders();`, doubling the tree rebuild. (2) `Folders.svelte`'s reactive statement lists `$selectedFolder` as a dependency, but every consequential `selectedFolder` write also rebuilds `folders` via that same Sidebar reactive, re-running the statement anyway — so the `$selectedFolder` dependency only ever adds a duplicate sweep.
- **Fix:** Skip the route's refetch when `selectedFolder` already holds the folder for this route (the sidebar-click case), and drop the redundant `$selectedFolder` dependency from the sweep trigger.

```diff
--- a/src/routes/(app)/folders/[folderId]/+page.svelte
-		const folder = await getFolderById(localStorage.token, folderId).catch((error) => {
-			toast.error(`${error}`);
-			return null;
-		});
-
-		if (!folder) {
-			await goto('/');
-			return;
+		// The sidebar click handler already fetches the folder and sets
+		// `selectedFolder` before navigating here; refetching would duplicate
+		// the request and re-trigger the sidebar's folder refresh.
+		if ($selectedFolder?.id !== folderId) {
+			const folder = await getFolderById(localStorage.token, folderId).catch((error) => {
+				toast.error(`${error}`);
+				return null;
+			});
+
+			if (!folder) {
+				await goto('/');
+				return;
+			}
+
+			await selectedFolder.set(folder);
 		}
 
-		await selectedFolder.set(folder);
 		ready = true;
```

```diff
--- a/src/lib/components/layout/Sidebar/Folders.svelte
-	$: if (folders || ($selectedFolder && $chatId)) {
+	$: if (folders || $chatId) {
 		loadFolderItems();
 	}
```

**Why no behavior is lost:**

- Direct URL loads and page refreshes hit the route guard with a null/stale `selectedFolder` and take the full original fetch path. If the click handler's fetch fails, the store is never set, so the route's fetch still acts as the fallback.
- Selection-driven folder sweeps still happen — exactly once, via the `folders` rebuild that `initFolders()` performs on every `selectedFolder` write. Chat-open refreshes keep their `$chatId` trigger.
- Renames/icon changes made from the folder page header (`FolderTitle.svelte`) still propagate to the sidebar: they re-set `selectedFolder`, which triggers `Sidebar.svelte`'s `initFolders()` — that catch-all is deliberately left untouched because it is the only propagation path for those edits.

### Changed

- Deduplicated the network requests triggered by selecting a sidebar folder: the folder, the folder tree, and each expanded folder's chat list are now fetched exactly once per click (previously 2×, 2×, and 3–4× respectively).

---

### Additional Information

- Companion to #27535, which fixed the visual flash this same request burst caused in expanded folders; this PR removes the burst itself. The two changes are independent and touch disjoint files.
- This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Manual Verification Performed

1. Instrumented `window.fetch` to count requests per URL, clicked a folder title once: every request URL — `/api/v1/folders/<id>`, `/api/v1/folders/`, `/api/v1/folders/shared`, and each expanded folder's `/shared/chats?page=1` — was fetched exactly once (previously 2×/2×/3–4×).
2. Renamed a folder and changed its icon from the folder page header — the sidebar tree updates as before.
3. Loaded `/folders/<id>` directly by URL and via F5 refresh — the page resolves normally (exercises the guarded fallback path).
4. Opened chats from inside folders and used sidebar folder rename/move/delete — all refresh behavior unchanged.

### Screenshots or Videos

- Not applicable — no visual changes; request counts are documented in the linked issue.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
