### PR TITLE
fix: keep regenerate button visible in High Contrast mode

### DIFF
--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -1384,7 +1384,7 @@
 													<button
 														type="button"
 														aria-label={$i18n.t('Regenerate')}
-														class="{isLastMessage
+														class="{isLastMessage || ($settings?.highContrastMode ?? false)
 															? 'visible'
 															: 'invisible group-hover:visible'} p-1.5 hover:bg-black/5 dark:hover:bg-white/5 rounded-lg dark:hover:text-white hover:text-black transition"
 													>
@@ -1411,7 +1411,7 @@
 												<button
 													type="button"
 													aria-label={$i18n.t('Regenerate')}
-													class="{isLastMessage
+													class="{isLastMessage || ($settings?.highContrastMode ?? false)
 														? 'visible'
 														: 'invisible group-hover:visible'} p-1.5 hover:bg-black/5 dark:hover:bg-white/5 rounded-lg dark:hover:text-white hover:text-black transition regenerate-response-button"
 													on:click={() => {


### PR DESCRIPTION
# Pull Request Checklist

Closes #27638

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27638
- [x] **Target branch:** Targets the `dev` branch.
- [x] **Description:** See changelog below.
- [x] **Changelog:** Included below.
- [x] **Testing:** Manual repro from the issue verified.
- [x] **No Unchecked AI Code:** Reviewed and manually tested.
- [x] **Self-Review:** Matches the 11 existing `highContrastMode` gates in the same file.
- [x] **Architecture:** No new settings; uses the existing High Contrast toggle.
- [x] **Git Hygiene:** Atomic single commit, rebased on `dev`.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

Every action button on a response message gates its visibility on `isLastMessage || ($settings?.highContrastMode ?? false)` so buttons stay visible (not hover-only) when High Contrast mode is on. The two **Regenerate** buttons — the one inside `RegenerateMenu` and the fallback in the `{:else}` branch — were missed and still gated on `isLastMessage` alone, so on any non-last message the Regenerate icon was invisible until mouse-over even with High Contrast enabled.

### Fixed

- Added the `highContrastMode` clause to both Regenerate buttons in `ResponseMessage.svelte`, matching the other action buttons. After this change every `isLastMessage` visibility toggle in the file consistently includes the High Contrast check.

### Additional Information

Repro: Settings → Interface → enable **High Contrast Mode** → open a chat with 2+ AI messages. Before: Regenerate icon on earlier messages invisible until hover. After: stays visible on all messages.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.