### PR TITLE
fix: hide chat delete actions when the chat delete permission is disabled

### DIFF
--- a/src/lib/components/chat/Settings/ArchivedChats.svelte
+++ b/src/lib/components/chat/Settings/ArchivedChats.svelte
@@ -19,7 +19,7 @@
 		getArchivedChatList,
 		unarchiveAllChats
 	} from '$lib/apis/chats';
-	import { chatId, showSettings } from '$lib/stores';
+	import { chatId, showSettings, user } from '$lib/stores';
 	import { refreshChatList } from '$lib/stores/chatList';
 	import { formatNumber } from '$lib/utils';
 	import ConfirmDialog from '$lib/components/common/ConfirmDialog.svelte';
@@ -348,19 +348,21 @@
 									<UndoAction className="size-3.5" strokeWidth="1.5" />
 								</button>
 							</Tooltip>
-							<Tooltip content={$i18n.t('Delete Chat')}>
-								<button
-									class="rounded-lg p-1 text-gray-400 transition-colors hover:text-gray-700 dark:text-gray-600 dark:hover:text-gray-300"
-									type="button"
-									aria-label={$i18n.t('Delete Chat')}
-									on:click={() => {
-										selectedChatId = chat.id;
-										showDeleteConfirmDialog = true;
-									}}
-								>
-									<Trash className="size-3.5" strokeWidth="1.5" />
-								</button>
-							</Tooltip>
+							{#if $user?.role === 'admin' || ($user?.permissions?.chat?.delete ?? true)}
+								<Tooltip content={$i18n.t('Delete Chat')}>
+									<button
+										class="rounded-lg p-1 text-gray-400 transition-colors hover:text-gray-700 dark:text-gray-600 dark:hover:text-gray-300"
+										type="button"
+										aria-label={$i18n.t('Delete Chat')}
+										on:click={() => {
+											selectedChatId = chat.id;
+											showDeleteConfirmDialog = true;
+										}}
+									>
+										<Trash className="size-3.5" strokeWidth="1.5" />
+									</button>
+								</Tooltip>
+							{/if}
 						</div>
 					</div>
 				{/each}

--- a/src/lib/components/chat/Settings/DataControls.svelte
+++ b/src/lib/components/chat/Settings/DataControls.svelte
@@ -216,20 +216,22 @@
 				</button>
 			</UserSettingRow>
 
-			<UserSettingRow
-				label={$i18n.t('Delete All Chats')}
-				description={$i18n.t('Permanently delete every chat after confirmation.')}
-			>
-				<button
-					class={actionButtonClass}
-					on:click={() => {
-						showDeleteConfirmDialog = true;
-					}}
-					type="button"
+			{#if $user?.role === 'admin' || ($user?.permissions?.chat?.delete ?? true)}
+				<UserSettingRow
+					label={$i18n.t('Delete All Chats')}
+					description={$i18n.t('Permanently delete every chat after confirmation.')}
 				>
-					{$i18n.t('Delete All')}
-				</button>
-			</UserSettingRow>
+					<button
+						class={actionButtonClass}
+						on:click={() => {
+							showDeleteConfirmDialog = true;
+						}}
+						type="button"
+					>
+						{$i18n.t('Delete All')}
+					</button>
+				</UserSettingRow>
+			{/if}
 		</UserSettingSection>
 
 		<UserSettingSection title={$i18n.t('Files')}>

--- a/src/lib/components/chat/Settings/DataControls.svelte
+++ b/src/lib/components/chat/Settings/DataControls.svelte
@@ -216,20 +216,22 @@
 				</button>
 			</UserSettingRow>
 
-			<UserSettingRow
-				label={$i18n.t('Delete All Chats')}
-				description={$i18n.t('Permanently delete every chat after confirmation.')}
-			>
-				<button
-					class={actionButtonClass}
-					on:click={() => {
-						showDeleteConfirmDialog = true;
-					}}
-					type="button"
+			{#if $user?.role === 'admin' || ($user.permissions?.chat?.delete ?? true)}
+				<UserSettingRow
+					label={$i18n.t('Delete All Chats')}
+					description={$i18n.t('Permanently delete every chat after confirmation.')}
 				>
-					{$i18n.t('Delete All')}
-				</button>
-			</UserSettingRow>
+					<button
+						class={actionButtonClass}
+						on:click={() => {
+							showDeleteConfirmDialog = true;
+						}}
+						type="button"
+					>
+						{$i18n.t('Delete All')}
+					</button>
+				</UserSettingRow>
+			{/if}
 		</UserSettingSection>
 
 		<UserSettingSection title={$i18n.t('Files')}>

--- a/src/lib/components/layout/Navbar/Menu.svelte
+++ b/src/lib/components/layout/Navbar/Menu.svelte
@@ -487,16 +487,18 @@
 					<div class="flex items-center">{$i18n.t('Archive')}</div>
 				</button>
 
-				<button
-					draggable="false"
-					class="flex h-[1.6875rem] w-full items-center gap-2 rounded-xl px-2 text-[0.8125rem] cursor-pointer select-none hover:bg-gray-50/40 dark:hover:bg-gray-800/40"
-					on:click={() => {
-						deleteChatHandler();
-					}}
-				>
-					<GarbageBin className="size-3.5" strokeWidth="1.5" />
-					<div class="flex items-center">{$i18n.t('Delete')}</div>
-				</button>
+				{#if $user?.role === 'admin' || ($user?.permissions?.chat?.delete ?? true)}
+					<button
+						draggable="false"
+						class="flex h-[1.6875rem] w-full items-center gap-2 rounded-xl px-2 text-[0.8125rem] cursor-pointer select-none hover:bg-gray-50/40 dark:hover:bg-gray-800/40"
+						on:click={() => {
+							deleteChatHandler();
+						}}
+					>
+						<GarbageBin className="size-3.5" strokeWidth="1.5" />
+						<div class="flex items-center">{$i18n.t('Delete')}</div>
+					</button>
+				{/if}
 
 				<hr class="border-gray-50/30 dark:border-gray-800/30 mx-1 my-0.5" />
 

--- a/src/lib/components/layout/Navbar/Menu.svelte
+++ b/src/lib/components/layout/Navbar/Menu.svelte
@@ -487,16 +487,18 @@
 					<div class="flex items-center">{$i18n.t('Archive')}</div>
 				</button>
 
-				<button
-					draggable="false"
-					class="flex h-[1.6875rem] w-full items-center gap-2 rounded-xl px-2 text-[13px] cursor-pointer select-none hover:bg-gray-50/40 dark:hover:bg-gray-800/40"
-					on:click={() => {
-						deleteChatHandler();
-					}}
-				>
-					<GarbageBin className="size-3.5" strokeWidth="1.5" />
-					<div class="flex items-center">{$i18n.t('Delete')}</div>
-				</button>
+				{#if $user?.role === 'admin' || ($user.permissions?.chat?.delete ?? true)}
+					<button
+						draggable="false"
+						class="flex h-[1.6875rem] w-full items-center gap-2 rounded-xl px-2 text-[13px] cursor-pointer select-none hover:bg-gray-50/40 dark:hover:bg-gray-800/40"
+						on:click={() => {
+							deleteChatHandler();
+						}}
+					>
+						<GarbageBin className="size-3.5" strokeWidth="1.5" />
+						<div class="flex items-center">{$i18n.t('Delete')}</div>
+					</button>
+				{/if}
 
 				<hr class="border-gray-50/30 dark:border-gray-800/30 mx-1 my-0.5" />
 

--- a/src/lib/components/layout/SearchModal.svelte
+++ b/src/lib/components/layout/SearchModal.svelte
@@ -786,17 +786,19 @@
 												</button>
 											</Tooltip>
 
-											<Tooltip content={$i18n.t('Delete')}>
-												<button
-													class="self-center dark:hover:text-white transition"
-													on:click|stopPropagation={() => {
-														deleteChatHandler(chat.id);
-													}}
-													type="button"
-												>
-													<GarbageBin strokeWidth="2" />
-												</button>
-											</Tooltip>
+											{#if $user?.role === 'admin' || ($user?.permissions?.chat?.delete ?? true)}
+												<Tooltip content={$i18n.t('Delete')}>
+													<button
+														class="self-center dark:hover:text-white transition"
+														on:click|stopPropagation={() => {
+															deleteChatHandler(chat.id);
+														}}
+														type="button"
+													>
+														<GarbageBin strokeWidth="2" />
+													</button>
+												</Tooltip>
+											{/if}
 										</div>
 									{:else}
 										<div class="flex items-center">

--- a/src/lib/components/layout/Sidebar/ChatItem.svelte
+++ b/src/lib/components/layout/Sidebar/ChatItem.svelte
@@ -677,18 +677,20 @@
 						</button>
 					</Tooltip>
 
-					<Tooltip content={$i18n.t('Delete')}>
-						<button
-							class=" self-center dark:hover:text-white transition disabled:cursor-not-allowed"
-							disabled={deleting}
-							on:click={() => {
-								deleteChatHandler(id);
-							}}
-							type="button"
-						>
-							<GarbageBinIcon className="size-3.5" strokeWidth="1.7" />
-						</button>
-					</Tooltip>
+					{#if $user?.role === 'admin' || ($user?.permissions?.chat?.delete ?? true)}
+						<Tooltip content={$i18n.t('Delete')}>
+							<button
+								class=" self-center dark:hover:text-white transition disabled:cursor-not-allowed"
+								disabled={deleting}
+								on:click={() => {
+									deleteChatHandler(id);
+								}}
+								type="button"
+							>
+								<GarbageBinIcon className="size-3.5" strokeWidth="1.7" />
+							</button>
+						</Tooltip>
+					{/if}
 				</div>
 			{:else}
 				<div class="flex self-center z-10 items-end">
@@ -727,7 +729,7 @@
 						</button>
 					</ChatMenu>
 
-					{#if id === $chatId}
+					{#if id === $chatId && ($user?.role === 'admin' || ($user?.permissions?.chat?.delete ?? true))}
 						<!-- Shortcut support using "delete-chat-button" id -->
 						<button
 							id="delete-chat-button"

--- a/src/lib/components/layout/Sidebar/ChatMenu.svelte
+++ b/src/lib/components/layout/Sidebar/ChatMenu.svelte
@@ -456,16 +456,18 @@
 				<div class="flex items-center">{$i18n.t('Archive')}</div>
 			</button>
 
-			<button
-				draggable="false"
-				class="flex h-[1.6875rem] gap-2 items-center rounded-xl px-2 text-[0.8125rem] cursor-pointer hover:bg-gray-50/40 dark:hover:bg-gray-800/40 w-full"
-				on:click={() => {
-					deleteHandler();
-				}}
-			>
-				<TrashIcon className="size-3.5" strokeWidth="1.5" />
-				<div class="flex items-center">{$i18n.t('Delete')}</div>
-			</button>
+			{#if $user?.role === 'admin' || ($user?.permissions?.chat?.delete ?? true)}
+				<button
+					draggable="false"
+					class="flex h-[1.6875rem] gap-2 items-center rounded-xl px-2 text-[0.8125rem] cursor-pointer hover:bg-gray-50/40 dark:hover:bg-gray-800/40 w-full"
+					on:click={() => {
+						deleteHandler();
+					}}
+				>
+					<TrashIcon className="size-3.5" strokeWidth="1.5" />
+					<div class="flex items-center">{$i18n.t('Delete')}</div>
+				</button>
+			{/if}
 		</DropdownMenu>
 	</div>
 </Dropdown>

--- a/src/lib/components/layout/Sidebar/ChatMenu.svelte
+++ b/src/lib/components/layout/Sidebar/ChatMenu.svelte
@@ -456,16 +456,18 @@
 				<div class="flex items-center">{$i18n.t('Archive')}</div>
 			</button>
 
-			<button
-				draggable="false"
-				class="flex h-[1.6875rem] gap-2 items-center rounded-xl px-2 text-[13px] cursor-pointer hover:bg-gray-50/40 dark:hover:bg-gray-800/40 w-full"
-				on:click={() => {
-					deleteHandler();
-				}}
-			>
-				<TrashIcon className="size-3.5" strokeWidth="1.5" />
-				<div class="flex items-center">{$i18n.t('Delete')}</div>
-			</button>
+			{#if $user?.role === 'admin' || ($user?.permissions?.chat?.delete ?? true)}
+				<button
+					draggable="false"
+					class="flex h-[1.6875rem] gap-2 items-center rounded-xl px-2 text-[13px] cursor-pointer hover:bg-gray-50/40 dark:hover:bg-gray-800/40 w-full"
+					on:click={() => {
+						deleteHandler();
+					}}
+				>
+					<TrashIcon className="size-3.5" strokeWidth="1.5" />
+					<div class="flex items-center">{$i18n.t('Delete')}</div>
+				</button>
+			{/if}
 		</DropdownMenu>
 	</div>
 </Dropdown>


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27713 — chat delete controls remain visible when the `chat.delete` permission is disabled.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable — this aligns existing UI with an existing permission; no new setting or documented behavior is introduced.
- [ ] **Dependencies:** No new dependencies.
- [x] **Testing:** Verified by the author on a live instance: with `Allow Chat Delete` disabled for a non-admin user, all eight delete affordances disappear (sidebar menu, sidebar Shift+hover trash, keyboard shortcut, chat navbar menu, search modal menu, search modal Shift trash, Delete All Chats, Archived Chats per-row trash), while Archive/Unarchive and the admin experience are unaffected. Prettier, a full production build, and `vitest run` all pass.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Reuses the existing `chat.delete` permission so the UI matches the authority that already enforces it. No new settings, no backend change.
- [x] **Git Hygiene:** The PR is atomic (one logical change), based on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

**Problem** — Every chat deletion control is rendered unconditionally, even for users the backend will refuse. A user without `chat.delete` sees the control, clicks it, and gets `You do not have permission to access this resource. Please contact your administrator for assistance.` An admin who disables the permission expecting the feature to be hidden still sees it offered to their users.

**Root Cause** — `chat.delete` is the only permission key the backend enforces that the frontend never checked anywhere. The endpoints gate correctly for non-admins:

| Endpoint | Gate |
|---|---|
| `DELETE /api/v1/chats/{id}` | `has_permission(user.id, 'chat.delete', ...)` |
| `DELETE /api/v1/chats/` (delete all) | `has_permission(user.id, 'chat.delete', ...)` |
| `DELETE /api/v1/folders/{id}` (when it contains chats) | `has_permission(user.id, 'chat.delete', ...)` |

…but none of the affordances reaching them carried the matching condition. The gap is visible *within* single files: `DataControls.svelte` gates its **Import Chats** and **Export Chats** rows on `chat.import` / `chat.export` yet leaves **Delete All Chats** ungated three rows below; `ChatMenu.svelte` gates share, export, and clone, but not delete.

**Fix** — Apply the same condition the backend enforces, using the established idiom already present in these components:

```svelte
{#if $user?.role === 'admin' || ($user?.permissions?.chat?.delete ?? true)}
```

**Entry-point coverage** — All eight affordances were audited and gated; the two Shift-key paths are easy to miss because they render inline icons *instead of* the `⋯` menu, bypassing it entirely:

| # | Entry point | File | Status |
|---|---|---|---|
| 1 | Sidebar chat `⋯` menu → Delete | `Sidebar/ChatMenu.svelte` | Gated |
| 2 | Sidebar **Shift + hover** inline trash | `Sidebar/ChatItem.svelte` | Gated |
| 3 | Sidebar hidden keyboard-shortcut target (`#delete-chat-button`) | `Sidebar/ChatItem.svelte` | Gated |
| 4 | Open chat's top navbar `⋯` menu → Delete | `layout/Navbar/Menu.svelte` | Gated |
| 5 | Search modal chat `⋯` menu → Delete | via `ChatMenu.svelte` | Covered by #1 |
| 6 | Search modal **Shift-held** inline trash | `layout/SearchModal.svelte` | Gated |
| 7 | Settings → Data Controls → Delete All Chats | `chat/Settings/DataControls.svelte` | Gated |
| 8 | Settings → Archived Chats → per-row trash | `chat/Settings/ArchivedChats.svelte` | Gated |

The keyboard shortcut needs no separate handler change: `(app)/+layout.svelte` invokes it via `document.getElementById('delete-chat-button')?.click()`, so the optional chaining already no-ops once the target is not rendered.

**Deliberately unchanged**

- **Archive / Unarchive** controls sit beside several of these delete buttons and are governed by their own behavior, not `chat.delete` — left untouched.
- **Folder deletion** (`DELETE /api/v1/folders/{id}`) requires `chat.delete` only *when the folder contains chats*, so a static gate would wrongly hide folder deletion for empty folders. Surfacing the error there is correct.
- **`ChatsModal.svelte`** contains a delete button inside a large commented-out block, so it renders nothing today and was left alone rather than modified inside dead markup.
- **`NoteEditor.svelte`'s embedded-chat delete** removes a chat backing a Note (a Notes-feature surface gated by `features.notes`, not present in the chat list or search). Gating it on `chat.delete` would conflate two features; out of scope here.

### Fixed

- Fixed chat delete controls being shown to users without the `chat.delete` permission the delete endpoints require, which made every one of them fail with "Access prohibited" when used.

---

### Additional Information

- No backend change: the enforcement was already correct and complete. This PR only stops the UI from offering what the backend will reject.
- Prior art, both closed and neither covering this: #993 (2024 — `Delete All Chats` actually deleted chats without permission; the backend check was added, but the control was never hidden) and #25920 (`delete_folder_by_id` bypassing `chat.delete`, fixed backend-side).
- The permission expression was confirmed against the backend gates and the sibling `chat.share` / `chat.export` / `chat.import` gates in the same components, so the UI and the enforcer now use one identical condition.
- This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Screenshots or Videos

Non-admin user with the `chat.delete` permission **disabled**:

| | Before | After |
|---|---|---|
| Sidebar chat `⋯` menu | <img width="422" height="292" alt="image" src="https://github.com/user-attachments/assets/07d80733-1cc7-4206-aebf-6058da939bb1" /> | <img width="422" height="292" alt="image" src="https://github.com/user-attachments/assets/ab918e95-69f2-4046-b079-cd76453100c1" /> |
| Sidebar Shift + hover inline actions | Hard for me to get a screenshot of on Ubuntu OS | Hard for me to get a screenshot of on Ubuntu OS |
| Chat top navbar `⋯` menu | <img width="325" height="257" alt="image" src="https://github.com/user-attachments/assets/08a16062-a781-4a69-a92c-a446a1af3b36" /> | <img width="325" height="257" alt="image" src="https://github.com/user-attachments/assets/476d11a8-6d06-492e-8943-d51325680c5d" /> |
| Search modal (Shift held) | Hard for me to get a screenshot of on Ubuntu OS | Hard for me to get a screenshot of on Ubuntu OS |
| Settings → Data Controls | <img width="1292" height="875" alt="image" src="https://github.com/user-attachments/assets/a4645f02-507e-4ccf-b75a-bc0f4b01c2ea" /> | <img width="1292" height="875" alt="image" src="https://github.com/user-attachments/assets/e87417ec-f3eb-4c7b-a378-25c9525ae480" /> |
| Settings → Archived Chats | <img width="1292" height="875" alt="image" src="https://github.com/user-attachments/assets/dacb63cb-d1b5-4647-aa69-fba6148f2d17" /> | <img width="1292" height="875" alt="image" src="https://github.com/user-attachments/assets/9b965327-3ac5-482a-8abd-d69767846b0c" /> |

Before, every control is offered and using it fails with "Access prohibited". After, none are rendered. Archive/Unarchive remain available, and admins see no change.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
