### PR TITLE
fix: normalize OAuth server metadata URLs

### DIFF
--- a/backend/open_webui/routers/configs.py
+++ b/backend/open_webui/routers/configs.py
@@ -15,6 +15,7 @@ from open_webui.models.oauth_sessions import OAuthSessions
 from open_webui.utils.auth import get_admin_user, get_verified_user
 from open_webui.utils.headers import get_custom_headers
 from open_webui.utils.mcp.client import MCPClient
+from open_webui.utils.oauth_metadata import normalize_oauth_metadata
 from open_webui.utils.oauth import (
     OAuthClientInformationFull,
     apply_connection_oauth_options,
@@ -568,7 +569,9 @@ async def verify_tool_servers_config(request: Request, form_data: ToolServerConn
                             if oauth_server_metadata_response.status == 200:
                                 try:
                                     oauth_server_metadata = OAuthMetadata.model_validate(
-                                        await oauth_server_metadata_response.json()
+                                        normalize_oauth_metadata(
+                                            await oauth_server_metadata_response.json(), discovery_url
+                                        )
                                     )
                                     return {
                                         'status': True,

--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -88,6 +88,7 @@ from open_webui.retrieval.web.utils import get_ssrf_safe_session, validate_url
 from open_webui.utils.auth import create_token, get_password_hash
 from open_webui.utils.groups import apply_default_group_assignment
 from open_webui.utils.misc import parse_duration
+from open_webui.utils.oauth_metadata import normalize_oauth_metadata
 from open_webui.utils.validate import validate_profile_image_url
 from starlette.responses import RedirectResponse
 
@@ -535,7 +536,7 @@ async def get_oauth_client_info_with_dynamic_client_registration(
                     if oauth_server_metadata_response.status == 200:
                         try:
                             oauth_server_metadata = OAuthMetadata.model_validate(
-                                await oauth_server_metadata_response.json()
+                                normalize_oauth_metadata(await oauth_server_metadata_response.json(), url)
                             )
                             oauth_server_metadata_url = url
                             if (
@@ -663,7 +664,9 @@ async def get_oauth_client_info_with_static_credentials(
                 async with session.get(url, ssl=AIOHTTP_CLIENT_SESSION_SSL) as resp:
                     if resp.status == 200:
                         try:
-                            oauth_server_metadata = OAuthMetadata.model_validate(await resp.json())
+                            oauth_server_metadata = OAuthMetadata.model_validate(
+                                normalize_oauth_metadata(await resp.json(), url)
+                            )
                             oauth_server_metadata_url = url
                             break
                         except Exception as e:

--- a/backend/open_webui/utils/oauth_metadata.py
+++ b/backend/open_webui/utils/oauth_metadata.py
@@ -1,0 +1,14 @@
+import urllib.parse
+
+
+def normalize_oauth_metadata(metadata: dict, metadata_url: str) -> dict:
+    normalized = dict(metadata)
+    parsed_url = urllib.parse.urlparse(metadata_url)
+    origin = f'{parsed_url.scheme}://{parsed_url.netloc}'
+    normalized.setdefault('issuer', origin)
+
+    for field, value in normalized.items():
+        if isinstance(value, str) and (field == 'issuer' or field.endswith('_endpoint') or field == 'jwks_uri'):
+            normalized[field] = urllib.parse.urljoin(f'{origin}/', value)
+
+    return normalized


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Relates to #26059
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [x] **Documentation:** No documentation change necessary.
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **BREAKING CHANGE**: Changes affecting backward compatibility
  - **build**: Build system or dependency changes
  - **ci**: CI/CD workflow changes
  - **chore**: Refactoring, cleanup, or non-functional changes
  - **docs**: Documentation additions or updates
  - **feat**: New features or enhancements
  - **fix**: Bug fixes or corrections
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvements
  - **refactor**: Code restructuring
  - **style**: Formatting changes (whitespace, semicolons, etc.)
  - **test**: Test additions or corrections
  - **WIP**: Work in progress


## Description

OAuth discovery currently passes provider metadata directly to the MCP SDK's strict `OAuthMetadata` model. Providers such as Home Assistant return valid, origin-relative endpoint paths and omit `issuer`, causing discovery to fail before authentication can begin.

This change normalizes OAuth metadata before validation by deriving a missing issuer from the discovery URL and resolving relative endpoint and JWKS URLs against the provider origin. The same normalization is applied during connection verification, dynamic client registration, and static OAuth configuration.

Example OAuth metadata returned from Home Assistant:

```json
{
  "authorization_endpoint": "/auth/authorize",
  "token_endpoint": "/auth/token",
  "revocation_endpoint": "/auth/revoke",
  "client_id_metadata_document_supported": true,
  "response_types_supported": ["code"],
  "service_documentation": "https://developers.home-assistant.io/docs/auth_api"
}
```

# Changelog Entry

### Description

- Normalize OAuth authorization server metadata before validating it with the MCP SDK.

### Fixed

- Fixed OAuth discovery failures for providers that omit `issuer` or return relative authorization, token, revocation, registration, or JWKS URLs.

---

### Additional Information

- Home Assistant MCP OAuth behavior docs: https://www.home-assistant.io/integrations/mcp_server/.
- This does not implement Client ID Metadata Documents. It allows the existing static OAuth flow to consume Home Assistant's discovery metadata.
- No dependencies or configuration options were added.
- OAuth metadata normalization was validated against the MCP SDK's `OAuthMetadata` model.

### Screenshots or Videos

Not applicable. This change has no visual surface.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.