### PR TITLE
fix: keep local-only accounts out of the SCIM endpoints

### DIFF
--- a/backend/open_webui/models/users.py
+++ b/backend/open_webui/models/users.py
@@ -284,6 +284,7 @@ class UsersTable:
         role: str = 'pending',
         username: str | None = None,
         oauth: dict | None = None,
+        scim: dict | None = None,
         db: AsyncSession | None = None,
     ) -> UserModel | None:
         try:
@@ -304,6 +305,7 @@ class UsersTable:
                     'updated_at': int(time.time()),
                     'username': username,
                     'oauth': oauth,
+                    'scim': scim,
                 }
             )
             result = User(**user.model_dump())
@@ -449,6 +451,10 @@ class UsersTable:
                             )
                         )
                     )
+
+                if filter.get('externally_managed'):
+                    # An absent identity is stored as the JSON literal null, not only as SQL NULL
+                    stmt = stmt.filter(or_(User.oauth.cast(String) != 'null', User.scim.cast(String) != 'null'))
 
                 roles = filter.get('roles')
                 if roles:

--- a/backend/open_webui/routers/scim.py
+++ b/backend/open_webui/routers/scim.py
@@ -316,6 +316,17 @@ def get_scim_provider() -> str:
     return SCIM_AUTH_PROVIDER
 
 
+def is_externally_managed(user: UserModel) -> bool:
+    """True when an identity provider backs the account; OAuth links count, purely local accounts do not."""
+    return user.scim is not None or user.oauth is not None
+
+
+async def get_scim_user_by_id(user_id: str, db=None) -> Optional[UserModel]:
+    """Resolve a user for SCIM, treating local-only accounts as non-existent."""
+    user = await Users.get_user_by_id(user_id, db=db)
+    return user if user and is_externally_managed(user) else None
+
+
 async def find_user_by_external_id(external_id: str, db=None) -> Optional[UserModel]:
     """Find a user by SCIM externalId, falling back to OAuth sub match."""
     provider = get_scim_provider()
@@ -513,24 +524,23 @@ async def get_users(
     limit = count
 
     # Get users from database
-    if filter:
-        # Simple filter parsing - supports userName eq, externalId eq
-        if 'userName eq' in filter:
-            email = filter.split('"')[1]
-            user = await Users.get_user_by_email(email, db=db)
-            users_list = [user] if user else []
-            total = 1 if user else 0
-        elif 'externalId eq' in filter:
-            external_id = filter.split('"')[1]
-            user = await find_user_by_external_id(external_id, db=db)
-            users_list = [user] if user else []
-            total = 1 if user else 0
-        else:
-            response = await Users.get_users(skip=skip, limit=limit, db=db)
-            users_list = response['users']
-            total = response['total']
+    # Simple filter parsing - supports userName eq, externalId eq
+    filter = filter or ''
+    if 'userName eq' in filter:
+        email = filter.split('"')[1]
+        user = await Users.get_user_by_email(email, db=db)
+        users_list = [user] if user and is_externally_managed(user) else []
+        total = len(users_list)
+    elif 'externalId eq' in filter:
+        external_id = filter.split('"')[1]
+        user = await find_user_by_external_id(external_id, db=db)
+        users_list = [user] if user else []
+        total = len(users_list)
     else:
-        response = await Users.get_users(skip=skip, limit=limit, db=db)
+        # order_by keeps the default ordering that a non-empty filter would otherwise suppress
+        response = await Users.get_users(
+            filter={'externally_managed': True, 'order_by': 'created_at'}, skip=skip, limit=limit, db=db
+        )
         users_list = response['users']
         total = response['total']
 
@@ -553,7 +563,7 @@ async def get_user(
     db: AsyncSession = Depends(get_async_session),
 ):
     """Get SCIM User by ID"""
-    user = await Users.get_user_by_id(user_id, db=db)
+    user = await get_scim_user_by_id(user_id, db=db)
     if not user:
         return scim_error(status_code=status.HTTP_404_NOT_FOUND, detail=f'User {user_id} not found')
 
@@ -615,6 +625,8 @@ async def create_user(
         email=email,
         profile_image_url=profile_image,
         role='user' if user_data.active else 'pending',
+        # Stamped even without an externalId, else the account is invisible to SCIM
+        scim={get_scim_provider(): {'external_id': user_data.externalId}},
         db=db,
     )
 
@@ -623,12 +635,6 @@ async def create_user(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail='Failed to create user',
         )
-
-    # Store externalId in the scim field
-    if user_data.externalId:
-        provider = get_scim_provider()
-        await Users.update_user_scim_by_id(user_id, provider, user_data.externalId, db=db)
-        new_user = await Users.get_user_by_id(user_id, db=db)
 
     await publish_event(
         request,
@@ -654,7 +660,7 @@ async def update_user(
     db: AsyncSession = Depends(get_async_session),
 ):
     """Update SCIM User (full update)"""
-    user = await Users.get_user_by_id(user_id, db=db)
+    user = await get_scim_user_by_id(user_id, db=db)
     if not user:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -734,7 +740,7 @@ async def patch_user(
     db: AsyncSession = Depends(get_async_session),
 ):
     """Update SCIM User (partial update)"""
-    user = await Users.get_user_by_id(user_id, db=db)
+    user = await get_scim_user_by_id(user_id, db=db)
     if not user:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -808,7 +814,7 @@ async def delete_user(
     db: AsyncSession = Depends(get_async_session),
 ):
     """Delete SCIM User"""
-    user = await Users.get_user_by_id(user_id, db=db)
+    user = await get_scim_user_by_id(user_id, db=db)
     if not user:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/backend/open_webui/routers/scim.py
+++ b/backend/open_webui/routers/scim.py
@@ -316,6 +316,17 @@ def get_scim_provider() -> str:
     return SCIM_AUTH_PROVIDER
 
 
+def is_externally_managed(user: UserModel) -> bool:
+    """True when an identity provider backs the account; OAuth links count, purely local accounts do not."""
+    return user.scim is not None or user.oauth is not None
+
+
+async def get_scim_user_by_id(user_id: str, db=None) -> Optional[UserModel]:
+    """Resolve a user for SCIM, treating local-only accounts as non-existent."""
+    user = await Users.get_user_by_id(user_id, db=db)
+    return user if user and is_externally_managed(user) else None
+
+
 async def find_user_by_external_id(external_id: str, db=None) -> Optional[UserModel]:
     """Find a user by SCIM externalId, falling back to OAuth sub match."""
     provider = get_scim_provider()
@@ -513,24 +524,23 @@ async def get_users(
     limit = count
 
     # Get users from database
-    if filter:
-        # Simple filter parsing - supports userName eq, externalId eq
-        if 'userName eq' in filter:
-            email = filter.split('"')[1]
-            user = await Users.get_user_by_email(email, db=db)
-            users_list = [user] if user else []
-            total = 1 if user else 0
-        elif 'externalId eq' in filter:
-            external_id = filter.split('"')[1]
-            user = await find_user_by_external_id(external_id, db=db)
-            users_list = [user] if user else []
-            total = 1 if user else 0
-        else:
-            response = await Users.get_users(skip=skip, limit=limit, db=db)
-            users_list = response['users']
-            total = response['total']
+    # Simple filter parsing - supports userName eq, externalId eq
+    filter = filter or ''
+    if 'userName eq' in filter:
+        email = filter.split('"')[1]
+        user = await Users.get_user_by_email(email, db=db)
+        users_list = [user] if user and is_externally_managed(user) else []
+        total = len(users_list)
+    elif 'externalId eq' in filter:
+        external_id = filter.split('"')[1]
+        user = await find_user_by_external_id(external_id, db=db)
+        users_list = [user] if user else []
+        total = len(users_list)
     else:
-        response = await Users.get_users(skip=skip, limit=limit, db=db)
+        # order_by keeps the default ordering that a non-empty filter would otherwise suppress
+        response = await Users.get_users(
+            filter={'externally_managed': True, 'order_by': 'created_at'}, skip=skip, limit=limit, db=db
+        )
         users_list = response['users']
         total = response['total']
 
@@ -553,7 +563,7 @@ async def get_user(
     db: AsyncSession = Depends(get_async_session),
 ):
     """Get SCIM User by ID"""
-    user = await Users.get_user_by_id(user_id, db=db)
+    user = await get_scim_user_by_id(user_id, db=db)
     if not user:
         return scim_error(status_code=status.HTTP_404_NOT_FOUND, detail=f'User {user_id} not found')
 
@@ -615,6 +625,8 @@ async def create_user(
         email=email,
         profile_image_url=profile_image,
         role='user' if user_data.active else 'pending',
+        # Stamped even without an externalId, else the account is invisible to SCIM
+        scim={get_scim_provider(): {'external_id': user_data.externalId}},
         db=db,
     )
 
@@ -623,12 +635,6 @@ async def create_user(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail='Failed to create user',
         )
-
-    # Store externalId in the scim field
-    if user_data.externalId:
-        provider = get_scim_provider()
-        await Users.update_user_scim_by_id(user_id, provider, user_data.externalId, db=db)
-        new_user = await Users.get_user_by_id(user_id, db=db)
 
     await publish_event(
         request,
@@ -654,7 +660,7 @@ async def update_user(
     db: AsyncSession = Depends(get_async_session),
 ):
     """Update SCIM User (full update)"""
-    user = await Users.get_user_by_id(user_id, db=db)
+    user = await get_scim_user_by_id(user_id, db=db)
     if not user:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -722,7 +728,7 @@ async def patch_user(
     db: AsyncSession = Depends(get_async_session),
 ):
     """Update SCIM User (partial update)"""
-    user = await Users.get_user_by_id(user_id, db=db)
+    user = await get_scim_user_by_id(user_id, db=db)
     if not user:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -783,7 +789,7 @@ async def delete_user(
     db: AsyncSession = Depends(get_async_session),
 ):
     """Delete SCIM User"""
-    user = await Users.get_user_by_id(user_id, db=db)
+    user = await get_scim_user_by_id(user_id, db=db)
     if not user:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,


### PR DESCRIPTION
The SCIM `/Users` endpoints operated on every account in the database, not just the ones an identity provider had provisioned. `GET /Users` listed local accounts, and `GET`, `PUT`, `PATCH` and `DELETE /Users/{id}` accepted their ids, so an IdP running a pruning sync saw accounts it had never created, concluded they should not exist, and deleted them. That is how a deliberately local admin account, kept out of SCIM precisely so a sync issue could never remove admin access, got deleted.

SCIM now only sees accounts that have an identity provider behind them: a SCIM record or an OAuth link. Purely local accounts are invisible to the list endpoint, and addressing one by id returns 404, so an IdP can neither enumerate nor delete them. The list filter runs in SQL so `totalResults` and paging stay correct.

`POST /Users` now always records the provider on the account it creates, with or without an `externalId`. Previously the SCIM record was only written when the IdP supplied an `externalId`, which under the new rule would have left the IdP unable to address a user it had just created.

Known consequences worth stating:

- Group membership is unchanged. `PUT`/`PATCH /Groups/{id}` still replace the full member set from the IdP-supplied list, and group member listings still show local accounts. Filtering only the read side would make an IdP's read-modify-write drop local members, so that path needs its own fix rather than a half measure.
- Accounts an IdP provisioned before this change without an `externalId` carry no SCIM record and are therefore no longer visible to SCIM. The same applies to LDAP-provisioned accounts, which record neither a SCIM nor an OAuth identity.
- `POST /Users` now requires `SCIM_AUTH_PROVIDER` to be set and fails with 500 otherwise, where before it only needed it when an `externalId` was supplied.

Fixes #27662

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
