### PR TITLE
fix(admin): show workspace models in admin model settings

### DIFF
--- a/src/lib/components/admin/Settings/Models.svelte
+++ b/src/lib/components/admin/Settings/Models.svelte
@@ -258,7 +258,11 @@
 		}
 
 		workspaceModels = await getBaseModels(localStorage.token, selectedTag);
-		baseModels = await getModels(localStorage.token, null, true);
+		// Fetch ALL models (base + workspace). Passing base=true here restricted
+		// the admin list to connection/base models only, so public workspace
+		// models never appeared and could not be ordered, defaulted, or pinned
+		// (#27702, regression from v0.10.2).
+		baseModels = await getModels(localStorage.token, null, false);
 		const workspaceModelIds = new Set<string>(workspaceModels.map((wm: ModelListItem) => wm.id));
 
 		models = baseModels


### PR DESCRIPTION
# Pull Request Checklist

Closes #27702

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27702
- [x] **Target branch:** Targets the `dev` branch.
- [x] **Description:** See changelog below.
- [x] **Changelog:** Included below.
- [x] **Testing:** Verified the model list now includes workspace models.
- [x] **No Unchecked AI Code:** Reviewed and manually tested.
- [x] **Self-Review:** Minimal one-line change with comment.
- [x] **Architecture:** No new settings; restores v0.10.2 behavior.
- [x] **Git Hygiene:** Atomic single commit, rebased on `dev`.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

The admin Models settings page fetched its list with `getModels(token, null, true)`, where the third argument (`base=true`) routes to `/api/models/base` — which returns only connection/base models (`base_model_id IS NULL`). Public workspace models therefore never appeared in the list, so they could not be ordered, set as the default, or pinned globally. Saving also silently stripped any workspace order/defaults set via the API.

### Fixed

- Fetch all models (base + workspace) by passing `base=false`, restoring the v0.10.2 behavior where workspace models appear alongside connection models in the admin list.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.