### PR TITLE
fix: do not inject task tools in temporary chats

### DIFF
--- a/backend/open_webui/utils/tools.py
+++ b/backend/open_webui/utils/tools.py
@@ -666,8 +666,11 @@ async def get_builtin_tools(
     if extra_params.get('__skill_ids__'):
         builtin_functions.append(view_skill)
 
-    # Task management - break down complex work into trackable steps
-    if is_builtin_tool_enabled('tasks'):
+    # Task management - break down complex work into trackable steps.
+    # Task state is persisted on the `chats` row; temporary chats (local:/channel:)
+    # have no such row, so the tools cannot round-trip and must not be injected there.
+    is_temporary_chat = bool(chat_id) and chat_id.startswith(('local:', 'channel:'))
+    if is_builtin_tool_enabled('tasks') and not is_temporary_chat:
         builtin_functions.extend([create_tasks, update_task])
 
     # Automation tools - create and manage scheduled automations from chat


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Closes #27432
- [x] **Target branch:** Targets the `dev` branch.
- [x] **Description:** Provided below.
- [x] **Changelog:** Included below.
- [ ] **Documentation:** N/A — no user-facing docs affected.
- [ ] **Dependencies:** None added.
- [x] **Testing:** Verified task tools are absent in Temporary Chat (no more 0/N widget or "Task not found"); persistent chats still get the tools and work as before.
- [x] **No Unchecked AI Code:** Reviewed and manually tested.
- [x] **Self-Review:** Done.
- [x] **Architecture:** Smart default, no new settings and no new state; temporary chats stay ephemeral.
- [x] **Git Hygiene:** Atomic, single-file change, rebased on `dev`.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

- With builtin Task Management tools enabled, Temporary Chats called `create_tasks` (widget stuck at 0/N) and then `update_task` failed with `{"error": "Task with id \"1\" not found"}`. Task state is persisted on the `chats` row via `Chats.update_chat_tasks_by_id`, but temporary chats use a `local:`/`channel:` `chat_id` that has no such row, so writes silently no-op and reads return `[]`. The tools cannot round-trip in temporary chats.

### Fixed

- Do not inject the `create_tasks` / `update_task` builtin tools when the chat is temporary (`local:`/`channel:`), so the model never enters the broken task flow. Persistent chats are unaffected and continue to get the tools.

---

### Additional Information

- Single-file change in `backend/open_webui/utils/tools.py` (`get_builtin_tools`), gating the task tools on `not is_temporary_chat`. Uses the same `chat_id.startswith(('local:', 'channel:'))` temporary-chat check already used elsewhere in the codebase. No new settings or state introduced.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
