### PR TITLE
fix: do not offer task management tools in temporary chats

### DIFF
--- a/backend/open_webui/utils/tools.py
+++ b/backend/open_webui/utils/tools.py
@@ -666,8 +666,9 @@ async def get_builtin_tools(
     if extra_params.get('__skill_ids__'):
         builtin_functions.append(view_skill)
 
-    # Task management - break down complex work into trackable steps
-    if is_builtin_tool_enabled('tasks'):
+    # Task management - break down complex work into trackable steps.
+    # Temporary chats have no DB record to store the task list in, so the tools cannot work there.
+    if is_builtin_tool_enabled('tasks') and not chat_id.startswith(('local:', 'channel:')):
         builtin_functions.extend([create_tasks, update_task])
 
     # Automation tools - create and manage scheduled automations from chat


### PR DESCRIPTION
The create_tasks/update_task builtin tools store the task list on the chat row via Chats.update_chat_tasks_by_id(). Temporary chats (and channel chats) have no DB record, so the write is a no-op and the following update_task call reads back an empty list and returns `Task with id "1" not found`. The model sees a broken tool, the task widget stays stuck at 0/N, and the model abandons its plan mid-answer.

Skip injecting the two tools when the chat id carries the `local:`/`channel:` prefix, matching the guard already used elsewhere in this function for temporary chats. The model then never calls a tool that cannot succeed, and no conversation state is stored server-side for a mode whose contract is that the server keeps nothing.

Fixes #27432

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
