### PR TITLE
fix: send stream_options.include_usage for backend-initiated chats

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -1093,6 +1093,9 @@ async def chat_completion(
             model = model_item
             await _set_direct_model(request, model, user)
 
+        # Read before the fallback below can rebind model to a different one.
+        model_capabilities = ((model.get('info') or {}).get('meta') or {}).get('capabilities') or {}
+
         # Model params: global defaults as base, per-model overrides win
         default_model_params = await Config.get('models.default_params', {}) or {}
         model_info_params = {
@@ -1132,6 +1135,10 @@ async def chat_completion(
         # Model Params
         if model_info_params.get('stream_response') is not None:
             form_data['stream'] = model_info_params.get('stream_response')
+
+        # Providers only report token counts when asked, so ask on every caller's behalf.
+        if form_data.get('stream') and model_capabilities.get('usage'):
+            form_data['stream_options'] = {**(form_data.get('stream_options') or {}), 'include_usage': True}
 
         if model_info_params.get('stream_delta_chunk_size'):
             stream_delta_chunk_size = model_info_params.get('stream_delta_chunk_size')
@@ -1935,13 +1942,6 @@ async def generate_messages(
 
     # Convert Anthropic payload to OpenAI format
     openai_payload = convert_anthropic_to_openai_payload(form_data, passthrough_params)
-    model_meta = model_info.meta.model_dump() if model_info and model_info.meta else {}
-    if (model_meta.get('capabilities') or {}).get('usage') is True:
-        if openai_payload.get('stream'):
-            stream_options = openai_payload.get('stream_options')
-            if not isinstance(stream_options, dict):
-                stream_options = {}
-            openai_payload['stream_options'] = {**stream_options, 'include_usage': True}
 
     # Route through the existing chat_completion handler
     response = await chat_completion(request, openai_payload, user)

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -3180,15 +3180,7 @@
 							}
 						: {}),
 					follow_up_generation: $settings?.autoFollowUps ?? true
-				},
-
-				...(stream && (model.info?.meta?.capabilities?.usage ?? false)
-					? {
-							stream_options: {
-								include_usage: true
-							}
-						}
-					: {})
+				}
 			},
 			`${WEBUI_BASE_URL}/api`
 		).catch(async (error) => {


### PR DESCRIPTION
Only the frontend added `stream_options: {include_usage: true}` to the completion payload, gated on the model's `usage` capability. Every backend-initiated run builds its own payload (automations, timers, subagents, channels) and omitted it, so those responses came back without token counts and never rendered the usage block, even with the capability enabled on the model.

Set it in `chat_completion` instead, the single handler all of those callers go through, and drop the two duplicate copies (the Anthropic-compat handler and the frontend). Capabilities are read from the resolved model before the custom-model fallback can rebind it, and the flag is applied after the model's `stream_response` override so a non-streaming model is unaffected.

Fixes #27653

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
