### PR TITLE
fix: hide chat fork actions when chat import permission is disabled

### DIFF
--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -1183,7 +1183,9 @@
 					canCompact: () => !!history?.currentId && contextCompactionEnabled,
 					compactDisabled: () => isActive,
 					canStatus: () => !!history?.currentId,
-					canFork: () => !!history?.currentId,
+					canFork: () =>
+						!!history?.currentId &&
+						($_user?.role === 'admin' || ($_user?.permissions?.chat?.import ?? true)),
 					forkDisabled: () => isActive,
 					contextUsage: () => statusContextUsage,
 					onCompact: compactHandler,

--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -1482,7 +1482,7 @@
 										</Tooltip>
 									{/each}
 
-									{#if message.done && !readOnly && forkHandler}
+									{#if message.done && !readOnly && forkHandler && ($user?.role === 'admin' || ($user?.permissions?.chat?.import ?? true))}
 										<Tooltip content="Fork chat" placement="bottom">
 											<button
 												aria-label="Fork chat"


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27692 — the Fork chat button remains visible for users who lack the permission the backend requires to fork.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable — this aligns existing UI with an existing permission; no new setting or documented behavior is introduced.
- [ ] **Dependencies:** No new dependencies.
- [x] **Testing:** Verified by the author on a live instance: with `chat.import` disabled for a non-admin user, both the Fork chat message action and the `/fork` slash-command suggestion disappear. Admins and permitted users are unaffected. A full production build passes.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Reuses the existing `chat.import` permission rather than introducing a new one, so the UI gate matches the backend's authoritative check exactly. No new settings.
- [x] **Git Hygiene:** The PR is atomic (one logical change), based on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

> **Credit**: The fix in this PR is the work of @Nameless-Monster-Nerd, originally submitted as #27701. That PR was auto-closed by the bot because the CLA checkbox was left unticked. Their diff is carried here **unchanged** (byte-identical), with attribution as commit co-author, so the contribution is not lost. Full credit for the fix belongs to them.

# Changelog Entry

### Description

**Problem** — The Fork chat entry points are rendered unconditionally, even for users the backend will refuse. A user without the `chat.import` permission sees the Fork button, clicks it, and gets an "Access prohibited" error — a dead control that advertises a capability the user does not have. As reported in #27692, this also means an admin who disables the permission expecting the feature to be hidden still sees it offered to their users.

**Root Cause** — The fork endpoint (`POST /api/v1/chats/{id}/fork`) gates on `chat.import` via `require_chat_import_permission`, and the frontend's `handleForkChat` in `Chat.svelte` already performs the same check before calling the API. The two *visible* affordances that reach that handler were never given the matching condition:

- the Fork chat action in the response message toolbar (`ResponseMessage.svelte`)
- the `/fork` slash-command suggestion (`canFork` passed to `CommandSuggestionList`)

**Fix** — Apply the same `chat.import` condition already used by `handleForkChat` to both affordances, so the UI stops offering an action the backend will reject.

```diff
-					canFork: () => !!history?.currentId,
+					canFork: () =>
+						!!history?.currentId &&
+						($_user?.role === 'admin' || ($_user?.permissions?.chat?.import ?? true)),
```

```diff
-									{#if message.done && !readOnly && forkHandler}
+									{#if message.done && !readOnly && forkHandler && ($user?.role === 'admin' || ($user?.permissions?.chat?.import ?? true))}
```

**Why `chat.import` and not a new `chat.fork` permission** — #27692 suggests adding a dedicated `chat.fork` permission and `USER_PERMISSIONS_CHAT_FORK` env var. This PR deliberately does not, because the backend already treats forking as an import-class operation: `fork_chat_by_id` calls `require_chat_import_permission` before anything else. Reusing that permission makes the UI agree with the authority that actually enforces it, in two lines and with no new configuration surface. If a dedicated fork permission is wanted later, that is an additive backend + config + admin-UI change best discussed separately — but the reported bug (a visible control that always fails) is fixed either way.

**Entry-point coverage** — All four paths to a fork were audited; no gap remains:

| Entry point | Status |
|---|---|
| Fork action in response message toolbar | Gated by this PR |
| `/fork` slash-command suggestion | Gated by this PR |
| Typing `/fork` literally and submitting | Already gated — routes through `handleForkChat`, which checks the permission and toasts "Access prohibited" |
| `POST /api/v1/chats/{id}/fork` | Already gated — `require_chat_import_permission` |

The single gate in `ResponseMessage.svelte` covers every place a response message is rendered (`Message.svelte`, `MultiResponseMessages.svelte`, and all three `forkHandler` call sites in `Chat.svelte`), since they all pass the handler down to that component.

### Fixed

- Fixed the Fork chat action and `/fork` slash command being shown to users without the `chat.import` permission that the fork endpoint requires, which made the control fail with "Access prohibited" when used.

---

### Additional Information

- **Scope note on #27692**: the issue body also raises a second, distinct request — propagating the parent chat's session identity to downstream backends so a forked chat continues the same session (e.g. Langflow keyed on `session_id`). **This PR does not address that.** A fork is deliberately a new chat with a new id, and whether/how that identity should be forwarded downstream is a separate design question worth its own issue or discussion. This PR fixes the reported bug in the issue's title: the permission gate not being reflected in the UI.
- Verification beyond the manual pass: the permission expression was confirmed by reading the backend endpoint (`require_chat_import_permission` at `backend/open_webui/routers/chats.py`) and the existing frontend check in `handleForkChat`, so all three now use one identical condition.
- This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Screenshots or Videos

Non-admin user with the `chat.import` permission **disabled**:

| | Before | After |
|---|---|---|
| Fork action in the response message toolbar | <img width="357" height="74" alt="image" src="https://github.com/user-attachments/assets/2c968d59-6005-4b74-a37b-cef1764d48b9" /> | <img width="357" height="74" alt="image" src="https://github.com/user-attachments/assets/10b0cb91-adec-4a29-bb1a-6c724e3e7ee7" /> |
| `/fork` slash-command suggestion | <img width="378" height="184" alt="image" src="https://github.com/user-attachments/assets/8fe3a3d2-f4f3-4d98-b948-59ee2234f45c" /> | <img width="378" height="184" alt="image" src="https://github.com/user-attachments/assets/52e19f79-7ef5-4233-8638-3376baf9981a" /> |

Before, both controls are offered and clicking Fork fails with "Access prohibited". After, neither is rendered. Admins and users who hold the permission see no change.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
