### PR TITLE
feat: download Open Terminal files linked in a chat message

### DIFF
--- a/src/lib/components/chat/Messages/ContentRenderer.svelte
+++ b/src/lib/components/chat/Messages/ContentRenderer.svelte
@@ -1,5 +1,5 @@
 <script>
-	import { onDestroy, onMount, tick, getContext } from 'svelte';
+	import { onDestroy, onMount, tick, getContext, setContext } from 'svelte';
 	const i18n = getContext('i18n');
 
 	import Markdown from './Markdown.svelte';
@@ -15,6 +15,9 @@
 	} from '$lib/stores';
 	import FloatingButtons from '../ContentRenderer/FloatingButtons.svelte';
 	import { createMessagesList, replaceOutsideCode } from '$lib/utils';
+
+	// Only assistant output may point at paths on the terminal
+	setContext('allowTerminalFileLinks', true);
 
 	/**
 	 * Extracts all top-level <details>...</details> blocks from content,

--- a/src/lib/components/chat/Messages/Markdown/MarkdownInlineTokens.svelte
+++ b/src/lib/components/chat/Messages/Markdown/MarkdownInlineTokens.svelte
@@ -7,9 +7,12 @@
 	import { goto } from '$app/navigation';
 
 	const i18n = getContext('i18n');
+	const allowTerminalFileLinks = getContext<boolean>('allowTerminalFileLinks');
 
 	import { WEBUI_BASE_URL } from '$lib/constants';
-	import { copyToClipboard, unescapeHtml } from '$lib/utils';
+	import { selectedTerminalId, showControls, showFileNavPath } from '$lib/stores';
+	import { copyToClipboard, displayFileHandler, unescapeHtml } from '$lib/utils';
+	import { terminalPath } from '$lib/utils/terminal';
 
 	import Image from '$lib/components/common/Image.svelte';
 	import KatexRenderer from './KatexRenderer.svelte';
@@ -46,10 +49,19 @@
 	};
 
 	/**
-	 * Handle link clicks - intercept same-origin app URLs for in-app navigation
+	 * Handle link clicks - open terminal paths, intercept same-origin app URLs
 	 */
 	const handleLinkClick = (e: MouseEvent, href: string) => {
 		try {
+			// A filesystem path points at the terminal the chat is attached to, not an app
+			// route, so open it in the file browser instead of resolving it against the origin
+			const path = allowTerminalFileLinks && $selectedTerminalId ? terminalPath(href) : null;
+			if (path) {
+				e.preventDefault();
+				displayFileHandler(path, { showControls, showFileNavPath });
+				return;
+			}
+
 			const url = new URL(href, window.location.origin);
 			// Check if same origin and an in-app route
 			if (

--- a/src/lib/components/chat/Messages/MultiResponseMessages.svelte
+++ b/src/lib/components/chat/Messages/MultiResponseMessages.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { onMount, tick, getContext } from 'svelte';
+	import { onMount, tick, getContext, setContext } from 'svelte';
 	import { createEventDispatcher } from 'svelte';
 
 	import { mobile, models, settings } from '$lib/stores';
@@ -21,6 +21,9 @@
 	import equal from 'fast-deep-equal';
 	import { formatMessageTimestamp, formatMessageTimestampFull } from '$lib/utils';
 	const i18n = getContext('i18n');
+
+	// Assistant output; the merged response renders Markdown directly
+	setContext('allowTerminalFileLinks', true);
 
 	export let chatId;
 	export let history;

--- a/src/lib/components/chat/Messages/MultiResponseMessages.svelte
+++ b/src/lib/components/chat/Messages/MultiResponseMessages.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { onMount, tick, getContext } from 'svelte';
+	import { onMount, tick, getContext, setContext } from 'svelte';
 	import { createEventDispatcher } from 'svelte';
 
 	import { mobile, models, settings } from '$lib/stores';
@@ -20,6 +20,9 @@
 	import equal from 'fast-deep-equal';
 	import { formatMessageTimestamp, formatMessageTimestampFull } from '$lib/utils';
 	const i18n = getContext('i18n');
+
+	// Assistant output; the merged response renders Markdown directly
+	setContext('allowTerminalFileLinks', true);
 
 	export let chatId;
 	export let history;

--- a/src/lib/utils/terminal.ts
+++ b/src/lib/utils/terminal.ts
@@ -1,0 +1,78 @@
+// Tracks the top-level names under src/routes and static/, plus the backend's mounts
+const APP_ROUTES = [
+	'_app',
+	'admin',
+	'api',
+	'assets',
+	'audio',
+	'auth',
+	'automations',
+	'c',
+	'cache',
+	'calendar',
+	'channels',
+	'error',
+	'folders',
+	'notes',
+	'oauth',
+	'ollama',
+	'openai',
+	'playground',
+	'pyodide',
+	's',
+	'static',
+	'watch',
+	'workspace',
+	'ws'
+];
+
+/**
+ * Models link files on the terminal with an invented scheme (file://, sandbox:/…)
+ * or a bare filesystem path. Returns the path such a link points at, or null if it
+ * is a normal web or in-app link. A `file://` authority is read as a directory,
+ * since models write `file://home/user/…` for `/home/user/…`.
+ */
+export const terminalPath = (href: string): string | null => {
+	const scheme = href.match(/^([a-z][a-z0-9+.-]*):/i)?.[1]?.toLowerCase();
+	if (href.startsWith('//') || (scheme && scheme !== 'file' && scheme !== 'sandbox')) {
+		return null;
+	}
+
+	const raw = (scheme ? href.slice(scheme.length + 1) : href).split(/[?#]/)[0];
+
+	// A schemeless host is a web link the model forgot to write in full
+	if (!scheme && !raw.startsWith('/') && /^[^/.][^/]*\.[a-z]{2,}(\/|$)/i.test(raw)) {
+		return null;
+	}
+
+	// Malformed escapes throw; fall back to the encoded form
+	let decoded: string;
+	try {
+		decoded = decodeURIComponent(raw);
+	} catch {
+		decoded = raw;
+	}
+
+	const segments: string[] = [];
+	for (const segment of decoded.split('/')) {
+		if (!segment || segment === '.') {
+			continue;
+		}
+		if (segment === '..') {
+			segments.pop();
+		} else {
+			segments.push(segment);
+		}
+	}
+
+	// '/home' is an Open WebUI route, but '/home/user/…' is the terminal's home directory
+	if (
+		!segments.length ||
+		(segments.length === 1 && segments[0] === 'home') ||
+		APP_ROUTES.includes(segments[0])
+	) {
+		return null;
+	}
+
+	return '/' + segments.join('/');
+};


### PR DESCRIPTION
When a model creates a file through the Open Terminal integration it routinely presents that file to the user as a markdown link, using either the bare filesystem path (`/home/user/report.xlsx`) or an invented scheme (`file://`, `sandbox:/mnt/data/…`). The browser resolves those against the Open WebUI origin, so clicking them returns 404 even though the file exists and the Open Terminal file browser can preview and download it. The user has to open the sidebar and locate the file by hand.

Such links now download the file through the same authenticated action the file browser already uses. The href is left exactly as the model wrote it; the click is intercepted at render time, so stored message content is untouched and nothing is injected into the model's output.

A link is treated as a terminal path only inside assistant output, only while a terminal is attached to the chat, and only when the href is not an ordinary web link: a scheme other than `file:` or `sandbox:` is rejected, as are protocol-relative URLs and `.`/`..` segments, and the path must have both a directory and a file extension, which is what a generated file looks like and what Open WebUI's own routes never do. User messages, citations, uploaded documents and channel messages are excluded, so only content the model produced can point at the terminal filesystem.

Fixes #27650

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
