### PR TITLE
fix: enforce a single open user profile preview across ProfilePreview instances

### DIFF
--- a/src/lib/components/channel/Messages/Message/ProfilePreview.svelte
+++ b/src/lib/components/channel/Messages/Message/ProfilePreview.svelte
@@ -1,6 +1,17 @@
+<script context="module" lang="ts">
+	/**
+	 * At most one user profile preview may be open across all ProfilePreview
+	 * instances. bits-ui's safe-polygon close only re-evaluates on pointermove,
+	 * so a preview can be left open when the pointer stops on a neighboring
+	 * row while still inside the previous row's grace area; opening a preview
+	 * therefore force-closes whichever one is still up.
+	 */
+	let closeActiveProfilePreview: (() => void) | null = null;
+</script>
+
 <script lang="ts">
 	import { LinkPreview } from 'bits-ui';
-	import { getContext } from 'svelte';
+	import { getContext, onDestroy } from 'svelte';
 
 	const i18n = getContext('i18n');
 	import UserStatus from './UserStatus.svelte';
@@ -13,6 +24,23 @@
 	export let sideOffset = 8;
 
 	let openPreview = false;
+
+	const closeProfilePreview = () => {
+		if (openPreview) {
+			openPreview = false;
+		}
+	};
+
+	$: if (openPreview && closeActiveProfilePreview !== closeProfilePreview) {
+		closeActiveProfilePreview?.();
+		closeActiveProfilePreview = closeProfilePreview;
+	}
+
+	onDestroy(() => {
+		if (closeActiveProfilePreview === closeProfilePreview) {
+			closeActiveProfilePreview = null;
+		}
+	});
 </script>
 
 <LinkPreview.Root openDelay={0} closeDelay={200} bind:open={openPreview}>


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27577 — two user profile hover previews can be open at once (Admin Users list); same root cause as #27548
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable — no user-facing documentation changes.
- [ ] **Dependencies:** No new dependencies.
- [x] **Testing:** Manual tests have been performed to verify the fix works correctly and does not introduce regressions.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Applies the exact invariant pattern already merged for chat hover previews in #27549; module-context state for ephemeral UI logic, no new settings.
- [x] **Git Hygiene:** The PR is atomic (one logical change), based on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

Follow-up to #27548 / #27549: the same stuck-preview overlap fixed there for sidebar chat previews also affects **user profile previews** — most visibly in Admin Panel → Users, where hovering an avatar and moving to a neighboring row can leave the previous user's profile card stuck open behind the new one. This PR applies the same single-open invariant to `ProfilePreview.svelte` (+29/−1, one file).

**Problem → Root Cause → Fix**

- **Problem:** Two profile preview cards can be visible at once — a stuck one behind a newly opened one. With this component's `openDelay={0}` / `closeDelay={200}`, even ordinary row-to-row hovering can transiently stack two cards for up to 200 ms.
- **Root Cause:** Identical to #27548: each `ProfilePreview` instance owns an independent bits-ui `LinkPreview.Root` with no cross-instance invariant, and bits-ui's `SafePolygon` close path only re-evaluates on `pointermove` — a pointer that stops on a neighboring row while still inside the previous row's grace wedge leaves that preview open indefinitely (full bits-ui trace in #27548).
- **Fix:** The same module-context pattern merged in #27549 for `ChatItem.svelte`: a module-level variable holds the close callback of the currently open preview; whenever any instance opens (hover or click-toggle — both flow through the bound `open` state), it force-closes the previously registered preview and registers itself. The registered closer is guarded so stale invocations are no-ops, and `onDestroy` clears the module reference when a registered instance unmounts.

Because `ProfilePreview` is shared, one change covers all four surfaces: the Admin Users list, channel message avatars, the channel info member list, and the workspace member selector.

```js
const closeProfilePreview = () => {
	if (openPreview) {
		openPreview = false;
	}
};

$: if (openPreview && closeActiveProfilePreview !== closeProfilePreview) {
	closeActiveProfilePreview?.();
	closeActiveProfilePreview = closeProfilePreview;
}
```

### Fixed

- Fixed stale user profile hover previews remaining open behind a newly opened preview (Admin Users list, channel avatars, member lists); at most one profile preview can now be open at a time, which also removes the brief two-card stack during fast row-to-row hovering.

---

### Additional Information

- Deliberately out of scope: `MentionToken.svelte` (@mention previews in message prose) owns a separate uncontrolled `LinkPreview.Root` (no `bind:open`) and cannot join a force-close registry without restructuring; its inline geometry does not produce the stacked-rows failure. Documented in #27577.
- This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Manual Verification Performed

1. Reproduced the overlap on `dev` in Admin Panel → Users (hover an avatar, drift diagonally to the next row, stop), then verified with the fix that the old card closes the moment the new one opens.
2. Fast hovering up and down the Users list — never two cards at once (previously up to 200 ms of stacking).
3. Click-toggled previews on two different users — opening the second closes the first.
4. Smoke-tested channel message avatars, which share the component.

### Screenshots or Videos

- [Placeholder — before screenshot/recording showing the stacked profile previews]

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
