### PR TITLE
feat: add Apiário Dev as a suggested OpenAI-compatible provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,11 @@ OLLAMA_BASE_URL='http://localhost:11434'
 OPENAI_API_BASE_URL=''
 OPENAI_API_KEY=''
 
+# Apiário Dev - Provider brasileiro de IA com dezenas de modelos
+# https://apiario.dev
+APIARIO_API_BASE_URL='https://api.apiario.dev/v1'
+APIARIO_API_KEY=''
+
 # AUTOMATIC1111_BASE_URL="http://localhost:7860"
 
 # For production, you should only need one host as

--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -358,6 +358,27 @@ OPENAI_API_BASE_URL = 'https://api.openai.com/v1'
 
 
 ####################################
+# APIÁRIO DEV
+####################################
+
+APIARIO_API_KEY = os.getenv('APIARIO_API_KEY', '')
+APIARIO_API_BASE_URL = os.getenv('APIARIO_API_BASE_URL', 'https://api.apiario.dev/v1')
+
+if APIARIO_API_BASE_URL.endswith('/'):
+    APIARIO_API_BASE_URL = APIARIO_API_BASE_URL[:-1]
+
+# If APIARIO_API_KEY is set, prepend the Apiário connection to the OpenAI list
+if APIARIO_API_KEY:
+    if APIARIO_API_BASE_URL not in OPENAI_API_BASE_URLS:
+        OPENAI_API_BASE_URLS.insert(0, APIARIO_API_BASE_URL)
+        OPENAI_API_KEYS.insert(0, APIARIO_API_KEY)
+        OPENAI_API_CONFIGS[str(len(OPENAI_API_BASE_URLS) - 1)] = {
+            'provider': 'apiario',
+            'connection_type': 'external',
+        }
+
+
+####################################
 # MODELS
 ####################################
 

--- a/src/lib/components/AddConnectionModal.svelte
+++ b/src/lib/components/AddConnectionModal.svelte
@@ -351,6 +351,7 @@
 											<option value="https://api.groq.com/openai/v1" />
 											<option value="https://openrouter.ai/api/v1" />
 											<option value="https://api.x.ai/v1" />
+											<option value="https://api.apiario.dev/v1" />
 										</datalist>
 									{/if}
 								</div>
@@ -598,6 +599,7 @@
 											<option value="azure">{$i18n.t('Azure OpenAI')}</option>
 											<option value="llama.cpp">{$i18n.t('llama.cpp')}</option>
 											<option value="litellm">{$i18n.t('LiteLLM')}</option>
+											<option value="apiario">{$i18n.t('Apiário Dev')}</option>
 										</select>
 									</div>
 								</div>


### PR DESCRIPTION
# feat: add Apiário Dev as a native provider option in Open WebUI

## Description

This PR adds [Apiário Dev](https://apiario.dev) as a suggested OpenAI-compatible provider in Open WebUI. Apiário Dev is a Brazilian AI gateway that provides access to 25+ models from providers like OpenAI, Anthropic, DeepSeek, Maritaca (Sabiá), Moonshot, and others through a single OpenAI-compatible endpoint (https://api.apiario.dev/v1), with pricing in BRL and payment via PIX.

Unlike other providers that require specific API types (like Anthropic's separate format), Apiário is fully OpenAI-compatible, making it a natural addition to the existing OpenAI Connections system.

## Changes

### Added

- **`.env.example`** — Added `APIARIO_API_BASE_URL` and `APIARIO_API_KEY` environment variables documentation
- **`backend/open_webui/config.py`** — Added Apiário Dev configuration block:
  - Reads `APIARIO_API_KEY` and `APIARIO_API_BASE_URL` from environment variables
  - If `APIARIO_API_KEY` is set, automatically prepends the Apiário connection to the OpenAI connections list with `provider: 'apiario'` for identification
  - Uses sensible defaults: `https://api.apiario.dev/v1` base URL
- **`src/lib/components/AddConnectionModal.svelte`** — Added `https://api.apiario.dev/v1` to the URL suggestions datalist, so users can discover and add Apiário with one click
- **`src/lib/components/AddConnectionModal.svelte`** — Added `apiario` as a recognized provider type in the Provider select dropdown (alongside Azure, llama.cpp, LiteLLM)

### Why Apiário?

- **Brazilian-focused**: Pricing in BRL, payment via PIX, no IOF, no USD conversion fees
- **25+ models**: Access to global (OpenAI, Anthropic, DeepSeek) and local Brazilian models (Maritaca/Sabiá) through a single endpoint
- **OpenAI-compatible**: Works out-of-the-box with Open WebUI's existing OpenAI Connections system — no custom engine needed
- **Low latency**: Infrastructure hosted in Brazil for lower latency
- **No auth required for /models**: The /v1/models endpoint is public, so model discovery works without an API key

### Verification

- `GET https://api.apiario.dev/v1/models` — returns 25 models in standard OpenAI format (works without auth)
- `POST https://api.apiario.dev/v1/chat/completions` — requires Bearer token, returns standard OpenAI format
- Error format follows OpenAI convention: `{"error": {"code": "...", "message": "...", "type": "..."}}`
- Streaming via SSE is supported
- CORS headers (`Vary: Origin`) indicate CORS support

## Changelog Entry

### Description

- Added Apiário Dev as a discoverable OpenAI-compatible provider in Open WebUI

### Added

- URL suggestion for Apiário Dev (`https://api.apiario.dev/v1`) in the Add Connection modal datalist
- `apiario` provider type option in the Provider select dropdown
- `APIARIO_API_BASE_URL` and `APIARIO_API_KEY` environment variables for automated configuration
- Automatic Apiário connection registration when `APIARIO_API_KEY` env var is set
- Documentation in `.env.example` for Apiário Dev environment variables

---

### Additional Information

- **Discussion:** Relates to https://github.com/open-webui/open-webui/discussions/27704
- Apiário is **100% OpenAI-compatible** — no custom backend treatment needed
- The `/v1/models` endpoint is public (no auth required for model discovery)
- Provider type `apiario` is registered for identification in configs and future extensibility
- Tested manually against the live Apiário API endpoint
