### PR TITLE
feat: emit user.updated on OAuth profile sync

### DIFF
--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -1955,6 +1955,8 @@ class OAuthManager:
                         data={'role': determined_role, 'provider': provider},
                     )
 
+                synced_fields = []
+
                 if auth_config.OAUTH_UPDATE_NAME_ON_LOGIN:
                     username_claim = auth_config.OAUTH_USERNAME_CLAIM
                     if username_claim:
@@ -1962,6 +1964,7 @@ class OAuthManager:
                         if new_name and new_name != user.name:
                             await Users.update_user_by_id(user.id, {'name': new_name}, db=db)
                             user.name = new_name
+                            synced_fields.append('name')
                             log.debug('Updated name for user %s', user.email)
 
                 if auth_config.OAUTH_UPDATE_EMAIL_ON_LOGIN:
@@ -1977,6 +1980,7 @@ class OAuthManager:
                             else:
                                 await Auths.update_email_by_id(user.id, new_email.lower(), db=db)
                                 user.email = new_email.lower()
+                                synced_fields.append('email')
                                 log.debug('Updated email for user %s', user.id)
 
                 # Update profile picture if enabled and different from current
@@ -1992,7 +1996,18 @@ class OAuthManager:
                         )
                         if processed_picture_url != user.profile_image_url:
                             await Users.update_user_profile_image_url_by_id(user.id, processed_picture_url, db=db)
+                            synced_fields.append('profile_image_url')
                             log.debug('Updated profile picture for user %s', user.email)
+
+                if synced_fields:
+                    await publish_event(
+                        request,
+                        EVENTS.USER_UPDATED,
+                        actor=user,
+                        subject_id=user.id,
+                        source='oauth',
+                        data={'updated_fields': synced_fields, 'provider': provider},
+                    )
             else:
                 # If the user does not exist, check if signups are enabled
                 if auth_config.ENABLE_OAUTH_SIGNUP:

--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -1909,6 +1909,8 @@ class OAuthManager:
                     # to avoid problems with the ENABLE_OAUTH_GROUP_MANAGEMENT check below
                     user.role = determined_role
 
+                synced_fields = []
+
                 if auth_config.OAUTH_UPDATE_NAME_ON_LOGIN:
                     username_claim = auth_config.OAUTH_USERNAME_CLAIM
                     if username_claim:
@@ -1916,6 +1918,7 @@ class OAuthManager:
                         if new_name and new_name != user.name:
                             await Users.update_user_by_id(user.id, {'name': new_name}, db=db)
                             user.name = new_name
+                            synced_fields.append('name')
                             log.debug(f'Updated name for user {user.email}')
 
                 if auth_config.OAUTH_UPDATE_EMAIL_ON_LOGIN:
@@ -1931,6 +1934,7 @@ class OAuthManager:
                             else:
                                 await Auths.update_email_by_id(user.id, new_email.lower(), db=db)
                                 user.email = new_email.lower()
+                                synced_fields.append('email')
                                 log.debug(f'Updated email for user {user.id}')
 
                 # Update profile picture if enabled and different from current
@@ -1946,7 +1950,18 @@ class OAuthManager:
                         )
                         if processed_picture_url != user.profile_image_url:
                             await Users.update_user_profile_image_url_by_id(user.id, processed_picture_url, db=db)
+                            synced_fields.append('profile_image_url')
                             log.debug(f'Updated profile picture for user {user.email}')
+
+                if synced_fields:
+                    await publish_event(
+                        request,
+                        EVENTS.USER_UPDATED,
+                        actor=user,
+                        subject_id=user.id,
+                        source='oauth',
+                        data={'updated_fields': synced_fields, 'provider': provider},
+                    )
             else:
                 # If the user does not exist, check if signups are enabled
                 if auth_config.ENABLE_OAUTH_SIGNUP:


### PR DESCRIPTION
With OAUTH_UPDATE_NAME_ON_LOGIN, OAUTH_UPDATE_EMAIL_ON_LOGIN or OAUTH_UPDATE_PICTURE_ON_LOGIN enabled, OWUI rewrites the stored name, email and profile picture from the IdP claims on every SSO login. Those writes emitted nothing, so an account whose email or display name is driven entirely by the IdP could change underneath every event consumer without a single event.

Emits one user.updated per login carrying data.updated_fields, published only when at least one field was actually persisted, so a login that changes nothing stays silent. This matches how the admin user-update endpoint reports the same fields, and the payload carries source "oauth" and data.provider like the other events on this callback.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
