### PR TITLE
fix: use configured timeout for Anthropic passthrough

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -73,6 +73,7 @@ from open_webui.config import (
 from open_webui.constants import ERROR_MESSAGES, TASKS
 from open_webui.env import (
     AIOHTTP_CLIENT_SESSION_SSL,
+    AIOHTTP_CLIENT_TIMEOUT,
     AUDIT_EXCLUDED_PATHS,
     AUDIT_INCLUDED_PATHS,
     AUDIT_LOG_LEVEL,
@@ -1836,7 +1837,7 @@ async def passthrough_anthropic_messages(request: Request, form_data: dict, user
             headers=headers,
             cookies=cookies,
             ssl=AIOHTTP_CLIENT_SESSION_SSL,
-            timeout=aiohttp.ClientTimeout(total=openai.AIOHTTP_CLIENT_TIMEOUT),
+            timeout=aiohttp.ClientTimeout(total=AIOHTTP_CLIENT_TIMEOUT),
         )
 
         if 'text/event-stream' in response.headers.get('Content-Type', ''):


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Fixes open-webui/open-webui#27595.
- [x] **Target branch:** This pull request targets the `dev` branch.
- [x] **Description:** A concise description is provided below.
- [x] **Changelog:** A Keep a Changelog entry is included below.
- [x] **Documentation:** N/A — this fixes an internal timeout reference without changing configuration or user-facing behavior.
- [x] **Dependencies:** N/A — no dependencies were added or updated.
- [ ] **Testing:** End-to-end Cline testing was not available; targeted runtime, syntax, formatting, lint, and diff checks passed as listed below.
- [x] **No Unchecked AI Code:** The two-line fix was reviewed against the timeout definition and validated with targeted checks.
- [x] **Self-Review:** The diff was reviewed for scope and consistency with existing environment imports.
- [x] **Architecture:** The existing configured timeout remains the source of truth; no setting or architecture change was introduced.
- [x] **Git Hygiene:** The PR is atomic, based on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The title uses the `fix` prefix.

## Description

The Anthropic Messages passthrough referenced `AIOHTTP_CLIENT_TIMEOUT` through the `openai` router module, which does not export that setting. Import the setting from `open_webui.env`, where it is defined, so `/api/v1/messages` can construct its configured client timeout instead of returning HTTP 502 with `AttributeError`.

## Validation

- `ruff format --check backend/open_webui/main.py`
- `ruff check --select=F --ignore=F401,F403,F405,F541,F811,F841 backend/open_webui/main.py`
- `python3 -m py_compile backend/open_webui/main.py`
- Runtime import/construction check for `AIOHTTP_CLIENT_TIMEOUT` and `aiohttp.ClientTimeout`
- `git diff --check`

# Changelog Entry

### Description

- Restore Anthropic Messages passthrough requests by using the configured aiohttp timeout from its defining module.

### Added

- N/A

### Changed

- N/A

### Deprecated

- N/A

### Removed

- N/A

### Fixed

- Fixed `/api/v1/messages` returning HTTP 502 because the timeout setting was read from a module that does not export it.

### Security

- N/A

### Breaking Changes

- N/A

---

### Additional Information

- Fixes open-webui/open-webui#27595.

### Screenshots or Videos

- N/A — backend-only change.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [ ] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
