### PR TITLE
fix: preserve complete user context in agentic retrieval

### DIFF
--- a/backend/open_webui/tools/builtin.py
+++ b/backend/open_webui/tools/builtin.py
@@ -103,11 +103,12 @@ async def _emit_note_updated(request: Request, user: dict, note) -> None:
 
 async def _has_read_access_to_file(
     file,
-    user_id: str,
-    user_role: str,
+    user: dict,
     model_knowledge: Optional[list[dict]] = None,
 ) -> bool:
     """Check if a user can read a file via ownership, admin role, model attachment, or access grants."""
+    user_id = user.get('id')
+    user_role = user.get('role', 'user')
     if file.user_id == user_id or user_role == 'admin':
         return True
     if model_knowledge and any(item.get('type') == 'file' and item.get('id') == file.id for item in model_knowledge):
@@ -117,7 +118,7 @@ async def _has_read_access_to_file(
     return await has_access_to_file(
         file_id=file.id,
         access_type='read',
-        user=UserModel(**{'id': user_id, 'role': user_role}),
+        user=UserModel(**user),
     )
 
 
@@ -2200,8 +2201,6 @@ async def _get_accessible_chat_files(
 ) -> list[tuple[dict, object]]:
     from open_webui.models.files import Files
 
-    user_id = user.get('id')
-    user_role = user.get('role', 'user')
     accessible = []
     seen = set()
 
@@ -2223,7 +2222,7 @@ async def _get_accessible_chat_files(
         seen.add(fid)
 
         file = await Files.get_file_by_id(fid)
-        if file and await _has_read_access_to_file(file, user_id, user_role):
+        if file and await _has_read_access_to_file(file, user):
             accessible.append((normalized, file))
 
     return accessible
@@ -2445,7 +2444,7 @@ async def query_chat_files(
         if not embedding_function and not full_context:
             return JSONCodec.dumps({'error': 'Embedding function not configured'})
 
-        user_model = UserModel.model_validate(__user__)
+        user_model = UserModel(**__user__)
         sources = await get_sources_from_items(
             request=__request__,
             items=file_items,
@@ -2538,7 +2537,7 @@ async def grep_knowledge_files(
             # Single file mode — verify access
             file = await Files.get_file_by_id(file_id)
             if file:
-                if not await _has_read_access_to_file(file, user_id, user_role, __model_knowledge__):
+                if not await _has_read_access_to_file(file, __user__, __model_knowledge__):
                     return JSONCodec.dumps({'error': 'File not found'})
                 files_to_search.append(file)
         elif __model_knowledge__:
@@ -2660,14 +2659,11 @@ async def view_file(
     try:
         from open_webui.models.files import Files
 
-        user_id = __user__.get('id')
-        user_role = __user__.get('role', 'user')
-
         file = await Files.get_file_by_id(file_id)
         if not file:
             return JSONCodec.dumps({'error': 'File not found'})
 
-        if not await _has_read_access_to_file(file, user_id, user_role, __model_knowledge__):
+        if not await _has_read_access_to_file(file, __user__, __model_knowledge__):
             return JSONCodec.dumps({'error': 'File not found'})
 
         content = ''
@@ -3075,7 +3071,7 @@ async def query_knowledge_files(
         embedding_function = getattr(__request__.app.state, 'EMBEDDING_FUNCTION', None)
         if not embedding_function:
             return JSONCodec.dumps({'error': 'Embedding function not configured'})
-        user_model = UserModel.model_validate(__user__)
+        user_model = UserModel(**__user__)
 
         collection_names = []
         external_knowledges = []
@@ -3269,7 +3265,7 @@ async def query_knowledge_bases(
         embedding_function = getattr(__request__.app.state, 'EMBEDDING_FUNCTION', None)
         if not embedding_function:
             return JSONCodec.dumps({'error': 'Embedding function not configured'})
-        user_model = UserModel.model_validate(__user__)
+        user_model = UserModel(**__user__)
         query_embedding = await embedding_function(query, prefix=RAG_EMBEDDING_QUERY_PREFIX, user=user_model)
 
         # Min-heap of (distance, knowledge_base_id) - only holds top `count` results

--- a/backend/open_webui/tools/builtin.py
+++ b/backend/open_webui/tools/builtin.py
@@ -2445,10 +2445,7 @@ async def query_chat_files(
         if not embedding_function and not full_context:
             return JSONCodec.dumps({'error': 'Embedding function not configured'})
 
-        user_model = UserModel.model_construct(
-            id=__user__.get('id'),
-            role=__user__.get('role', 'user'),
-        )
+        user_model = UserModel.model_validate(__user__)
         sources = await get_sources_from_items(
             request=__request__,
             items=file_items,
@@ -3078,7 +3075,7 @@ async def query_knowledge_files(
         embedding_function = getattr(__request__.app.state, 'EMBEDDING_FUNCTION', None)
         if not embedding_function:
             return JSONCodec.dumps({'error': 'Embedding function not configured'})
-        user_model = UserModel.model_construct(id=user_id, role=user_role)
+        user_model = UserModel.model_validate(__user__)
 
         collection_names = []
         external_knowledges = []
@@ -3272,7 +3269,7 @@ async def query_knowledge_bases(
         embedding_function = getattr(__request__.app.state, 'EMBEDDING_FUNCTION', None)
         if not embedding_function:
             return JSONCodec.dumps({'error': 'Embedding function not configured'})
-        user_model = UserModel.model_construct(id=user_id, role=__user__.get('role', 'user'))
+        user_model = UserModel.model_validate(__user__)
         query_embedding = await embedding_function(query, prefix=RAG_EMBEDDING_QUERY_PREFIX, user=user_model)
 
         # Min-heap of (distance, knowledge_base_id) - only holds top `count` results

--- a/backend/open_webui/tools/builtin.py
+++ b/backend/open_webui/tools/builtin.py
@@ -96,11 +96,12 @@ async def _emit_note_updated(request: Request, user: dict, note) -> None:
 
 async def _has_read_access_to_file(
     file,
-    user_id: str,
-    user_role: str,
+    user: dict,
     model_knowledge: Optional[list[dict]] = None,
 ) -> bool:
     """Check if a user can read a file via ownership, admin role, model attachment, or access grants."""
+    user_id = user.get('id')
+    user_role = user.get('role', 'user')
     if file.user_id == user_id or user_role == 'admin':
         return True
     if model_knowledge and any(item.get('type') == 'file' and item.get('id') == file.id for item in model_knowledge):
@@ -110,7 +111,7 @@ async def _has_read_access_to_file(
     return await has_access_to_file(
         file_id=file.id,
         access_type='read',
-        user=UserModel(**{'id': user_id, 'role': user_role}),
+        user=UserModel(**user),
     )
 
 
@@ -2172,8 +2173,6 @@ async def _get_accessible_chat_files(
 ) -> list[tuple[dict, object]]:
     from open_webui.models.files import Files
 
-    user_id = user.get('id')
-    user_role = user.get('role', 'user')
     accessible = []
     seen = set()
 
@@ -2195,7 +2194,7 @@ async def _get_accessible_chat_files(
         seen.add(fid)
 
         file = await Files.get_file_by_id(fid)
-        if file and await _has_read_access_to_file(file, user_id, user_role):
+        if file and await _has_read_access_to_file(file, user):
             accessible.append((normalized, file))
 
     return accessible
@@ -2417,7 +2416,7 @@ async def query_chat_files(
         if not embedding_function and not full_context:
             return json.dumps({'error': 'Embedding function not configured'})
 
-        user_model = UserModel.model_validate(__user__)
+        user_model = UserModel(**__user__)
         sources = await get_sources_from_items(
             request=__request__,
             items=file_items,
@@ -2510,7 +2509,7 @@ async def grep_knowledge_files(
             # Single file mode — verify access
             file = await Files.get_file_by_id(file_id)
             if file:
-                if not await _has_read_access_to_file(file, user_id, user_role, __model_knowledge__):
+                if not await _has_read_access_to_file(file, __user__, __model_knowledge__):
                     return json.dumps({'error': 'File not found'})
                 files_to_search.append(file)
         elif __model_knowledge__:
@@ -2632,14 +2631,11 @@ async def view_file(
     try:
         from open_webui.models.files import Files
 
-        user_id = __user__.get('id')
-        user_role = __user__.get('role', 'user')
-
         file = await Files.get_file_by_id(file_id)
         if not file:
             return json.dumps({'error': 'File not found'})
 
-        if not await _has_read_access_to_file(file, user_id, user_role, __model_knowledge__):
+        if not await _has_read_access_to_file(file, __user__, __model_knowledge__):
             return json.dumps({'error': 'File not found'})
 
         content = ''
@@ -3047,7 +3043,7 @@ async def query_knowledge_files(
         embedding_function = getattr(__request__.app.state, 'EMBEDDING_FUNCTION', None)
         if not embedding_function:
             return json.dumps({'error': 'Embedding function not configured'})
-        user_model = UserModel.model_validate(__user__)
+        user_model = UserModel(**__user__)
 
         collection_names = []
         external_knowledges = []
@@ -3241,7 +3237,7 @@ async def query_knowledge_bases(
         embedding_function = getattr(__request__.app.state, 'EMBEDDING_FUNCTION', None)
         if not embedding_function:
             return json.dumps({'error': 'Embedding function not configured'})
-        user_model = UserModel.model_validate(__user__)
+        user_model = UserModel(**__user__)
         query_embedding = await embedding_function(query, prefix=RAG_EMBEDDING_QUERY_PREFIX, user=user_model)
 
         # Min-heap of (distance, knowledge_base_id) - only holds top `count` results

--- a/backend/open_webui/tools/builtin.py
+++ b/backend/open_webui/tools/builtin.py
@@ -2417,10 +2417,7 @@ async def query_chat_files(
         if not embedding_function and not full_context:
             return json.dumps({'error': 'Embedding function not configured'})
 
-        user_model = UserModel.model_construct(
-            id=__user__.get('id'),
-            role=__user__.get('role', 'user'),
-        )
+        user_model = UserModel.model_validate(__user__)
         sources = await get_sources_from_items(
             request=__request__,
             items=file_items,
@@ -3050,7 +3047,7 @@ async def query_knowledge_files(
         embedding_function = getattr(__request__.app.state, 'EMBEDDING_FUNCTION', None)
         if not embedding_function:
             return json.dumps({'error': 'Embedding function not configured'})
-        user_model = UserModel.model_construct(id=user_id, role=user_role)
+        user_model = UserModel.model_validate(__user__)
 
         collection_names = []
         external_knowledges = []
@@ -3244,7 +3241,7 @@ async def query_knowledge_bases(
         embedding_function = getattr(__request__.app.state, 'EMBEDDING_FUNCTION', None)
         if not embedding_function:
             return json.dumps({'error': 'Embedding function not configured'})
-        user_model = UserModel.model_construct(id=user_id, role=__user__.get('role', 'user'))
+        user_model = UserModel.model_validate(__user__)
         query_embedding = await embedding_function(query, prefix=RAG_EMBEDDING_QUERY_PREFIX, user=user_model)
 
         # Min-heap of (distance, knowledge_base_id) - only holds top `count` results


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27641.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [x] **Documentation:** Not required, this fixes internal user-context propagation without changing configuration or behavior..
- [x] **Dependencies:** No dependencies were added or updated.
- [x] **Testing:** Manual tests have been performed to verify the fix works correctly and does not introduce regressions.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No settings or architectural changes were introduced.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses **fix**

# Changelog Entry

### Description

Agentic retrieval tools receive a complete user dictionary through `__user__`, but four code paths rebuilt an incomplete `UserModel` containing only `id` and `role`.

Three paths used `model_construct`, producing an object without required `name` and `email` attributes. With `ENABLE_FORWARD_USER_INFO_HEADERS=true`, embedding and external reranking requests dereference those attributes while preparing the forwarded identity headers. This caused `query_chat_files`, `query_knowledge_files`, and `query_knowledge_bases` to fail before completing retrieval. With the setting disabled, those three paths do not normally dereference the missing identity fields, so this specific failure is not triggered.

The fourth path used the validating constructor with the same partial data. It raised a `ValidationError` when a regular non-owner accessed a file through an access grant. Owner, administrator, and directly attached-file paths returned early, which masked this failure. Unlike the other three paths, this failure does not depend on `ENABLE_FORWARD_USER_INFO_HEADERS` and can occur with the default setting.

This PR consistently constructs `UserModel` from the complete injected user context:

```python
user_model = UserModel(**__user__)
```

It also passes that complete context through `_has_read_access_to_file`, allowing the existing `has_access_to_file` authorization check to return its intended decision.

### Fixed

- Fixed `query_chat_files`, `query_knowledge_files`, and `query_knowledge_bases` failing with `ENABLE_FORWARD_USER_INFO_HEADERS=true` because downstream services received a partial `UserModel`.
- Fixed granted file access failing with missing `email` and `name` validation errors for regular non-owner users.
- Preserved user fields needed by plain forwarded headers and forwarded-user JWTs.

### Security

- Authorization rules are unchanged. Ownership, administrator access, direct model attachment, and access-grant checks retain their existing behavior.
- The access-grant fallback continues to delegate the decision to `has_access_to_file`; this change only supplies the complete validated user record it requires.

---

### Additional Information

- No dependencies or settings were added.
- Documentation changes are not required.
- `UserModel(**__user__)` matches the established construction pattern used elsewhere in `builtin.py`.
- The complete user dictionary is already supplied by middleware; the affected paths were discarding required fields.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
