### PR TITLE
fix(docker): make model cache world-readable for runAsNonRoot sidecars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -162,6 +162,11 @@ RUN set -e; \
     fi; \
     fi; \
     mkdir -p /app/backend/data; chown -R $UID:$GID /app/backend/data/; \
+    # huggingface_hub creates some cache files (e.g. trees/*.json) with 0600
+    # permissions. When the pod runs with runAsNonRoot and a sidecar copies
+    # the data volume, those files are unreadable (#27651). Make the model
+    # cache world-readable so any UID can copy it.
+    chmod -R a+rX /app/backend/data/cache/ 2>/dev/null || true; \
     rm -rf /var/lib/apt/lists/*;
 
 # Install Ollama if requested


### PR DESCRIPTION
# Pull Request Checklist

Closes #27651

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27651
- [x] **Target branch:** Targets the `dev` branch.
- [x] **Description:** See changelog below.
- [x] **Changelog:** Included below.
- [x] **Testing:** Verified the permission bits on the whisper cache files.
- [x] **No Unchecked AI Code:** Reviewed and manually tested.
- [x] **Self-Review:** Minimal, guarded change.
- [x] **Architecture:** No new settings; fixes existing build step.
- [x] **Git Hygiene:** Atomic single commit, rebased on `dev`.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

`huggingface_hub` creates some cache files (e.g. whisper `trees/*.json`) with `0600` permissions owned by root. The build `chown`s the data dir to the app UID but leaves those mode bits, so when a pod runs with `runAsNonRoot` and a sidecar copies the data volume, the copy fails with `Permission denied`.

### Fixed

- Added `chmod -R a+rX /app/backend/data/cache/` after the `chown` so any UID can read the cached model files. Guarded with `|| true` for slim/CUDA images that defer the download to first use.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.