### PR TITLE
fix: keep currentId on writes to ancestor messages

### DIFF
--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -911,6 +911,7 @@ class ChatTable:
     @staticmethod
     def upsert_message_to_history(history: dict, message_id: str, message: dict) -> dict:
         messages = history.setdefault('messages', {})
+        is_new = message_id not in messages
 
         if message_id in messages:
             messages[message_id] = {
@@ -950,7 +951,20 @@ class ChatTable:
                 'role': role,
                 'timestamp': message.get('timestamp') or int(time.time()),
             }
+
+        current_id = history.get('currentId')
+        if is_new or current_id not in messages:
             history['currentId'] = message_id
+        else:
+            node = message_id
+            seen = set()
+            while node and node not in seen:
+                if node == current_id:
+                    history['currentId'] = message_id
+                    break
+                seen.add(node)
+                node = (messages.get(node) or {}).get('parentId')
+
         return messages[message_id]
 
     async def backfill_messages_by_chat_id(self, chat_id: str, user_id: str, messages: dict[str, dict]) -> None:

--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -835,6 +835,7 @@ class ChatTable:
     @staticmethod
     def upsert_message_to_history(history: dict, message_id: str, message: dict) -> dict:
         messages = history.setdefault('messages', {})
+        is_new = message_id not in messages
 
         if message_id in messages:
             messages[message_id] = {
@@ -875,7 +876,25 @@ class ChatTable:
                 'timestamp': message.get('timestamp') or int(time.time()),
             }
 
-        history['currentId'] = message_id
+        # New messages always become the tip: a regenerated answer or an edited
+        # prompt is a sibling of the current leaf, not a descendant, and must
+        # show. Updates to existing messages only advance the tip when they land
+        # on the current branch at or below it — background writes to ancestors
+        # (outlet filters, context compaction checkpoints) must not re-point the
+        # branch at them and truncate the visible history.
+        current_id = history.get('currentId')
+        if is_new or current_id not in messages:
+            history['currentId'] = message_id
+        else:
+            node = message_id
+            seen = set()
+            while node and node not in seen:
+                if node == current_id:
+                    history['currentId'] = message_id
+                    break
+                seen.add(node)
+                node = (messages.get(node) or {}).get('parentId')
+
         return messages[message_id]
 
     async def backfill_messages_by_chat_id(self, chat_id: str, user_id: str, messages: dict[str, dict]) -> None:


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27618
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** No documentation changes required.
- [ ] **Dependencies:** No new dependencies.
- [x] **Testing:** Verified by executing the real chat upsert path against a scratch database across all writer flows, pre- and post-fix (details below); live confirmation is invited from the issue reporter, whose diagnosis this implements.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Single chokepoint change — `upsert_message_to_history` has exactly one caller (`upsert_message_to_chat_by_id_and_message_id`), through which every message writer flows, so the pointer rule lands once and covers them all.
- [x] **Git Hygiene:** The PR is atomic (one logical change), based on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

Any backend write to an existing chat message — including a pure metadata stamp — makes that message the current branch tip (`history.currentId` + the `current_message_id` column). Write to an *ancestor*, and after a reload the chat renders truncated at that ancestor: everything below it is off the current branch and invisible (not deleted — orphaned from the view).

Two first-party writers hit this today:

- **Outlet filters** (`outlet_filter_handler`, `utils/middleware.py`): persists `{content, originalContent}` for every message a filter changed, oldest-first. A filter touching only an ancestor leaves `currentId` pointing there. (A filter that also modifies the leaf accidentally restores the tip with the loop's last write — which is why this stayed hidden.)
- **Context compaction** (`utils/context_compaction.py`): stamps `{'contextSummary': …}` onto the checkpoint message — `recent_messages[0]`, the *oldest* message of the recent window, an ancestor by construction. Compaction alone can truncate the visible history with no custom filter involved.

### Root Cause

`upsert_message_to_history` (`models/chats.py`) ends with

```python
history['currentId'] = message_id
```

outside every conditional, so the write API interprets "write to message X" as "make X the tip of the current branch".

### Fix

Advance the tip only when the write can legitimately move it — implementing the pointer-advance logic proposed by @LostPhysx in #27618:

- **New messages advance unconditionally**: a regenerated answer or an edited prompt is a *sibling* of the current leaf, not a descendant, and must show (a descendant-only rule would store them and never display them — the reporter called out this subtlety explicitly).
- **Updates to existing messages advance only when they land on the current branch at or below the tip** (`message_id == currentId`, or `currentId` is reached walking up the written message's parents — cycle-guarded).
- **An invalid stored pointer is repointed** (`currentId not in messages`); in the integrated path `_repair_chat_current_id` already fixes this upstream, so the in-method guard is defense-in-depth keeping the static method safe standalone.

Background writes to ancestors and to other branches no longer move the tip; streaming leaf updates and new-turn/regenerate flows behave exactly as before.

### Verification (real write path, scratch database)

An AI-copilot harness (disclosed as such) builds a six-message chat and drives the **real** `Chats.upsert_message_to_chat_by_id_and_message_id` through every writer flow, asserting both `history.currentId` and the `current_message_id` column:

| Flow | Pristine `dev` | This branch |
| --- | --- | --- |
| Compaction-style metadata stamp on an ancestor | ❌ tip moves to ancestor | ✅ tip stays |
| Outlet-filter-style content write on an ancestor | ❌ tip moves to ancestor | ✅ tip stays |
| Off-branch write (sibling branch of the tip) | ❌ tip switches branches | ✅ tip stays |
| Streaming-style leaf update | ✅ | ✅ unchanged |
| New user turn | ✅ advances | ✅ unchanged |
| Regenerated sibling answer | ✅ advances | ✅ unchanged |
| Descendant write below a raised tip | ✅ advances | ✅ unchanged |
| Invalid stored tip (integrated + static-method unit) | ✅ repaired | ✅ repaired |

Pristine fails exactly the three bug flows; this branch passes all checks.

### Fixed

- Fixed backend writes to older messages (outlet filters persisting filter-modified ancestors, context compaction stamping its checkpoint) silently re-pointing the chat's current branch at the written message and truncating the visible history after reload.

---

### Additional Information

- Full credit for the diagnosis and the pointer-advance logic to @LostPhysx (#27618) — this PR implements their proposed fix nearly verbatim, with the sibling-must-advance subtlety they identified preserved. Testing it against your original setup (the content-modifying filter) would be the definitive live confirmation.
- The compaction vector was found while verifying the report and is called out in [this comment](https://github.com/open-webui/open-webui/issues/27618#issuecomment-5109546733); it likely also explains the `currentId`-at-checkpoint symptom the triage bot cross-referenced from #24157.
- This PR was prepared with AI copilot assistance and has been thoroughly reviewed by the author.

### Screenshots or Videos

- N/A (branch-pointer fix; verification table above).

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
