### PR TITLE
fix: left-edge clipping of the Open Terminal cloud icon and Account profile avatar

### DIFF
--- a/src/lib/components/chat/Settings/Account/UserProfileImage.svelte
+++ b/src/lib/components/chat/Settings/Account/UserProfileImage.svelte
@@ -85,7 +85,7 @@
 	<div class="mb-2 flex items-center gap-4">
 		<button
 			class="group relative flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-full bg-gray-100
-			ring-1 ring-gray-200 transition-all duration-200 hover:ring-2 hover:ring-gray-300 dark:bg-white/8 dark:ring-white/10 dark:hover:ring-white/20"
+			ring-1 ring-inset ring-gray-200 transition-all duration-200 hover:ring-2 hover:ring-gray-300 dark:bg-white/8 dark:ring-white/10 dark:hover:ring-white/20"
 			type="button"
 			on:click={() => {
 				profileImageInputElement.click();

--- a/src/lib/components/icons/Cloud.svelte
+++ b/src/lib/components/icons/Cloud.svelte
@@ -4,7 +4,7 @@
 </script>
 
 <svg
-	class={className}
+	class="overflow-visible {className}"
 	aria-hidden="true"
 	xmlns="http://www.w3.org/2000/svg"
 	stroke-width={strokeWidth}


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27690 — the Open Terminal cloud icon (chat input) and the Account profile avatar are cut off on their left side.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable — visual bug fix with no behavioral or configuration changes.
- [ ] **Dependencies:** No new dependencies.
- [x] **Testing:** Manually verified by the author on desktop: the cloud icon in both its untoggled and toggled (server selected) states, and the Account avatar including its hover state. Computed-style verification details below.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Two one-class fixes; no new settings, no layout or geometry changes. The `ring-inset` utility already has precedent in the codebase (`FileEntryRow.svelte`).
- [x] **Git Hygiene:** The PR is atomic (one logical change: left-edge clipping), based on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

Fixes two independent UI elements that render visibly cut off on their left-hand side. Both share the same root story: **artwork drawn flush against a clipping boundary gets its left edge shaved**, which becomes clearly visible at small sizes and fractional device-pixel positions.

**Bug 1 — Open Terminal cloud icon (chat input)**

- **Problem**: The cloud icon next to the chat input is flattened on its left side, in both its untoggled and toggled states.
- **Root cause**: The cloud path in `Cloud.svelte` touches `x=1` and `x=23` inside a 24-unit viewBox. The chat input renders it with `stroke-width="2"`, so the stroke's outer edge lands *exactly* on the viewBox boundary — where the SVG's default `overflow: hidden` clips it. No ancestor container is involved: walking the computed styles of every ancestor confirms the icon sits 40+ px inside the nearest scroll container, leaving the svg's own viewport as the only clipper.
- **Fix**: `overflow-visible` on the svg. Zero geometry change — it simply stops the SVG viewport from clipping its own legitimate artwork. All four Cloud usages (chat input selector, terminal dropdown rows, admin/user integrations settings) render with intact edges.

```diff
 <svg
-	class={className}
+	class="overflow-visible {className}"
 	aria-hidden="true"
```

**Bug 2 — Account profile avatar (Settings → Account)**

- **Problem**: The round profile avatar under **Settings → Account → Profile** has its left edge chopped flat — with an uploaded photo, the initials avatar, and the default image alike — and the cut worsens on hover.
- **Root cause**: The avatar button sits *exactly* flush-left (identical fractional `getBoundingClientRect().left` values, verified on both desktop and mobile layouts) with two clipping ancestors: the tab's `overflow-y-auto` scroll wrapper and the settings modal's `overflow-hidden` content pane. The button's `ring-1` / `hover:ring-2` is an **outset** box-shadow, so the ring plus the boundary pixel of the circle is clipped on the left. (Note that `overflow-y-auto` forces `overflow-x` to compute to `auto`, so the horizontal clip applies even though only vertical scrolling was intended.)
- **Fix**: `ring-inset`, so the ring draws inside the button bounds where nothing can clip it. On a 40px avatar the 1px inward shift is imperceptible, and it makes the component robust inside any clipping container. Precedent: `FileEntryRow.svelte` already uses `ring-inset` for exactly this class of situation.

```diff
-			ring-1 ring-gray-200 transition-all duration-200 hover:ring-2 ...
+			ring-1 ring-inset ring-gray-200 transition-all duration-200 hover:ring-2 ...
```

### Fixed

- Fixed the Open Terminal cloud icon in the chat input being cut off on its left side (SVG viewport clipping an exact-boundary stroke).
- Fixed the profile avatar in Settings → Account being cut off on its left side (outset ring clipped by the tab's scroll container), including the more pronounced clipping on hover.

---

### Additional Information

- Verification performed beyond eyeballing: ancestor-walk of computed `overflow` styles confirmed the clipper in each case (the svg's own viewport for the icon; the flush-left `overflow-y-auto`/`overflow-hidden` ancestors for the avatar), and the fixed avatar's computed `box-shadow` now reports `0 0 0 1px inset` — nothing rendered outside the clip boundary.
- This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Screenshots or Videos

| | Before | After |
|---|---|---|
| Open Terminal icon (untoggled) | <img width="142" height="72" alt="image" src="https://github.com/user-attachments/assets/fd352e3d-9680-4eda-8008-d93f26fe56a2" /> | <img width="142" height="72" alt="image" src="https://github.com/user-attachments/assets/f426f88d-c301-496a-9b2c-448ca9292c8b" /> |
| Open Terminal icon (toggled) | <img width="239" height="72" alt="image" src="https://github.com/user-attachments/assets/961cd641-990e-4780-9e60-1bc01712f670" /> | <img width="239" height="72" alt="image" src="https://github.com/user-attachments/assets/21e92c4e-e002-4aad-9866-a2692c188816" /> |
| Account avatar | <img width="358" height="141" alt="image" src="https://github.com/user-attachments/assets/5060ed1e-0262-491b-aeb1-037216dcf4d5" /> | <img width="358" height="141" alt="image" src="https://github.com/user-attachments/assets/5df19e02-21bd-4d26-aa7e-dce6ecb9040d" /> |

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
