### PR TITLE
fix: stop channel message hover actions overlapping code and table toolbars

### DIFF
--- a/src/lib/components/channel/Messages/Message.svelte
+++ b/src/lib/components/channel/Messages/Message.svelte
@@ -209,7 +209,7 @@
 				: 'transition: transform 0.3s cubic-bezier(0.2, 0.9, 0.3, 1);'}"
 		>
 			{#if !edit && !disabled}
-				<div class=" absolute {showButtons ? '' : 'hover-reveal'} right-1 -top-2 z-10">
+				<div class=" absolute {showButtons ? '' : 'hover-reveal'} right-1 -top-7 z-30">
 					<div
 						class="flex gap-1 rounded-lg bg-white dark:bg-gray-850 shadow-md p-0.5 border border-gray-100/30 dark:border-gray-850/30"
 					>

--- a/src/lib/components/channel/Messages/Message.svelte
+++ b/src/lib/components/channel/Messages/Message.svelte
@@ -210,7 +210,7 @@
 		>
 			{#if !edit && !disabled}
 				<div
-					class=" absolute {showButtons ? '' : 'invisible group-hover:visible'} right-1 -top-2 z-10"
+					class=" absolute {showButtons ? '' : 'invisible group-hover:visible'} right-1 -top-7 z-30"
 				>
 					<div
 						class="flex gap-1 rounded-lg bg-white dark:bg-gray-850 shadow-md p-0.5 border border-gray-100/30 dark:border-gray-850/30"

--- a/src/lib/components/channel/PinnedMessagesModal.svelte
+++ b/src/lib/components/channel/PinnedMessagesModal.svelte
@@ -94,7 +94,7 @@
 							</div>
 						{:else}
 							<div
-								class="flex flex-col gap-2 max-h-[60vh] overflow-y-auto scrollbar-thin scrollbar-thumb-gray-300 dark:scrollbar-thumb-gray-700 scrollbar-track-transparent py-2"
+								class="flex flex-col gap-2 max-h-[60vh] overflow-y-auto scrollbar-thin scrollbar-thumb-gray-300 dark:scrollbar-thumb-gray-700 scrollbar-track-transparent pt-7 pb-2"
 							>
 								{#if pinnedMessages.length === 0}
 									<div class=" text-center text-xs text-gray-500 dark:text-gray-400 py-6">

--- a/src/lib/components/channel/Thread.svelte
+++ b/src/lib/components/channel/Thread.svelte
@@ -188,7 +188,7 @@
 			</div>
 		</div>
 
-		<div class="flex-1 min-h-0 w-full overflow-y-auto" bind:this={messagesContainerElement}>
+		<div class="flex-1 min-h-0 w-full overflow-y-auto pt-7" bind:this={messagesContainerElement}>
 			{#if messages !== null}
 				<Messages
 					id={threadId}

--- a/src/lib/components/channel/Thread.svelte
+++ b/src/lib/components/channel/Thread.svelte
@@ -188,7 +188,7 @@
 			</div>
 		</div>
 
-		<div class=" max-h-full w-full overflow-y-auto" bind:this={messagesContainerElement}>
+		<div class=" max-h-full w-full overflow-y-auto pt-7" bind:this={messagesContainerElement}>
 			{#if messages !== null}
 				<Messages
 					id={threadId}


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27736 — channel message hover actions and code/table toolbars overlap, leaving one set of buttons unclickable.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable — a bug fix with no new setting or configuration surface.
- [ ] **Dependencies:** No new dependencies.
- [x] **Testing:** The bug was reproduced on unmodified `dev` and the fix verified on a live instance by the author — messages starting with a code block and with a table, the code header's own buttons while the actions row is showing, pinned messages, the thread pane, and the Pinned Messages modal. The click-geometry claims were additionally verified with a `document.elementFromPoint` hit-test harness in headless Chrome (details below). Prettier passes on all three files; no new strings, so zero locale churn.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new settings, no new props, no dependency changes — three one-line Tailwind class changes in channel components.
- [x] **Git Hygiene:** A single commit, +3/−3 across three files, based on the current `dev`.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

**Problem** — For a channel message that starts with a code block, the hover actions row (react, reply, pin, thread, edit, delete) is completely dead: every click lands on the code block's `Collapse`/`Run`/`Copy` header instead. For a message starting with a table, the table's copy/export toolbar and the actions row fight over the same pixels, so one of the two sets of buttons is always blocked. Pinned messages behave correctly only because the "Pinned" label band happens to push the content down out of the way.

**Root Cause** — The message container carries an inline `transform: translateX(...)` for swipe-to-reply, and a transform always creates a stacking context, so everything positioned inside the message competes in that one context:

| element | z-index | DOM order |
|---|---|---|
| hover actions row (`channel/Messages/Message.svelte`) | `z-10` | first |
| code block sticky header (`chat/Messages/CodeBlock.svelte`) | `z-10` | later |
| table copy/export toolbar (`chat/Messages/Markdown/MarkdownTokens.svelte`) | `z-20` | later |

The actions row is anchored `right-1 -top-2`, which puts ~20px of its 30px height inside the message's content band — exactly where the code header and table toolbar render. At equal `z-10`, paint order decides and later-in-DOM wins, so the code header swallows the clicks; the table toolbar at `z-20` wins outright.

This is **not fixable with z-index alone**: the button groups genuinely occupy the same pixels, so raising the actions row just transfers the dead buttons to the content side (an intermediate `z-30`-only version of this fix did exactly that — the table's copy/export buttons became the blocked ones).

**Fix** — Move the actions row so it straddles the message's top boundary instead of intruding into the content band, the same placement Discord and Slack use for their hover toolbars:

```diff
-	class=" absolute {showButtons ? '' : 'invisible group-hover:visible'} right-1 -top-2 z-10"
+	class=" absolute {showButtons ? '' : 'invisible group-hover:visible'} right-1 -top-7 z-30"
```

`-top-7` reduces the intrusion into the content band from ~20px to ~2px, clearing both the table toolbar (which starts at `top-1`) and the code header buttons (which start at `py-1.5`); `z-30` keeps the row on top for the 2px sliver that still meets the content edge.

Two scroll containers place a message at their very top, so their `overflow-y-auto` would clip the straddled row on their first message. Both get matching `pt-7` headroom:

- `channel/Thread.svelte` — in thread mode, `Messages.svelte` renders its intro/loader block only `{:else if !thread}`, so the thread's root message sits flush at the container top.
- `channel/PinnedMessagesModal.svelte` — the list container had `py-2`, now `pt-7 pb-2`.

The main channel list needs no change: it already has `pt-6` and the channel intro / pagination loader always renders above the first message.

**Behavioral note for review** — on hover, the actions row now overlaps the bottom edge of the *previous* message (hover-only, matching Discord/Slack) instead of covering the current message's own content. This is the visible trade the fix makes, and it is what makes both button groups reachable.

### Fixed

- Fixed the hover actions row on channel messages being unclickable when the message starts with a code block (and colliding with the copy/export toolbar when it starts with a table), by making the row straddle the message's top boundary instead of overlapping the content, with matching headroom in the thread pane and Pinned Messages modal so the row is not clipped on their first message.

---

### Additional Information

**Overlaps with another open PR.** This touches `src/lib/components/channel/Thread.svelte`, which #27768 also modifies, and the two conflict in that file. They are independent channel fixes, one for hover action overlap and one for reply input placement. Either order works; whichever merges second needs a rebase.


- This PR was prepared with AI copilot assistance and reviewed by the author.

### Manual Verification Performed

1. **Reproduced on unmodified `dev`:** posted a channel message starting with a fenced code block — every button in the hover actions row was dead, with clicks landing on the code header. A message starting with a table showed the reverse collision.
2. **Hit-test verification:** built a standalone harness reproducing the exact markup geometry (transform stacking context, `z-10` sticky code header, `z-20` table toolbar) and ran `document.elementFromPoint` over every button center in headless Chrome. Current `dev` geometry: 6/6 action buttons blocked on a code-first message. A z-index-only fix: table toolbar buttons become blocked instead. The straddle: 0 blocked across all three button groups (message actions, code header, table toolbar), in both the code-first and table-first cases. The same harness verified that a first-row message inside an `overflow-y-auto` container clips the straddled row without `pt-7` headroom, and does not clip it with it.
3. **Verified the fix on a live instance:** messages starting with a table and with a code block — both the actions row and the content controls (table copy/export, code header `Copy`) fully clickable; pinned messages still correct; the thread pane's root message and the Pinned Messages modal's first row show the full hover row un-clipped.
4. Prettier passes on all three changed files; no new translatable strings, so `i18n:parse` produces zero locale churn.

### Screenshots or Videos

#### Before: actions row covering the table's copy/export toolbar

<img width="1266" height="146" alt="image" src="https://github.com/user-attachments/assets/d553e3fa-69d1-44f5-a106-826d28ccb7f5" />

<img width="1262" height="365" alt="image" src="https://github.com/user-attachments/assets/26b772b5-3e3f-4b7d-9610-fd2d2c640bee" />

#### After: straddled actions row with both toolbars accessible

<img width="1266" height="146" alt="image" src="https://github.com/user-attachments/assets/655611f1-fc67-41d2-819c-166ac731fa3a" />

<img width="1264" height="385" alt="image" src="https://github.com/user-attachments/assets/2ed797e3-37dc-4612-8d2c-f296a03d030b" />

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.

