### PR TITLE
fix: add stable prompt cache routing for OpenAI Responses

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -1066,6 +1066,11 @@ async def chat_completion(
     form_data: dict,
     user=Depends(get_verified_user),
 ):
+    """日期：2026-07-30；作者：苍朮；用途：处理聊天完成请求并保留根聊天缓存作用域。
+
+    参数：request 为 HTTP 请求，form_data 为聊天负载，user 为已验证用户。
+    返回：聊天完成响应或流式响应。
+    """
     if not request.app.state.MODELS:
         await get_all_models(request, user=user)
 
@@ -1196,6 +1201,7 @@ async def chat_completion(
             'user_message_id': user_message.get('id') if user_message else None,
             'assistant_message_id': form_data.pop('assistant_message_id', None),
             'session_id': form_data.pop('session_id', None),
+            'root_chat_id': form_data.pop('root_chat_id', None),
             'folder_id': form_data.pop('folder_id', None),
             'filter_ids': form_data.pop('filter_ids', []),
             'tool_ids': form_data.get('tool_ids', None),

--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -49,6 +49,7 @@ from open_webui.utils.misc import (
     convert_logit_bias_input_to_json,
     stream_chunks_handler,
 )
+from open_webui.utils.openai_prompt_cache import apply_responses_prompt_cache_key
 from open_webui.utils.payload import (
     apply_model_params_to_body_openai,
     apply_system_prompt_to_body,
@@ -1193,6 +1194,16 @@ async def generate_chat_completion(
     form_data: dict,
     user=Depends(get_verified_user),
 ):
+    """日期：2026-07-30；作者：苍朮；用途：将聊天请求按连接配置转发到 OpenAI-compatible 上游。
+
+    参数：
+        request：当前 FastAPI 请求上下文。
+        form_data：OpenAI Chat Completions 兼容请求负载。
+        user：已验证的当前用户。
+
+    返回：
+        上游返回的普通响应、流式响应或错误响应。
+    """
     if not await Config.get('openai.enable'):
         raise HTTPException(status_code=503, detail='OpenAI API is disabled')
 
@@ -1291,6 +1302,7 @@ async def generate_chat_completion(
     headers, cookies = await get_headers_and_cookies(request, url, key, api_config, metadata, user=user)
 
     is_responses = api_config.get('api_type') == 'responses'
+    payload = apply_responses_prompt_cache_key(payload, metadata, api_config)
 
     if api_config.get('azure') or api_config.get('provider') == 'azure':
         # Only set api-key header if not using Azure Entra ID authentication

--- a/backend/open_webui/utils/openai_prompt_cache.py
+++ b/backend/open_webui/utils/openai_prompt_cache.py
@@ -1,0 +1,32 @@
+"""OpenAI Responses prompt-cache request helpers."""
+
+
+def apply_responses_prompt_cache_key(
+    payload: dict,
+    metadata: dict | None,
+    api_config: dict,
+) -> dict:
+    """日期：2026-07-30；作者：苍朮；用途：按根聊天标识为 OpenAI Responses 请求注入稳定缓存键。
+
+    参数：
+        payload：即将发送给 OpenAI-compatible 上游的请求负载。
+        metadata：包含当前聊天与可选根聊天标识的 Open WebUI 内部元数据。
+        api_config：当前 OpenAI-compatible 连接配置。
+
+    返回：
+        注入缓存键后的原请求负载。
+    """
+    if api_config.get('api_type') != 'responses' or api_config.get('azure') or api_config.get('provider') == 'azure':
+        return payload
+
+    if 'prompt_cache_key' in payload:
+        return payload
+
+    metadata = metadata or {}
+    root_chat_id = metadata.get('root_chat_id')
+    chat_id = root_chat_id if isinstance(root_chat_id, str) and root_chat_id.strip() else metadata.get('chat_id')
+    if not isinstance(chat_id, str) or not chat_id.strip():
+        return payload
+
+    payload['prompt_cache_key'] = chat_id.strip()
+    return payload

--- a/backend/open_webui/utils/subagents.py
+++ b/backend/open_webui/utils/subagents.py
@@ -75,6 +75,11 @@ async def process_pending_internal_messages(
     user_id: str,
     run: dict,
 ) -> None:
+    """日期：2026-07-30；作者：苍朮；用途：合并待处理内部消息并继承根聊天上下文生成回复。
+
+    参数：source_request 为来源请求，parent_chat_id 为当前父聊天，user_id 为用户，run 为代理运行上下文。
+    返回：无。
+    """
     lock = _parent_locks.setdefault(parent_chat_id, asyncio.Lock())
     while await has_active_tasks(source_request.app.state.redis, parent_chat_id):
         await asyncio.sleep(0.25)
@@ -252,6 +257,7 @@ async def process_pending_internal_messages(
             'parent_id': parent_id,
             'user_message': user_message,
             'session_id': run.get('session_id') or f'{kind}-result:{parent_chat_id}',
+            'root_chat_id': run.get('root_chat_id') or parent_chat_id,
             'background_tasks': {},
             'tool_ids': run.get('tool_ids') or [],
             'skill_ids': run.get('skill_ids') or [],
@@ -278,6 +284,11 @@ async def delegate(
     parent_chat_id: str,
     parent_message_id: str | None,
 ) -> str:
+    """日期：2026-07-30；作者：苍朮；用途：创建子代理并继承根聊天缓存作用域。
+
+    参数：task 为任务，context 为补充上下文，background 控制异步执行，其余关键字参数提供请求、用户与父聊天上下文。
+    返回：前台子代理结果或后台委派状态 JSON。
+    """
     global _foreground_semaphore
 
     task = task.strip()
@@ -313,9 +324,15 @@ async def delegate(
         and await Config.get('code_interpreter.engine', 'pyodide') != 'jupyter'
     ):
         features.pop('code_interpreter')
+    root_chat_id = metadata.get('root_chat_id')
+    if not isinstance(root_chat_id, str) or not root_chat_id.strip():
+        root_chat_id = parent_chat_id
+    else:
+        root_chat_id = root_chat_id.strip()
     run = {
         'model_id': metadata.get('model_id') or (metadata.get('model') or {}).get('id'),
         'session_id': metadata.get('session_id'),
+        'root_chat_id': root_chat_id,
         'tool_ids': copy.deepcopy(metadata.get('tool_ids') or []),
         'skill_ids': copy.deepcopy(metadata.get('skill_ids') or []),
         'system_prompt': metadata.get('system_prompt'),
@@ -442,6 +459,7 @@ async def delegate(
                     'content': prompt,
                 },
                 'session_id': run.get('session_id') or f'subagent:{chat_id}',
+                'root_chat_id': run['root_chat_id'],
                 'background_tasks': {},
                 'tool_ids': run.get('tool_ids') or [],
                 'skill_ids': run.get('skill_ids') or [],


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Relates to https://github.com/open-webui/open-webui/discussions/27182
- [x] **Target branch:** This PR targets `dev`.
- [x] **Description:** The change and its scope are described below.
- [x] **Changelog:** A changelog entry is included.
- [x] **Documentation:** No user-facing documentation changes are required.
- [x] **Dependencies:** No dependencies were added or updated.
- [x] **Testing:** Manual tests were performed; screenshots are attached below.
- [x] **No Unchecked AI Code:** The code has undergone human review and manual testing.
- [x] **Self-Review:** A self-review of the code has been performed.
- [x] **Architecture:** The change uses an automatic default without adding settings.
- [x] **Git Hygiene:** The PR contains one atomic commit with no unrelated changes.
- [x] **Title Prefix:** The PR title uses the `fix` prefix.

## Summary

OpenAI-compatible Responses connections did not automatically send a stable
`prompt_cache_key`, which could reduce prompt-cache affinity across multi-turn
conversations and subagent requests.

This PR:

- automatically sets `prompt_cache_key` for non-Azure Responses connections;
- uses the root chat ID as the stable cache-routing key;
- propagates the root chat ID to child and nested subagents;
- preserves an explicitly provided `prompt_cache_key`.

Chat Completions and Azure request paths are unchanged.

## Validation

Tested locally with an OpenAI-compatible Responses connection:

- normal multi-turn requests completed successfully;
- two parallel background subagents were created and completed successfully;
- both subagents inherited the parent cache-routing scope;
- local usage records reported cached input tokens for both child chats and
  the parent continuation;
- the affected Python runtime files compiled successfully.

## Changelog Entry

### Fixed

- Added stable prompt-cache routing for OpenAI-compatible Responses connections.

### Screenshots or Videos

<img width="2194" height="1384" alt="image" src="https://github.com/user-attachments/assets/4efbb32e-335f-4b63-828f-d43a3bd078aa" />


### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.