### PR TITLE
fix: prevent 503 on chat completion when a direct terminal is selected

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -3113,8 +3113,14 @@
 		// in the message so the backend can inject their full content.
 		const skillIds = [...selectedSkillIds];
 
-		// Use the user-selected terminal from the dropdown
-		const activeTerminalId = $selectedTerminalId ?? null;
+		// Use the user-selected terminal from the dropdown. Only system terminals
+		// resolve by id on the backend; direct terminals are identified by URL and
+		// already travel through tool_servers below.
+		const activeTerminalId = ($terminalServers ?? []).some(
+			(t) => t.id && t.id === $selectedTerminalId
+		)
+			? $selectedTerminalId
+			: null;
 
 		// Only send terminal_id if the model has terminal capability enabled
 		const terminalEnabled = model.info?.meta?.capabilities?.terminal ?? true;


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27621
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** No documentation changes required.
- [ ] **Dependencies:** No new dependencies.
- [x] **Testing:** Manually verified by the author on a live instance: the reported failure state was reproduced exactly on pre-fix `dev`, and the fix branch resolves it (details below).
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Frontend-only, minimal change; reuses the system-vs-direct terminal distinction the codebase already encodes (`isTerminalAvailable` in `Chat.svelte`, the `t.id` filters in `ChatControls.svelte` / `TerminalMenu.svelte`).
- [x] **Git Hygiene:** The PR is atomic (one logical change), based on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

Since v0.11.0, selecting a **direct** (user-configured, Settings → Integrations) Open Terminal makes every chat completion fail with HTTP 503:

```
Terminal unavailable: Terminal server 'http://localhost:4001' not found
```

The terminal icon renders, the terminal is selectable, and the direct terminal server itself is healthy — but sending any message kills the whole chat.

### Root Cause

The frontend identifies terminals two different ways: **system** (admin-configured) terminals by generated connection id, **direct** (user-settings) terminals by URL (`TerminalMenu.svelte` — `selectDirect` sets `selectedTerminalId` to `terminal.url`). `Chat.svelte` then sent whatever was selected as `terminal_id` unconditionally:

```js
terminal_id: terminalEnabled ? (activeTerminalId ?? undefined) : undefined,
```

But `terminal_id` only means something for system terminals: the backend resolves it against the admin `terminal_server.connections` config (`get_terminal_tools`, `utils/tools.py`), where a direct terminal's URL never matches. Direct terminals were never meant to go through that path — they already travel client-side via `tool_servers` (the `...($terminalServers ?? []).filter((t) => !t.id)` entry a few lines below).

Through v0.10.2 this mismatch was silently absorbed: `get_terminal_tools` logged a warning and returned `{}`, and the direct terminal worked via `tool_servers`. Commit `7088d245b` (first shipped in v0.11.0) hardened `get_terminal_tools` to `raise RuntimeError` on an unknown id — correct for genuinely broken system-terminal references, which should fail loudly — and `process_chat_payload` wraps that in a 503. The previously-harmless stray URL became a chat-killing error.

### Fix

Only send `terminal_id` when the selection is a system terminal (matches a `t.id` in `$terminalServers`) — the same id-vs-URL distinction `Chat.svelte`'s own `isTerminalAvailable` and `ChatControls.svelte` already use. Direct terminals keep flowing through `tool_servers` exactly as before:

```diff
-		// Use the user-selected terminal from the dropdown
-		const activeTerminalId = $selectedTerminalId ?? null;
+		// Use the user-selected terminal from the dropdown. Only system terminals
+		// resolve by id on the backend; direct terminals are identified by URL and
+		// already travel through tool_servers below.
+		const activeTerminalId = ($terminalServers ?? []).some(
+			(t) => t.id && t.id === $selectedTerminalId
+		)
+			? $selectedTerminalId
+			: null;
```

The backend raise from `7088d245b` is intentionally left untouched: for system terminals a dangling id (e.g. the admin deleted the connection mid-session) *should* surface an error rather than silently dropping tools.

### Verification performed (author, live instance)

1. **Reported state reproduced exactly on pre-fix `dev`**: a healthy Open Terminal added as a **direct** terminal under user Settings → Integrations (browser-reachable URL) — the Files side panel connects and browses the server's directory tree without issue, yet sending any chat message fails with `Terminal unavailable: Terminal server 'http://host.docker.internal:8376' not found` (503). This matches #27621's report byte-for-byte, including the "file explorer continues to work correctly" observation: the Files panel connects directly from the browser, while the chat path dies at the backend config lookup before any connection attempt (which is also why the reporter's open-terminal logs show no incoming request).
2. **Also confirmed reachability is irrelevant to the failure**: an unreachable dummy-URL direct terminal produces the identical 503, since the error fires on the config-lookup line before any HTTP request — "not found" refers to the admin connection list, not the server.
3. **On this branch**: with the same direct terminal selected, chat completions succeed normally.
4. **System-terminal path**: unchanged by construction — when the selection matches a system terminal's id, the sent `terminal_id` is identical to before; the guard only withholds values that could never resolve.

Additional confirmation from the reporter's `http://localhost:4001` setup is of course still welcome.

### Fixed

- Fixed chat completions failing with a 503 "Terminal server not found" error when a direct (user-configured) Open Terminal is selected, a regression introduced in v0.11.0.

---

### Additional Information

- @JKGeovision — this implements the fix for your report; confirmation against your actual `http://localhost:4001` setup is welcome.
- Related but distinct terminal issues, for triage clarity: #27580/#27581 (backend listing filtered grant-less connections; merged) and #27064 (icon never rendered on v0.10.2; closed as fixed in dev). This regression is a third, separate mechanism and is still present on `dev` without this patch.
- This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Screenshots or Videos

| Before (`dev`, direct terminal selected) | After (this branch, same setup) |
| --- | --- |
| <img width="2326" height="1276" alt="image" src="https://github.com/user-attachments/assets/afc2ae83-d775-4d9f-8304-d602a1b19869" /> **chat 503 "Terminal server '…' not found" while the Files panel browses the same server without issue** | <img width="2326" height="1276" alt="image" src="https://github.com/user-attachments/assets/fbce457c-2e2f-4fee-a5c2-67e8a4635197" /> **chat completes normally with the direct terminal selected** |

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
