### PR TITLE
fix: persist the Open Sharing permission in default user permissions

### DIFF
--- a/backend/open_webui/routers/users.py
+++ b/backend/open_webui/routers/users.py
@@ -203,6 +203,7 @@ class SharingPermissions(BaseModel):
     public_notes: bool = True
     folders: bool = False
     public_chats: bool = False
+    open_chats: bool = False
     public_calendars: bool = False
 
 


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27607 — Open Sharing cannot be enabled in admin panel
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable.
- [ ] **Dependencies:** No new dependencies.
- [x] **Testing:** Manual tests have been performed to verify the fix works correctly and does not introduce regressions.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** One-line schema completion; no new settings.
- [x] **Git Hygiene:** The PR is atomic (one logical change), based on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

The v0.11.0 "Chats Open Sharing" permission toggle in the admin panel's default user permissions can never be enabled: saving appears to succeed, but the toggle is off again on reload.

**Problem → Root Cause → Fix**

- **Problem:** Enabling and saving the Open Sharing permission does not persist.
- **Root Cause:** Every layer knows about `sharing.open_chats` — the admin UI switch, the frontend `DEFAULT_PERMISSIONS` template, the config defaults (`USER_PERMISSIONS_CHAT_ALLOW_OPEN_SHARING`), and the enforcement check in the share endpoint — except the `SharingPermissions` Pydantic model in `routers/users.py`, which both `GET` and `POST /api/v1/users/default/permissions` validate through. Pydantic ignores unknown fields, so `open_chats` was silently dropped from the save payload **and** stripped from the read-back response — the toggle could neither persist nor ever display as enabled.
- **Fix:** Add the missing field, defaulting to `False` to match the env var's default:

```diff
     folders: bool = False
     public_chats: bool = False
+    open_chats: bool = False
     public_calendars: bool = False
```

Every other key in the config's `sharing` dict was cross-checked against the model — `open_chats` was the sole omission, so this is the complete fix rather than one instance of a wider gap. Group-level permissions were never affected at the API layer (group forms accept a raw permissions dict); the failure was specific to the default-permissions panel.

### Fixed

- Fixed the "Chats Open Sharing" default user permission being silently dropped on save and read-back, making it impossible to enable from the admin panel.

---

### Additional Information

- Verified with a functional round-trip test: `SharingPermissions(open_chats=True)` now validates and dumps the field (previously silently ignored), with default `False` matching `USER_PERMISSIONS_CHAT_ALLOW_OPEN_SHARING`.
- This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Manual Verification Performed

1. Admin → Users → default permissions: enabled "Chats Open Sharing", saved, reloaded — the toggle now stays enabled (previously reverted to off).
2. Verified the same toggle inside a group's edit modal continues to work as before.

### Screenshots or Videos

- Not applicable — behavioral persistence fix.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
