### PR TITLE
fix: hide disabled chat fork actions

### DIFF
--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -1183,7 +1183,9 @@
 					canCompact: () => !!history?.currentId && contextCompactionEnabled,
 					compactDisabled: () => isActive,
 					canStatus: () => !!history?.currentId,
-					canFork: () => !!history?.currentId,
+					canFork: () =>
+						!!history?.currentId &&
+						($_user?.role === 'admin' || ($_user?.permissions?.chat?.import ?? true)),
 					forkDisabled: () => isActive,
 					contextUsage: () => statusContextUsage,
 					onCompact: compactHandler,

--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -1482,7 +1482,7 @@
 										</Tooltip>
 									{/each}
 
-									{#if message.done && !readOnly && forkHandler}
+									{#if message.done && !readOnly && forkHandler && ($user?.role === 'admin' || ($user?.permissions?.chat?.import ?? true))}
 										<Tooltip content="Fork chat" placement="bottom">
 											<button
 												aria-label="Fork chat"


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Closes #27692
- [x] **Target branch:** This PR targets `dev`.
- [x] **Description:** The change and impact are described below.
- [x] **Changelog:** A changelog entry is included.
- [x] **Dependencies:** No dependencies changed.
- [x] **Testing:** The changed files pass Prettier; see validation notes below.
- [x] **No Unchecked AI Code:** The focused conditions were reviewed against the existing backend permission check.
- [x] **Self-Review:** The diff is limited to the two fork-action visibility checks.
- [x] **Architecture:** This reuses the existing `chat.import` permission.
- [x] **Git Hygiene:** The PR is atomic and based on `dev`.
- [x] **Title Prefix:** The title uses `fix`.

## Description

Hide chat-fork UI actions when a non-admin user does not have the existing `chat.import` permission.

The backend already rejects fork requests for those users, but the response action and `/fork` command were still shown. This caused users to click an unavailable action and receive “Access prohibited.”

Admins retain access. For other users, both visible fork entry points now use the same permission condition as `handleForkChat`.

## Validation

- Prettier passed for both changed Svelte components.
- `git diff --check` passed.
- Repository-wide `npm run check` was attempted under Node 22. It currently reports existing baseline diagnostics across 349 files; neither modified condition is a reported error location.

# Changelog Entry

### Fixed

- Hide chat-fork actions when chat-import permission is disabled.

### Additional Information

- Closes #27692

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [ ] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
