### PR TITLE
fix(retrieval): JSON-serialize complex & boolean params in DoclingLoader

### DIFF
--- a/backend/open_webui/retrieval/loaders/main.py
+++ b/backend/open_webui/retrieval/loaders/main.py
@@ -206,7 +206,10 @@ class DoclingLoader:
                 data={
                     'image_export_mode': 'placeholder',
                     'md_page_break_placeholder': page_break_marker,
-                    **self.params,
+                    **{
+                        k: (json.dumps(v) if isinstance(v, (dict, list, bool)) else v)
+                        for k, v in self.params.items()
+                    },
                 },
                 headers=headers,
                 verify=AIOHTTP_CLIENT_SESSION_SSL,

--- a/backend/open_webui/retrieval/loaders/test_docling_loader.py
+++ b/backend/open_webui/retrieval/loaders/test_docling_loader.py
@@ -1,0 +1,55 @@
+import json
+from unittest.mock import MagicMock, patch
+import pytest
+
+from open_webui.retrieval.loaders.main import DoclingLoader
+
+
+def test_docling_loader_serializes_complex_and_bool_params(tmp_path):
+    dummy_file = tmp_path / "test.pdf"
+    dummy_file.write_bytes(b"%PDF-1.4 dummy content")
+
+    params = {
+        "picture_description_api": {"endpoint": "http://localhost:11434", "model": "llava"},
+        "do_picture_description": True,
+        "do_ocr": False,
+        "max_num_pages": 5,
+        "pipeline_options": ["table", "layout"],
+        "simple_str": "hello",
+    }
+
+    loader = DoclingLoader(
+        url="http://localhost:8080",
+        api_key="test-key",
+        file_path=str(dummy_file),
+        mime_type="application/pdf",
+        params=params,
+    )
+
+    mock_response = MagicMock()
+    mock_response.ok = True
+    mock_response.json.return_value = {
+        "document": {"md_content": "Extracted text content"}
+    }
+
+    with patch("open_webui.retrieval.loaders.main.requests.post", return_value=mock_response) as mock_post:
+        docs = loader.load()
+
+        assert len(docs) == 1
+        assert docs[0].page_content == "Extracted text content"
+
+        mock_post.assert_called_once()
+        call_kwargs = mock_post.call_args.kwargs
+        data = call_kwargs["data"]
+
+        # Verify dict is JSON-serialized string
+        assert data["picture_description_api"] == json.dumps(params["picture_description_api"])
+        # Verify bool is JSON-serialized string ("true" / "false")
+        assert data["do_picture_description"] == "true"
+        assert data["do_ocr"] == "false"
+        # Verify list is JSON-serialized string
+        assert data["pipeline_options"] == json.dumps(params["pipeline_options"])
+        # Verify primitives remain unchanged
+        assert data["max_num_pages"] == 5
+        assert data["simple_str"] == "hello"
+        assert data["image_export_mode"] == "placeholder"


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27572
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [x] **Documentation:** Relevant documentation has been added or updated.
- [x] **Dependencies:** No new dependencies added.
- [x] **Testing:** Unit tests added and verified locally.
- [x] **No Unchecked AI Code:** Thoroughly reviewed and tested.
- [x] **Self-Review:** Performed self-review adhering to project standards.
- [x] **Git Hygiene:** Atomic change rebased on `dev`.
- [x] **Title Prefix:** `fix:` Bug fixes or corrections

# Changelog Entry

### Fixed

- Fixed `DoclingLoader` parameter serialization for complex objects (`dict`, `list`) and boolean flags (`do_picture_description`, `picture_description_api`), ensuring they are formatted as valid JSON strings in multipart form data to prevent validation errors on `docling-serve` (#27572).

---

### Additional Information

Fixes #27572. When user-configured `DOCLING_PARAMS` contains nested objects or booleans, passing `**self.params` directly to `requests.post(..., data=...)` in `DoclingLoader.load()` does not JSON-serialize non-primitive values for multipart form fields, resulting in `ValueError: Invalid JSON for field 'picture_description_api'`.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
