### PR TITLE
fix: count task generation tokens in analytics

### DIFF
--- a/backend/open_webui/models/chat_messages.py
+++ b/backend/open_webui/models/chat_messages.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta
 from typing import Any, Optional
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
-from sqlalchemy import select, delete, func, cast, Integer, distinct
+from sqlalchemy import select, delete, func, cast, Integer, distinct, case
 from sqlalchemy.ext.asyncio import AsyncSession
 from open_webui.internal.db import Base, get_async_db_context
 from open_webui.utils.response import merge_usage, normalize_usage
@@ -134,7 +134,7 @@ class ChatMessage(Base):
     user_id = Column(Text, index=True)
 
     # Structure
-    role = Column(Text, nullable=False)  # user, assistant, system
+    role = Column(Text, nullable=False)  # user, assistant, system, task
     parent_id = Column(Text, nullable=True)
 
     # Content
@@ -199,6 +199,12 @@ class ChatMessageModel(BaseModel):
     context_summary: Optional[str] = None
     created_at: int
     updated_at: int
+
+
+# Role 'task' rows are background generations (title, tags, queries): tokens, but not messages.
+TASK_ROLE = 'task'
+TOKEN_USAGE_ROLES = ('assistant', TASK_ROLE)
+ASSISTANT_MESSAGE_COUNT = func.count(case((ChatMessage.role == 'assistant', ChatMessage.id)))
 
 
 ####################
@@ -312,7 +318,10 @@ class ChatMessageTable:
     async def get_messages_by_chat_id(self, chat_id: str, db: Optional[AsyncSession] = None) -> list[ChatMessageModel]:
         async with get_async_db_context(db) as db:
             result = await db.execute(
-                select(ChatMessage).filter_by(chat_id=chat_id).order_by(ChatMessage.created_at.asc())
+                select(ChatMessage)
+                .filter_by(chat_id=chat_id)
+                .filter(ChatMessage.role != TASK_ROLE)
+                .order_by(ChatMessage.created_at.asc())
             )
             messages = result.scalars().all()
             return [ChatMessageModel.model_validate(message) for message in messages]
@@ -337,7 +346,9 @@ class ChatMessageTable:
         embedded JSON blob for legacy chats).
         """
         async with get_async_db_context(db) as db:
-            result = await db.execute(select(ChatMessage).filter_by(chat_id=chat_id))
+            result = await db.execute(
+                select(ChatMessage).filter_by(chat_id=chat_id).filter(ChatMessage.role != TASK_ROLE)
+            )
             rows = result.scalars().all()
 
         if not rows:
@@ -402,6 +413,7 @@ class ChatMessageTable:
             result = await db.execute(
                 select(ChatMessage)
                 .filter_by(user_id=user_id)
+                .filter(ChatMessage.role != TASK_ROLE)
                 .order_by(ChatMessage.created_at.desc())
                 .offset(skip)
                 .limit(limit)
@@ -419,7 +431,7 @@ class ChatMessageTable:
         db: Optional[AsyncSession] = None,
     ) -> list[ChatMessageModel]:
         async with get_async_db_context(db) as db:
-            stmt = select(ChatMessage).filter_by(model_id=model_id)
+            stmt = select(ChatMessage).filter_by(model_id=model_id).filter(ChatMessage.role != TASK_ROLE)
             if start_date:
                 stmt = stmt.filter(ChatMessage.created_at >= start_date)
             if end_date:
@@ -444,7 +456,7 @@ class ChatMessageTable:
             stmt = select(
                 ChatMessage.chat_id,
                 func.max(ChatMessage.created_at).label('last_message_at'),
-            ).filter(ChatMessage.model_id == model_id)
+            ).filter(ChatMessage.model_id == model_id, ChatMessage.role != TASK_ROLE)
             if start_date:
                 stmt = stmt.filter(ChatMessage.created_at >= start_date)
             if end_date:
@@ -574,9 +586,9 @@ class ChatMessageTable:
                 ChatMessage.model_id,
                 func.coalesce(func.sum(input_tokens), 0).label('input_tokens'),
                 func.coalesce(func.sum(output_tokens), 0).label('output_tokens'),
-                func.count(ChatMessage.id).label('message_count'),
+                ASSISTANT_MESSAGE_COUNT.label('message_count'),
             ).filter(
-                ChatMessage.role == 'assistant',
+                ChatMessage.role.in_(TOKEN_USAGE_ROLES),
                 ChatMessage.model_id.isnot(None),
                 ChatMessage.usage.isnot(None),
             )
@@ -622,9 +634,9 @@ class ChatMessageTable:
                 ChatMessage.user_id,
                 func.coalesce(func.sum(input_tokens), 0).label('input_tokens'),
                 func.coalesce(func.sum(output_tokens), 0).label('output_tokens'),
-                func.count(ChatMessage.id).label('message_count'),
+                ASSISTANT_MESSAGE_COUNT.label('message_count'),
             ).filter(
-                ChatMessage.role == 'assistant',
+                ChatMessage.role.in_(TOKEN_USAGE_ROLES),
                 ChatMessage.user_id.isnot(None),
                 ChatMessage.usage.isnot(None),
             )
@@ -666,13 +678,14 @@ class ChatMessageTable:
 
             messages_stmt = select(ChatMessage.role, func.count(ChatMessage.id).label('count')).filter(
                 ChatMessage.user_id == user_id,
+                ChatMessage.role != TASK_ROLE,
             )
             token_stmt = select(
                 func.coalesce(func.sum(input_tokens), 0).label('input_tokens'),
                 func.coalesce(func.sum(output_tokens), 0).label('output_tokens'),
             ).filter(
                 ChatMessage.user_id == user_id,
-                ChatMessage.role == 'assistant',
+                ChatMessage.role.in_(TOKEN_USAGE_ROLES),
                 ChatMessage.usage.isnot(None),
             )
             models_stmt = select(func.count(distinct(ChatMessage.model_id)).label('models_used')).filter(
@@ -698,7 +711,9 @@ class ChatMessageTable:
             active_days = set()
             if include_active_days:
                 tz = _timezone(timezone)
-                day_stmt = select(ChatMessage.created_at).filter(ChatMessage.user_id == user_id)
+                day_stmt = select(ChatMessage.created_at).filter(
+                    ChatMessage.user_id == user_id, ChatMessage.role != TASK_ROLE
+                )
                 if start_date:
                     day_stmt = day_stmt.filter(ChatMessage.created_at >= start_date)
                 if end_date:
@@ -777,8 +792,9 @@ class ChatMessageTable:
                         'models': Counter(),
                     },
                 )
-                entry['messages'] += 1
-                entry['chat_ids'].add(row.chat_id)
+                if row.role != TASK_ROLE:
+                    entry['messages'] += 1
+                    entry['chat_ids'].add(row.chat_id)
                 if row.role == 'assistant' and row.model_id:
                     entry['models'][row.model_id] += 1
                 if row.usage:

--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -10,7 +10,7 @@ import uuid
 # local imports
 from open_webui.internal.db import Base, JSONField, get_async_db_context
 from open_webui.models.automations import AutomationRun
-from open_webui.models.chat_messages import ChatMessage, ChatMessages
+from open_webui.models.chat_messages import TASK_ROLE, ChatMessage, ChatMessages
 from open_webui.models.folders import Folders
 from open_webui.models.tags import Tag, TagModel, Tags
 from open_webui.utils.misc import get_output_text, sanitize_data_for_db, sanitize_text_for_db
@@ -1439,7 +1439,9 @@ class ChatTable:
 
         async with get_async_db_context(db) as session:
             chat_ids = (
-                select(ChatMessage.chat_id).filter(ChatMessage.model_id == model_id).group_by(ChatMessage.chat_id)
+                select(ChatMessage.chat_id)
+                .filter(ChatMessage.model_id == model_id, ChatMessage.role != TASK_ROLE)
+                .group_by(ChatMessage.chat_id)
             )
 
             if filter:
@@ -1629,7 +1631,7 @@ class ChatTable:
             messages_stmt = (
                 select(ChatMessage.chat_id, ChatMessage.created_at)
                 .join(Chat, Chat.id == ChatMessage.chat_id)
-                .where(*chat_filter, ChatMessage.created_at.isnot(None))
+                .where(*chat_filter, ChatMessage.created_at.isnot(None), ChatMessage.role != TASK_ROLE)
                 .order_by(ChatMessage.chat_id, ChatMessage.created_at.asc())
             )
             messages_result = await session.execute(messages_stmt)

--- a/backend/open_webui/utils/chat.py
+++ b/backend/open_webui/utils/chat.py
@@ -11,6 +11,8 @@ from aiocache import cached
 from fastapi import HTTPException, Request, status
 from open_webui.env import BYPASS_MODEL_ACCESS_CONTROL, GLOBAL_LOG_LEVEL
 from open_webui.functions import generate_function_chat_completion
+from open_webui.models.chat_messages import TASK_ROLE, ChatMessages
+from open_webui.models.chats import Chats
 from open_webui.models.models import Models
 from open_webui.models.users import UserModel
 from open_webui.routers.ollama import (
@@ -148,6 +150,34 @@ async def generate_direct_chat_completion(
         return res
 
 
+async def record_task_usage(metadata: dict, model_id: str, user: Any, response: Any) -> None:
+    """Persist a task call's token usage. Task calls bypass the response middleware that persists it for chats."""
+    task = metadata.get('task')
+    chat_id = metadata.get('chat_id')
+    usage = response.get('usage') if isinstance(response, dict) else None
+    if not task or not chat_id or not usage:
+        return
+
+    # Rejects another user's chat id, and temporary or unsaved chats, which have no row for the foreign key.
+    if not await Chats.is_chat_owner(chat_id, user.id):
+        return
+
+    try:
+        await ChatMessages.upsert_message(
+            message_id=f'task-{uuid.uuid4()}',
+            chat_id=chat_id,
+            user_id=user.id,
+            data={
+                'role': TASK_ROLE,
+                'model': model_id,
+                'usage': usage,
+                'meta': {'task': task},
+            },
+        )
+    except Exception as e:
+        log.warning(f'Failed to record usage for task {task}: {e}')
+
+
 async def generate_chat_completion(
     request: Request,
     form_data: dict,
@@ -195,8 +225,11 @@ async def generate_chat_completion(
     if model is None:
         raise Exception('Model not found')
 
+    # Captured before generate_direct_chat_completion, which pops it off form_data.
+    task_metadata = form_data.get('metadata') or {}
+
     if getattr(request.state, 'direct', False) and model_id == getattr(request.state, 'model', {}).get('id'):
-        return await generate_direct_chat_completion(request, form_data, user=user, models=models)
+        response = await generate_direct_chat_completion(request, form_data, user=user, models=models)
     else:
         # Check if user has access to the model
         if not bypass_filter and user.role == 'user':
@@ -246,6 +279,7 @@ async def generate_chat_completion(
                     await check_model_access(user, selected_model)
 
         if selected_model_id:
+            # Returns early: the recursive call records the usage under the resolved model.
             if form_data.get('stream') == True:
 
                 async def stream_wrapper(stream):
@@ -281,30 +315,33 @@ async def generate_chat_completion(
 
         if model.get('pipe'):
             # Below does not require bypass_filter because this is the only route the uses this function and it is already bypassing the filter
-            return await generate_function_chat_completion(request, form_data, user=user, models=models)
-        if model.get('owned_by') == 'ollama':
+            response = await generate_function_chat_completion(request, form_data, user=user, models=models)
+        elif model.get('owned_by') == 'ollama':
             # Using /ollama/api/chat endpoint
             form_data = convert_payload_openai_to_ollama(form_data)
-            response = await generate_ollama_chat_completion(
+            ollama_response = await generate_ollama_chat_completion(
                 request=request,
                 form_data=form_data,
                 user=user,
             )
             if form_data.get('stream'):
-                response.headers['content-type'] = 'text/event-stream'
-                return StreamingResponse(
-                    convert_streaming_response_ollama_to_openai(response),
-                    headers=dict(response.headers),
-                    background=response.background,
+                ollama_response.headers['content-type'] = 'text/event-stream'
+                response = StreamingResponse(
+                    convert_streaming_response_ollama_to_openai(ollama_response),
+                    headers=dict(ollama_response.headers),
+                    background=ollama_response.background,
                 )
             else:
-                return convert_response_ollama_to_openai(response)
+                response = convert_response_ollama_to_openai(ollama_response)
         else:
-            return await generate_openai_chat_completion(
+            response = await generate_openai_chat_completion(
                 request=request,
                 form_data=form_data,
                 user=user,
             )
+
+    await record_task_usage(task_metadata, model_id, user, response)
+    return response
 
 
 chat_completion = generate_chat_completion

--- a/src/lib/components/admin/Analytics/Dashboard.svelte
+++ b/src/lib/components/admin/Analytics/Dashboard.svelte
@@ -130,7 +130,13 @@
 			summary = summaryRes ?? summary;
 
 			const modelsMap = new Map($models.map((m) => [m.id, m.name || m.id]));
-			modelStats = (modelsRes?.models ?? []).map((entry) => ({
+			const messageCounts = modelsRes?.models ?? [];
+			const countedModelIds = new Set(messageCounts.map((m) => m.model_id));
+			// A task model spends tokens without owning any message of its own.
+			const tokenOnlyModels = (tokensRes?.models ?? [])
+				.filter((entry) => !countedModelIds.has(entry.model_id))
+				.map((entry) => ({ model_id: entry.model_id, count: 0 }));
+			modelStats = [...messageCounts, ...tokenOnlyModels].map((entry) => ({
 				...entry,
 				name: modelsMap.get(entry.model_id) || entry.model_id
 			}));


### PR DESCRIPTION
Analytics aggregates over the `chat_message` table, and task completions (title, tags, follow-ups, RAG query generation, image prompt, emoji, context compaction, tool selection, memory review) never write a row: they call `generate_chat_completion` directly and skip the response middleware that persists usage for chats. Every token they spend is therefore invisible on the dashboard, which is why the reported totals do not match what the provider bills.

Record each task completion as a `chat_message` row with `role='task'`, at the one chokepoint every task call goes through. Because all existing count queries filter `role == 'assistant'`, those rows are automatically excluded from message counts, and the token aggregations opt them in explicitly. The remaining role-agnostic queries (message listings, the history map used to rebuild a chat, activity metrics) now exclude them, so a task row contributes tokens and nothing else. The admin dashboard additionally lists models that have token usage but no messages of their own, so the per-model rows still account for the headline total when a separate task model is configured.

Not recorded: task calls that have no saved chat to attach to (temporary chats, autocomplete before a chat exists) and streamed task calls, which carry no usage at this layer. Note that a busy turn now writes a few extra rows into `chat_message`, and that the write happens before the task response returns.

Fixes #26997

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
