### PR TITLE
fix: repair chat shell accessibility semantics

### DIFF
--- a/src/lib/components/chat/Placeholder.svelte
+++ b/src/lib/components/chat/Placeholder.svelte
@@ -120,7 +120,6 @@
 									placement="top"
 								>
 									<button
-										aria-hidden={models.length <= 1}
 										aria-label={$i18n.t('Get information on {{name}} in the UI', {
 											name: models[modelIdx]?.name
 										})}

--- a/src/lib/components/chat/Suggestions.svelte
+++ b/src/lib/components/chat/Suggestions.svelte
@@ -86,45 +86,45 @@
 
 <div class="h-36 w-full">
 	{#if filteredPrompts.length > 0}
-		<div role="list" class="max-h-36 overflow-auto scrollbar-none items-start {className}">
+		<ul class="m-0 max-h-36 list-none overflow-auto p-0 scrollbar-none items-start {className}">
 			{#each filteredPrompts as prompt, idx (prompt.id || `${prompt.content}-${idx}`)}
-				<!-- svelte-ignore a11y-no-interactive-element-to-noninteractive-role -->
-				<button
-					role="listitem"
-					class="waterfall flex flex-col flex-1 shrink-0 w-full justify-between
+				<li>
+					<button
+						class="waterfall flex flex-col flex-1 shrink-0 w-full justify-between
 				       px-2.5 py-1.5 rounded-lg bg-transparent transition-colors
 				       hover:text-gray-950 dark:hover:text-white group"
-					style="animation-delay: {idx * 45}ms"
-					on:click={() => onSelect({ type: 'prompt', data: prompt.content })}
-				>
-					<div class="flex flex-col text-left leading-snug">
-						{#if prompt.title && prompt.title[0] !== ''}
-							<div
-								class="text-sm font-normal group-hover:text-gray-950 dark:text-gray-300 dark:group-hover:text-white transition line-clamp-1"
-							>
-								{prompt.title[0]}
-							</div>
-							<div
-								class="text-xs text-gray-600 group-hover:text-gray-900 dark:text-gray-400 dark:group-hover:text-gray-100 font-normal line-clamp-1"
-							>
-								{prompt.title[1]}
-							</div>
-						{:else}
-							<div
-								class="text-sm font-normal group-hover:text-gray-950 dark:text-gray-300 dark:group-hover:text-white transition line-clamp-1"
-							>
-								{prompt.content}
-							</div>
-							<div
-								class="text-xs text-gray-600 group-hover:text-gray-900 dark:text-gray-400 dark:group-hover:text-gray-100 font-normal line-clamp-1"
-							>
-								{$i18n.t('Prompt')}
-							</div>
-						{/if}
-					</div>
-				</button>
+						style="animation-delay: {idx * 45}ms"
+						on:click={() => onSelect({ type: 'prompt', data: prompt.content })}
+					>
+						<div class="flex flex-col text-left leading-snug">
+							{#if prompt.title && prompt.title[0] !== ''}
+								<div
+									class="text-sm font-normal group-hover:text-gray-950 dark:text-gray-300 dark:group-hover:text-white transition line-clamp-1"
+								>
+									{prompt.title[0]}
+								</div>
+								<div
+									class="text-xs text-gray-600 group-hover:text-gray-900 dark:text-gray-400 dark:group-hover:text-gray-100 font-normal line-clamp-1"
+								>
+									{prompt.title[1]}
+								</div>
+							{:else}
+								<div
+									class="text-sm font-normal group-hover:text-gray-950 dark:text-gray-300 dark:group-hover:text-white transition line-clamp-1"
+								>
+									{prompt.content}
+								</div>
+								<div
+									class="text-xs text-gray-600 group-hover:text-gray-900 dark:text-gray-400 dark:group-hover:text-gray-100 font-normal line-clamp-1"
+								>
+									{$i18n.t('Prompt')}
+								</div>
+							{/if}
+						</div>
+					</button>
+				</li>
 			{/each}
-		</div>
+		</ul>
 	{/if}
 </div>
 

--- a/src/lib/components/common/Dropdown.svelte
+++ b/src/lib/components/common/Dropdown.svelte
@@ -64,9 +64,20 @@
 		};
 	}
 
-	/** Svelte action: captures the first child element as the trigger reference */
-	function trigger(node: HTMLElement) {
-		triggerEl = (node.firstElementChild as HTMLElement | null) || node;
+	/** Svelte action: captures and describes the slotted interactive trigger. */
+	function trigger(node: HTMLElement, expanded: boolean) {
+		const syncTrigger = () => {
+			triggerEl =
+				node.querySelector<HTMLElement>(
+					'button, a[href], input, select, textarea, [role="button"], [tabindex]:not([tabindex="-1"])'
+				) ||
+				(node.firstElementChild as HTMLElement | null) ||
+				node;
+			triggerEl.setAttribute('aria-haspopup', 'menu');
+			triggerEl.setAttribute('aria-expanded', String(expanded));
+		};
+
+		syncTrigger();
 		function handleClick(e: MouseEvent) {
 			e.preventDefault();
 			toggleOpen();
@@ -80,6 +91,10 @@
 		node.addEventListener('click', handleClick);
 		node.addEventListener('keydown', handleKeydown);
 		return {
+			update(nextExpanded: boolean) {
+				expanded = nextExpanded;
+				syncTrigger();
+			},
 			destroy() {
 				node.removeEventListener('click', handleClick);
 				node.removeEventListener('keydown', handleKeydown);
@@ -330,7 +345,7 @@
 	on:resize={positionContent}
 />
 
-<span use:trigger style="display: contents; cursor: pointer;">
+<span use:trigger={show} style="display: contents; cursor: pointer;">
 	<slot />
 </span>
 

--- a/src/lib/components/common/Dropdown.svelte
+++ b/src/lib/components/common/Dropdown.svelte
@@ -330,13 +330,7 @@
 	on:resize={positionContent}
 />
 
-<span
-	use:trigger
-	style="display: contents; cursor: pointer;"
-	role="button"
-	aria-haspopup="true"
-	aria-expanded={show}
->
+<span use:trigger style="display: contents; cursor: pointer;">
 	<slot />
 </span>
 

--- a/src/lib/components/common/RichTextInput.svelte
+++ b/src/lib/components/common/RichTextInput.svelte
@@ -967,7 +967,7 @@
 			editorProps: {
 				// the tiptap placeholder never becomes the field's accessible name;
 				// function form so a placeholder change is picked up after mount
-				attributes: () => ({ id, 'aria-label': _placeholder }),
+				attributes: () => ({ id, ...(editable ? { 'aria-label': _placeholder } : {}) }),
 				handleDrop: (view, event) => {
 					// Intercept sidebar chat item drops to prevent ProseMirror
 					// from inserting the raw JSON as text. The actual handling

--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -1130,6 +1130,7 @@
 				<a
 					class="flex items-center rounded-xl size-8.5 h-full justify-center hover:bg-gray-50 dark:hover:bg-gray-900 transition no-drag-region"
 					href="/"
+					aria-label={$i18n.t('New Chat')}
 					draggable="false"
 					on:click={newChatHandler}
 				>
@@ -1475,7 +1476,7 @@
 							<Tooltip content={$i18n.t('More')}>
 								<button
 									type="button"
-									class="flex items-center justify-center w-7 h-7 rounded-lg text-gray-300 hover:text-gray-500 dark:text-gray-600 dark:hover:text-gray-400 transition-colors duration-100"
+									class="flex items-center justify-center w-7 h-7 rounded-lg text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300 transition-colors duration-100"
 									aria-label={$i18n.t('More')}
 									on:pointerup|stopPropagation
 								>

--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -935,12 +935,7 @@
 		role="navigation"
 		aria-label={$i18n.t('Chat history')}
 	>
-		<button
-			class="flex flex-col flex-1 {isWindows ? 'cursor-pointer' : 'cursor-[e-resize]'}"
-			on:click={async () => {
-				showSidebar.set(!$showSidebar);
-			}}
-		>
+		<div class="flex flex-col flex-1">
 			<div class="pb-1">
 				<Tooltip
 					content={$showSidebar ? $i18n.t('Close Sidebar') : $i18n.t('Open Sidebar')}
@@ -951,6 +946,9 @@
 							? 'cursor-pointer'
 							: 'cursor-[e-resize]'}"
 						aria-label={$showSidebar ? $i18n.t('Close Sidebar') : $i18n.t('Open Sidebar')}
+						on:click={() => {
+							showSidebar.set(!$showSidebar);
+						}}
 					>
 						<div
 							class=" self-center flex size-[30px] items-center justify-center rounded-lg transition group-hover:bg-gray-50 dark:group-hover:bg-gray-900"
@@ -1060,7 +1058,7 @@
 					{/if}
 				{/each}
 			</div>
-		</button>
+		</div>
 
 		<div>
 			<div>

--- a/src/lib/components/layout/Sidebar/Folders/FolderMenu.svelte
+++ b/src/lib/components/layout/Sidebar/Folders/FolderMenu.svelte
@@ -36,6 +36,7 @@
 >
 	<Tooltip content={$i18n.t('More')}>
 		<button
+			aria-label={$i18n.t('More')}
 			on:pointerup|stopPropagation
 			on:click={(e) => {
 				e.stopPropagation();

--- a/src/lib/components/layout/Sidebar/Folders/FolderMenu.svelte
+++ b/src/lib/components/layout/Sidebar/Folders/FolderMenu.svelte
@@ -36,6 +36,7 @@
 >
 	<Tooltip content={$i18n.t('More')}>
 		<button
+			on:pointerup|stopPropagation
 			on:click={(e) => {
 				e.stopPropagation();
 				show = !show;

--- a/src/lib/components/layout/Sidebar/RecursiveFolder.svelte
+++ b/src/lib/components/layout/Sidebar/RecursiveFolder.svelte
@@ -837,7 +837,7 @@
 
 				{#if !folders[folderId]?.shared || folders[folderId]?.permission === 'write'}
 					<div
-						class="absolute z-10 right-2 invisible group-hover:visible self-center flex items-center dark:text-gray-300"
+						class="absolute z-10 right-2 pointer-events-none opacity-0 group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100 self-center flex items-center dark:text-gray-300"
 					>
 						<FolderMenu
 							onEdit={() => {

--- a/src/lib/components/layout/Sidebar/RecursiveFolder.svelte
+++ b/src/lib/components/layout/Sidebar/RecursiveFolder.svelte
@@ -586,10 +586,6 @@
 		setFolderItems();
 	}
 
-	const shouldIgnoreRowClick = (target) => {
-		return target instanceof Element && !!target.closest('button, a, input, [role="menu"]');
-	};
-
 	const openFolderHandler = async () => {
 		const folder = await getFolderById(localStorage.token, folderId).catch((error) => {
 			toast.error(`${error}`);
@@ -733,7 +729,6 @@
 			dispatch('open', state);
 		}}
 	>
-		<!-- svelte-ignore a11y-no-static-element-interactions -->
 		<div class="w-full group">
 			<div
 				id="folder-{folderId}-button"
@@ -741,38 +736,6 @@
 				folderId
 					? 'bg-gray-100/80 dark:bg-gray-850/50 selected'
 					: ''}"
-				on:dblclick={(e) => {
-					if (folders[folderId]?.shared && folders[folderId]?.permission !== 'write') return;
-					if (clickTimer) {
-						clearTimeout(clickTimer); // cancel the single-click action
-						clickTimer = null;
-					}
-					renameHandler();
-				}}
-				role="button"
-				tabindex="0"
-				on:click={async (e) => {
-					if (shouldIgnoreRowClick(e.target)) return;
-					if (clickTimer) {
-						clearTimeout(clickTimer);
-						clickTimer = null;
-					}
-
-					clickTimer = setTimeout(async () => {
-						await openFolderHandler();
-						clickTimer = null;
-					}, 100); // 100ms delay (typical double-click threshold)
-				}}
-				on:keydown={(e) => {
-					if (e.currentTarget !== e.target) return;
-					if (e.key === 'Enter' || e.key === ' ') {
-						e.preventDefault();
-						openFolderHandler();
-					}
-				}}
-				on:pointerup={(e) => {
-					e.stopPropagation();
-				}}
 			>
 				<button
 					class="text-gray-600 dark:text-gray-400 transition-all p-1 hover:bg-gray-50/40 dark:hover:bg-gray-800/40 rounded-lg"
@@ -838,23 +801,39 @@
 							class="w-full h-full bg-transparent outline-hidden"
 						/>
 					{:else}
-						<div class="min-w-0 truncate">
-							{folders[folderId].name}
-						</div>
+						<button
+							type="button"
+							class="flex min-w-0 flex-1 items-center gap-1.5 text-start"
+							on:dblclick={() => {
+								if (folders[folderId]?.shared && folders[folderId]?.permission !== 'write') return;
+								if (clickTimer) clearTimeout(clickTimer);
+								clickTimer = null;
+								renameHandler();
+							}}
+							on:click={() => {
+								if (clickTimer) clearTimeout(clickTimer);
+								clickTimer = setTimeout(async () => {
+									await openFolderHandler();
+									clickTimer = null;
+								}, 100);
+							}}
+						>
+							<span class="min-w-0 truncate">{folders[folderId].name}</span>
 
-						{#if !folders[folderId]?.shared && (folders[folderId]?.unread_count ?? 0) > 0}
-							<div
-								class="inline-flex h-4 min-w-4 shrink-0 items-center justify-center rounded-md bg-sky-500/10 px-1 text-[10px] font-semibold leading-4 text-sky-600 dark:bg-sky-400/10 dark:text-sky-300"
-								title={$i18n.t('Unread')}
-							>
-								{formatUnreadCount(folders[folderId].unread_count)}
-							</div>
-						{/if}
+							{#if !folders[folderId]?.shared && (folders[folderId]?.unread_count ?? 0) > 0}
+								<span
+									class="inline-flex h-4 min-w-4 shrink-0 items-center justify-center rounded-md bg-sky-500/10 px-1 text-[10px] font-semibold leading-4 text-sky-600 dark:bg-sky-400/10 dark:text-sky-300"
+									title={$i18n.t('Unread')}
+								>
+									{formatUnreadCount(folders[folderId].unread_count)}
+								</span>
+							{/if}
+						</button>
 					{/if}
 				</div>
 
 				{#if !folders[folderId]?.shared || folders[folderId]?.permission === 'write'}
-					<button
+					<div
 						class="absolute z-10 right-2 invisible group-hover:visible self-center flex items-center dark:text-gray-300"
 					>
 						<FolderMenu
@@ -882,7 +861,7 @@
 								<MoreHorizontal className="size-3.5" strokeWidth="2" />
 							</div>
 						</FolderMenu>
-					</button>
+					</div>
 				{/if}
 			</div>
 		</div>

--- a/src/lib/components/layout/Sidebar/RecursiveFolder.svelte
+++ b/src/lib/components/layout/Sidebar/RecursiveFolder.svelte
@@ -739,6 +739,7 @@
 			>
 				<button
 					class="text-gray-600 dark:text-gray-400 transition-all p-1 hover:bg-gray-50/40 dark:hover:bg-gray-800/40 rounded-lg"
+					on:pointerup|stopPropagation
 					on:click={(e) => {
 						e.stopPropagation();
 						e.stopImmediatePropagation();
@@ -779,6 +780,7 @@
 							id="folder-{folderId}-input"
 							type="text"
 							bind:value={name}
+							on:pointerup|stopPropagation
 							on:blur={() => {
 								console.log('Blur');
 								updateHandler({ name });
@@ -804,6 +806,7 @@
 						<button
 							type="button"
 							class="flex min-w-0 flex-1 items-center gap-1.5 text-start"
+							on:pointerup|stopPropagation
 							on:dblclick={() => {
 								if (folders[folderId]?.shared && folders[folderId]?.permission !== 'write') return;
 								if (clickTimer) clearTimeout(clickTimer);

--- a/src/lib/components/layout/Sidebar/Section.svelte
+++ b/src/lib/components/layout/Sidebar/Section.svelte
@@ -148,7 +148,7 @@
 					{#if onAdd}
 						<button
 							type="button"
-							class="flex items-center justify-center w-7 h-7 rounded-lg text-gray-300 hover:text-gray-500 dark:text-gray-600 dark:hover:text-gray-400 transition-colors duration-100"
+							class="flex items-center justify-center w-7 h-7 rounded-lg text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300 transition-colors duration-100"
 							aria-label={onAddLabel}
 							on:pointerup={(e) => {
 								e.stopPropagation();

--- a/src/lib/components/layout/sidebar-a11y.test.ts
+++ b/src/lib/components/layout/sidebar-a11y.test.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const source = (path: string) => readFileSync(resolve(process.cwd(), path), 'utf8');
+
+describe('sidebar accessibility markup', () => {
+	const sidebar = source('src/lib/components/layout/Sidebar.svelte');
+	const folder = source('src/lib/components/layout/Sidebar/RecursiveFolder.svelte');
+	const section = source('src/lib/components/layout/Sidebar/Section.svelte');
+	const appLayout = source('src/routes/(app)/+layout.svelte');
+
+	it('does not wrap sidebar controls in an interactive container', () => {
+		expect(sidebar).not.toContain('class="flex flex-col flex-1 {isWindows');
+	});
+
+	it('keeps the collapsed sidebar toggle actionable', () => {
+		const collapsedRail = sidebar.slice(
+			sidebar.indexOf('{#if !$mobile && !$showSidebar}'),
+			sidebar.indexOf("<!-- {$i18n.t('New Folder')} -->")
+		);
+		expect(collapsedRail).toMatch(
+			/<button[^>]*aria-label=\{\$showSidebar \? \$i18n\.t\('Close Sidebar'\) : \$i18n\.t\('Open Sidebar'\)\}[^>]*on:click/
+		);
+	});
+
+	it('does not expose folder controls through a parent button role', () => {
+		expect(folder).not.toMatch(/role="button"[\s\S]*?<button/);
+	});
+
+	it('uses an accessible default contrast for section actions', () => {
+		expect(section).toContain('text-gray-500 hover:text-gray-700 dark:text-gray-400');
+	});
+
+	it('keeps the skip-link destination programmatically focusable', () => {
+		expect(appLayout).toContain('<main id="main-content" tabindex="-1"');
+	});
+});

--- a/src/lib/components/layout/sidebar-a11y.test.ts
+++ b/src/lib/components/layout/sidebar-a11y.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { compile } from 'svelte/compiler';
 import { describe, expect, it } from 'vitest';
 
 const source = (path: string) => readFileSync(resolve(process.cwd(), path), 'utf8');
@@ -8,7 +9,10 @@ describe('sidebar accessibility markup', () => {
 	const sidebar = source('src/lib/components/layout/Sidebar.svelte');
 	const folder = source('src/lib/components/layout/Sidebar/RecursiveFolder.svelte');
 	const section = source('src/lib/components/layout/Sidebar/Section.svelte');
+	const rootLayout = source('src/routes/+layout.svelte');
 	const appLayout = source('src/routes/(app)/+layout.svelte');
+	const dropdown = source('src/lib/components/common/Dropdown.svelte');
+	const suggestions = source('src/lib/components/chat/Suggestions.svelte');
 
 	it('does not wrap sidebar controls in an interactive container', () => {
 		expect(sidebar).not.toContain('class="flex flex-col flex-1 {isWindows');
@@ -22,17 +26,38 @@ describe('sidebar accessibility markup', () => {
 		expect(collapsedRail).toMatch(
 			/<button[^>]*aria-label=\{\$showSidebar \? \$i18n\.t\('Close Sidebar'\) : \$i18n\.t\('Open Sidebar'\)\}[^>]*on:click/
 		);
+		expect(collapsedRail).not.toContain('aria-hidden');
 	});
 
 	it('does not expose folder controls through a parent button role', () => {
 		expect(folder).not.toMatch(/role="button"[\s\S]*?<button/);
+		expect(folder).toContain('on:pointerup|stopPropagation');
 	});
 
 	it('uses an accessible default contrast for section actions', () => {
 		expect(section).toContain('text-gray-500 hover:text-gray-700 dark:text-gray-400');
 	});
 
-	it('keeps the skip-link destination programmatically focusable', () => {
+	it('compiles the skip link and its programmatically focusable destination', () => {
+		expect(() => compile(rootLayout, { generate: 'server' })).not.toThrow();
+		expect(() => compile(appLayout, { generate: 'server' })).not.toThrow();
+		expect(rootLayout).toContain('href="#main-content"');
 		expect(appLayout).toContain('<main id="main-content" tabindex="-1"');
+	});
+
+	it('keeps slotted dropdown triggers as the only interactive control', () => {
+		expect(dropdown).not.toContain('role="button"');
+		expect(dropdown).not.toContain('aria-haspopup="true"');
+	});
+
+	it('uses native list semantics without changing suggestion buttons into list items', () => {
+		expect(suggestions).toContain('<ul');
+		expect(suggestions).toContain('<li');
+		expect(suggestions).not.toContain('role="listitem"');
+	});
+
+	it('names the favicon home link and keeps More above the contrast floor', () => {
+		expect(sidebar).toContain("aria-label={$i18n.t('New Chat')}");
+		expect(sidebar).toContain('text-gray-500 hover:text-gray-700 dark:text-gray-400');
 	});
 });

--- a/src/lib/components/layout/sidebar-a11y.test.ts
+++ b/src/lib/components/layout/sidebar-a11y.test.ts
@@ -8,10 +8,13 @@ const source = (path: string) => readFileSync(resolve(process.cwd(), path), 'utf
 describe('sidebar accessibility markup', () => {
 	const sidebar = source('src/lib/components/layout/Sidebar.svelte');
 	const folder = source('src/lib/components/layout/Sidebar/RecursiveFolder.svelte');
+	const folderMenu = source('src/lib/components/layout/Sidebar/Folders/FolderMenu.svelte');
 	const section = source('src/lib/components/layout/Sidebar/Section.svelte');
 	const rootLayout = source('src/routes/+layout.svelte');
 	const appLayout = source('src/routes/(app)/+layout.svelte');
 	const dropdown = source('src/lib/components/common/Dropdown.svelte');
+	const richTextInput = source('src/lib/components/common/RichTextInput.svelte');
+	const placeholder = source('src/lib/components/chat/Placeholder.svelte');
 	const suggestions = source('src/lib/components/chat/Suggestions.svelte');
 
 	it('does not wrap sidebar controls in an interactive container', () => {
@@ -34,6 +37,12 @@ describe('sidebar accessibility markup', () => {
 		expect(folder).toContain('on:pointerup|stopPropagation');
 	});
 
+	it('names the folder menu and reveals it on keyboard focus', () => {
+		expect(folderMenu).toContain("aria-label={$i18n.t('More')}");
+		expect(folder).toContain('group-focus-within:opacity-100');
+		expect(folder).not.toContain('invisible group-hover:visible');
+	});
+
 	it('uses an accessible default contrast for section actions', () => {
 		expect(section).toContain('text-gray-500 hover:text-gray-700 dark:text-gray-400');
 	});
@@ -41,13 +50,35 @@ describe('sidebar accessibility markup', () => {
 	it('compiles the skip link and its programmatically focusable destination', () => {
 		expect(() => compile(rootLayout, { generate: 'server' })).not.toThrow();
 		expect(() => compile(appLayout, { generate: 'server' })).not.toThrow();
-		expect(rootLayout).toContain('href="#main-content"');
+		expect(rootLayout).not.toContain('href="#main-content"');
+		expect(appLayout).toMatch(
+			/{#if loaded}[\s\S]*?href="#main-content"[\s\S]*?<main id="main-content" tabindex="-1"/
+		);
+		expect(appLayout.indexOf('href="#main-content"')).toBeLessThan(
+			appLayout.indexOf('<Sidebar />')
+		);
+		expect(appLayout).toContain('focus:absolute focus:top-2 focus:left-2 focus:z-[9999]');
 		expect(appLayout).toContain('<main id="main-content" tabindex="-1"');
 	});
 
-	it('keeps slotted dropdown triggers as the only interactive control', () => {
-		expect(dropdown).not.toContain('role="button"');
-		expect(dropdown).not.toContain('aria-haspopup="true"');
+	it('keeps slotted dropdown triggers as the only interactive control with popup state', () => {
+		const dropdownMarkup = dropdown.slice(dropdown.indexOf('</script>'));
+		expect(dropdownMarkup).not.toContain('role="button"');
+		expect(dropdown).toContain('use:trigger={show}');
+		expect(dropdown).toContain("setAttribute('aria-haspopup', 'menu')");
+		expect(dropdown).toContain("setAttribute('aria-expanded', String(expanded))");
+	});
+
+	it('does not name a rich text editor while it is non-editable', () => {
+		expect(() => compile(richTextInput, { generate: 'server' })).not.toThrow();
+		expect(richTextInput).toMatch(
+			/attributes:\s*\(\)\s*=>\s*\(\{\s*id,\s*\.\.\.\(editable\s*\?\s*\{\s*'aria-label':\s*_placeholder\s*\}\s*:\s*\{\}\)\s*\}\)/
+		);
+	});
+
+	it('keeps the single-model information control out of aria-hidden', () => {
+		expect(() => compile(placeholder, { generate: 'server' })).not.toThrow();
+		expect(placeholder).not.toContain('aria-hidden={models.length <= 1}');
 	});
 
 	it('uses native list semantics without changing suggestion buttons into list items', () => {

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -514,6 +514,15 @@
 					</div>
 				{/if}
 
+				{#if loaded}
+					<a
+						href="#main-content"
+						class="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-[9999] focus:rounded-lg focus:bg-white focus:px-4 focus:py-2 focus:text-sm focus:font-medium focus:text-gray-900 focus:shadow-lg dark:focus:bg-gray-800 dark:focus:text-gray-100"
+					>
+						{$i18n.t('Skip to main content')}
+					</a>
+				{/if}
+
 				<Sidebar />
 
 				{#if loaded}

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -517,7 +517,7 @@
 				<Sidebar />
 
 				{#if loaded}
-					<main id="main-content" class="contents">
+					<main id="main-content" tabindex="-1" class="contents">
 						<slot />
 					</main>
 				{:else}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1324,13 +1324,6 @@
 	/>
 </svelte:head>
 
-<a
-	href="#main-content"
-	class="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-[9999] focus:rounded-lg focus:bg-white focus:px-4 focus:py-2 focus:text-sm focus:font-medium focus:text-gray-900 focus:shadow-lg dark:focus:bg-gray-800 dark:focus:text-gray-100"
->
-	{$i18n.t('Skip to main content')}
-</a>
-
 {#if showRefresh}
 	<div class=" py-5">
 		<Spinner className="size-5" />


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Closes #27698
- [x] **Target branch:** This targets `dev`.
- [x] **Description:** The accessibility fixes are summarized below.
- [x] **Changelog:** Included below.
- [x] **Documentation:** No configuration or user documentation change is required.
- [x] **Dependencies:** No dependencies were added or updated.
- [x] **Testing:** Node 22 component tests, Svelte compilation, keyboard/mouse runtime checks, axe-core, Prettier, and diff checks were run.
- [ ] **No Unchecked AI Code:** Final human review is intentionally left for the contributor before merge.
- [x] **Self-Review:** The diff received two independent adversarial review rounds and the findings were repaired.
- [x] **Architecture:** Reuses existing Svelte actions/components and adds no settings or dependencies.
- [x] **Git Hygiene:** Three atomic commits on fresh `dev`; no unrelated files.
- [x] **Title Prefix:** Uses `fix:`.

## Description

Repairs a cluster of accessibility issues in the authenticated chat shell and sidebar:

- moves dropdown popup state onto the actual native trigger without nested interactive wrappers;
- keeps folder actions named and keyboard-visible;
- removes prohibited ARIA from a non-editable rich-text input;
- renders the skip link only where its focusable main target exists;
- removes `aria-hidden` from a focusable model-information control;
- preserves native list/button semantics and improves action contrast.

No branding, logo, favicon, static asset, or template files are changed.

## Testing

- Focused Node 22 accessibility suite: 11/11 passed
- Ten changed Svelte components compile
- Native dropdown mouse, Enter, and Space interaction verified; `aria-expanded` changes `false` to `true`
- Skip link verified at visible focus geometry and transfers focus to `main[tabindex="-1"]`
- axe-core `aria-hidden-focus`: serious violation before, zero after
- Prettier and `git diff --check`: passed

# Changelog Entry

### Fixed

- Fixed nested and missing interactive semantics in sidebar dropdown and folder controls.
- Fixed non-editable chat-input ARIA, skip-link targeting, and hidden focusable model information.

### Added

- Added focused accessibility regression coverage for the repaired chat-shell paths.

### Changed

- None.

### Deprecated

- None.

### Removed

- None.

### Security

- None.

### Breaking Changes

- None.

---

### Additional Information

- Closes #27698.
- Runtime evidence was collected in an isolated component harness; this PR does not claim live production deployment.

### Screenshots or Videos

- Focus behavior and axe-core results are described in the testing section; no branding or visual design change is included.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.