### PR TITLE
fix: keep channel message data through updates that reset the lazy-load sentinel

### DIFF
--- a/src/lib/components/channel/Messages/Message.svelte
+++ b/src/lib/components/channel/Messages/Message.svelte
@@ -10,7 +10,7 @@
 	dayjs.extend(isYesterday);
 	dayjs.extend(localizedFormat);
 
-	import { getContext, onMount } from 'svelte';
+	import { getContext } from 'svelte';
 	const i18n = getContext<Writable<i18nType>>('i18n');
 
 	import { formatDate } from '$lib/utils';
@@ -137,22 +137,41 @@
 		swipeLocked = false;
 	};
 
+	let loadingMessageData = false;
+	let messageDataLoadFailed = false;
+
 	const loadMessageData = async () => {
-		if (message && message?.data === true) {
+		if (!message || message?.data !== true || loadingMessageData || messageDataLoadFailed) {
+			return;
+		}
+
+		loadingMessageData = true;
+		try {
 			const res = await getMessageData(localStorage.token, channel?.id, message.id);
 			if (res) {
 				message.data = res;
+			} else {
+				messageDataLoadFailed = true;
 			}
+		} catch (error) {
+			console.error('Failed to load message data:', error);
+			messageDataLoadFailed = true;
+		} finally {
+			loadingMessageData = false;
 		}
 	};
 
-	onMount(async () => {
-		if (message && message?.data === true) {
-			await loadMessageData();
-		}
-	});
+	$: if (message?.data === true) {
+		loadMessageData();
+	}
 
-	$: messageOutput = Array.isArray(message?.data?.output) ? message.data.output : [];
+	let resolvedData = null;
+	$: if (message?.data && message.data !== true) {
+		resolvedData = message.data;
+	}
+	$: messageData = message?.data && message.data !== true ? message.data : resolvedData;
+
+	$: messageOutput = Array.isArray(messageData?.output) ? messageData.output : [];
 	$: hasStructuredOutput = buildOutputDisplayItems(messageOutput).length > 0;
 </script>
 
@@ -455,17 +474,16 @@
 						</Name>
 					{/if}
 
-					{#if message?.data === true}
-						<!-- loading indicator -->
+					{#if message?.data === true && !resolvedData}
 						<div class=" my-2">
 							<Skeleton />
 						</div>
-					{:else if (message?.data?.files ?? []).length > 0}
+					{:else if (messageData?.files ?? []).length > 0}
 						<div
 							class="my-2.5 w-full flex overflow-x-auto gap-2 flex-wrap"
 							dir={$settings?.chatDirection ?? 'auto'}
 						>
-							{#each message?.data?.files as file}
+							{#each messageData?.files as file}
 								{@const fileUrl =
 									file.url.startsWith('data') || file.url.startsWith('http')
 										? file.url

--- a/src/lib/components/channel/Messages/Message.svelte
+++ b/src/lib/components/channel/Messages/Message.svelte
@@ -10,7 +10,7 @@
 	dayjs.extend(isYesterday);
 	dayjs.extend(localizedFormat);
 
-	import { getContext, onMount } from 'svelte';
+	import { getContext } from 'svelte';
 	const i18n = getContext<Writable<i18nType>>('i18n');
 
 	import { formatDate } from '$lib/utils';
@@ -137,22 +137,53 @@
 		swipeLocked = false;
 	};
 
+	// `data === true` is the backend's "there is data, fetch it separately" sentinel.
+	// Guarded so a slow or failing fetch cannot be re-entered by the reactive
+	// statement below, and a failure does not retry in a loop.
+	let loadingMessageData = false;
+	let messageDataLoadFailed = false;
+
 	const loadMessageData = async () => {
-		if (message && message?.data === true) {
+		if (!message || message?.data !== true || loadingMessageData || messageDataLoadFailed) {
+			return;
+		}
+
+		loadingMessageData = true;
+		try {
 			const res = await getMessageData(localStorage.token, channel?.id, message.id);
 			if (res) {
 				message.data = res;
+			} else {
+				messageDataLoadFailed = true;
 			}
+		} catch (error) {
+			console.error('Failed to load message data:', error);
+			messageDataLoadFailed = true;
+		} finally {
+			loadingMessageData = false;
 		}
 	};
 
-	onMount(async () => {
-		if (message && message?.data === true) {
-			await loadMessageData();
-		}
-	});
+	// Not onMount: pin, reaction and reply updates replace the message object and
+	// can reintroduce the sentinel, and the keyed {#each} reuses this component
+	// instead of remounting it — so a mount-only fetch would not run again for the
+	// life of that instance, leaving the message on its loading indicator until
+	// something remounts it.
+	$: if (message?.data === true) {
+		loadMessageData();
+	}
 
-	$: messageOutput = Array.isArray(message?.data?.output) ? message.data.output : [];
+	// Hold on to the payload once resolved. When an update puts the sentinel back,
+	// the content stays on screen while it is re-fetched instead of flashing the
+	// loading indicator. Safe to keep for the component's lifetime: the list is
+	// keyed by message id, so an instance only ever renders one message.
+	let resolvedData = null;
+	$: if (message?.data && message.data !== true) {
+		resolvedData = message.data;
+	}
+	$: messageData = message?.data && message.data !== true ? message.data : resolvedData;
+
+	$: messageOutput = Array.isArray(messageData?.output) ? messageData.output : [];
 	$: hasStructuredOutput = buildOutputDisplayItems(messageOutput).length > 0;
 </script>
 
@@ -455,17 +486,17 @@
 						</Name>
 					{/if}
 
-					{#if message?.data === true}
-						<!-- loading indicator -->
+					{#if message?.data === true && !resolvedData}
+						<!-- loading indicator, only when there is nothing to show yet -->
 						<div class=" my-2">
 							<Skeleton />
 						</div>
-					{:else if (message?.data?.files ?? []).length > 0}
+					{:else if (messageData?.files ?? []).length > 0}
 						<div
 							class="my-2.5 w-full flex overflow-x-auto gap-2 flex-wrap"
 							dir={$settings?.chatDirection ?? 'auto'}
 						>
-							{#each message?.data?.files as file}
+							{#each messageData?.files as file}
 								{@const fileUrl =
 									file.url.startsWith('data') || file.url.startsWith('http')
 										? file.url


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27731 — pinning a channel message replaces its attachment with a loading indicator.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable — a bug fix with no new setting or configuration surface.
- [ ] **Dependencies:** No new dependencies.
- [x] **Testing:** The bug was reproduced on unmodified `dev` and the fix verified on a live instance by the author — pinning and unpinning, reactions and replies on a message with an attachment, and a first-time-loading message (which must still show the loading indicator). Format, i18n, a full production build, `ruff format --check` and `vitest run` all pass, with no locale changes.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new settings and no dependency changes — one component, replacing a mount-only fetch with a reactive one.
- [x] **Git Hygiene:** A single commit touching a single file, based on the current `dev`.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

**Problem** — Pinning a channel message that has an attachment replaces its content with the loading indicator (a small pulsing dot), and it stays that way for the rest of that view. It recovers on a reload, an unpin, or leaving and re-entering the channel — and pinning again reproduces it.

**Root Cause** — Channel messages support lazily-loaded `data`. `MessageUserSlimResponse` collapses the field to a boolean, so a message can legitimately arrive with `data === true` meaning "there is data, fetch it separately":

```python
class MessageUserSlimResponse(MessageUserResponse):
    data: bool | None = None

    @field_validator('data', mode='before')
    def convert_data_to_bool(cls, v):
        if not isinstance(v, dict):
            return False
        return any(bool(val) for val in v.values())
```

The component renders its loading indicator for that sentinel:

```svelte
{#if message?.data === true}
    <!-- loading indicator -->
    <div class=" my-2"><Skeleton /></div>
{:else if (message?.data?.files ?? []).length > 0}
```

…but resolved it **only on mount**, and `loadMessageData` had exactly one caller:

```js
onMount(async () => {
    if (message && message?.data === true) {
        await loadMessageData();
    }
});
```

The message list is keyed by id (`{#each messageList as message, messageIdx (…message.id)}`), so an update reuses the existing component instance instead of remounting it. Once the sentinel reappears after mount, nothing fetches the data again for the life of that instance — which is exactly why only the three remounting actions recover it.

Pinning replaces the message object: `pinHandler` rebuilds it with `{ ...message, is_pinned, pinned_by, pinned_at }`, and the `message:update` socket handler assigns `messages[idx] = data` wholesale. The same wholesale replacement is used for `message:reply` and `message:reaction`.

**Fix** — resolve the data reactively rather than at mount, so the fetch runs whenever the sentinel appears:

```diff
-	onMount(async () => {
-		if (message && message?.data === true) {
-			await loadMessageData();
-		}
-	});
+	$: if (message?.data === true) {
+		loadMessageData();
+	}
```

with guards inside `loadMessageData` so the reactive statement cannot re-enter a slow fetch, and a failed fetch does not retry in a loop:

```js
if (!message || message?.data !== true || loadingMessageData || messageDataLoadFailed) {
    return;
}
```

That alone still left the loading indicator visible for the duration of the re-fetch, since the sentinel is rendered the moment the message object is replaced. So the resolved payload is also retained and rendered while the re-fetch runs:

```js
let resolvedData = null;
$: if (message?.data && message.data !== true) {
    resolvedData = message.data;
}
$: messageData = message?.data && message.data !== true ? message.data : resolvedData;
```

The loading indicator is now gated on `message?.data === true && !resolvedData`, so it appears only when there is genuinely nothing to show — which is what it is for. Keeping the cache for the component's lifetime is safe because the list is keyed by message id, so an instance only ever renders one message.

This fixes the class of problem — any update that reintroduces the sentinel — rather than the pin path alone, which matters because I could not pin down which specific payload reintroduces it (see below).

**Why not fix `pinHandler` instead** — that would address only pinning. Reactions and replies replace the message object identically, and any future updater doing the same would reintroduce the bug. Making the load respond to the state it is meant to resolve is the smaller and more durable change.

### Fixed

- Fixed a channel message showing a loading indicator instead of its attachment after being pinned, because the lazily-loaded message data was only fetched on mount and the keyed message list reuses the component across updates. The resolved payload is now retained across such updates, so pinning and unpinning no longer flashes the loading indicator either.

---

### Additional Information

**Why the fetch is reactive rather than in `onMount`.** `data === true` is the backend's sentinel for "there is data, fetch it separately". Pin, reaction and reply updates replace the message object and can reintroduce that sentinel, and the keyed `{#each}` reuses this component instead of remounting it. A mount-only fetch would therefore never run again for the life of that instance, leaving the message stuck on its loading indicator until something forced a remount.

The fetch is guarded so a slow or failing request cannot be re-entered by the reactive statement, and a failure does not retry in a loop.

**Why the resolved payload is retained.** Once resolved it is held for the component's lifetime, so when an update puts the sentinel back the existing content stays on screen while it is re-fetched, instead of flashing the loading indicator. That is safe because the list is keyed by message id, so an instance only ever renders one message.

- **One thing I could not determine:** which payload specifically reintroduces `data === true` during a pin. The pin endpoint broadcasts via `MessageUserResponse`, which does *not* apply the boolean conversion, so on the face of it the socket payload should carry the full dict. Rather than guess, I fixed the component so it recovers regardless of which path is responsible. If the reintroduction is itself unintended, that is worth fixing separately — this change would still be correct, since a mount-only resolver for a state that can recur is fragile either way.
- The `onMount` import was removed from the component, as that block was its only use.
- This PR was prepared with AI copilot assistance and reviewed by the author.

### Manual Verification Performed

1. **Reproduced on unmodified `dev`:** posted a channel message with an image, pinned it, and watched the attachment become a pulsing dot that persisted until a reload, an unpin, or leaving and re-entering the channel. Pinning again reproduced it on demand.
2. Traced the mechanism end to end — the `Skeleton` render condition, `loadMessageData`'s single `onMount` caller, the keyed `{#each}` that prevents a remount, and the two places that replace the message object wholesale.
3. **Verified the fix on a live instance:** pinning and unpinning a message with an attachment no longer shows the loading indicator at all, in either direction, across repeated cycles.
4. **Checked the sibling paths** that replace the message object the same way: adding a reaction to, and replying to, a message with an attachment. Both behave correctly.
5. **Checked the path that must not regress:** a message loading its data for the first time still shows the loading indicator as before.
6. Verified the build: `npm run format`, `npm run i18n:parse` (no locale changes — no new strings), a full production build, `ruff format --check`, and `vitest run` all pass.

### Screenshots or Videos

#### Before

<img width="1047" height="421" alt="image" src="https://github.com/user-attachments/assets/0f750b2f-aa04-4577-b429-f36840bded64" />

#### After

<img width="1058" height="777" alt="image" src="https://github.com/user-attachments/assets/25b725fa-3aa6-47f7-92cd-3c93ab39b4c8" />

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.

