### PR TITLE
fix: align public_tools and public_notes sharing permission defaults with the config

### DIFF
--- a/backend/open_webui/routers/users.py
+++ b/backend/open_webui/routers/users.py
@@ -196,11 +196,11 @@ class SharingPermissions(BaseModel):
     prompts: bool = False
     public_prompts: bool = False
     tools: bool = False
-    public_tools: bool = True
+    public_tools: bool = False
     skills: bool = False
     public_skills: bool = False
     notes: bool = False
-    public_notes: bool = True
+    public_notes: bool = False
     folders: bool = False
     public_chats: bool = False
     public_calendars: bool = False


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27715 — `public_tools` and `public_notes` default to enabled in `SharingPermissions`, disagreeing with the config.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable — this corrects two field defaults to match the documented env-var defaults; no new or changed setting.
- [ ] **Dependencies:** No new dependencies.
- [ ] **Testing:** Left honestly unticked — **no manual UI test was performed.** Verification was done by *executing* the affected code paths (see Additional Information): the defect and its fix were confirmed against the real `SharingPermissions` / `UserPermissions` classes and `fill_missing_permissions`, plus a three-layer diff of all 65 permission keys. `ruff format --check` reports the file already formatted, and `ruff check` finds exactly the same 37 pre-existing findings before and after (none introduced). A live end-to-end check is invited from a reviewer or from anyone running an upgraded instance — reproducing it requires removing the two keys from the stored `user.permissions` row, which the UI cannot do.
- [x] **No Unchecked AI Code:** Prepared with AI copilot assistance and reviewed by the author. To be precise about what that means here: the author reviewed the change and the analysis; verification was programmatic rather than a manual UI pass, as described in the Testing box above.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Two field defaults corrected to match the existing config defaults. No new settings, no migration, no behavior change for correctly-populated configs.
- [x] **Git Hygiene:** The PR is atomic (one logical change), based on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

**Problem** — `SharingPermissions.public_tools` and `SharingPermissions.public_notes` default to `True`, while their config defaults (`USER_PERMISSIONS_WORKSPACE_TOOLS_ALLOW_PUBLIC_SHARING`, `USER_PERMISSIONS_NOTES_ALLOW_PUBLIC_SHARING`) are both `False`. On any instance whose stored `user.permissions` row predates those keys, the admin panel reports both permissions as **enabled** while the enforcer denies them — and saving any unrelated toggle then persists the phantom `True`, granting public tool and note sharing the admin never enabled.

**Root Cause** — The read path and the enforce path fill a missing key from *different sources*:

| Path | Fills a missing key from | Value |
|---|---|---|
| `GET /api/v1/users/default/permissions` → `SharingPermissions(**stored)` | the **Pydantic** default | `True` |
| `has_permission()` → `fill_missing_permissions(perms, DEFAULT_USER_PERMISSIONS)` | the **config** default | `False` |

`Config.get('user.permissions')` returns the stored DB row verbatim — no merge, no reseed on boot — so the divergence persists indefinitely. Because the admin UI loads the `GET` result and `POST`s the whole object back (`updateDefaultPermissionsHandler` in `admin/Users/Groups.svelte`), the wrong value is written on the next save of *any* permission, after which it is enforced for real at six sites (`routers/tools.py` ×3, `routers/notes.py` ×3).

This is an incomplete normalization rather than a deliberate choice: `50b3f47f8` introduced `public_models` / `public_knowledge` / `public_prompts` / `public_tools` all defaulting to `True`, and `f69e37a85` later corrected the first three to `False` to match the config — leaving `public_tools` behind, alongside the separately-introduced `public_notes`.

**Fix**

```diff
     tools: bool = False
-    public_tools: bool = True
+    public_tools: bool = False
     skills: bool = False
     public_skills: bool = False
     notes: bool = False
-    public_notes: bool = True
+    public_notes: bool = False
```

After the change, all three layers agree, matching every sibling key:

| `sharing` key | env default | frontend `DEFAULT_PERMISSIONS` | `SharingPermissions` |
|---|---|---|---|
| `public_models` | `False` | `false` | `False` |
| `public_knowledge` | `False` | `false` | `False` |
| `public_prompts` | `False` | `false` | `False` |
| `public_tools` | `False` | `false` | `False` ← changed |
| `public_notes` | `False` | `false` | `False` ← changed |

**No migration needed.** The default is only consulted when a key is *absent*, so correctly-populated configs are untouched; an admin who wants public tool or note sharing still has the toggle, and it now persists honestly.

### Fixed

- Fixed the `public_tools` and `public_notes` sharing permissions defaulting to enabled in the default-permissions model while the configuration defaults them to disabled, which made the admin panel show them as on — and silently persist them as on — on instances whose stored permissions predate those keys.

---

### Additional Information

- **Relationship to #27609:** complementary, no overlap. #27609 adds the *missing* `open_chats` field to the same model; this PR corrects two *existing* fields' defaults. A three-layer diff of all 65 permission keys (config `DEFAULT_USER_PERMISSIONS` ↔ the Pydantic models ↔ `src/lib/constants/permissions.ts`) shows `open_chats` is the only remaining missing field and these two the only default-value divergences — so together the two PRs close the model out completely.
- **Precedent:** #27296 (merged) fixed the same *class* of bug — `SharingPermissions` disagreeing with the config for `folders` — for issue #27120.
- **Verification performed** (executed against the real classes on `dev` @ 810378c0b, simulating a stored row missing both keys):

  ```
  BEFORE                                                 AFTER
  key           GET   POST  enforced                     key           GET    POST   enforced
  public_tools  True  True  False   ← mismatch           public_tools  False  False  False   ← agree
  public_notes  True  True  False   ← mismatch           public_notes  False  False  False   ← agree
  ```

  The `GET` column is `SharingPermissions(**stored).model_dump()`, the `POST` column is `UserPermissions(**got).model_dump(by_alias=True)`, and the `enforced` column is `fill_missing_permissions(stored, DEFAULT_USER_PERMISSIONS['sharing'])` — i.e. the exact expressions the two endpoint bodies and `has_permission` use. A runnable version is in #27715.
- **Scope note:** this only corrects the fallback value. It does not add a config migration to repair rows already poisoned with `true` by a previous save; an admin can simply turn the toggle off, which now works correctly.

### Screenshots or Videos

Not applicable — the change is a backend model default with no visual component of its own. The user-visible symptom (the two Sharing toggles reading **on** when the config says off) requires an instance whose stored `user.permissions` row predates the keys; #27715 documents both a runnable reproduction and the SQL to simulate that state.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
