### PR TITLE
fix: keep admin access to connections without access grants when admin bypass is disabled

### DIFF
--- a/backend/open_webui/utils/access_control/__init__.py
+++ b/backend/open_webui/utils/access_control/__init__.py
@@ -163,10 +163,16 @@ async def has_connection_access(
     if user.role == 'admin' and BYPASS_ADMIN_ACCESS_CONTROL:
         return True
 
+    access_grants = (connection.get('config') or {}).get('access_grants', [])
+    if not access_grants:
+        # No grants configured → private, admin-only: admins must keep access
+        # to connections only they can configure, even when they do not bypass
+        # access control globally.
+        return user.role == 'admin'
+
     if user_group_ids is None:
         user_group_ids = {group.id for group in await Groups.get_groups_by_member_id(user.id)}
 
-    access_grants = (connection.get('config') or {}).get('access_grants', [])
     return await has_access(user.id, 'read', access_grants, user_group_ids)
 
 

--- a/src/lib/components/admin/Settings/Integrations.svelte
+++ b/src/lib/components/admin/Settings/Integrations.svelte
@@ -297,7 +297,7 @@
 
 					<div class="mt-1 text-[0.6875rem] text-gray-400 dark:text-gray-600">
 						{$i18n.t(
-							'Connect to Open Terminal instances. All users will have access to file browsing and terminal tools through these servers.'
+							'Connect to Open Terminal instances. Admins and users granted access can use file browsing and terminal tools through these servers.'
 						)}
 					</div>
 					<a

--- a/src/lib/i18n/locales/en-US/translation.json
+++ b/src/lib/i18n/locales/en-US/translation.json
@@ -581,7 +581,7 @@
 	"Connect to a stable-diffusion-webui server running with the `--api` flag.": "",
 	"Connect to an AI provider to start chatting": "",
 	"Connect to Open Terminal instances to browse files and use them as always-on tools. Only one can be active at a time.": "",
-	"Connect to Open Terminal instances. All users will have access to file browsing and terminal tools through these servers.": "",
+	"Connect to Open Terminal instances. Admins and users granted access can use file browsing and terminal tools through these servers.": "",
 	"Connect to the ComfyUI server used for generation.": "",
 	"Connect to the ComfyUI server used for image edits.": "",
 	"Connect to your own OpenAI compatible API endpoints.": "",


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27580 — connections without access grants lock out admins when `BYPASS_ADMIN_ACCESS_CONTROL=false`
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable — behavior now matches the function's existing documented contract.
- [ ] **Dependencies:** No new dependencies.
- [x] **Testing:** Manual tests have been performed to verify the fix works correctly and does not introduce regressions.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new settings; implements the already-documented contract of `has_connection_access`.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

`has_connection_access` documents three cases — admin bypass, "missing/empty access_grants → private, **admin-only**", and grant delegation — but the admin-only case was never implemented: admins were only let through via the `BYPASS_ADMIN_ACCESS_CONTROL` fast-path. On hardened instances running `BYPASS_ADMIN_ACCESS_CONTROL=false`, a connection with empty `access_grants` (the state every freshly created connection starts in) is therefore inaccessible to **everyone, including the admin who configured it**.

**Problem → Root Cause → Fix**

- **Problem:** On an instance with `BYPASS_ADMIN_ACCESS_CONTROL=false`, an admin adds an Open Terminal connection and the terminal cloud icon never appears in the chat input — `GET /api/v1/terminals/` filters the healthy, enabled connection out of the listing even for the admin. The connection tests fine in the admin panel, so it presents as a frontend bug. The same lockout applies to every `has_connection_access` consumer: external tool servers, MCP servers, and OpenAI connections without grants.
- **Root Cause:** With the bypass disabled, admins fall through to `has_access(user.id, 'read', [], ...)`, which unconditionally returns `False` for empty grants. The documented "private, admin-only" branch does not exist in the code.
- **Fix:** Implement it — empty grants now return `user.role == 'admin'`:

```diff
     if user.role == 'admin' and BYPASS_ADMIN_ACCESS_CONTROL:
         return True
 
+    access_grants = (connection.get('config') or {}).get('access_grants', [])
+    if not access_grants:
+        # No grants configured → private, admin-only: admins must keep access
+        # to connections only they can configure, even when they do not bypass
+        # access control globally.
+        return user.role == 'admin'
+
     if user_group_ids is None:
         user_group_ids = {group.id for group in await Groups.get_groups_by_member_id(user.id)}
 
-    access_grants = (connection.get('config') or {}).get('access_grants', [])
     return await has_access(user.id, 'read', access_grants, user_group_ids)
```

The change is strictly additive: admins gain access to ungranted connections when the bypass is off; no non-admin user gains or loses anything; connections with grants resolve exactly as before. Moving the empty-grants check above the group lookup also skips a needless DB query for the common private case.

Also corrects the Integrations UI copy for the Open Terminal section — "All users will have access to file browsing and terminal tools through these servers" is inaccurate under grant-controlled access (a fresh connection grants access to no one). It now reads "Admins and users granted access can use file browsing and terminal tools through these servers." (component string + en-US locale key, replaced in place).

### Fixed

- Fixed admins losing access to connections (Open Terminal, external tool servers, MCP servers, OpenAI connections) that have no access grants configured when `BYPASS_ADMIN_ACCESS_CONTROL=false`, which hid the terminal cloud icon and blocked proxy access despite a healthy connection; behavior now matches the function's documented "private, admin-only" contract.
- Fixed misleading Integrations copy claiming all users have access to Open Terminal servers.

---

### Additional Information

- Not related despite the identical symptom: #27064's own diagnostics show `GET /api/v1/terminals/` returning the connection (backend listing passes; that failure is frontend-side on v0.10.2), whereas this PR fixes the listing coming back empty. This PR does not address #27064.
- This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Manual Verification Performed

1. With `BYPASS_ADMIN_ACCESS_CONTROL=false` and a system Open Terminal connection with no grants: reproduced the missing cloud icon and empty `GET /api/v1/terminals/` on `dev`, then verified with this fix that the listing returns the connection and the icon appears for the admin.
2. Verified a non-admin account still does not see the ungranted connection (grants remain required for users — the hardening semantics are preserved).
3. Verified default behavior (`BYPASS_ADMIN_ACCESS_CONTROL` unset → `true`) is unchanged.
4. Verified the updated Integrations copy renders correctly.

### Screenshots or Videos

- Not applicable — behavioral fix; request/response evidence is documented in #27580.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
