### PR TITLE
feat: retrieval.content.failed event for failed file processing

### DIFF
--- a/backend/open_webui/events.py
+++ b/backend/open_webui/events.py
@@ -411,6 +411,11 @@ class EventDefinitions(BaseModel):
         description='Retrieval content was processed.',
         message='Retrieval Content processed',
     )
+    RETRIEVAL_CONTENT_FAILED: EventDefinition = EventDefinition(
+        name='retrieval.content.failed',
+        description='Retrieval content processing failed.',
+        message='Retrieval Content failed',
+    )
     RETRIEVAL_COLLECTION_DELETED: EventDefinition = EventDefinition(
         name='retrieval.collection.deleted',
         description='A retrieval collection was deleted.',
@@ -666,6 +671,7 @@ NOTIFICATION_EVENTS = (
     EVENTS.CHAT_FAILED.name,
     EVENTS.CHANNEL_MESSAGE.name,
     EVENTS.CALENDAR_ALERT.name,
+    EVENTS.RETRIEVAL_CONTENT_FAILED.name,
 )
 
 

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -1998,7 +1998,11 @@ async def process_file(
             hash = calculate_sha256_string(text_content)
 
             if config.BYPASS_EMBEDDING_AND_RETRIEVAL:
-                await Files.update_file_data_by_id(file.id, {'status': 'completed'}, db=db)
+                # save_docs_to_vector_db rejects empty extractions, this branch never runs it.
+                if not text_content.strip():
+                    raise ValueError(ERROR_MESSAGES.EMPTY_CONTENT)
+
+                await Files.update_file_data_by_id(file.id, {'status': 'completed', 'error': None}, db=db)
                 await Files.update_file_hash_by_id(file.id, hash, db=db)
                 await publish_event(
                     request,
@@ -2057,7 +2061,7 @@ async def process_file(
 
                             await Files.update_file_data_by_id(
                                 file.id,
-                                {'status': 'completed'},
+                                {'status': 'completed', 'error': None},
                                 db=session,
                             )
                             await Files.update_file_hash_by_id(file.id, hash, db=session)
@@ -2087,11 +2091,24 @@ async def process_file(
             async with get_async_db() as session:
                 await Files.update_file_data_by_id(
                     file.id,
-                    {'status': 'failed'},
+                    {'status': 'failed', 'error': str(e)},
                     db=session,
                 )
                 # Clear the hash so the file can be re-uploaded after fixing the issue
                 await Files.update_file_hash_by_id(file.id, None, db=session)
+
+            await publish_event(
+                request,
+                EVENTS.RETRIEVAL_CONTENT_FAILED,
+                actor=user,
+                subject_id=file.id,
+                subject_type='file',
+                data={
+                    'collection_name': collection_name,
+                    'filename': file.filename,
+                    'message': f'{file.filename}: {e}',
+                },
+            )
 
             if 'No pandoc was found' in str(e):
                 raise HTTPException(

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -1970,7 +1970,11 @@ async def process_file(
             hash = calculate_sha256_string(text_content)
 
             if config.BYPASS_EMBEDDING_AND_RETRIEVAL:
-                await Files.update_file_data_by_id(file.id, {'status': 'completed'}, db=db)
+                # save_docs_to_vector_db rejects empty extractions, this branch never runs it.
+                if not text_content.strip():
+                    raise ValueError(ERROR_MESSAGES.EMPTY_CONTENT)
+
+                await Files.update_file_data_by_id(file.id, {'status': 'completed', 'error': None}, db=db)
                 await Files.update_file_hash_by_id(file.id, hash, db=db)
                 await publish_event(
                     request,
@@ -2027,7 +2031,7 @@ async def process_file(
 
                             await Files.update_file_data_by_id(
                                 file.id,
-                                {'status': 'completed'},
+                                {'status': 'completed', 'error': None},
                                 db=session,
                             )
                             await Files.update_file_hash_by_id(file.id, hash, db=session)
@@ -2057,11 +2061,24 @@ async def process_file(
             async with get_async_db() as session:
                 await Files.update_file_data_by_id(
                     file.id,
-                    {'status': 'failed'},
+                    {'status': 'failed', 'error': str(e)},
                     db=session,
                 )
                 # Clear the hash so the file can be re-uploaded after fixing the issue
                 await Files.update_file_hash_by_id(file.id, None, db=session)
+
+            await publish_event(
+                request,
+                EVENTS.RETRIEVAL_CONTENT_FAILED,
+                actor=user,
+                subject_id=file.id,
+                subject_type='file',
+                data={
+                    'collection_name': collection_name,
+                    'filename': file.filename,
+                    'message': f'{file.filename}: {e}',
+                },
+            )
 
             if 'No pandoc was found' in str(e):
                 raise HTTPException(


### PR DESCRIPTION
Document processing failures were only visible in the server log. When an embedding request failed the file was flagged failed in the database, but nothing was published, so event webhooks and event functions had no way to react and users could not subscribe a notification target to it.

process_file now publishes retrieval.content.failed from the same handler that flags the file, so every caller is covered: /files/, /knowledge/{id}/file/add, /knowledge/{id}/file/update and reindex. The event is subscribable as a notification target and renders through the generic webhook builder as "Retrieval Content failed" with "<filename>: <error>" as the body.

The same handler now also writes the error text to file.data.error. Both GET /files/{id}/process/status?stream=true and the upload UI already read that key, but only the /files/ upload wrapper ever wrote it, so failures arriving through the other callers showed a bare "failed" with no reason. It is cleared again on success so a fixed and re-processed file does not keep a stale error.

Finally, BYPASS_EMBEDDING_AND_RETRIEVAL skips save_docs_to_vector_db, which is where empty extractions are rejected in the normal path. A document that yielded no text was stored and flagged completed, and the model then answered from an empty context without anyone noticing. That branch now rejects empty content the same way, so the file ends up failed with a clear reason instead of silently useless.

Fixes #6311

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
