### PR TITLE
fix: drop the white backdrop behind model icons in the admin Models list

### DIFF
--- a/src/lib/components/admin/Settings/Models.svelte
+++ b/src/lib/components/admin/Settings/Models.svelte
@@ -933,7 +933,7 @@
 									}}
 								>
 									<div class="self-center">
-										<div class="flex bg-white rounded-xl">
+										<div class="flex rounded-xl">
 											<div
 												class="{(model?.is_active ?? true)
 													? ''


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27611 — model icons with transparent backgrounds get a white backdrop in the admin Models list, unlike workspace and model selector
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable.
- [ ] **Dependencies:** No new dependencies.
- [x] **Testing:** Manual tests have been performed to verify the fix works correctly and does not introduce regressions.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Restores visual parity with the existing workspace Models page and model selector; no new styling introduced.
- [x] **Git Hygiene:** The PR is atomic (one logical change), based on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

Model profile images with transparent backgrounds (SVG provider logos, transparent PNGs) render on a hardcoded white box in the admin panel's Models list, while the identical images render transparently on the workspace Models page and in the chat input's model selector. The white box is most glaring in dark mode.

**Problem → Root Cause → Fix**

- **Problem:** Transparent model icons get a white backdrop, but only in the admin Models list.
- **Root Cause:** The admin list's icon wrapper is `<div class="flex bg-white rounded-xl">` — a hardcoded `bg-white` with no `dark:` variant (introduced in refactor `43e792a8f`); the inner wrapper is `bg-transparent`, so the white box shows through any transparent image. The workspace Models page wraps the same image endpoint in a plain `bg-transparent` container, and the model selector applies no backdrop.
- **Fix:** Remove the `bg-white` token; layout classes stay.

```diff
-										<div class="flex bg-white rounded-xl">
+										<div class="flex rounded-xl">
```

The file's remaining `bg-white` occurrences were audited: all are hover-state utilities (`dark:hover:bg-white/5`) or the correctly dark-paired primary button — this was the sole icon backdrop.

### Fixed

- Fixed transparent model profile images rendering on a white box in the admin Models list; icons now render consistently with the workspace Models page and the chat model selector in both themes.

---

### Additional Information

- Spotted by @Classic298; reproduced and fixed with credit.
- This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Manual Verification Performed

1. Admin Panel → Settings → Models in dark and light mode: transparent SVG/PNG model icons now render without the white box.
2. Workspace → Models and the chat input model selector: unchanged (they never shared this markup).

### Screenshots or Videos

#### Before

<img width="1429" height="969" alt="image" src="https://github.com/user-attachments/assets/b1545a32-1399-43ff-9589-e30664dee76a" />

#### After

<img width="1429" height="969" alt="image" src="https://github.com/user-attachments/assets/8ab853f6-7f7c-4084-b48a-a555f45a94d9" />

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
