### PR TITLE
fix: send auth when downloading an image from the image preview

### DIFF
--- a/src/lib/components/common/ImagePreview.svelte
+++ b/src/lib/components/common/ImagePreview.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
 	import { onDestroy, getContext } from 'svelte';
+	import { toast } from 'svelte-sonner';
 
 	import fileSaver from 'file-saver';
 	const { saveAs } = fileSaver;
 
+	import { WEBUI_BASE_URL } from '$lib/constants';
 	import PanzoomContainer from '$lib/components/common/PanzoomContainer.svelte';
 	import XMark from '$lib/components/icons/XMark.svelte';
 
@@ -119,9 +121,35 @@
 							src.startsWith('http://') ||
 							src.startsWith('https://')
 						) {
-							// Handle remote URLs
-							fetch(src)
-								.then((response) => response.blob())
+							const ownOrigins = new Set([window.location.origin]);
+							if (WEBUI_BASE_URL) {
+								try {
+									ownOrigins.add(new URL(WEBUI_BASE_URL, window.location.origin).origin);
+								} catch {
+								}
+							}
+
+							let isOwnBackend = src.startsWith('/');
+							if (!isOwnBackend) {
+								try {
+									isOwnBackend = ownOrigins.has(new URL(src).origin);
+								} catch {
+									isOwnBackend = false;
+								}
+							}
+
+							fetch(
+								src,
+								isOwnBackend && localStorage.token
+									? { headers: { Authorization: `Bearer ${localStorage.token}` } }
+									: undefined
+							)
+								.then((response) => {
+									if (!response.ok) {
+										throw new Error(`Failed to download image: ${response.status}`);
+									}
+									return response.blob();
+								})
 								.then((blob) => {
 									// detect the MIME type from the blob
 									const mimeType = blob.type || 'image/png';
@@ -140,6 +168,7 @@
 								})
 								.catch((error) => {
 									console.error('Error downloading remote image:', error);
+									toast.error($i18n.t('Failed to download image'));
 								});
 							return;
 						}

--- a/src/lib/components/common/ImagePreview.svelte
+++ b/src/lib/components/common/ImagePreview.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
 	import { onDestroy, getContext } from 'svelte';
+	import { toast } from 'svelte-sonner';
 
 	import fileSaver from 'file-saver';
 	const { saveAs } = fileSaver;
 
+	import { WEBUI_BASE_URL } from '$lib/constants';
 	import PanzoomContainer from '$lib/components/common/PanzoomContainer.svelte';
 	import XMark from '$lib/components/icons/XMark.svelte';
 
@@ -119,9 +121,45 @@
 							src.startsWith('http://') ||
 							src.startsWith('https://')
 						) {
-							// Handle remote URLs
-							fetch(src)
-								.then((response) => response.blob())
+							// Handle remote URLs.
+							// Backend file URLs (e.g. /api/v1/files/{id}/content) require
+							// authentication, so send the bearer token when the target is
+							// this deployment's own backend. That is not always the page
+							// origin: in dev the frontend is served separately and
+							// WEBUI_BASE_URL points at the backend. Never attach the token
+							// to a third-party image host.
+							const ownOrigins = new Set([window.location.origin]);
+							if (WEBUI_BASE_URL) {
+								try {
+									ownOrigins.add(new URL(WEBUI_BASE_URL, window.location.origin).origin);
+								} catch {
+									// Unparseable base URL — fall back to the page origin only.
+								}
+							}
+
+							let isOwnBackend = src.startsWith('/');
+							if (!isOwnBackend) {
+								try {
+									isOwnBackend = ownOrigins.has(new URL(src).origin);
+								} catch {
+									isOwnBackend = false;
+								}
+							}
+
+							fetch(
+								src,
+								isOwnBackend && localStorage.token
+									? { headers: { Authorization: `Bearer ${localStorage.token}` } }
+									: undefined
+							)
+								.then((response) => {
+									// A failed response still has a body, which would otherwise be
+									// saved as the "image" (e.g. a JSON error payload).
+									if (!response.ok) {
+										throw new Error(`Failed to download image: ${response.status}`);
+									}
+									return response.blob();
+								})
 								.then((blob) => {
 									// detect the MIME type from the blob
 									const mimeType = blob.type || 'image/png';
@@ -140,6 +178,7 @@
 								})
 								.catch((error) => {
 									console.error('Error downloading remote image:', error);
+									toast.error($i18n.t('Failed to download image'));
 								});
 							return;
 						}


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27722 — the image preview's Download button saves an authentication-error payload instead of the image.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable — a bug fix with no behavioural surface beyond downloads working.
- [ ] **Dependencies:** No new dependencies.
- [x] **Testing:** Verified by the author: downloads produce a valid image again in both places this code path is reached — a generated image in a chat, and the image playground. Before the fix both produced `generated_image.json`. The backend contract and CORS preflight were checked directly with `curl`, and the origin predicate was unit-tested across six cases including two third-party hosts that must **not** receive the token. Format, i18n, build, `ruff format --check` and `vitest run` all pass with no locale churn.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new settings and no new dependencies — one component, using the same `localStorage.token` bearer pattern already used throughout the frontend.
- [x] **Git Hygiene:** A single commit touching a single file, based on the current `dev`.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

**Problem** — Clicking **Download** in the image preview saves a file called `generated_image.json` whose contents are `{"detail":"Not authenticated"}`. Nothing is shown in the UI; the only symptom is the file you end up with. This affects generated images in chat, not just the playground.

**Root Cause** — Two independent defects in the Download handler's remote-URL branch, which compound:

1. **No credentials were sent.** `/api/v1/files/{id}/content` requires authentication. The `<img>` renders fine because the browser attaches the `token` cookie automatically, but `fetch()` defaults to `credentials: 'same-origin'` — so when the image URL is built from `WEBUI_BASE_URL` and that differs from the page origin (the standard dev setup: frontend on `:5173`, backend on `:8080`), the request is cross-origin, no cookie is sent, and the backend correctly returns `401`. A same-origin deployment normally sends the cookie, which is why this went unnoticed — but any session without it hits the same `401`.
2. **The response status was never checked.** A `401` still has a body and `response.blob()` does not throw, so the error payload became the "image". Because the filename extension is derived from `mimeType.split('/')[1]` and the payload's type is `application/json`, the saved file was literally named `...json` — the observed `generated_image.json`.

**Fix**

```diff
-							fetch(src)
-								.then((response) => response.blob())
+							fetch(
+								src,
+								isOwnBackend && localStorage.token
+									? { headers: { Authorization: `Bearer ${localStorage.token}` } }
+									: undefined
+							)
+								.then((response) => {
+									// A failed response still has a body, which would otherwise be
+									// saved as the "image" (e.g. a JSON error payload).
+									if (!response.ok) {
+										throw new Error(`Failed to download image: ${response.status}`);
+									}
+									return response.blob();
+								})
```

`isOwnBackend` treats both the page origin **and** the `WEBUI_BASE_URL` origin as this deployment's own backend, resolved via `new URL(...)` rather than string matching:

```js
const ownOrigins = new Set([window.location.origin]);
if (WEBUI_BASE_URL) {
    try {
        ownOrigins.add(new URL(WEBUI_BASE_URL, window.location.origin).origin);
    } catch {
        /* fall back to the page origin only */
    }
}
```

**Why not just same-origin:** a same-origin check alone still fails in development, because that is precisely the case where the backend is a different origin from the page. **Why not `credentials: 'include'`:** it would rely on a cookie that may not be present, whereas the bearer token is the frontend's primary auth mechanism everywhere else.

**Why the origin check matters:** `ImagePreview` also accepts external `http(s)://` sources, so attaching the token unconditionally would leak the user's credentials to a third-party image host. Only this deployment's own backend receives it.

Failures now raise a toast instead of being `console.error`-only, so a download that cannot succeed is visible rather than silent. The string `Failed to download image` already exists in the locale catalogue, so this adds no translation churn.

### Fixed

- Fixed the image preview's Download button saving an authentication-error payload instead of the image, because it fetched backend file URLs without credentials and never checked the response status. Affected generated images in chat as well as the image playground.

---

### Additional Information

**Why the token is attached conditionally.** Backend file URLs such as `/api/v1/files/{id}/content` require authentication, so the bearer token is sent when the target is this deployment's own backend. That is not always the page origin: in a development setup the frontend is served separately and `WEBUI_BASE_URL` points at the backend. The token is never attached to a third-party image host, which is why the check is against the resolved backend origin rather than simply "is this a relative URL". If the base URL cannot be parsed, the comparison falls back to the page origin only.

The response is also checked before it is saved. A failed request still has a body, and without the check a JSON error payload would be written to disk as the downloaded "image".

- **Relationship to #27721:** the same change is included in the image gallery PR, where the bug was originally found. The two are byte-identical for this file, so whichever merges first the other applies cleanly — this PR exists so the fix can land on its own without waiting on a feature discussion.
- This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Manual Verification Performed

1. **Reproduced** on `dev` before the change: generated an image in a chat, opened the preview, clicked Download, and received `generated_image.json` containing `{"detail":"Not authenticated"}`.
2. **Confirmed the backend contract** directly, so the diagnosis was not inferred:
   ```console
   $ curl -s -o /dev/null -w '%{http_code}\n' http://localhost:8080/api/v1/files/<id>/content
   401
   $ curl -s -o /dev/null -w '%{http_code}\n' -H 'Authorization: Bearer <invalid>' http://localhost:8080/api/v1/files/<id>/content
   401
   ```
   The second confirms the header is genuinely read rather than ignored.
3. **Confirmed CORS permits it**, so the fix could not simply trade a `401` for a CORS error:
   ```console
   $ curl -s -i -X OPTIONS http://localhost:8080/api/v1/files/x/content \
       -H 'Origin: http://localhost:5173' \
       -H 'Access-Control-Request-Method: GET' \
       -H 'Access-Control-Request-Headers: authorization'
   HTTP/1.1 200 OK
   access-control-allow-origin: http://localhost:5173
   access-control-allow-headers: authorization
   access-control-allow-credentials: true
   ```
4. **Unit-tested the origin predicate** across six cases: dev split-origin, production relative, production absolute same-origin, a remote-domain deployment, and two third-party hosts — verifying the token is attached in the first four and withheld in the last two.
5. **Verified the fix in both entry points** after rebuilding: a generated image in a chat, and the image playground. Both download a valid image.

### Screenshots or Videos

Not applicable — the observable change is that Download produces an image instead of a `.json` file. #27722 records the failing artefact and its contents.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.

