### PR TITLE
fix: read context usage tokens with the same key precedence as backend compaction

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -281,13 +281,25 @@
 
 		for (let idx = activeMessages.length - 1; idx >= 0; idx -= 1) {
 			const usage = activeMessages[idx]?.usage ?? activeMessages[idx]?.info?.usage;
-			const inputTokens = usage?.input_tokens ?? usage?.prompt_tokens;
-			if (inputTokens) {
+			const usageTokens =
+				Number(
+					usage?.prompt_tokens ||
+						usage?.input_tokens ||
+						usage?.prompt_eval_count ||
+						usage?.prompt_n ||
+						0
+				) +
+				Number(
+					usage?.completion_tokens ||
+						usage?.output_tokens ||
+						usage?.eval_count ||
+						usage?.predicted_n ||
+						0
+				) +
+				Number(usage?.cache_n || 0);
+			if (usageTokens) {
 				hasUsageCheckpoint = true;
-				estimatedTokens =
-					Number(inputTokens || 0) +
-					Number(usage.output_tokens ?? usage.completion_tokens ?? 0) +
-					estimateMessagesTokens(activeMessages.slice(idx + 1));
+				estimatedTokens = usageTokens + estimateMessagesTokens(activeMessages.slice(idx + 1));
 				break;
 			}
 		}

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -281,13 +281,26 @@
 
 		for (let idx = activeMessages.length - 1; idx >= 0; idx -= 1) {
 			const usage = activeMessages[idx]?.usage ?? activeMessages[idx]?.info?.usage;
-			const inputTokens = usage?.input_tokens ?? usage?.prompt_tokens;
-			if (inputTokens) {
+			// Key precedence must match backend get_chat_context_usage (context_compaction.py)
+			const usageTokens =
+				Number(
+					usage?.prompt_tokens ||
+						usage?.input_tokens ||
+						usage?.prompt_eval_count ||
+						usage?.prompt_n ||
+						0
+				) +
+				Number(
+					usage?.completion_tokens ||
+						usage?.output_tokens ||
+						usage?.eval_count ||
+						usage?.predicted_n ||
+						0
+				) +
+				Number(usage?.cache_n || 0);
+			if (usageTokens) {
 				hasUsageCheckpoint = true;
-				estimatedTokens =
-					Number(inputTokens || 0) +
-					Number(usage.output_tokens ?? usage.completion_tokens ?? 0) +
-					estimateMessagesTokens(activeMessages.slice(idx + 1));
+				estimatedTokens = usageTokens + estimateMessagesTokens(activeMessages.slice(idx + 1));
 				break;
 			}
 		}

--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -444,13 +444,25 @@
 
 		for (let idx = activeMessages.length - 1; idx >= 0; idx -= 1) {
 			const usage = activeMessages[idx]?.usage ?? activeMessages[idx]?.info?.usage;
-			const inputTokens = usage?.input_tokens ?? usage?.prompt_tokens;
-			if (inputTokens) {
+			const usageTokens =
+				Number(
+					usage?.prompt_tokens ||
+						usage?.input_tokens ||
+						usage?.prompt_eval_count ||
+						usage?.prompt_n ||
+						0
+				) +
+				Number(
+					usage?.completion_tokens ||
+						usage?.output_tokens ||
+						usage?.eval_count ||
+						usage?.predicted_n ||
+						0
+				) +
+				Number(usage?.cache_n || 0);
+			if (usageTokens) {
 				hasUsageCheckpoint = true;
-				estimatedTokens =
-					Number(inputTokens || 0) +
-					Number(usage.output_tokens ?? usage.completion_tokens ?? 0) +
-					estimateMessagesTokens(activeMessages.slice(idx + 1));
+				estimatedTokens = usageTokens + estimateMessagesTokens(activeMessages.slice(idx + 1));
 				break;
 			}
 		}

--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -444,13 +444,26 @@
 
 		for (let idx = activeMessages.length - 1; idx >= 0; idx -= 1) {
 			const usage = activeMessages[idx]?.usage ?? activeMessages[idx]?.info?.usage;
-			const inputTokens = usage?.input_tokens ?? usage?.prompt_tokens;
-			if (inputTokens) {
+			// Key precedence must match backend get_chat_context_usage (context_compaction.py)
+			const usageTokens =
+				Number(
+					usage?.prompt_tokens ||
+						usage?.input_tokens ||
+						usage?.prompt_eval_count ||
+						usage?.prompt_n ||
+						0
+				) +
+				Number(
+					usage?.completion_tokens ||
+						usage?.output_tokens ||
+						usage?.eval_count ||
+						usage?.predicted_n ||
+						0
+				) +
+				Number(usage?.cache_n || 0);
+			if (usageTokens) {
 				hasUsageCheckpoint = true;
-				estimatedTokens =
-					Number(inputTokens || 0) +
-					Number(usage.output_tokens ?? usage.completion_tokens ?? 0) +
-					estimateMessagesTokens(activeMessages.slice(idx + 1));
+				estimatedTokens = usageTokens + estimateMessagesTokens(activeMessages.slice(idx + 1));
 				break;
 			}
 		}


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27608 — Compaction reports input tokens incorrectly
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable.
- [ ] **Dependencies:** No new dependencies.
- [x] **Testing:** Manual tests have been performed to verify the fix works correctly and does not introduce regressions (details below); confirmation from the reporter's upstream is additionally invited.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Aligns the frontend with the backend's existing, authoritative token-key precedence; no new behavior invented.
- [x] **Git Hygiene:** The PR is atomic (one logical change), based on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

The context-usage number shown in the chat UI (the indicator near the input and the `/status` panel's "Context usage" row) and the backend's context compaction read the same per-message `usage` dicts through **different key preferences**, so on some upstreams the number users see and the number compaction acts on disagree — up to a brand-new chat displaying itself as at/over capacity (#27608).

**Problem → Root Cause → Fix**

- **Problem:** With an upstream that emits both `input_tokens` and `prompt_tokens` (with `input_tokens` carrying a wrong value), the UI computes context usage from `input_tokens` while compaction correctly uses `prompt_tokens`. Reported in #27608 and triaged with the reporter on Discord: `prompt_tokens` was correct (9,927) while the displayed usage claimed a fresh chat was full.
- **Root Cause:** Backend `get_chat_context_usage` (`utils/context_compaction.py`) reads `prompt_tokens || input_tokens || prompt_eval_count || prompt_n` (plus the completion-side chain and `cache_n`), skipping zeros. The frontend's duplicated checkpoint scan in `Chat.svelte`/`MessageInput.svelte` read `input_tokens ?? prompt_tokens` (and `output_tokens ?? completion_tokens`) — inverted precedence, `0`-accepting `??` semantics, no Ollama/llama.cpp keys (`prompt_eval_count`/`prompt_n`/`eval_count`/`predicted_n`), no `cache_n`, and a checkpoint condition on the input side only.
- **Fix:** Both frontend call sites now mirror the backend chain exactly — same key order, same zero-skipping semantics, same `cache_n` term, and the checkpoint condition on the combined total, matching `get_chat_context_usage`.

Note on "read only `prompt_tokens`": the fix deliberately keeps `input_tokens` as a *fallback* (matching the backend) rather than dropping it — providers that emit only the Anthropic-style shape still need it. `prompt_tokens` now simply always wins when both keys are present, which resolves the reported case.

Side benefit: Ollama and llama.cpp users previously never got a real usage checkpoint in the UI (their keys weren't read at all) and always saw rough client-side estimates; the indicator now uses their actual reported counts, same as compaction does.

### Fixed

- Fixed the chat context-usage display (input indicator and `/status`) disagreeing with backend context compaction on upstreams that report both `input_tokens` and `prompt_tokens`; the frontend now uses the backend's exact token-key precedence.
- Fixed the context-usage display ignoring Ollama (`prompt_eval_count`/`eval_count`) and llama.cpp (`prompt_n`/`predicted_n`/`cache_n`) usage keys, which forced rough estimates instead of real counts.

---

### Additional Information

**Key precedence is an invariant shared with the backend.** The order the frontend reads usage keys in must match `get_chat_context_usage` in `context_compaction.py`. Both call sites, `Chat.svelte` and `MessageInput.svelte`, follow that same order, so a change on either side has to be made in all three places or the displayed figure silently diverges from what the backend counted.

- Mechanism confirmed in Discord triage with the reporter (@frenzybiscuit) and @Classic298; verification against the reporter's both-keys upstream is warmly invited on this branch, since that exact shape can't be reproduced on the author's providers.
- This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Manual Verification Performed

1. Ollama model chat: `/status` → Context usage now tracks the real counts visible in the message info popup (`prompt_eval_count` + `eval_count`); previously this row was a rough character-based estimate for Ollama.
2. OpenAI-shaped provider chat: `/status` numbers unchanged from `dev` (those providers only send `prompt_tokens`, which the old code already fell back to) — no regression.
3. `/compact` on a longer chat still compacts, with a coherent usage readout afterwards.

### Screenshots or Videos

- Not applicable — numeric display fix; reporter screenshots are in #27608.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.

