### PR TITLE
fix: keep the selected model in sync when regenerating a response

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -3554,6 +3554,12 @@
 				scrollToBottom();
 			}
 
+			// Single-model turns follow the current selection; side-by-side turns regenerate the clicked column.
+			const isSideBySideTurn = (userMessage.models ?? selectedModels).length > 1;
+			if (!isSideBySideTurn) {
+				userMessage.models = selectedModels;
+			}
+
 			await sendMessage(history, userMessage.id, {
 				...(suggestionPrompt
 					? {
@@ -3561,9 +3567,8 @@
 							regenerationPrompt: suggestionPrompt
 						}
 					: {}),
-				...((userMessage?.models ?? [...selectedModels]).length > 1
+				...(isSideBySideTurn
 					? {
-							// If multiple models are selected, use the model from the message
 							modelId: message.model,
 							modelIdx: message.modelIdx
 						}

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -3392,6 +3392,12 @@
 				scrollToBottom();
 			}
 
+			// Single-model turns follow the current selection; side-by-side turns regenerate the clicked column.
+			const isSideBySideTurn = (userMessage.models ?? selectedModels).length > 1;
+			if (!isSideBySideTurn) {
+				userMessage.models = selectedModels;
+			}
+
 			await sendMessage(history, userMessage.id, {
 				...(suggestionPrompt
 					? {
@@ -3399,9 +3405,8 @@
 							regenerationPrompt: suggestionPrompt
 						}
 					: {}),
-				...((userMessage?.models ?? [...selectedModels]).length > 1
+				...(isSideBySideTurn
 					? {
-							// If multiple models are selected, use the model from the message
 							modelId: message.model,
 							modelIdx: message.modelIdx
 						}


### PR DESCRIPTION
Switching the model in the dropdown and regenerating a response left the chat's stored model list pointing at the model that was used when the user message was first sent. Leaving the chat and coming back restored that stale entry, so the dropdown kept snapping back to the original model (and could even show a model that is no longer used by any response in the chat, or one that no longer exists).

The chat's model list is persisted from the user message's `models` field, which is written when the message is created and was never refreshed afterwards. Regeneration is the one send path that reuses an existing user message, so it now refreshes that field from the current selection.

Side-by-side turns are left untouched: those regenerate the clicked column and keep their full model list, which is also what the column grouping in MultiResponseMessages relies on.

Fixes #25052

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
