### PR TITLE
fix(chat): keep regenerate button visible in High Contrast mode

### DIFF
--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -1384,7 +1384,7 @@
 													<button
 														type="button"
 														aria-label={$i18n.t('Regenerate')}
-														class="{isLastMessage
+														class="{isLastMessage || ($settings?.highContrastMode ?? false)
 															? 'visible'
 															: 'invisible group-hover:visible'} p-1.5 hover:bg-black/5 dark:hover:bg-white/5 rounded-lg dark:hover:text-white hover:text-black transition"
 													>
@@ -1411,7 +1411,7 @@
 												<button
 													type="button"
 													aria-label={$i18n.t('Regenerate')}
-													class="{isLastMessage
+													class="{isLastMessage || ($settings?.highContrastMode ?? false)
 														? 'visible'
 														: 'invisible group-hover:visible'} p-1.5 hover:bg-black/5 dark:hover:bg-white/5 rounded-lg dark:hover:text-white hover:text-black transition regenerate-response-button"
 													on:click={() => {


### PR DESCRIPTION
## Summary

Fixes #27638

Every action button on a response message gates its visibility on:

```svelte
isLastMessage || ($settings?.highContrastMode ?? false) ? 'visible' : 'invisible group-hover:visible'
```

so buttons stay visible (not hover-only) when **High Contrast mode** is enabled. The two **Regenerate** buttons — the one inside `RegenerateMenu` and the fallback in the `{:else}` branch — were missed and still gated on `isLastMessage` alone. As a result, on any non-last message the Regenerate icon was invisible until mouse-over even with High Contrast on.

## Fix

Add the same `highContrastMode` clause to both Regenerate buttons, matching the other action buttons in `ResponseMessage.svelte`. After this change, every `isLastMessage` visibility toggle in the file consistently includes the High Contrast check.

## Testing

Template-only change, structurally identical to the 11 existing `highContrastMode` gates in the same file. Manual repro from the issue:

1. Settings → Interface → enable **High Contrast Mode**
2. Open a chat with at least two AI messages
3. Before: Regenerate icon on earlier messages invisible until hover
4. After: Regenerate icon stays visible on all messages