### PR TITLE
fix: keep calendar search end within bigint range

### DIFF
--- a/backend/open_webui/tools/builtin.py
+++ b/backend/open_webui/tools/builtin.py
@@ -4010,9 +4010,7 @@ async def search_calendar_events(
 
             try:
                 end_ns = (
-                    _dt_to_ns(end, tz)
-                    if end
-                    else int(time.time() * 1_000) * 1_000_000 + 365 * 86400 * 1_000_000_000_000
+                    _dt_to_ns(end, tz) if end else int(time.time() * 1_000) * 1_000_000 + 365 * 86400 * 1_000_000_000
                 )
             except (ValueError, TypeError) as e:
                 return json.dumps({'error': f'Invalid end datetime: {e}'})


### PR DESCRIPTION
## Summary

Fix the default upper bound used by `search_calendar_events` when callers omit `end`.

The existing expression multiplies one year in seconds by `10^12`, producing an epoch-nanosecond value around `3.33e19`, beyond PostgreSQL's signed `BIGINT` maximum. This changes the multiplier to the correct `10^9`, preserving the intended one-year window.

Closes #27717

## Verification

- Production-path probe against untouched `dev`: captured `end=33321390000000000000` (`fits_bigint=false`)
- The same probe after this patch: captured `end=1816926000000000000` (`fits_bigint=true`, exactly 365 days after the fixed probe time)
- PostgreSQL 18:
  - old value: `ERROR: bigint out of range`
  - patched value: inserted into a temporary `BIGINT` column successfully
- `ruff format --check backend/open_webui/tools/builtin.py`
- `ruff check --select=F --ignore=F401,F403,F405,F541,F811,F841 backend/open_webui/tools/builtin.py`
- `python3 -m py_compile backend/open_webui/tools/builtin.py`
- `git diff --check`

No live calendar UI/model E2E was run; the validation exercises the production function's omitted-`end` branch and a real PostgreSQL `BIGINT` boundary.

## Changelog Entry

### Fixed

- Prevent calendar searches without an explicit end date from overflowing PostgreSQL `BIGINT`.

### Additional Information

- No dependency, configuration, API, or documentation changes.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
