### PR TITLE
fix: rate limit the OAuth token exchange endpoint

### DIFF
--- a/backend/open_webui/routers/auths.py
+++ b/backend/open_webui/routers/auths.py
@@ -84,6 +84,9 @@ log = logging.getLogger(__name__)
 # Forgive us our failed attempts, as we forgive those
 # who exceed their allotted rate against this gate.
 signin_rate_limiter = RateLimiter(redis_client=get_redis_client(), limit=5 * 3, window=60 * 3)
+# Best-effort throttle only. There is no caller identity before the provider answers, and the
+# source address is client-controlled via X-Forwarded-For under forwarded_allow_ips='*'.
+token_exchange_rate_limiter = RateLimiter(redis_client=get_redis_client(), limit=5 * 3, window=60 * 3)
 
 ADMIN_CONFIG_KEYS = {
     'SHOW_ADMIN_DETAILS': 'auth.admin.show',
@@ -1516,6 +1519,12 @@ async def token_exchange(
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail='Token exchange is disabled',
+        )
+
+    if token_exchange_rate_limiter.is_limited(request.client.host if request.client else 'unknown'):
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail=ERROR_MESSAGES.RATE_LIMIT_EXCEEDED,
         )
 
     provider = provider.lower()


### PR DESCRIPTION
The token exchange endpoint accepts an OAuth access token and issues a session with no throttling at all, while `/signin` limits attempts through `signin_rate_limiter`. That leaves unlimited attempts available to anyone working through leaked or guessed tokens.

Apply the same limit, keyed on the source address because the endpoint has no caller identity until the provider's userinfo call answers.

This is a throttle rather than a security boundary, and the comment says so. The launchers run uvicorn with `--forwarded-allow-ips '*'`, so the source address is taken from the leftmost `X-Forwarded-For` entry and is therefore client-controlled. Bounding the cost of automated probing is still worth having; treating it as an authentication control would not be.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
