### PR TITLE
chore: remove no-op stopPropagation statement from the folder title click handler

### DIFF
--- a/src/lib/components/layout/Sidebar/RecursiveFolder.svelte
+++ b/src/lib/components/layout/Sidebar/RecursiveFolder.svelte
@@ -569,7 +569,6 @@
 					renameHandler();
 				}}
 				on:click={async (e) => {
-					(e) => e.stopPropagation();
 					if (clickTimer) {
 						clearTimeout(clickTimer);
 						clickTimer = null;


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27541 — no-op stopPropagation statement in the sidebar folder title click handler
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable.
- [ ] **Dependencies:** No new dependencies.
- [x] **Testing:** Manual smoke test performed — folder title click still navigates and double-click still renames; no behavior change, as expected for a no-op removal.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been reviewed by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Dead-code removal only; no settings or architectural changes.
- [x] **Git Hygiene:** The PR is atomic (one logical change), based on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `chore`

# Changelog Entry

### Description

The sidebar folder title click handler in `RecursiveFolder.svelte` begins with `(e) => e.stopPropagation();` — a statement that constructs an arrow function and immediately discards it, so `stopPropagation` is never called. This PR deletes the dead statement.

Repairing it to a working `e.stopPropagation();` was considered and deliberately not done: the header's click bubbles through one inert wrapper `<div>` directly to the `Collapsible` component's root, whose no-title branch already stops click propagation (`Collapsible.svelte`). Folder-header clicks therefore never propagate past the `Collapsible` root today, so a repaired call would be redundant — it would stop the event one element earlier with nothing listening in between. Removal is provably behavior-preserving; repair would only resurrect a duplicate of the `Collapsible` guard.

```diff
 				on:click={async (e) => {
-					(e) => e.stopPropagation();
 					if (clickTimer) {
 						clearTimeout(clickTimer);
 						clickTimer = null;
```

### Removed

- Removed a no-op `(e) => e.stopPropagation();` statement from the sidebar folder title click handler.

---

### Additional Information

- No functional change: the deleted statement evaluated an arrow function expression and discarded it. Event propagation behavior is identical before and after.
- This PR was prepared with AI copilot assistance and has been reviewed by the author.

### Screenshots or Videos

- Not applicable — no visual or behavioral changes.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
