### PR TITLE
fix: mount the code editor in its own container so duplicated message renders don't collide

### DIFF
--- a/src/lib/components/channel/Messages/Message.svelte
+++ b/src/lib/components/channel/Messages/Message.svelte
@@ -49,7 +49,7 @@
 
 	export let showUserProfile = true;
 	export let thread = false;
-	export let id = null;
+	export let id: string | null = null;
 
 	export let replyToMessage = false;
 	export let disabled = false;

--- a/src/lib/components/channel/PinnedMessagesModal.svelte
+++ b/src/lib/components/channel/PinnedMessagesModal.svelte
@@ -103,6 +103,7 @@
 								{:else}
 									{#each pinnedMessages as message, messageIdx (message.id)}
 										<Message
+											id="pinned"
 											className="rounded-xl px-2"
 											{message}
 											{channel}

--- a/src/lib/components/common/CodeEditor.svelte
+++ b/src/lib/components/common/CodeEditor.svelte
@@ -79,6 +79,7 @@
 	export let lang = '';
 
 	let codeEditor: EditorView | null = null;
+	let codeEditorContainerElement: HTMLDivElement | undefined = undefined;
 
 	export const focus = () => {
 		codeEditor?.focus();
@@ -249,7 +250,7 @@ print("${endTag}")
 				doc: _value,
 				extensions: extensions
 			}),
-			parent: document.getElementById(`code-textarea-${id}`)
+			parent: codeEditorContainerElement
 		});
 
 		if (isDarkMode) {
@@ -319,4 +320,8 @@ print("${endTag}")
 	});
 </script>
 
-<div id="code-textarea-{id}" class="{className} h-full w-full min-w-0 overflow-hidden" />
+<div
+	bind:this={codeEditorContainerElement}
+	id="code-textarea-{id}"
+	class="{className} h-full w-full min-w-0 overflow-hidden"
+/>


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27739 — code blocks in pinned messages render empty in the Pinned Messages modal and duplicate into the channel view.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable — a bug fix with no new setting or configuration surface.
- [ ] **Dependencies:** No new dependencies.
- [x] **Testing:** The bug was reproduced on unmodified `dev` and the fix verified on a live instance by the author — the Pinned Messages modal now renders code block contents, the channel view no longer duplicates them while the modal is open, and chat code blocks continue to render and edit normally. Prettier passes on all three files; no new strings, so zero locale churn; the targeted svelte-check error count comes out one *lower* than `dev`.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new settings, no new props on shared components, no dependency changes — a `bind:this` mount in `CodeEditor`, an id prefix in the modal following the existing `Thread.svelte` pattern, and one type annotation.
- [x] **Git Hygiene:** A single commit, +9/−3 across three files, based on the current `dev`.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

**Problem** — If a pinned channel message contains code blocks, the Pinned Messages modal renders each block's header bar (language label, `Collapse`, `Copy`, `Run`) with an empty body — the code is missing. At the same time, the very same message's code blocks in the channel view behind the modal get visually **duplicated** while the modal is open.

**Root Cause** — `CodeEditor.svelte` mounts CodeMirror with a global id lookup:

```js
codeEditor = new EditorView({
	...
	parent: document.getElementById(`code-textarea-${id}`)
});
```

`document.getElementById` returns the **first** match in document order, and three facts combine against that:

1. The main channel view renders `Messages` without an `id` prefix, so a message's code blocks get DOM ids `code-textarea-{messageId}-{tokenIdx}`.
2. `PinnedMessagesModal.svelte` renders the same `Message` component, also unprefixed — byte-identical ids for the same message.
3. `Modal.svelte` portals itself to the end of `<body>`, so the channel's copy of any duplicated id always comes first.

The modal's editor therefore mounts **into the channel's container**: the channel shows the code twice, and the modal's own container stays empty. The thread panel escapes only because `Thread.svelte` happens to pass `id={threadId}`, which prefixes everything.

**Fix** —

1. **`common/CodeEditor.svelte`** — mount CodeMirror into the component's own element via `bind:this` instead of the global lookup. A component that locates its mount point with `document.getElementById` can never safely exist twice on a page; binding the element makes every instance self-contained for all consumers (chat code blocks, the admin function editor, the tool editor, admin image settings), whose single-instance behaviour is unchanged. The `id` attribute stays on the element, so nothing that targets it externally changes.
2. **`channel/PinnedMessagesModal.svelte`** — pass `id="pinned"` to `Message`, mirroring the `Thread.svelte` pattern. The modal was also cloning the channel's other global ids: `message-{id}` (a reply-jump `scrollIntoView` target) and `plt-canvas-{id}` (the matplotlib output target when running Python from a code block). With the prefix, every DOM id the modal renders is unique.
3. **`channel/Messages/Message.svelte`** — `export let id: string | null = null;` so the string prefix type-checks (`Thread.svelte` passes a variable; the modal now passes a literal).

### Fixed

- Fixed code blocks in pinned channel messages rendering empty in the Pinned Messages modal — and duplicating into the channel view behind it — by mounting the code editor into its own bound element instead of a global id lookup that resolved to the channel's copy of the same message, and by giving the modal's messages a unique DOM id prefix.

---

### Additional Information

- This PR was prepared with AI copilot assistance and reviewed by the author.

### Manual Verification Performed

1. **Reproduced on unmodified `dev`:** pinned a channel message containing several fenced code blocks, opened the Pinned Messages modal with the message still rendered in the channel behind it — the modal showed empty code block bodies and the channel's code blocks doubled.
2. **Verified the fix on a live instance:** the modal renders the code block contents, and the channel view no longer duplicates them while the modal is open.
3. **Checked the shared consumer that must not regress:** code blocks in normal chat messages still render and remain editable.
4. Prettier passes on all three changed files; no new translatable strings, so `i18n:parse` produces zero locale churn. A targeted before/after `svelte-check` comparison on the touched files shows one error *fewer* than `dev` (the previous `HTMLElement | null` parent assignability complaint is resolved by the typed bound element).

### Screenshots or Videos

#### Before: modal showing empty code block bodies, channel showing doubled code

<img width="2330" height="1275" alt="image" src="https://github.com/user-attachments/assets/2668c94e-f792-409c-9818-a179858483db" />

#### After: modal rendering the code

<img width="2330" height="1275" alt="image" src="https://github.com/user-attachments/assets/8ad06bf2-946a-4388-b77f-811af873be1e" />

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
