### PR TITLE
fix: toggle collapsibles on click so taps work on mobile

### DIFF
--- a/src/lib/components/common/Collapsible.svelte
+++ b/src/lib/components/common/Collapsible.svelte
@@ -140,8 +140,8 @@
 			class="{buttonClassName} cursor-pointer"
 			on:click={(e) => {
 				e.stopPropagation();
+				toggleOpen();
 			}}
-			on:pointerup={toggleOpen}
 		>
 			<div>
 				<div class="flex items-start justify-between">
@@ -162,7 +162,7 @@
 					{#if open && !hide}
 						<div
 							transition:slide={{ duration: 300, easing: quintOut, axis: 'y' }}
-							on:pointerup={(e) => {
+							on:click={(e) => {
 								e.stopPropagation();
 							}}
 						>

--- a/src/lib/components/common/Folder.svelte
+++ b/src/lib/components/common/Folder.svelte
@@ -175,9 +175,6 @@
 					{#if onAdd}
 						<button
 							class="absolute z-10 right-2 invisible group-hover:visible self-center flex items-center dark:text-gray-300"
-							on:pointerup={(e) => {
-								e.stopPropagation();
-							}}
 							on:click={(e) => {
 								e.stopPropagation();
 								onAdd();

--- a/src/lib/components/common/ToolCallDisplay.svelte
+++ b/src/lib/components/common/ToolCallDisplay.svelte
@@ -122,7 +122,7 @@
 		<!-- svelte-ignore a11y-no-static-element-interactions -->
 		<div
 			class="{buttonClassName} cursor-pointer"
-			on:pointerup={() => {
+			on:click={() => {
 				open = !open;
 			}}
 		>

--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -1479,7 +1479,6 @@
 									type="button"
 									class="flex items-center justify-center w-7 h-7 rounded-lg text-gray-300 hover:text-gray-500 dark:text-gray-600 dark:hover:text-gray-400 transition-colors duration-100"
 									aria-label={$i18n.t('More')}
-									on:pointerup|stopPropagation
 								>
 									<MoreHorizontalIcon className="size-3.5" strokeWidth="2" />
 								</button>

--- a/src/lib/components/layout/Sidebar/RecursiveFolder.svelte
+++ b/src/lib/components/layout/Sidebar/RecursiveFolder.svelte
@@ -752,6 +752,7 @@
 				role="button"
 				tabindex="0"
 				on:click={async (e) => {
+					e.stopPropagation();
 					if (shouldIgnoreRowClick(e.target)) return;
 					if (clickTimer) {
 						clearTimeout(clickTimer);
@@ -769,9 +770,6 @@
 						e.preventDefault();
 						openFolderHandler();
 					}
-				}}
-				on:pointerup={(e) => {
-					e.stopPropagation();
 				}}
 			>
 				<button

--- a/src/lib/components/layout/Sidebar/Section.svelte
+++ b/src/lib/components/layout/Sidebar/Section.svelte
@@ -131,8 +131,6 @@
 						class="group flex flex-1 h-full items-center gap-1 text-left text-xs text-gray-400 hover:text-gray-500 dark:text-gray-500 dark:hover:text-gray-400 transition-colors duration-100 {buttonClassName}"
 						aria-expanded={open}
 						aria-controls="{id}-content"
-						on:pointerup|stopPropagation
-						on:click={() => setOpen(!open)}
 					>
 						<span>{name}</span>
 						<span
@@ -143,16 +141,21 @@
 						</span>
 					</button>
 
-					<slot name="action" />
+					<!-- svelte-ignore a11y-no-static-element-interactions a11y-click-events-have-key-events -->
+					<div
+						class="contents"
+						on:click={(e) => {
+							e.stopPropagation();
+						}}
+					>
+						<slot name="action" />
+					</div>
 
 					{#if onAdd}
 						<button
 							type="button"
 							class="flex items-center justify-center w-7 h-7 rounded-lg text-gray-300 hover:text-gray-500 dark:text-gray-600 dark:hover:text-gray-400 transition-colors duration-100"
 							aria-label={onAddLabel}
-							on:pointerup={(e) => {
-								e.stopPropagation();
-							}}
 							on:click={(e) => {
 								e.stopPropagation();
 								onAdd();


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27241
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** No documentation changes required.
- [ ] **Dependencies:** No new dependencies.
- [x] **Testing:** Full desktop regression pass manually verified by the author on a live instance (details below). Real-device touch verification is explicitly invited from the issue's reporters — desktop DevTools viewport emulation cannot reproduce the `pointercancel` behavior this fixes.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Fixes the event choice once in `Collapsible` and aligns every consumer of the title-less branch with it; net diff is negative (+13/−16).
- [x] **Git Hygiene:** The PR is atomic (one logical change), based on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

Sidebar section headers (and other slot-headed disclosures) can be dead to taps on mobile while working fine with a mouse — the intermittent "chats and folders unclickable" behavior reported in #27241, most reproducible right after scrolling the sidebar.

### Root Cause

Credit for the diagnosis to @djedi-knight on the issue: the `title === null` branch of `Collapsible.svelte` toggles on **`on:pointerup`**. Inside a scrollable container, touch browsers fire `pointercancel` instead of `pointerup` whenever the tap competes with pan-gesture recognition (sloppy taps, taps during scroll momentum), so the toggle never runs. A mouse always delivers `pointerup`, which is why desktop was unaffected — and why the reports were device-dependent and intermittent.

#27489 already (incidentally) fixed the main sidebar section headers by giving them a real `<button on:click>`. Two live surfaces still toggled purely on `pointerup`:

- the **Pinned** chats sub-header (`common/Folder.svelte` — its header has no click handler of its own, so it relied entirely on the fragile Collapsible toggle), and
- **tool-call disclosure blocks** in chat messages (`ToolCallDisplay.svelte`, same pattern inline).

### Fix

Switch the title-less `Collapsible` branch (and `ToolCallDisplay`) to click semantics, and align every consumer so nothing double-toggles or leaks clicks into the new toggle:

- `Collapsible.svelte`: the title-less wrapper toggles on `click` (keeping its existing stop-propagation behavior); the `grow` content guard converts from a `pointerup` stop to a `click` stop. The `title` branch was already a `<button on:click>` and is untouched.
- `Section.svelte`: the header button drops its own handlers — its clicks bubble to the Collapsible toggle, whose existing `onChange={setOpen}` keeps dispatch + persisted open-state identical, and keyboard Enter/Space still works through the button's synthetic click. The action slot gets a click-stopping `display: contents` wrapper so action controls (e.g. the Chats "⋯" menu) can never toggle the section.
- `RecursiveFolder.svelte`: the folder row stops click propagation — a row tap stays navigation, never a section toggle (replacing its old `pointerup` stop, which guarded the removed listener).
- Now-vestigial `pointerup` guards removed (`Section`/`Folder` add-buttons, the Chats dropdown trigger in `Sidebar.svelte`).
- `common/Folder.svelte` (the Pinned header) needs no handler at all — it simply inherits the click toggle, which is the actual hole being patched.

Section contents can't accidentally toggle their section: `grow` defaults to `false`, so content renders outside the clickable element; the two `grow={true}` consumers (`WebSearchResults`, playground) keep their content guarded by the converted click stop.

### For triage clarity

#27241's thread contains a second, distinct bug (chat list disappearing on sidebar reopen — stale `$currentChatPage` pagination, duplicate of #27014). That one is already resolved on `dev` by the chat-list store refactor, confirmed in-thread on 2026-07-27. This PR addresses the remaining live defect from the original report.

### Fixed

- Fixed collapsible section headers (including the sidebar's Pinned chats header) and tool-call disclosure blocks being unresponsive to taps on mobile, by toggling on `click` instead of `pointerup`, which touch browsers replace with `pointercancel` when a tap competes with scrolling.

---

### Additional Information

- Root-cause diagnosis by @djedi-knight in #27241, including the heads-up about `RecursiveFolder`'s row needing matching click hygiene — implemented as suggested.
- This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Verification Performed

**Desktop regression pass** (author, live instance running this branch): all section headers click-toggle with persisted open-state; the Pinned header toggles; the Chats "⋯" menu opens without toggling its section; "+" buttons don't toggle; folder rows keep single-click navigation, double-click rename, and chevron expand with no stray toggles; chats/items inside sections don't collapse anything; keyboard Enter/Space on headers still toggles (#27489's WCAG behavior preserved); tool-call blocks click-toggle.

**Touch verification**: honestly stated — not yet performed on a real device. The mechanism guarantees the improvement (`click` is delivered for taps wherever `pointerup` is, and additionally survives the tap-vs-scroll cases where touch browsers emit `pointercancel`; desktop viewport emulation cannot exercise that path). @skorphil / @djedi-knight — running the original repro (scroll the sidebar, open a chat, reopen it, tap the Chats/Folders/Pinned headers) on your Android devices against this branch (`silentoplayz:fix/collapsible-touch-toggle`) would be the definitive confirmation.

### Screenshots or Videos

- N/A (interaction fix; verification above).

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
