### PR TITLE
fix: clip settings modal contents to its rounded corners

### DIFF
--- a/src/lib/components/chat/SettingsModal.svelte
+++ b/src/lib/components/chat/SettingsModal.svelte
@@ -905,7 +905,7 @@
 <Modal
 	size="full"
 	containerClassName="p-4 sm:p-6 lg:p-8"
-	className="!w-[calc(100vw-2rem)] sm:!w-[calc(100vw-3rem)] lg:!w-[calc(100vw-4rem)] !max-w-[80rem] h-[min(max(54rem,80dvh),calc(100dvh-4rem))] max-h-[calc(100dvh-4rem)] flex flex-col md:flex-row bg-white dark:bg-gray-900 rounded-4xl"
+	className="!w-[calc(100vw-2rem)] sm:!w-[calc(100vw-3rem)] lg:!w-[calc(100vw-4rem)] !max-w-[80rem] h-[min(max(54rem,80dvh),calc(100dvh-4rem))] max-h-[calc(100dvh-4rem)] flex flex-col md:flex-row bg-white dark:bg-gray-900 rounded-4xl overflow-hidden"
 	bind:show={modalShow}
 >
 	<nav

--- a/src/lib/components/chat/SettingsModal.svelte
+++ b/src/lib/components/chat/SettingsModal.svelte
@@ -886,7 +886,7 @@
 <Modal
 	size="full"
 	containerClassName="p-4 sm:p-6 lg:p-8"
-	className="!w-[calc(100vw-2rem)] sm:!w-[calc(100vw-3rem)] lg:!w-[calc(100vw-4rem)] !max-w-[80rem] h-[min(54rem,calc(100dvh-4rem))] max-h-[calc(100dvh-4rem)] flex flex-col md:flex-row bg-white dark:bg-gray-900 rounded-4xl"
+	className="!w-[calc(100vw-2rem)] sm:!w-[calc(100vw-3rem)] lg:!w-[calc(100vw-4rem)] !max-w-[80rem] h-[min(54rem,calc(100dvh-4rem))] max-h-[calc(100dvh-4rem)] flex flex-col md:flex-row bg-white dark:bg-gray-900 rounded-4xl overflow-hidden"
 	bind:show={modalShow}
 >
 	<nav


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27616 — settings nav tabs paint across the modal's bottom-left rounded corner while scrolling
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable.
- [ ] **Dependencies:** No new dependencies.
- [x] **Testing:** Manual tests have been performed to verify the fix works correctly and does not introduce regressions.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Clipping scoped to the settings modal only; `common/Modal.svelte` untouched so other modals keep their current behavior.
- [x] **Git Hygiene:** The PR is atomic (one logical change), based on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

Settings-nav tab rows can visibly overlap the settings modal's bottom-left rounded corner: while the tab list scrolls, a tab or icon fragment paints square across the 2rem corner curve and appears to float outside the modal on the backdrop.

**Problem → Root Cause → Fix**

- **Problem:** Tabs like "Database"/"Audio" bleed across the modal's bottom-left corner curve while the nav scrolls.
- **Root Cause:** The modal content wrapper has `rounded-4xl` but no `overflow-hidden` — a border radius rounds the box without clipping children. The nav's `overflow-y-auto` tab list stretches to the modal's full height with a square box of its own, and scroll containers clip at their padding edge, so rows legitimately render into the corner-cut zone while scrolling. Padding can't prevent this; only clipping at the rounded boundary can.
- **Fix:** Clip the settings modal's contents to its shape:

```diff
-... flex flex-col md:flex-row bg-white dark:bg-gray-900 rounded-4xl"
+... flex flex-col md:flex-row bg-white dark:bg-gray-900 rounded-4xl overflow-hidden"
```

Nothing inside the settings modal relies on escaping its box: dropdown menus are portaled to `document.body`, tooltips are tippy (body-level), and native `<select>` popups are OS-rendered — all verified unaffected. Scoped to `SettingsModal.svelte` rather than `common/Modal.svelte` to leave every other modal's behavior unchanged.

### Fixed

- Fixed settings-nav tabs painting across the settings modal's rounded corners (stray tab/icon fragments visible outside the modal shape while scrolling the nav).

---

### Additional Information

**Overlaps with another open PR.** This touches `src/lib/components/chat/SettingsModal.svelte`, which #27615 also modifies, and the two conflict in that file. Both were opened the same day and are independent fixes to the same modal, one for corner clipping and one for height. Either order works; whichever merges second needs a rebase.


- Note for sequencing: this PR and #27615 edit the same `className` line (different tokens); whichever merges second will need a trivial rebase, which I will handle promptly.
- This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Manual Verification Performed

1. Scrolled the settings nav so tabs pass through the bottom-left corner in dark and light themes — no fragment renders outside the curve anymore.
2. Opened dropdowns and tooltips near the modal edges (admin Models row menus, selects at the bottom of tabs) — all still pop out fully (portaled/OS-rendered).
3. Mobile-size sanity pass — the top-bar nav layout is clean at the top corners.

### Screenshots or Videos

#### Before (icon fragment outside the corner)

<img width="282" height="87" alt="image" src="https://github.com/user-attachments/assets/2eb702e6-5bbd-4a2e-8bbe-0ae52bf8c523" />

#### After (clean clip)

<img width="282" height="87" alt="image" src="https://github.com/user-attachments/assets/8e7f2c66-2db7-4b90-9960-a6b9046d15a2" />

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.

