### PR TITLE
fix(build): skip pyodide fetch during Docker builds to prevent network failures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ RUN npm ci --force
 
 COPY . .
 ENV APP_BUILD_HASH=${BUILD_HASH}
+ENV SKIP_PYODIDE_FETCH=1
 RUN npm run build
 
 ######## WebUI backend ########

--- a/scripts/prepare-pyodide.js
+++ b/scripts/prepare-pyodide.js
@@ -26,7 +26,7 @@ const pypiPackages = ['black', 'pathspec', 'mypy_extensions', 'pytokens'];
 
 import { loadPyodide } from 'pyodide';
 import { setGlobalDispatcher, ProxyAgent } from 'undici';
-import { writeFile, readFile, copyFile, readdir, rmdir, access } from 'fs/promises';
+import { writeFile, readFile, copyFile, readdir, rmdir, access } from 'node:fs/promises';
 
 /**
  * Loading network proxy configurations from the environment variables.
@@ -40,22 +40,22 @@ function initNetworkProxyFromEnv() {
 	const allProxy = process.env.all_proxy || process.env.ALL_PROXY;
 	const httpsProxy = process.env.https_proxy || process.env.HTTPS_PROXY;
 	const httpProxy = process.env.http_proxy || process.env.HTTP_PROXY;
-	const preferedProxy = httpsProxy || allProxy || httpProxy;
+	const preferredProxy = httpsProxy || allProxy || httpProxy;
 	/**
 	 * use only http(s) proxy because socks5 proxy is not supported currently:
 	 * @see https://github.com/nodejs/undici/issues/2224
 	 */
-	if (!preferedProxy || !preferedProxy.startsWith('http')) return;
-	let preferedProxyURL;
+	if (!preferredProxy?.startsWith('http')) return;
+	let preferredProxyURL;
 	try {
-		preferedProxyURL = new URL(preferedProxy).toString();
+		preferredProxyURL = new URL(preferredProxy).toString();
 	} catch {
-		console.warn(`Invalid network proxy URL: "${preferedProxy}"`);
+		console.warn(`Invalid network proxy URL: "${preferredProxy}"`);
 		return;
 	}
-	const dispatcher = new ProxyAgent({ uri: preferedProxyURL });
+	const dispatcher = new ProxyAgent({ uri: preferredProxyURL });
 	setGlobalDispatcher(dispatcher);
-	console.log(`Initialized network proxy "${preferedProxy}" from env`);
+	console.log(`Initialized network proxy "${preferredProxy}" from env`);
 }
 
 async function downloadPackages() {
@@ -175,7 +175,7 @@ async function downloadPyPIWheels() {
 		}
 
 		// Inject into pyodide-lock.json so micropip resolves locally
-		const normalizedName = pkg.replace(/-/g, '_');
+		const normalizedName = pkg.replaceAll('-', '_');
 		if (!lockData.packages[normalizedName]) {
 			lockData.packages[normalizedName] = {
 				name: normalizedName,
@@ -196,6 +196,12 @@ async function downloadPyPIWheels() {
 }
 
 initNetworkProxyFromEnv();
-await downloadPackages();
-await copyPyodide();
-await downloadPyPIWheels();
+
+if (process.env.SKIP_PYODIDE_FETCH === '1' || process.env.SKIP_PYODIDE_FETCH === 'true') {
+	console.log('SKIP_PYODIDE_FETCH is set, skipping pyodide package downloads');
+	console.log('Ensure static/pyodide/ is pre-populated or packages will be fetched at runtime');
+} else {
+	await downloadPackages();
+	await copyPyodide();
+	await downloadPyPIWheels();
+}


### PR DESCRIPTION
## Summary

Docker image builds fail when network access is restricted or unreliable during the frontend build stage. The `prepare-pyodide.js` script attempts to download packages from PyPI and jsdelivr CDN as part of `npm run build`, and any timeout or connectivity issue causes the entire build to fail.

This affects CI runners with limited egress, corporate firewalls, and air-gapped environments.

## Root Cause

`prepare-pyodide.js` unconditionally fetches pyodide packages and PyPI wheels during build. There is no way to skip these network-dependent operations when building the Docker image.

## Fix

- Add a `SKIP_PYODIDE_FETCH` environment variable check to `prepare-pyodide.js`. When set to `"1"` or `"true"`, the script logs a message and exits early without making any network requests.
- Set `SKIP_PYODIDE_FETCH=1` in the Dockerfile frontend build stage.

The `static/pyodide/` directory (included in the image via `COPY . .`) already contains the base pyodide runtime files. Missing wheel packages are resolved at runtime by the browser through micropip when users execute Python code.

## Changes

- `scripts/prepare-pyodide.js` — env var guard around download logic
- `Dockerfile` — set `SKIP_PYODIDE_FETCH=1` before `npm run build`

## Testing

- `node --check scripts/prepare-pyodide.js` passes
- Docker build completes successfully with these changes
- Local `npm run build` (without the env var) continues to work as before
