### PR TITLE
feat: emit auth.login on SSO logins and attribute SSO logouts

### DIFF
--- a/backend/open_webui/routers/auths.py
+++ b/backend/open_webui/routers/auths.py
@@ -950,6 +950,9 @@ async def signout(request: Request, response: Response, db: AsyncSession = Depen
     if token is None:
         token = request.cookies.get('token')
 
+    oauth_session_id = request.cookies.get('oauth_session_id')
+    session = await OAuthSessions.get_session_by_id(oauth_session_id, db=db) if oauth_session_id else None
+
     if token:
         actor = None
         data = decode_token(token)
@@ -962,17 +965,15 @@ async def signout(request: Request, response: Response, db: AsyncSession = Depen
             actor=actor,
             subject_id=actor.id if actor else None,
             subject_type='user' if actor else None,
+            **({'source': 'oauth', 'data': {'auth_method': 'oauth', 'provider': session.provider}} if session else {}),
         )
 
     response.delete_cookie('token')
     response.delete_cookie('oui-session')
     response.delete_cookie('oauth_id_token')
 
-    oauth_session_id = request.cookies.get('oauth_session_id')
     if oauth_session_id:
         response.delete_cookie('oauth_session_id')
-
-        session = await OAuthSessions.get_session_by_id(oauth_session_id, db=db)
 
         # If a custom end_session_endpoint is configured (e.g. AWS Cognito), redirect
         # there directly instead of attempting OIDC discovery.

--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -2050,6 +2050,16 @@ class OAuthManager:
             **({'max_age': cookie_max_age} if cookie_max_age is not None else {}),
         )
 
+        await publish_event(
+            request,
+            EVENTS.AUTH_LOGIN,
+            actor=user,
+            subject_id=user.id,
+            subject_type='user',
+            source='oauth',
+            data={'auth_method': 'oauth', 'provider': provider},
+        )
+
         # Legacy cookies for compatibility with older frontend versions
         if ENABLE_OAUTH_ID_TOKEN_COOKIE:
             response.set_cookie(


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27613 — Support for auth.login event when using SSO
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable — extends an existing documented event to one more login path.
- [ ] **Dependencies:** No new dependencies.
- [ ] **Testing:** Honest status: the author does not run an SSO provider, so a live SSO login has not been exercised. Static/plumbing verification is documented below, and @jeremytbrun — who runs SSO and the exact event-handler use case from #27613 — is warmly invited to verify on this branch; this box will be ticked once a live SSO login has been confirmed.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new event names, sources, or payload fields beyond existing in-file conventions; single emission point in the OAuth callback.
- [x] **Git Hygiene:** The PR is atomic (one logical change), based on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `feat`

# Changelog Entry

### Description

The `auth.login` event fires for every internal login path (password, LDAP, trusted header, API token exchange) via `create_session_response`, but the browser SSO flow in `OAuthManager.handle_callback` builds its session by hand and never emits it — so event-handler functions (e.g., provisioning users into LiteLLM, as described in #27613) never see SSO logins.

**Change:** emit the same `EVENTS.AUTH_LOGIN` at the equivalent point in the OAuth callback — immediately after the session token cookie is set (mirroring `create_session_response`'s after-cookie placement), and after the error early-return, so it fires only on definitively successful logins.

```py
await publish_event(
    request,
    EVENTS.AUTH_LOGIN,
    actor=user,
    subject_id=user.id,
    subject_type='user',
    source='oauth',
    data={'auth_method': 'oauth', 'provider': provider},
)
```

Every naming choice follows an existing precedent rather than inventing anything new:

- `EVENTS.AUTH_LOGIN` / `subject_type='user'` — identical to the emission in `create_session_response` (routers/auths.py).
- `source='oauth'` — matches the existing token-exchange login (`create_session_response(..., source='oauth')`) and the `user.created` event already emitted in this same callback.
- `data.auth_method` — matches every other `auth.login` payload; `data.provider` — matches this callback's own `user.created` payload, and gives #27613's use case the per-provider key it needs.
- First-ever SSO login emits `user.created` followed by `auth.login`, consistent with the internal signup flow.

**Amendment (from @jeremytbrun's follow-up on the issue):** `auth.logout` already fires for SSO users — `POST /auths/signout` is the single logout endpoint and publishes the event before any OAuth-specific handling — but the payload carried no attribution, making SSO logouts indistinguishable from internal ones. The signout endpoint already fetches the user's OAuth session a few lines below the event; the second commit hoists that lookup above the publish and, when a session exists, attributes the event with the same shape as the new login event (`source: "oauth"`, `data: {"auth_method": "oauth", "provider": ...}`). Internal logouts are byte-identical to before (no session → no extra kwargs), and the normal-path DB lookup count is unchanged.

### Added

- The `auth.login` event is now emitted for SSO/OAuth logins (with `source: "oauth"` and the provider in the payload), matching the behavior of all internal login paths.
- The `auth.logout` event now carries the same OAuth attribution (`source: "oauth"`, provider in the payload) when the user logging out has an OAuth session; internal logouts are unchanged.

---

### Additional Information

- @jeremytbrun: if you can test this branch against your IdP + LiteLLM event handler, that would be the definitive verification — the payload gives you `data.provider` for per-provider provisioning.
- This PR was prepared with AI copilot assistance and has been thoroughly reviewed by the author.

### Verification Performed (plumbing — live SSO pending, see Testing above)

Performed with an AI-copilot harness against an isolated copy of `backend/` (scratch `DATA_DIR`/`STATIC_DIR`); disclosed as such rather than claimed as manual testing:

1. **Event registration:** `EVENTS.AUTH_LOGIN.name == 'auth.login'` — the emission reuses the registered event, no new names.
2. **Module import:** `open_webui.utils.oauth` imports cleanly with the change.
3. **Shipped-code extraction:** the exact `publish_event(EVENTS.AUTH_LOGIN, ...)` call expression was located inside `OAuthManager.handle_callback` via AST and executed *as shipped* (not a re-typed copy) —
4. **— through the real `publish_event`/`build_event`** with a capturing sink and stub request/user/provider. Resulting payload:

```json
{"event": "auth.login", "source": "oauth", "subject": {"type": "user", "id": "user-123"}, "data": {"auth_method": "oauth", "provider": "oidc"}}
```

5. **Signature binding:** the call's kwargs (`actor`, `data`, `source`, `subject_id`, `subject_type`) bind to `publish_event`'s signature.

The logout amendment was verified the same way (shipped call extracted from `signout` via AST, executed through the real `publish_event` with a capturing sink), in both directions:

```json
{"event": "auth.logout", "source": "oauth", "data": {"auth_method": "oauth", "provider": "oidc"}}
```

and with no OAuth session present: `{"event": "auth.logout", "source": "api", "data": {}}` — identical to current behavior for internal logouts.

What this does **not** cover: a live IdP handshake reaching the emission point in a real browser SSO flow — that is the verification invited from @jeremytbrun above, after which the Testing box will be ticked.

### Screenshots or Videos

- Not applicable — backend event emission.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
