### PR TITLE
chore: drop redundant background repaints so surfaces inherit their parent

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -685,7 +685,7 @@ html.high-contrast.dark .ProseMirror p.is-editor-empty:first-child::before {
 }
 
 .tiptap tr {
-	@apply bg-white dark:bg-gray-900 dark:border-gray-850 text-xs;
+	@apply dark:border-gray-850 text-xs;
 }
 
 .tippy-box[data-theme~='transparent'] {

--- a/src/lib/components/AddConnectionModal.svelte
+++ b/src/lib/components/AddConnectionModal.svelte
@@ -63,7 +63,7 @@
 	const inputClass =
 		'bg-transparent outline-hidden placeholder:text-gray-300 dark:placeholder:text-gray-700';
 	const selectClass =
-		'dark:bg-gray-900 bg-transparent pr-5 outline-hidden placeholder:text-gray-300 dark:placeholder:text-gray-700';
+		'bg-transparent pr-5 outline-hidden placeholder:text-gray-300 dark:placeholder:text-gray-700';
 
 	const parsePassthroughParams = (value: string) =>
 		value

--- a/src/lib/components/AddTerminalServerModal.svelte
+++ b/src/lib/components/AddTerminalServerModal.svelte
@@ -62,7 +62,7 @@
 	const inputClass =
 		'bg-transparent outline-hidden placeholder:text-gray-300 dark:placeholder:text-gray-700';
 	const selectClass =
-		'dark:bg-gray-900 bg-transparent pr-5 outline-hidden placeholder:text-gray-300 dark:placeholder:text-gray-700';
+		'bg-transparent pr-5 outline-hidden placeholder:text-gray-300 dark:placeholder:text-gray-700';
 
 	const stringifyJson = (value: object | null | undefined) => {
 		return JSON.stringify(value && Object.keys(value).length ? value : {}, null, 2);

--- a/src/lib/components/AddToolServerModal.svelte
+++ b/src/lib/components/AddToolServerModal.svelte
@@ -72,7 +72,7 @@
 	const inputClass =
 		'bg-transparent outline-hidden placeholder:text-gray-300 dark:placeholder:text-gray-700';
 	const selectClass =
-		'dark:bg-gray-900 bg-transparent pr-5 outline-hidden placeholder:text-gray-300 dark:placeholder:text-gray-700';
+		'bg-transparent pr-5 outline-hidden placeholder:text-gray-300 dark:placeholder:text-gray-700';
 
 	const registerOAuthClientHandler = async () => {
 		if (url === '') {

--- a/src/lib/components/admin/Analytics/Dashboard.svelte
+++ b/src/lib/components/admin/Analytics/Dashboard.svelte
@@ -468,7 +468,7 @@
 					<tbody>
 						{#each sortedModels as model, idx (model.model_id)}
 							<tr
-								class="bg-white dark:bg-gray-900 dark:border-gray-850 text-xs cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+								class="dark:border-gray-850 text-xs cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
 								on:click={() => {
 									selectedModel = { id: model.model_id, name: model.name };
 									showModelModal = true;
@@ -581,7 +581,7 @@
 					</thead>
 					<tbody>
 						{#each sortedUsers as user, idx (user.user_id)}
-							<tr class="bg-white dark:bg-gray-900 dark:border-gray-850 text-xs">
+							<tr class="dark:border-gray-850 text-xs">
 								<td class="px-3 py-1 text-gray-400">{idx + 1}</td>
 								<td class="px-3 py-1 font-normal text-gray-900 dark:text-white">
 									<div class="flex items-center gap-2">

--- a/src/lib/components/admin/Evaluations/Feedbacks.svelte
+++ b/src/lib/components/admin/Evaluations/Feedbacks.svelte
@@ -418,7 +418,7 @@
 					<tbody class="">
 						{#each items as feedback (feedback.id)}
 							<tr
-								class="bg-white dark:bg-gray-900 dark:border-gray-850 text-xs cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-850/50 transition rounded-xl"
+								class="dark:border-gray-850 text-xs cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-850/50 transition rounded-xl"
 								on:click={() => openFeedbackModal(feedback)}
 							>
 								<td class=" py-0.5 text-right font-normal">

--- a/src/lib/components/admin/Evaluations/Leaderboard.svelte
+++ b/src/lib/components/admin/Evaluations/Leaderboard.svelte
@@ -201,7 +201,7 @@
 				<tbody>
 					{#each sortedModels as model, idx (model.id)}
 						<tr
-							class="bg-white dark:bg-gray-900 text-xs group cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-850/50 transition"
+							class="text-xs group cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-850/50 transition"
 							on:click={() => openModal(model)}
 						>
 							<td class="px-3 py-1.5 font-normal text-gray-900 dark:text-white">

--- a/src/lib/components/admin/Users/Groups/Users.svelte
+++ b/src/lib/components/admin/Users/Groups/Users.svelte
@@ -234,7 +234,7 @@
 					</thead>
 					<tbody class="">
 						{#each users as user, userIdx (user?.id ?? userIdx)}
-							<tr class="bg-white dark:bg-gray-900 dark:border-gray-850 text-xs">
+							<tr class="dark:border-gray-850 text-xs">
 								<td class=" px-3 py-1 w-8">
 									<div class="flex w-full justify-center">
 										<Checkbox

--- a/src/lib/components/admin/Users/UserList.svelte
+++ b/src/lib/components/admin/Users/UserList.svelte
@@ -346,7 +346,7 @@
 			</thead>
 			<tbody class="">
 				{#each users as user (user.id)}
-					<tr class="bg-white dark:bg-gray-900 dark:border-gray-850 text-xs">
+					<tr class="dark:border-gray-850 text-xs">
 						<td class="px-3 py-1 font-normal text-gray-900 dark:text-white max-w-48">
 							<div class="flex items-center gap-2">
 								<ProfilePreview {user} side="right" align="center" sideOffset={6}>

--- a/src/lib/components/chat/Messages/Citations/CitationsModal.svelte
+++ b/src/lib/components/chat/Messages/Citations/CitationsModal.svelte
@@ -60,7 +60,7 @@
 				{#each citations as citation, idx}
 					<button
 						id={`source-${id}-${idx + 1}`}
-						class="no-toggle outline-hidden flex dark:text-gray-300 bg-white dark:bg-gray-900 rounded-xl gap-1.5 items-center"
+						class="no-toggle outline-hidden flex dark:text-gray-300 rounded-xl gap-1.5 items-center"
 						on:click={() => {
 							showCitationModal = true;
 							selectedCitation = citation;

--- a/src/lib/components/chat/Messages/Markdown/MarkdownTokens.svelte
+++ b/src/lib/components/chat/Messages/Markdown/MarkdownTokens.svelte
@@ -193,9 +193,7 @@
 					class=" w-full text-sm text-start text-gray-500 dark:text-gray-400 max-w-full rounded-xl"
 					dir="auto"
 				>
-					<thead
-						class="text-xs text-gray-700 uppercase bg-white dark:bg-gray-900 dark:text-gray-400 border-none"
-					>
+					<thead class="text-xs text-gray-700 uppercase dark:text-gray-400 border-none">
 						<tr class="">
 							{#each token.header as header, headerIdx}
 								<th
@@ -220,7 +218,7 @@
 					</thead>
 					<tbody>
 						{#each token.rows as row, rowIdx}
-							<tr class="bg-white dark:bg-gray-900 text-xs">
+							<tr class="text-xs">
 								{#each row ?? [] as cell, cellIdx}
 									<td
 										class="px-3! py-2! text-gray-900 dark:text-white w-max {token.rows.length -


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27575 — redundant background repaints block instance theming on same-colored parent surfaces.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **BREAKING CHANGE**: Changes affecting backward compatibility
  - **build**: Build system or dependency changes
  - **ci**: CI/CD workflow changes
  - **chore**: Refactoring, cleanup, or non-functional changes
  - **docs**: Documentation additions or updates
  - **feat**: New features or enhancements
  - **fix**: Bug fixes or corrections
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvements
  - **refactor**: Code restructuring
  - **style**: Formatting changes (whitespace, semicolons, etc.)
  - **test**: Test additions or corrections
  - **WIP**: Work in progress

# Changelog Entry

### Description

- Removes redundant background repaints in thirteen spots across eleven files: table/list body rows, a markdown-table header, and the connection-server modals' shared `selectClass` constant all painted the exact `bg-white dark:bg-gray-900` (or dark-only equivalent) color their parent surface already provides. Stock light and dark themes are visually unchanged; the elements now inherit their parent surface, so instance theming (admin-injected custom CSS) shows through instead of hitting opaque boxes. Two commits: the initial pass, and a follow-up sweep that caught the remaining copies of the same pattern.
- Scoping rule applied throughout: only exact parent-surface repaints were removed (removal is stock-identical in both light and dark). Intentional-contrast and functional surfaces were deliberately left untouched — the tiptap table header's gray-850 contrast band, sticky control bars that mask rows scrolling beneath them, disabled-state opacity scrims, and card-style containers.

```diff
 src/app.css                                                      | 2 +-
 src/lib/components/AddConnectionModal.svelte                     | 2 +-
 src/lib/components/AddTerminalServerModal.svelte                 | 2 +-
 src/lib/components/AddToolServerModal.svelte                     | 2 +-
 src/lib/components/admin/Analytics/Dashboard.svelte              | 4 ++--
 src/lib/components/admin/Evaluations/Feedbacks.svelte            | 2 +-
 src/lib/components/admin/Evaluations/Leaderboard.svelte          | 2 +-
 src/lib/components/admin/Users/Groups/Users.svelte               | 2 +-
 src/lib/components/admin/Users/UserList.svelte                   | 2 +-
 src/lib/components/chat/Messages/Citations/CitationsModal.svelte | 2 +-
 src/lib/components/chat/Messages/Markdown/MarkdownTokens.svelte  | 6 ++----
 11 files changed, 13 insertions(+), 15 deletions(-)
```

### Changed

- Removed redundant `bg-white dark:bg-gray-900` (and `selectClass` dark-only) background repaints from rows, a markdown-table header, and select controls that sit on same-colored parent surfaces (11 files) — no stock visual change; surfaces now inherit their parent so instance theming shows through.

---

### Additional Information

- **Relation to #27573 / #27574:** this branch originally also removed the same repaints inside `ModelUsage.svelte` / `UserUsage.svelte`; those hunks were dropped during the rebase because the components were dead code and were deleted outright in #27574 (merged). This PR touches neither file.
- **Why this matters despite zero stock visual change:** admins theming an instance via custom CSS can restyle a parent surface, but any child that repaints the parent's original color stays an opaque box. Every removed class was verified to repaint the exact color its parent already provides in both stock light and dark, so removal is behavior-preserving for stock installs by construction.

*This PR was prepared with AI copilot assistance. The author manually tested the change locally; after #27574 merged, the branch was rebased with AI assistance to drop the now-moot ModelUsage/UserUsage hunks, and the rebased diff was verified hunk-identical to the author-tested diff on all eleven remaining files.*

### Manual Verification Performed

1. Author: manually tested the branch locally — the touched surfaces render identically in stock light and dark before and after the change.
2. Rebase equivalence: the pre-rebase (author-tested) diff and the submitted diff were compared hunk-by-hunk, excluding the two files deleted by #27574 — byte-identical (index lines aside), i.e. the rebase introduced no content change.
3. No touched file changed on `dev` between the original branch base (2196b4e1f) and the current tip (8295f2dac), so every hunk applies to identical surrounding context.

### Screenshots or Videos

- Not applicable — the change is defined by having no stock visual difference in light or dark; its effect appears only under instance theming, where the previously opaque surfaces now follow the themed parent.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
