### PR TITLE
fix: enforce a single open chat hover preview across sidebar chat items

### DIFF
--- a/src/lib/components/layout/Sidebar/ChatItem.svelte
+++ b/src/lib/components/layout/Sidebar/ChatItem.svelte
@@ -3,6 +3,15 @@
 	const invisibleDragImage = new Image();
 	invisibleDragImage.src =
 		'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=';
+
+	/**
+	 * At most one chat hover preview may be open across all ChatItem instances.
+	 * bits-ui's safe-polygon close only re-evaluates on pointermove, so a
+	 * preview can be left open when the pointer stops on a neighboring row
+	 * while still inside the previous row's grace area; opening a preview
+	 * therefore force-closes whichever one is still up.
+	 */
+	let closeActiveHoverPreview: (() => void) | null = null;
 </script>
 
 <script lang="ts">
@@ -93,6 +102,17 @@
 
 	let mouseOver = false;
 	let openPreview = false;
+
+	const closeHoverPreview = () => {
+		if (openPreview) {
+			openPreview = false;
+		}
+	};
+
+	$: if (openPreview && closeActiveHoverPreview !== closeHoverPreview) {
+		closeActiveHoverPreview?.();
+		closeActiveHoverPreview = closeHoverPreview;
+	}
 
 	// Local state: tracks the last updatedAt seen while the user was viewing
 	// this chat.  Survives prop refreshes from sidebar data re-fetches that
@@ -311,6 +331,10 @@
 			el.removeEventListener('dragstart', onDragStart);
 			el.removeEventListener('drag', onDrag);
 			el.removeEventListener('dragend', onDragEndHandler);
+
+			if (closeActiveHoverPreview === closeHoverPreview) {
+				closeActiveHoverPreview = null;
+			}
 		};
 	});
 


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27548 — two sidebar chat hover previews can be open at once, stacked on top of each other
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable — no user-facing documentation changes.
- [ ] **Dependencies:** No new dependencies.
- [x] **Testing:** Manual tests have been performed to verify the fix works correctly and does not introduce regressions.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Local (module-context) state is used for ephemeral UI logic; no new settings introduced.
- [x] **Git Hygiene:** The PR is atomic (one logical change), based on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

Two sidebar chat hover previews can end up open simultaneously, one card stacked on the other: the preview of a chat the pointer already left stays open indefinitely while the newly hovered chat opens its own on top. This PR enforces the missing invariant — at most one chat hover preview open at a time — with a small module-level coordination in `ChatItem.svelte` (+24 lines, one file).

**Problem → Root Cause → Fix**

- **Problem:** A stale hover preview can remain open behind the newly hovered chat's preview.
- **Root Cause:** Each `ChatItem` owns an independent bits-ui `LinkPreview.Root`, so no single-open invariant exists app-side — and bits-ui's close path can legitimately fail to fire: once a preview is open, the trigger's `pointerleave` is a deliberate no-op and closing is delegated to bits-ui's `SafePolygon`, which re-evaluates **only on `pointermove`**. If the pointer leaves row A on a diagonal path toward the (tall, center-aligned) preview card and then stops on a neighboring row while still inside the grace wedge, no further pointermove ever occurs, row A's preview stays open, and the neighboring row's preview opens 300 ms later. (`SafePolygon` has a `transitIntentTimeout` that would handle the stalled pointer, but `LinkPreview` does not wire or expose it.)
- **Fix:** A module-context variable in `ChatItem.svelte` holds the close callback of the currently open preview. Whenever any item's preview opens — every open path (hover, keyboard focus) flows through the bound `open` state — it force-closes the previously registered preview and registers its own. This closes the stale card the moment a new one opens, regardless of which close path failed (pointer wedge, scrolling under a stationary cursor, list reorders).

```svelte
<script context="module" lang="ts">
	...
	let closeActiveHoverPreview: (() => void) | null = null;
</script>
```

```js
const closeHoverPreview = () => {
	if (openPreview) {
		openPreview = false;
	}
};

$: if (openPreview && closeActiveHoverPreview !== closeHoverPreview) {
	closeActiveHoverPreview?.();
	closeActiveHoverPreview = closeHoverPreview;
}
```

The registered closer is guarded so stale invocations are no-ops, and the `onMount` cleanup clears the module reference when a registered item unmounts, so nothing calls into a destroyed component.

### Fixed

- Fixed stale sidebar chat hover previews remaining open behind a newly opened preview; at most one chat hover preview can now be open at a time.

---

### Additional Information

- Known limitation, kept out of scope: a *single* preview can still linger if the pointer stops on a non-chat element inside bits-ui's grace wedge, because `LinkPreview.Root` does not expose `SafePolygon`'s `transitIntentTimeout`. That is an upstream bits-ui exposure gap documented in #27548; the overlap fixed here cannot occur regardless.
- This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Manual Verification Performed

1. Reproduced the overlap on `dev` (hover a chat, move diagonally to the next row, stop; second preview opens over the stuck first one), then verified with the fix that the old preview closes the moment the new one opens.
2. Normal hover browsing up and down the chat list — previews open and swap correctly with no overlap.
3. Preview open → click the chat — preview closes and navigation works.
4. Previews on chats inside an expanded folder — same single-open behavior.
5. Dragging a chat with a preview open — preview closes on drag start, as before.

### Screenshots or Videos

#### Before

[Screencast from 2026-07-26 16-22-33.webm](https://github.com/user-attachments/assets/0cf09462-4469-4335-942a-aa3b6f235c36)

#### After

[Screencast from 2026-07-26 16-21-06.webm](https://github.com/user-attachments/assets/dea5af5d-d6b4-418c-8f19-65bf543c3a31)

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
