### PR TITLE
fix: list publicly shared read-only notes in the Read Only view

### DIFF
--- a/backend/open_webui/models/access_grants.py
+++ b/backend/open_webui/models/access_grants.py
@@ -839,7 +839,8 @@ class AccessGrantsTable:
     ):
         """
         Filter for items where user has read BUT NOT write access.
-        Public items are NOT considered read_only.
+        A public (user:*) read grant counts as read access, so publicly shared
+        read-only items are listed rather than being reachable only by direct link.
 
         Note: This method builds SQLAlchemy expressions and does NOT perform I/O itself,
         so it remains synchronous. The caller is responsible for executing the query
@@ -850,7 +851,6 @@ class AccessGrantsTable:
 
         from sqlalchemy import exists as sa_exists
 
-        # Has read grant (not public)
         read_grant_exists = (
             select(AccessGrant.id)
             .where(
@@ -858,6 +858,10 @@ class AccessGrantsTable:
                 AccessGrant.resource_id == DocumentModel.id,
                 AccessGrant.permission == 'read',
                 or_(
+                    and_(
+                        AccessGrant.principal_type == 'user',
+                        AccessGrant.principal_id == '*',
+                    ),
                     *(
                         [
                             and_(
@@ -884,7 +888,6 @@ class AccessGrantsTable:
             .exists()
         )
 
-        # Does NOT have write grant
         write_grant_exists = (
             select(AccessGrant.id)
             .where(
@@ -892,6 +895,10 @@ class AccessGrantsTable:
                 AccessGrant.resource_id == DocumentModel.id,
                 AccessGrant.permission == 'write',
                 or_(
+                    and_(
+                        AccessGrant.principal_type == 'user',
+                        AccessGrant.principal_id == '*',
+                    ),
                     *(
                         [
                             and_(
@@ -918,21 +925,7 @@ class AccessGrantsTable:
             .exists()
         )
 
-        # Is NOT public
-        public_grant_exists = (
-            select(AccessGrant.id)
-            .where(
-                AccessGrant.resource_type == resource_type,
-                AccessGrant.resource_id == DocumentModel.id,
-                AccessGrant.permission == 'read',
-                AccessGrant.principal_type == 'user',
-                AccessGrant.principal_id == '*',
-            )
-            .correlate(DocumentModel)
-            .exists()
-        )
-
-        conditions = [read_grant_exists, ~write_grant_exists, ~public_grant_exists]
+        conditions = [read_grant_exists, ~write_grant_exists]
 
         # Not owner
         if user_id:

--- a/backend/open_webui/models/access_grants.py
+++ b/backend/open_webui/models/access_grants.py
@@ -839,7 +839,8 @@ class AccessGrantsTable:
     ):
         """
         Filter for items where user has read BUT NOT write access.
-        Public items are NOT considered read_only.
+        A public (user:*) read grant counts as read access, so publicly shared
+        read-only items are listed rather than being reachable only by direct link.
 
         Note: This method builds SQLAlchemy expressions and does NOT perform I/O itself,
         so it remains synchronous. The caller is responsible for executing the query
@@ -850,7 +851,7 @@ class AccessGrantsTable:
 
         from sqlalchemy import exists as sa_exists
 
-        # Has read grant (not public)
+        # Has read grant (public, direct, or via group)
         read_grant_exists = (
             select(AccessGrant.id)
             .where(
@@ -858,6 +859,10 @@ class AccessGrantsTable:
                 AccessGrant.resource_id == DocumentModel.id,
                 AccessGrant.permission == 'read',
                 or_(
+                    and_(
+                        AccessGrant.principal_type == 'user',
+                        AccessGrant.principal_id == '*',
+                    ),
                     *(
                         [
                             and_(
@@ -884,7 +889,7 @@ class AccessGrantsTable:
             .exists()
         )
 
-        # Does NOT have write grant
+        # Does NOT have write grant (public, direct, or via group)
         write_grant_exists = (
             select(AccessGrant.id)
             .where(
@@ -892,6 +897,10 @@ class AccessGrantsTable:
                 AccessGrant.resource_id == DocumentModel.id,
                 AccessGrant.permission == 'write',
                 or_(
+                    and_(
+                        AccessGrant.principal_type == 'user',
+                        AccessGrant.principal_id == '*',
+                    ),
                     *(
                         [
                             and_(
@@ -918,21 +927,7 @@ class AccessGrantsTable:
             .exists()
         )
 
-        # Is NOT public
-        public_grant_exists = (
-            select(AccessGrant.id)
-            .where(
-                AccessGrant.resource_type == resource_type,
-                AccessGrant.resource_id == DocumentModel.id,
-                AccessGrant.permission == 'read',
-                AccessGrant.principal_type == 'user',
-                AccessGrant.principal_id == '*',
-            )
-            .correlate(DocumentModel)
-            .exists()
-        )
-
-        conditions = [read_grant_exists, ~write_grant_exists, ~public_grant_exists]
+        conditions = [read_grant_exists, ~write_grant_exists]
 
         # Not owner
         if user_id:


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27487
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** No documentation changes required.
- [ ] **Dependencies:** No new dependencies.
- [x] **Testing:** The bug was reproduced live on `dev` by the author (see the issue thread); the fix is verified by executing the real `Notes.search_notes` query path against a scratch database across all grant combinations (details below). Live re-verification on this branch is invited from the reporter.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** The Read Only filter's definition becomes exactly its label — "can read, cannot write" — with public (`user:*`) grants treated the same way `has_access` and every other read path already treats them.
- [x] **Git Hygiene:** The PR is atomic (one logical change), based on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

A note shared **publicly with read-only access** (the share dialog's public toggle without "Allow public write access") is fully readable by every user via direct link — but appears in **no list view whatsoever**. It's absent from the default (Write) notes list, absent from the "Read Only" filter, and absent from the Shared view. Recipients can only ever find it if someone hands them the URL. Toggling public *write* access on makes the note appear (in the Write list), which is how #27487's reporter narrowed it down.

### Root Cause

The Notes list views cover two permission filters: the default list shows notes the user can **write**, and the "Read Only" option shows notes the user can **read but not write** (`_has_read_only_permission_filter` in `models/access_grants.py`). A public read-only note correctly fails the write filter — but the read-only filter excluded it too, on two separate clauses:

1. Its "has read grant" subquery only matched **direct user and group** grants, omitting the public `user:*` principal that `has_access` (direct note access) happily accepts.
2. A third condition, `~public_grant_exists`, excluded any note carrying a public read grant — even when the user **also** holds a direct personal read grant.

The net contract violation: an item the access system says you can read exists in no listing. (The exclusion dates back to the original read-only-notes implementation and was carried into the relational access-grants port, so this is a day-one design gap rather than a recent regression — but the share dialog offers "public + read-only" as a first-class configuration, and configurations whose result is an invisible-yet-accessible note can't be the intended UX.)

### Fix

Make the Read Only filter's semantics exactly its label — *read, but not write*:

- The read-grant subquery now also matches the public `user:*` principal (same treatment as `has_access` and the main `read` filter).
- The write-grant subquery now also matches public **write** grants, so a note with public write access is correctly considered writable and stays out of Read Only.
- The `~public_grant_exists` clause is removed — it's subsumed: public-write notes are excluded by the write check, and public-read notes are precisely what should be listed.
- Owner exclusion (`Note.user_id != user_id`) is unchanged: your own notes are never "Read Only" to you.

The `read_only` permission filter has exactly one consumer in the codebase — the Notes "Read Only" view — so the blast radius is precisely the broken surface.

### Verification (real query path, scratch database)

An AI-copilot harness (disclosed as such) creates notes covering every grant combination and runs the **real** `Notes.search_notes` for a non-owner viewer, pre- and post-fix:

| Note (grants) | Pristine `dev` Read Only | This branch Read Only |
| --- | --- | --- |
| public read (share dialog "public, read-only") | ❌ hidden | ✅ listed |
| public read **+ direct user read** | ❌ hidden | ✅ listed |
| direct user read | ✅ listed | ✅ listed (unchanged) |
| public read + public write | hidden (correct) | hidden (correct — writable) |
| direct read + direct write | hidden (correct) | hidden (correct — writable) |
| no grants (private) | hidden (correct) | hidden (correct) |

Also verified unchanged: the default Write list (`direct-rw`, `public-rw` only, before and after), no private-note leakage, and the owner's Read Only view staying empty for their own notes.

### Fixed

- Fixed publicly shared read-only notes being reachable only by direct link: they now appear in the Notes "Read Only" view, including when a public grant coexists with a direct user grant.

---

### Additional Information

- @skorphil — this makes your publicly-shared read-only notes appear under the **Read Only** filter (Notes → the Write/Read Only dropdown). Verifying on this branch (`silentoplayz:fix/public-read-only-notes-listing`) against your original repro would be welcome. Your broader suggestions in the thread (defaulting the list to all readable notes, search across both permissions) are UX-level changes to Tim's current view design and deserve their own discussion rather than being folded into this fix.
- This PR was prepared with AI copilot assistance and has been thoroughly reviewed by the author.

### Screenshots or Videos

- N/A (list-query fix; verification table above).

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
