### PR TITLE
fix: hide the sidebar Models section when no pinned models resolve

### DIFF
--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -122,6 +122,15 @@
 
 	let pinnedModels = [];
 
+	$: resolvedPinnedModels = (
+		($settings?.pinnedModels ?? []).length > 0
+			? ($settings?.pinnedModels ?? [])
+			: ($config?.default_pinned_models ?? '').split(',')
+	).filter((id) => {
+		const model = ($models ?? []).find((m) => m.id === id);
+		return model && !(model?.info?.meta?.hidden ?? false);
+	});
+
 	let showPinnedModels = false;
 	let showPinnedNotes = false;
 	let showChannels = false;
@@ -1276,7 +1285,7 @@
 						</div>
 					</div>
 
-					{#if ($models ?? []).length > 0 && (($settings?.pinnedModels ?? []).length > 0 || $config?.default_pinned_models)}
+					{#if resolvedPinnedModels.length > 0}
 						<SidebarSection
 							id="sidebar-models"
 							bind:open={showPinnedModels}

--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -122,6 +122,18 @@
 
 	let pinnedModels = [];
 
+	// Mirrors PinnedModelList's resolution (user pins, else adoptable instance
+	// defaults, kept only when they map to an existing non-hidden model) so the
+	// Models section is rendered only when it will actually contain a model.
+	$: resolvedPinnedModels = (
+		($settings?.pinnedModels ?? []).length > 0
+			? ($settings?.pinnedModels ?? [])
+			: ($config?.default_pinned_models ?? '').split(',')
+	).filter((id) => {
+		const model = ($models ?? []).find((m) => m.id === id);
+		return model && !(model?.info?.meta?.hidden ?? false);
+	});
+
 	let showPinnedModels = false;
 	let showPinnedNotes = false;
 	let showChannels = false;
@@ -1281,7 +1293,7 @@
 					</div>
 				</div>
 
-				{#if ($models ?? []).length > 0 && (($settings?.pinnedModels ?? []).length > 0 || $config?.default_pinned_models)}
+				{#if resolvedPinnedModels.length > 0}
 					<SidebarSection
 						id="sidebar-models"
 						bind:open={showPinnedModels}

--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -310,6 +310,7 @@ type Config = {
 	version: string;
 	default_locale: string;
 	default_models: string;
+	default_pinned_models?: string;
 	default_prompt_suggestions: PromptSuggestion[];
 	features: {
 		auth: boolean;

--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -309,6 +309,7 @@ type Config = {
 	version: string;
 	default_locale: string;
 	default_models: string;
+	default_pinned_models?: string;
 	default_prompt_suggestions: PromptSuggestion[];
 	features: {
 		auth: boolean;


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27633, relates to #27766
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** No documentation changes required.
- [ ] **Dependencies:** No new dependencies.
- [x] **Testing:** Manually verified by the author on a live instance that reproduced the empty section (details below).
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** The visibility gate now mirrors the exact resolution `PinnedModelList` performs (pins, else adoptable defaults, filtered to existing non-hidden models), stated as such in a comment so the two stay in sync.
- [x] **Git Hygiene:** The PR is atomic (one logical change), based on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

The "Models" section at the top of the sidebar can render permanently empty: a collapsible header with nothing inside it, whose only behavior is expanding and collapsing an empty body.

Since filing, root cause analysis on a live instance (written up in #27766) showed the same unresolved-defaults condition also has a destructive consequence beyond the cosmetic one, and that this fix closes the automatic trigger for it. Details under Root Cause.

### Root Cause

The render gate in `Sidebar.svelte` decides visibility from inputs that don't guarantee content:

```svelte
{#if ($models ?? []).length > 0 && (($settings?.pinnedModels ?? []).length > 0 || $config?.default_pinned_models)}
```

- `$config?.default_pinned_models` is a comma-separated id **string** used as a raw truthiness proxy: if an instance ever configured default pinned models whose ids no longer resolve (models removed or renamed), the clause stays truthy forever while producing zero rows.
- `$settings?.pinnedModels` entries are counted without checking they map to an existing, non-hidden model.

Whether those ids yield any rows is only determined inside `PinnedModelList` (default adoption on mount + stale-pin cleanup), which can't save the gate, because it only mounts **after** the gate passes.

**Destructive consequence of the same condition.** When the gate passes on the raw truthiness of `default_pinned_models`, `PinnedModelList` mounts and its onMount default-adoption block persists the full `{ ui: $settings }` object unconditionally, even when the filtered adoption result is empty. In a session whose in-memory settings are empty (the settings fetch failure at boot is caught and only logged, see #27766), that save overwrites the user's entire stored settings with `{ "pinnedModels": [] }` with no user interaction. This was observed live: server logs show the full-object `POST /api/v1/users/user/settings/update` landing 164 ms after the boot-time settings `GET`, and the database row afterwards contained nothing but `pinnedModels: []` plus a changelog version stamp. The full analysis, including the enabling conditions, is in #27766.

### Fix

Mirror the child's resolution in the gate itself and render the section iff the resolved list is non-empty:

```diff
+	// Mirrors PinnedModelList's resolution (user pins, else adoptable instance
+	// defaults, kept only when they map to an existing non-hidden model) so the
+	// Models section is rendered only when it will actually contain a model.
+	$: resolvedPinnedModels = (
+		($settings?.pinnedModels ?? []).length > 0
+			? ($settings?.pinnedModels ?? [])
+			: ($config?.default_pinned_models ?? '').split(',')
+	).filter((id) => {
+		const model = ($models ?? []).find((m) => m.id === id);
+		return model && !(model?.info?.meta?.hidden ?? false);
+	});
```

```diff
-				{#if ($models ?? []).length > 0 && (($settings?.pinnedModels ?? []).length > 0 || $config?.default_pinned_models)}
+				{#if resolvedPinnedModels.length > 0}
```

The previous `($models ?? []).length > 0` clause is subsumed: a resolved pin implies a loaded model. All legitimate paths are preserved: valid pins render, valid instance defaults still show the section on first run so `PinnedModelList` can mount and adopt them into user settings, and pinning/unpinning shows/hides the section reactively. Also adds the previously-untyped `default_pinned_models?: string` to the `Config` type, which this change reads.

Because `PinnedModelList` lives inside the gated section, gating on actual resolution also means the component never mounts when nothing resolves, so its unconditional onMount save never fires in that case. This closes the zero-interaction settings-overwrite trigger described above for the unresolvable-defaults scenario.

**Scope note:** this PR does not fix the general overwrite semantics (full-object saves from a session that booted with empty settings can still occur through other paths, including the same onMount save when the configured defaults do resolve). Those need the server-side or load-guard fixes discussed in #27766; this change removes the one trigger that required no user interaction and no resolvable model at all.

### Fixed

- Fixed the sidebar "Models" section rendering as a permanently empty collapsible header when configured default pinned models or saved pins no longer resolve to any existing, non-hidden model.
- Fixed configured-but-unresolvable default pinned models causing an automatic full settings save of an empty pinned list at session start, which could silently overwrite a user's stored settings when the session had booted without loaded settings (see #27766).

---

### Additional Information

- This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Verification Performed

Manual, by the author on a live instance that exhibited the bug (empty "Models" header rendering with no pinned models): on this branch the empty section no longer renders; pinning a model from the model selector makes the section appear immediately with that model; unpinning it hides the section again.

### Screenshots or Videos

| Before (empty section renders) | After (section hidden until a pin resolves) |
| --- | --- |
| <img width="228" height="308" alt="image" src="https://github.com/user-attachments/assets/90821419-6125-4033-8ad3-48d8e54c5c66" /> | <img width="228" height="308" alt="image" src="https://github.com/user-attachments/assets/f3930e92-0c4a-4672-95aa-fc9bf420886b" /> |

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
