### PR TITLE
fix: restore attached knowledge previews and retrieval settings in the model editor and folder settings

### DIFF
--- a/src/lib/components/common/Modal.svelte
+++ b/src/lib/components/common/Modal.svelte
@@ -107,7 +107,7 @@
 		if (focusTrap) {
 			focusTrap.deactivate();
 		}
-		if (modalElement) {
+		if (modalElement && modalElement.parentNode === document.body) {
 			document.body.removeChild(modalElement);
 		}
 	});

--- a/src/lib/components/workspace/Models/Knowledge.svelte
+++ b/src/lib/components/workspace/Models/Knowledge.svelte
@@ -3,6 +3,7 @@
 	import { config, knowledge, settings, user } from '$lib/stores';
 
 	import KnowledgeSelector from './Knowledge/KnowledgeSelector.svelte';
+	import FileItemModal from '$lib/components/common/FileItemModal.svelte';
 	import Tooltip from '$lib/components/common/Tooltip.svelte';
 	import Spinner from '$lib/components/common/Spinner.svelte';
 	import ChatBubble from '$lib/components/icons/ChatBubble.svelte';
@@ -26,6 +27,9 @@
 
 	let filesInputElement = null;
 	let inputFiles = null;
+
+	let showItemModal = false;
+	let selectedItemIdx = null;
 
 	$: if (selectedItems === null) {
 		selectedItems = [];
@@ -143,6 +147,10 @@
 	});
 </script>
 
+{#if showItemModal && selectedItemIdx !== null && selectedItems[selectedItemIdx]}
+	<FileItemModal bind:show={showItemModal} bind:item={selectedItems[selectedItemIdx]} edit={true} />
+{/if}
+
 <input
 	bind:this={filesInputElement}
 	bind:files={inputFiles}
@@ -222,25 +230,35 @@
 						<div
 							class="flex max-w-56 items-center gap-1.5 py-0.5 pr-2 text-xs text-gray-700 dark:text-gray-200"
 						>
-							<div class="shrink-0 text-gray-500 dark:text-gray-400">
-								{#if file.status === 'uploading'}
-									<Spinner className="size-3.5" />
-								{:else if file.type === 'collection'}
-									<Database className="size-3.5" />
-								{:else if file.type === 'note'}
-									<PageEdit className="size-3.5" />
-								{:else if file.type === 'chat'}
-									<ChatBubble className="size-3.5" />
-								{:else if file.type === 'folder'}
-									<Folder className="size-3.5" />
-								{:else}
-									<DocumentPage className="size-3.5" />
-								{/if}
-							</div>
+							<button
+								type="button"
+								class="flex min-w-0 items-center gap-1.5"
+								aria-label={$i18n.t('Edit')}
+								on:click={() => {
+									selectedItemIdx = fileIdx;
+									showItemModal = true;
+								}}
+							>
+								<div class="shrink-0 text-gray-500 dark:text-gray-400">
+									{#if file.status === 'uploading'}
+										<Spinner className="size-3.5" />
+									{:else if file.type === 'collection'}
+										<Database className="size-3.5" />
+									{:else if file.type === 'note'}
+										<PageEdit className="size-3.5" />
+									{:else if file.type === 'chat'}
+										<ChatBubble className="size-3.5" />
+									{:else if file.type === 'folder'}
+										<Folder className="size-3.5" />
+									{:else}
+										<DocumentPage className="size-3.5" />
+									{/if}
+								</div>
 
-							<div class="min-w-0 truncate">
-								{file.name || file.id}
-							</div>
+								<div class="min-w-0 truncate">
+									{file.name || file.id}
+								</div>
+							</button>
 
 							{#if file.status === 'uploading'}
 								<div class="shrink-0 text-gray-400 dark:text-gray-500">


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27684, closes #27801
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** No documentation changes required.
- [ ] **Dependencies:** No new dependencies.
- [x] **Testing:** Manually verified by the author on a live instance across three rounds (details below); the rounds caught and fixed two additional defects before this PR was opened.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Keeps the redesigned compact chips; restores functionality by making the chip open the same `FileItemModal` the chat surface uses, mounted per-open following the codebase's dominant modal pattern.
- [x] **Git Hygiene:** The PR is atomic (one logical change), based on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

Since v0.11.0, attached knowledge items offer no way to be previewed or have their retrieval mode changed ("Using Focused Retrieval" / "Using Entire Document") from the surfaces that render the shared Knowledge section component: the model editor (#27684) and folder settings (#27801). The functionality was available in v0.10.2 and still exists in chat. The setting isn't cosmetic: it writes the item's `context` field (`'full'` vs unset), which drives full-context injection vs focused retrieval in the backend, and #27801 additionally loses the read path (no way to open and view an attached item at all).

### Root Cause

Through v0.10.2 attached knowledge rendered as `FileItem` chips with `modal={true} edit={true}`: clicking one opened `FileItemModal`, whose edit mode holds the retrieval switch. The model editor redesign (`fa889837e`, first shipped in v0.11.0) replaced those chips with plain inline tags (icon, name, remove button) inside the shared component `src/lib/components/workspace/Models/Knowledge.svelte`, leaving the modal unreachable. Because the folder settings modal (`FolderModal.svelte`) renders this same component, the regression applies identically to knowledge attached to folders, which is what #27801 reports. Chat kept its `FileItem` chips, hence the asymmetry in the issues' screenshots.

### Fix

Keep the redesigned chips, restore the path to the modal: the chip's icon+name area becomes a button that opens the same `FileItemModal` in edit mode, bound to that item. `bind:item` propagates the switch's `context` mutation straight back into `selectedItems`, which the parent already persists on save. The remove button stays a sibling (no nested-button markup), and the modal is mounted only while open (`{#if showItemModal && …}`), the codebase's standard modal pattern.

Since the change lives in the shared component, both consuming surfaces regain the preview/edit modal from this one diff: the model editor's Knowledge section (#27684) and the folder settings Knowledge section (#27801).

Two additional defects were caught during the author's test rounds and are fixed here:

- **Per-item state bleed**: `FileItemModal` seeds its switch state from `item.context` only in `onMount`. A single long-lived modal instance rebinding `item` therefore displayed the previously toggled item's state for every subsequently opened item. Mounting a fresh instance per open (above) resolves this.
- **`Modal` teardown crash**: navigating away after using the editor could throw `Uncaught DOMException: Node.removeChild: The node to be removed is not a child of this node` from `Modal.svelte`'s `onDestroy`, which called `document.body.removeChild(modalElement)` unconditionally. Under the Svelte 5 runtime, child-effect teardown can detach the element before `onDestroy` runs while the `bind:this` reference is still populated, making the second remove throw. The teardown now checks the element is actually attached (`modalElement.parentNode === document.body`) first: a two-line hardening that protects every `Modal` consumer, including the nested modal-in-modal case the folder settings surface exercises.

### Fixed

- Fixed attached knowledge items being impossible to preview or configure since the v0.11.0 redesign on both surfaces that render the shared Knowledge section: the model editor and folder settings. Attached knowledge chips are clickable again and open the same editor modal used in chat, restoring the retrieval mode setting ("Using Focused Retrieval" / entire-document context) and item preview.
- Fixed a `Node.removeChild` DOMException thrown from `Modal`'s teardown when a modal instance is destroyed after its element was already detached (e.g. during page navigation).

---

### Additional Information

**Overlaps with other open PRs.** This touches `src/lib/components/workspace/Models/Knowledge.svelte`, which #26296 and #27983 also modify, and the three conflict with each other in that file. They are independent changes, so any merge order works, but the two that land later each need a rebase.


- @linbanana: this restores exactly what your report describes; verifying against your GMAP setup on this branch (`silentoplayz:fix/model-knowledge-context-toggle`) would be welcome confirmation.
- This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Verification Performed

Manual, by the author on a live instance running this branch, across three rounds (the first two rounds caught the state-bleed and teardown-crash defects described above; the final round verified all of the following clean):

- Clicking an attached knowledge chip opens the modal with the retrieval switch; toggling writes per-item state independently (item A's toggle no longer affects item B's display); state persists through model Save and editor reload.
- Removing a single item, Clear all, uploading a file into the section, and reopening the same chip repeatedly all behave.
- The post-save navigation runs with a clean browser console (previously the `removeChild` DOMException).
- Same behavior in the admin model editor (same component).
- Folder settings (Edit Folder > Knowledge): clicking an attached knowledge chip opens the same modal from within the folder modal, confirming the #27801 surface is restored by the shared component change.

### Screenshots or Videos

<img width="2328" height="1279" alt="image" src="https://github.com/user-attachments/assets/5576d7a3-9a63-4493-8411-bfaeb8780856" />

<img width="1149" height="531" alt="image" src="https://github.com/user-attachments/assets/82b8ce96-edfb-4a23-916d-9dbea3608f5a" />

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.

