### PR TITLE
fix(retrieval): JSON-serialize complex & boolean params in DoclingLoader

### DIFF
--- a/backend/open_webui/retrieval/loaders/main.py
+++ b/backend/open_webui/retrieval/loaders/main.py
@@ -206,7 +206,10 @@ class DoclingLoader:
                 data={
                     'image_export_mode': 'placeholder',
                     'md_page_break_placeholder': page_break_marker,
-                    **self.params,
+                    **{
+                        k: (json.dumps(v) if isinstance(v, (dict, list, bool)) else v)
+                        for k, v in self.params.items()
+                    },
                 },
                 headers=headers,
                 verify=AIOHTTP_CLIENT_SESSION_SSL,

--- a/backend/open_webui/retrieval/loaders/test_docling_loader.py
+++ b/backend/open_webui/retrieval/loaders/test_docling_loader.py
@@ -1,0 +1,55 @@
+import json
+from unittest.mock import MagicMock, patch
+import pytest
+
+from open_webui.retrieval.loaders.main import DoclingLoader
+
+
+def test_docling_loader_serializes_complex_and_bool_params(tmp_path):
+    dummy_file = tmp_path / "test.pdf"
+    dummy_file.write_bytes(b"%PDF-1.4 dummy content")
+
+    params = {
+        "picture_description_api": {"endpoint": "http://localhost:11434", "model": "llava"},
+        "do_picture_description": True,
+        "do_ocr": False,
+        "max_num_pages": 5,
+        "pipeline_options": ["table", "layout"],
+        "simple_str": "hello",
+    }
+
+    loader = DoclingLoader(
+        url="http://localhost:8080",
+        api_key="test-key",
+        file_path=str(dummy_file),
+        mime_type="application/pdf",
+        params=params,
+    )
+
+    mock_response = MagicMock()
+    mock_response.ok = True
+    mock_response.json.return_value = {
+        "document": {"md_content": "Extracted text content"}
+    }
+
+    with patch("open_webui.retrieval.loaders.main.requests.post", return_value=mock_response) as mock_post:
+        docs = loader.load()
+
+        assert len(docs) == 1
+        assert docs[0].page_content == "Extracted text content"
+
+        mock_post.assert_called_once()
+        call_kwargs = mock_post.call_args.kwargs
+        data = call_kwargs["data"]
+
+        # Verify dict is JSON-serialized string
+        assert data["picture_description_api"] == json.dumps(params["picture_description_api"])
+        # Verify bool is JSON-serialized string ("true" / "false")
+        assert data["do_picture_description"] == "true"
+        assert data["do_ocr"] == "false"
+        # Verify list is JSON-serialized string
+        assert data["pipeline_options"] == json.dumps(params["pipeline_options"])
+        # Verify primitives remain unchanged
+        assert data["max_num_pages"] == 5
+        assert data["simple_str"] == "hello"
+        assert data["image_export_mode"] == "placeholder"


### PR DESCRIPTION
### Fixes Issue

Fixes #27572

### Summary

When user-configured `DOCLING_PARAMS` contains nested objects (e.g. `picture_description_api`), lists, or boolean flags (e.g. `do_picture_description`), passing `**self.params` directly to `requests.post(..., data=...)` in `DoclingLoader.load()` does not JSON-serialize non-primitive values for multipart form fields.

As a result:
- `bool` values get passed as Python string representation `"True"` or `"False"` instead of JSON string `"true"` or `"false"`.
- `dict` and `list` values get converted into Python string representations which fail JSON validation on `docling-serve` (causing `ValueError: Invalid JSON for field 'picture_description_api'`).

### Changes Made

1. In `open_webui/retrieval/loaders/main.py`: JSON-encode `dict`, `list`, and `bool` values in `self.params` (`json.dumps(v)`) when constructing the `data` payload for `requests.post`.
2. Added unit test `open_webui/retrieval/loaders/test_docling_loader.py` verifying that dictionary, list, and boolean parameters in `self.params` are properly serialized to valid JSON strings in the HTTP request payload.

### Verification

Ran unit test:
`WEBUI_SECRET_KEY=secret_for_testing PYTHONPATH=backend pytest backend/open_webui/retrieval/loaders/test_docling_loader.py`

Result: `1 passed in 1.38s`.