### PR TITLE
fix: prevent duplicate users in concurrent trusted-header sign-in (#27117)

### DIFF
--- a/backend/open_webui/migrations/versions/a7f3c2e9b1d4_add_unique_index_user_email.py
+++ b/backend/open_webui/migrations/versions/a7f3c2e9b1d4_add_unique_index_user_email.py
@@ -1,0 +1,80 @@
+"""add unique index on user.email
+
+Revision ID: a7f3c2e9b1d4
+Revises: 959eaac8f909
+Create Date: 2026-07-26 20:30:00.000000
+
+The ORM has always declared ``User.email`` as ``unique=True``, but the initial
+schema was created with a raw ``create_table`` that never emitted a unique
+constraint or index, and no later migration added one. As a result the database
+did not actually enforce email uniqueness, which allowed concurrent sign-in
+requests for the same new email (notably the trusted-header path) to each pass a
+non-atomic ``get_user_by_email`` check and create duplicate accounts.
+
+This migration adds the missing DB-level guarantee so duplicate inserts are
+rejected and get-or-create becomes atomic across workers and replicas.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import context, op
+
+# revision identifiers, used by Alembic.
+revision: str = 'a7f3c2e9b1d4'
+down_revision: str | None = '959eaac8f909'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+INDEX_NAME = 'user_email_unique_idx'
+
+
+def upgrade() -> None:
+    if context.is_offline_mode():
+        op.create_index(INDEX_NAME, 'user', ['email'], unique=True)
+        return
+
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+
+    existing_indexes = {index['name'] for index in inspector.get_indexes('user')}
+    if INDEX_NAME in existing_indexes:
+        return
+
+    # A unique index can't be created if the table already contains duplicate
+    # emails (exactly the corruption this migration prevents going forward).
+    # Refuse to run rather than silently leaving uniqueness unenforced, and tell
+    # the operator how to inspect the duplicates so they can merge/remove them.
+    duplicates = conn.execute(
+        sa.text(
+            'SELECT lower(email) AS email, COUNT(*) AS c '
+            'FROM "user" '
+            'WHERE email IS NOT NULL '
+            'GROUP BY lower(email) '
+            'HAVING COUNT(*) > 1'
+        )
+    ).fetchall()
+    if duplicates:
+        details = ', '.join(f'{row.email} (x{row.c})' for row in duplicates)
+        raise RuntimeError(
+            'Cannot add a unique index on user.email because duplicate email '
+            f'addresses already exist: {details}. Resolve the duplicates (merge '
+            "or remove the extra accounts) and re-run the migration. Example:\n"
+            '  SELECT id, email, role, created_at FROM "user" '
+            'WHERE lower(email) IN (SELECT lower(email) FROM "user" '
+            'GROUP BY lower(email) HAVING COUNT(*) > 1) ORDER BY lower(email), created_at;'
+        )
+
+    op.create_index(INDEX_NAME, 'user', ['email'], unique=True)
+
+
+def downgrade() -> None:
+    if context.is_offline_mode():
+        op.drop_index(INDEX_NAME, table_name='user')
+        return
+
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    existing_indexes = {index['name'] for index in inspector.get_indexes('user')}
+    if INDEX_NAME in existing_indexes:
+        op.drop_index(INDEX_NAME, table_name='user')

--- a/backend/open_webui/routers/auths.py
+++ b/backend/open_webui/routers/auths.py
@@ -77,6 +77,7 @@ from open_webui.utils.misc import parse_duration, validate_email_format
 from open_webui.utils.rate_limit import RateLimiter
 from open_webui.utils.redis import get_redis_client
 from pydantic import BaseModel
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 router = APIRouter()
@@ -737,14 +738,25 @@ async def signin(
                 pass
 
         if not await Users.get_user_by_email(email.lower(), db=db):
-            await signup_handler(
-                request,
-                email,
-                str(uuid.uuid4()),
-                name,
-                db=db,
-                source='trusted_header',
-            )
+            try:
+                await signup_handler(
+                    request,
+                    email,
+                    str(uuid.uuid4()),
+                    name,
+                    db=db,
+                    source='trusted_header',
+                )
+            except IntegrityError:
+                # A concurrent trusted-header request won the race and created
+                # this user first. The DB-level unique constraint on user.email
+                # rejects our duplicate insert. Roll back the failed transaction
+                # and fall through to fetch the winning row, so all concurrent
+                # requests for the same new email resolve to a single account.
+                await db.rollback()
+                log.info(
+                    f'Trusted-header signup race for {email}; using the existing user.'
+                )
 
         user = await Auths.authenticate_user_by_email(email, db=db)
         if user:


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27117
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** No docs change required — behavior of `WEBUI_AUTH_TRUSTED_EMAIL_HEADER` is unchanged; this only removes duplicate-account creation.
- [ ] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Verified the concurrent case with the reporter's 16-request harness and a DB-level unique-constraint test (see below).
- [x] **No Unchecked AI Code:** This PR has undergone human review and manual testing.
- [x] **Self-Review:** A self-review of the code has been performed.
- [x] **Architecture:** Uses a DB-level uniqueness guarantee plus insert-and-refetch — no new settings introduced.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** Uses the `fix` prefix.

# Changelog Entry

### Description

- Concurrent trusted-header (`WEBUI_AUTH_TRUSTED_EMAIL_HEADER`) sign-in requests for the same previously-unknown email could each pass the non-atomic `get_user_by_email()` check and independently call `signup_handler()`, creating multiple `user`/`auth` rows (different UUIDs) for one email. The root cause is that the database never enforced email uniqueness: `User.email` is declared `unique=True` in the ORM, but the initial schema was created via a raw `create_table` with no unique constraint/index, and no later migration added one. This mirrors the races already fixed for the signup, LDAP, and OAuth paths, which the trusted-header path had missed.

### Added

- New Alembic migration `a7f3c2e9b1d4_add_unique_index_user_email` that creates a unique index `user_email_unique_idx` on `user.email`. It is idempotent, supports offline mode, and aborts with an actionable message (listing the offending addresses) if pre-existing duplicate emails would prevent the index from being created, rather than silently leaving uniqueness unenforced.

### Changed

- The trusted-header branch of `signin` now wraps `signup_handler()` in a `try/except IntegrityError`: losers of the create race roll back and fall through to `authenticate_user_by_email()`, so all concurrent requests for the same new email resolve to a single account.

### Deprecated

- None.

### Removed

- None.

### Fixed

- Concurrent trusted-header sign-ins for the same new email no longer create duplicate user/auth records; exactly one account is created and all requests resolve to it.

### Security

- None. Reported and addressed as a data-integrity / authentication-correctness bug, not a security vulnerability.

### Breaking Changes

- None. Note for operators: an existing database that already contains duplicate emails must have them merged/removed before this migration can apply — the migration will stop with instructions identifying the duplicates instead of failing opaquely.

---

### Additional Information

- Root cause and reproduction from #27117. Related prior fixes: #21631 (signup) and #23626 (LDAP/OAuth first-user race).
- **How the fix was verified:**
  - Reproduced with the reporter's harness (Postgres + `xargs -P16` 16 concurrent `POST /api/v1/auths/signin` for one new email): before the change up to 6 accounts were created; after, exactly one `user` row and one `auth` row exist and all requests return 200.
  - Unit-level check confirming a unique index on `email` causes a second insert of the same email to raise `IntegrityError` while exactly one row survives.
- **Case-sensitivity note:** the index is on the raw `email` column (matching the ORM's `unique=True`); the app already lowercases emails on write, so the reported case is fully covered. Case-insensitive enforcement across differing letter-case would require a functional `lower(email)` index, which is harder to make portable across SQLite and PostgreSQL.

### Screenshots or Videos

- N/A — reproduced and verified via the HTTP API / database queries rather than the UI.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
