### PR TITLE
fix: restore Enter-to-confirm in confirmation dialogs by explicitly focusing Confirm

### DIFF
--- a/src/lib/components/common/ConfirmDialog.svelte
+++ b/src/lib/components/common/ConfirmDialog.svelte
@@ -36,6 +36,7 @@
 	}
 
 	let modalElement = null;
+	let confirmButtonElement: HTMLButtonElement | null = null;
 	let mounted = false;
 
 	let focusTrap: FocusTrap.FocusTrap | null = null;
@@ -81,7 +82,10 @@
 	$: if (mounted) {
 		if (show && modalElement) {
 			document.body.appendChild(modalElement);
-			focusTrap = FocusTrap.createFocusTrap(modalElement);
+			focusTrap = FocusTrap.createFocusTrap(modalElement, {
+				initialFocus: () =>
+					modalElement.querySelector('input, textarea, select') ?? confirmButtonElement ?? undefined
+			});
 			focusTrap.activate();
 
 			window.addEventListener('keydown', handleKeyDown);
@@ -195,6 +199,7 @@
 						{cancelLabel}
 					</button>
 					<button
+						bind:this={confirmButtonElement}
 						class="text-sm bg-gray-900 hover:bg-gray-900/90 text-gray-100 dark:bg-gray-100 dark:hover:bg-gray-100/90 dark:text-gray-800 font-normal w-full py-1.5 rounded-full transition"
 						on:click={() => {
 							confirmHandler();

--- a/src/lib/components/common/ConfirmDialog.svelte
+++ b/src/lib/components/common/ConfirmDialog.svelte
@@ -36,6 +36,7 @@
 	}
 
 	let modalElement = null;
+	let confirmButtonElement: HTMLButtonElement | null = null;
 	let mounted = false;
 
 	let focusTrap: FocusTrap.FocusTrap | null = null;
@@ -81,7 +82,13 @@
 	$: if (mounted) {
 		if (show && modalElement) {
 			document.body.appendChild(modalElement);
-			focusTrap = FocusTrap.createFocusTrap(modalElement);
+			focusTrap = FocusTrap.createFocusTrap(modalElement, {
+				// Focus any input first so typing works immediately; otherwise focus
+				// Confirm so Enter confirms (the trap's default falls back to the
+				// first tabbable node, which is the Cancel button).
+				initialFocus: () =>
+					modalElement.querySelector('input, textarea, select') ?? confirmButtonElement ?? undefined
+			});
 			focusTrap.activate();
 
 			window.addEventListener('keydown', handleKeyDown);
@@ -195,6 +202,7 @@
 						{cancelLabel}
 					</button>
 					<button
+						bind:this={confirmButtonElement}
 						class="text-sm bg-gray-900 hover:bg-gray-900/90 text-gray-100 dark:bg-gray-100 dark:hover:bg-gray-100/90 dark:text-gray-800 font-normal w-full py-1.5 rounded-full transition"
 						on:click={() => {
 							confirmHandler();


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27629
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** No documentation changes required.
- [ ] **Dependencies:** No new dependencies.
- [x] **Testing:** Manually verified by the author on a live instance (details below).
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Completes #27491 rather than reverting any part of it: initial focus becomes a deliberate choice at the layer that owns it (the focus trap's configuration), and Enter semantics follow natively from focus.
- [x] **Git Hygiene:** The PR is atomic (one logical change), based on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

On current `dev`, pressing Enter in any confirmation dialog (delete chat, delete message, delete folder/model/knowledge, and the ~40 other `ConfirmDialog` call sites) closes the dialog **without** performing the action — Enter effectively always cancels.

### Root Cause

#27491 correctly changed the window-level Enter handler to defer to the focused control:

```js
if (target instanceof Element && target.closest('a, button, textarea')) {
	return; // let the focused control act on Enter itself
}
```

That fix's stated behavior — "Enter anywhere else still confirms as before" — is defeated by where focus actually lands. The dialog's focus trap is created with no `initialFocus`:

```js
focusTrap = FocusTrap.createFocusTrap(modalElement);
```

so focus-trap falls back to the first tabbable node in the container, which is the **Cancel** button (a fallback #27491's own description documents). The dialog opens with Cancel invisibly focused, and Enter now natively activates it.

The underlying defect is that `ConfirmDialog` never deliberately chose its initial focus. It never mattered while the old handler hijacked Enter globally; #27491 (correctly) made focus meaningful, which exposed the accidental Cancel default.

### Fix

Make initial focus explicit on the trap: any input inside the dialog first (so typing dialogs still focus their field immediately, matching the previous first-tabbable behavior for the `input` variants), otherwise the **Confirm** button:

```diff
-			focusTrap = FocusTrap.createFocusTrap(modalElement);
+			focusTrap = FocusTrap.createFocusTrap(modalElement, {
+				// Focus any input first so typing works immediately; otherwise focus
+				// Confirm so Enter confirms (the trap's default falls back to the
+				// first tabbable node, which is the Cancel button).
+				initialFocus: () =>
+					modalElement.querySelector('input, textarea, select') ?? confirmButtonElement ?? undefined
+			});
```

plus a `bind:this={confirmButtonElement}` on the Confirm button.

Everything #27491 established is preserved, and the keyboard model is now fully coherent with no special cases:

- The dialog opens with **Confirm focused**, and Enter does exactly what the focused control's label says (the WCAG 3.2.2 property #27491 fixed). The focus ring renders per the browser's `:focus-visible` heuristics: immediately for keyboard-driven interaction, and from the first keypress onward when the dialog was opened with the mouse — Enter confirms either way.
- Tab → Cancel → Enter cancels; Escape cancels.
- Enter inside the `input=true` textarea still inserts a newline; Enter inside a text/password input still confirms (form-submit convention, via the existing fallback).
- A markdown link in `message` is no longer the initial focus target either.

Implementation notes, verified against the focus-trap source in `node_modules` rather than assumed: the function form of `initialFocus` is supported, and a function returning `null` **throws** (`getNodeForOption`) while `undefined` falls back to the library default — hence the trailing `?? undefined`, which turns a theoretical missing-ref edge into graceful fallback instead of a crash.

### Fixed

- Fixed Enter no longer confirming confirmation dialogs (deletes silently cancelling), a `dev` regression from the interaction between #27491's corrected Enter handling and the focus trap's accidental initial focus on Cancel.

---

### Additional Information

**Why focus lands where it does.** Any `input`, `textarea` or `select` in the dialog is focused first, so typing works immediately. Only when there is none does focus go to Confirm, which is what makes plain Enter confirm. The focus trap's own default falls back to the first tabbable node, and that is the Cancel button, so relying on it would make Enter cancel instead.

- @Classic298 — this completes #27491 rather than reverting any part of it; your guard is what makes the explicit initial focus meaningful. Flagging in case you want to double-check the a11y angle.

### Verification Performed

Manual, by the author on a live instance running this branch: deleting a chat and deleting an own message — plain Enter now performs the deletion; Escape still cancels. Focus demonstrably starts on Confirm: the first Tab wraps to Cancel (first tabbable) and the second returns to Confirm with the visible ring, exactly as expected when the trap's initial focus is the last tabbable node. The input-focus branch (`input, textarea, select` preferred over Confirm) is verified by code trace against the focus-trap source, not manually.

- This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Screenshots or Videos

- N/A (keyboard-interaction fix; behavior described above).

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.

