### PR TITLE
fix: remove vestigial api_base_url param that broke the Tavily web loader

### DIFF
--- a/backend/open_webui/retrieval/web/utils.py
+++ b/backend/open_webui/retrieval/web/utils.py
@@ -404,7 +404,6 @@ class SafeTavilyLoader(BaseLoader, RateLimitMixin, URLProcessingMixin):
     def __init__(
         self,
         web_paths: Union[str, List[str]],
-        api_base_url: str,
         api_key: str,
         extract_depth: Literal['basic', 'advanced'] = 'basic',
         continue_on_failure: bool = True,
@@ -438,7 +437,6 @@ class SafeTavilyLoader(BaseLoader, RateLimitMixin, URLProcessingMixin):
 
         # Store parameters for creating TavilyLoader instances
         self.web_paths = web_paths if isinstance(web_paths, list) else [web_paths]
-        self.api_base_url = api_base_url
         self.api_key = api_key
         self.extract_depth = extract_depth
         self.continue_on_failure = continue_on_failure


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27602
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** No documentation changes required.
- [ ] **Dependencies:** No new dependencies.
- [x] **Testing:** Verified by executing the real `get_web_loader` factory pre- and post-fix (details below); end-to-end confirmation with a live Tavily API key is invited from the issue reporter.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Pure removal of a parameter nothing consumes, restoring the pre-v0.11.0 working signature.
- [x] **Git Hygiene:** The PR is atomic (one logical change), based on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

Since v0.11.0, any use of the Tavily **Web Loader Engine** (e.g. `fetch_url`, web-search content loading with the loader set to `tavily`) fails immediately:

```
TypeError: SafeTavilyLoader.__init__() missing 1 required positional argument: 'api_base_url'
```

### Root Cause

Commit `ce4a323f4` (first shipped in v0.11.0) added the Microsoft WebIQ loader — which legitimately takes an `api_base_url` — and, in the same commit, also added `api_base_url: str` as a **required positional parameter** to `SafeTavilyLoader.__init__`. For the Tavily loader the parameter is vestigial on every axis:

- `SafeTavilyLoader` only stores it; neither `lazy_load` nor `alazy_load` passes it to `TavilyLoader`, which hard-codes `https://api.tavily.com/extract`.
- No `TAVILY_API_BASE_URL` config, env var, or admin field exists anywhere in the codebase.
- The `engine == 'tavily'` branch of the `get_web_loader` factory was never updated to supply it — so `WebLoaderClass(**web_loader_args)` raises the `TypeError` on every call.
- It was never even added to the constructor's docstring `Args`.

### Fix

Remove the parameter and its dead assignment, restoring the pre-v0.11.0 working signature:

```diff
     def __init__(
         self,
         web_paths: Union[str, List[str]],
-        api_base_url: str,
         api_key: str,
```

```diff
         # Store parameters for creating TavilyLoader instances
         self.web_paths = web_paths if isinstance(web_paths, list) else [web_paths]
-        self.api_base_url = api_base_url
         self.api_key = api_key
```

Deliberately **not** done: inventing a `TAVILY_API_BASE_URL` config to feed the parameter — `TavilyLoader` cannot accept a custom endpoint, so that would be a new feature (self-hosted Tavily support) disguised as a fix, and is better proposed separately if wanted.

### Fixed

- Fixed the Tavily web loader engine failing on every invocation (`fetch_url`, web loader content extraction) with a `TypeError` since v0.11.0, caused by a vestigial required constructor parameter that nothing supplies or consumes.

---

### Additional Information

- @onikyannn — this should fix your report exactly as filed; if you're able to run your repro (Web Loader Engine `tavily` + valid API key + `fetch_url`) against this branch (`silentoplayz:fix/tavily-loader-vestigial-param`), that end-to-end confirmation with a live key would be the definitive sign-off.
- This PR was prepared with AI copilot assistance and has been thoroughly reviewed by the author.

### Verification Performed

Automated (AI-copilot harness, disclosed as such), executing the **real** `get_web_loader` factory from the shipped module against a scratch environment:

1. **Pristine `dev`**: `get_web_loader('https://example.com', loader_config={'web_loader_engine': 'tavily', 'tavily_api_key': …})` raises byte-for-byte the reported error — `TypeError: SafeTavilyLoader.__init__() missing 1 required positional argument: 'api_base_url'`.
2. **This branch**: the same call succeeds and returns a `SafeTavilyLoader` with the expected `api_key`/`web_paths`.

Ruff finding parity on the touched file: zero findings before and after. Live-API end-to-end testing is delegated to the reporter as above (the author's instance does not use Tavily).

### Screenshots or Videos

- N/A (backend `TypeError`; repro and verification above).

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
