### PR TITLE
fix: render code editor drawer above settings modal

### DIFF
--- a/src/lib/components/common/CodeEditorModal.svelte
+++ b/src/lib/components/common/CodeEditorModal.svelte
@@ -26,7 +26,7 @@
 	});
 </script>
 
-<Drawer bind:show className="h-full">
+<Drawer bind:show className="h-full" zIndexClass="z-99999">
 	<div class="flex h-full flex-col">
 		<div
 			class=" sticky top-0 z-30 flex justify-between bg-white px-4.5 pt-3 pb-3 dark:bg-gray-900 dark:text-gray-100"

--- a/src/lib/components/common/Drawer.svelte
+++ b/src/lib/components/common/Drawer.svelte
@@ -5,6 +5,7 @@
 
 	export let show = false;
 	export let className = '';
+	export let zIndexClass = 'z-999';
 	export let onClose = () => {};
 
 	let modalElement = null;
@@ -57,7 +58,7 @@
 {#if show}
 	<div
 		bind:this={modalElement}
-		class="modal fixed right-0 bottom-0 left-0 z-999 flex h-screen max-h-[100dvh] w-full justify-center overflow-hidden overscroll-contain bg-black/60"
+		class="modal fixed right-0 bottom-0 left-0 {zIndexClass} flex h-screen max-h-[100dvh] w-full justify-center overflow-hidden overscroll-contain bg-black/60"
 		in:fly={{ y: 100, duration: 100 }}
 		on:mousedown={() => {
 			show = false;


### PR DESCRIPTION
# Pull Request Checklist

Closes #27647

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27647
- [x] **Target branch:** Targets the `dev` branch.
- [x] **Description:** See changelog below.
- [x] **Changelog:** Included below.
- [x] **Testing:** Manual repro from the issue verified.
- [x] **No Unchecked AI Code:** Reviewed and manually tested.
- [x] **Self-Review:** Backward-compatible; default Drawer z-index unchanged.
- [x] **Architecture:** No new settings; reuses existing z-index scale.
- [x] **Git Hygiene:** Atomic single commit, rebased on `dev`.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

The ComfyUI `workflow.json` **Edit** drawer (`CodeEditorModal` → `Drawer`) used `z-999`, while the admin Settings dialog (`Modal`) uses `z-9999`. Since both are appended to `<body>`, the drawer rendered **behind** the settings dialog and appeared to open "in the background".

### Fixed

- Added an optional `zIndexClass` prop to `Drawer` (default `z-999`, preserving existing behaviour for all other callers).
- `CodeEditorModal` now passes `z-99999` so the editor surfaces above any enclosing modal.

### Additional Information

Repro: Admin Settings → Images → set engine to ComfyUI → click **Edit** on the workflow. Before: the editor opened behind the settings dialog. After: it appears on top.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.