### PR TITLE
fix: show a placeholder when an image cannot be loaded

### DIFF
--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -692,7 +692,7 @@
 								{#each message.files.filter((f) => ['image', 'file'].includes(f.type)) as file}
 									<div>
 										{#if file.type === 'image' || (file?.content_type ?? '').startsWith('image/')}
-											<Image src={file.url} alt={message.content} />
+											<Image src={file.url} alt={file.name || $i18n.t('Generated Image')} />
 										{:else}
 											<FileItem
 												item={file}

--- a/src/lib/components/common/Image.svelte
+++ b/src/lib/components/common/Image.svelte
@@ -5,6 +5,7 @@
 	import { settings } from '$lib/stores';
 	import ImagePreview from './ImagePreview.svelte';
 	import XMark from '$lib/components/icons/XMark.svelte';
+	import Photo from '$lib/components/icons/Photo.svelte';
 	import { getContext } from 'svelte';
 
 	export let src = '';
@@ -18,27 +19,62 @@
 	export let dismissible = false;
 	export let onDismiss = () => {};
 
+	/** Called when the image fails to load, e.g. its file has since been deleted. */
+	export let onError: () => void = () => {};
+
 	const i18n = getContext('i18n');
 
 	let _src = '';
 	$: _src = safeImageUrl(src.startsWith('/') ? `${WEBUI_BASE_URL}${src}` : src, allowExternal);
 
 	let showImagePreview = false;
+
+	let failed = false;
+	let attemptedSrc = '';
+	$: if (_src !== attemptedSrc) {
+		attemptedSrc = _src;
+		failed = false;
+	}
+
+	const handleError = () => {
+		failed = true;
+		showImagePreview = false;
+		onError();
+	};
 </script>
 
-<ImagePreview bind:show={showImagePreview} src={_src} {alt} />
+{#if !failed}
+	<ImagePreview bind:show={showImagePreview} src={_src} {alt} />
+{/if}
 
 <div class=" relative group w-fit flex items-center">
-	<button
-		class={className}
-		on:click={() => {
-			showImagePreview = true;
-		}}
-		aria-label={$i18n.t('Show image preview')}
-		type="button"
-	>
-		<img src={_src} {alt} class={imageClassName} draggable="false" data-cy="image" />
-	</button>
+	{#if failed}
+		<div
+			class="{imageClassName} flex items-center gap-2 px-3 py-2.5 border border-dashed border-gray-200 dark:border-gray-800 text-gray-400 dark:text-gray-600"
+			data-cy="image-unavailable"
+		>
+			<Photo className="size-4 shrink-0" strokeWidth="1.5" />
+			<span class="text-xs">{$i18n.t('Image unavailable')}</span>
+		</div>
+	{:else}
+		<button
+			class={className}
+			on:click={() => {
+				showImagePreview = true;
+			}}
+			aria-label={$i18n.t('Show image preview')}
+			type="button"
+		>
+			<img
+				src={_src}
+				{alt}
+				class={imageClassName}
+				draggable="false"
+				data-cy="image"
+				on:error={handleError}
+			/>
+		</button>
+	{/if}
 
 	{#if dismissible}
 		<div class=" absolute -top-1 -right-1">

--- a/src/lib/i18n/locales/en-US/translation.json
+++ b/src/lib/i18n/locales/en-US/translation.json
@@ -1406,6 +1406,7 @@
 	"Image Prompt Generation": "",
 	"Image Prompt Generation Prompt": "",
 	"Image Size": "",
+	"Image unavailable": "",
 	"image/*, video/*": "",
 	"Images": "",
 	"Import": "",


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27728 — deleted files leave a broken image in messages, with no error state or placeholder.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable — a bug fix with no new setting or configuration surface.
- [ ] **Dependencies:** No new dependencies.
- [x] **Testing:** Verified by the author on a live instance — the failing case now renders the placeholder instead of the response text, and normal images and the preview are unaffected. See "Manual Verification Performed". Format, i18n, production build, `ruff format --check` and `vitest run` all pass.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Handled once in the shared `Image` component rather than at each call site. The new `onError` prop defaults to a no-op, so the eight existing call sites are behaviourally unchanged.
- [x] **Git Hygiene:** A single commit, based on the current `dev`, with no unrelated changes.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

**Problem** — When a message references a file that no longer exists, the message renders a broken image. `src/lib/components/common/Image.svelte` has no error handling at all, so a failed load is never detected and nothing is substituted.

What the user actually sees depends on which surface it is, because browsers render `alt` text when an image fails and each caller passes something different:

| Surface | `alt` passed | Result when the file is gone |
|---|---|---|
| `Messages/ResponseMessage.svelte` | `alt={message.content}` | **the entire assistant message rendered inside the image frame** |
| `Messages/UserMessage.svelte` | none | an empty broken-image box |
| `channel/Messages/Message.svelte` | `alt={file.name}` | the filename |

Worse, clicking the broken image still opened the full-screen preview, which then displayed the same alt text across the whole viewport.

The backend is correct throughout — `get_file_content_by_id` returns `404 NOT_FOUND` for a missing file. Nothing on the frontend acts on it.

**Fix**

1. `Image.svelte` tracks a failed load and renders an **"Image unavailable"** placeholder in place of the broken image:

```diff
+		<img
+			src={_src}
+			{alt}
+			class={imageClassName}
+			draggable="false"
+			data-cy="image"
+			on:error={handleError}
+		/>
```

```js
const handleError = () => {
    failed = true;
    showImagePreview = false;
    onError();
};
```

2. The preview is not rendered for a failed source, so a deleted image can no longer be opened full-screen.

3. The failed state resets when the source changes, so a replaced or corrected URL is retried rather than being stuck as broken for the component's lifetime:

```js
let attemptedSrc = '';
$: if (_src !== attemptedSrc) {
    attemptedSrc = _src;
    failed = false;
}
```

4. Responses pass a meaningful `alt`:

```diff
-										<Image src={file.url} alt={message.content} />
+										<Image src={file.url} alt={file.name || $i18n.t('Generated Image')} />
```

`message.content` was never a description of the image, and it is what produced the "whole reply inside the image frame" symptom. `Generated Image` already exists in the locale catalogue, so only one new string is introduced (`Image unavailable`).

**Compatibility** — `Image.svelte` is used in eight places (chat response and user messages, channel messages, message input, queued messages, markdown inline tokens). The new `onError` prop defaults to a no-op and the placeholder only appears on an actual load failure, so none of them change behaviour.

### Added

- An `Image unavailable` placeholder shown when an image cannot be loaded, and an optional `onError` callback on the shared `Image` component for callers that need to react to a failed load.

### Fixed

- Fixed messages rendering a broken image when the underlying file no longer exists, which in an assistant response displayed the entire message text inside the image frame and still allowed the full-screen preview to be opened.

---

### Additional Information

- Found while working on image actions in chat: nothing anywhere noticed a failed image load, which is what made the broken state so inconsistent between surfaces.
- This is independent of the image-gallery work in #27721 and applies to any deleted file — an admin removing a user's files, storage cleanup, or a file removed outside the app. #27721 does make it easier to encounter, since deleting from the gallery breaks the image in whatever chat produced it, but the behaviour predates it.
- This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Manual Verification Performed

Local instance, ComfyUI engine, on `dev` with this change applied:

1. **Reproduced the original behaviour** first: generated an image in a chat, deleted the file, reloaded — the entire assistant response was rendered where the image had been, and clicking it opened that text full-screen in the preview.
2. Applied the change and repeated: the message now shows a compact **Image unavailable** placeholder, and it is not clickable — the preview no longer opens for a source that cannot load.
3. Confirmed **normal images are unaffected**: a live generated image in a chat still renders, still opens in the preview, and still downloads.
4. Checked the other surfaces that use the shared component — a user-uploaded image in a message, and an image in a channel message — both render and preview as before.

### Screenshots or Videos

| | Before | After |
|---|---|---|
| Assistant message with a deleted image | <img width="1050" height="559" alt="image" src="https://github.com/user-attachments/assets/d50b1d4b-84d2-4c1e-bc34-036558ae61ff" /> | <img width="1050" height="559" alt="image" src="https://github.com/user-attachments/assets/16956477-a6ee-491c-b171-9df0408487b9" /> |

#### Clicking it (Before)

<img width="1277" height="1275" alt="image" src="https://github.com/user-attachments/assets/60d08dd8-15a1-4828-a698-ac490fc997b9" />

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
