### PR TITLE
fix: accept null unused embedding provider fields

### DIFF
--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -481,13 +481,13 @@ class OpenAIConfigForm(BaseModel):
 
 class OllamaConfigForm(BaseModel):
     url: str
-    key: str
+    key: str | None = None
 
 
 class AzureOpenAIConfigForm(BaseModel):
-    url: str
-    key: str
-    version: str
+    url: str | None = None
+    key: str | None = None
+    version: str | None = None
 
 
 class EmbeddingModelUpdateForm(BaseModel):
@@ -540,12 +540,16 @@ async def update_embedding_config(request: Request, form_data: EmbeddingModelUpd
 
             if form_data.ollama_config is not None:
                 config.RAG_OLLAMA_BASE_URL = form_data.ollama_config.url
-                config.RAG_OLLAMA_API_KEY = form_data.ollama_config.key
+                if form_data.ollama_config.key is not None:
+                    config.RAG_OLLAMA_API_KEY = form_data.ollama_config.key
 
             if form_data.azure_openai_config is not None:
-                config.RAG_AZURE_OPENAI_BASE_URL = form_data.azure_openai_config.url
-                config.RAG_AZURE_OPENAI_API_KEY = form_data.azure_openai_config.key
-                config.RAG_AZURE_OPENAI_API_VERSION = form_data.azure_openai_config.version
+                if form_data.azure_openai_config.url is not None:
+                    config.RAG_AZURE_OPENAI_BASE_URL = form_data.azure_openai_config.url
+                if form_data.azure_openai_config.key is not None:
+                    config.RAG_AZURE_OPENAI_API_KEY = form_data.azure_openai_config.key
+                if form_data.azure_openai_config.version is not None:
+                    config.RAG_AZURE_OPENAI_API_VERSION = form_data.azure_openai_config.version
 
         request.app.state.ef = get_ef(
             config.RAG_EMBEDDING_ENGINE,


### PR DESCRIPTION
## What Problem This Solves

Saving OpenAI RAG embedding settings returned HTTP 422 when the frontend included unused Ollama or Azure OpenAI configuration fields as `null`.

## Why This Change Was Made

The provider config objects are optional, but their nested fields were validated as required strings. The API now accepts nullable values for the fields the UI can legitimately leave unused. Updates skip `None` values so inactive provider settings are preserved instead of overwritten.

This is handled at the backend validation boundary so all clients receive consistent behavior; frontend-only payload normalization would leave other API clients exposed to the same validation mismatch.

## User Impact

Admins can save OpenAI embedding settings without filling unrelated Ollama or Azure OpenAI fields. Existing non-null provider settings continue to update normally, and required top-level embedding engine/model fields remain required.

## Evidence

- Replayed the issue's exact payload shape against the production Pydantic model definitions.
- Confirmed the baseline model rejects the payload with `ValidationError`.
- Confirmed the patched model accepts it while still rejecting a payload missing the required embedding engine.
- `git diff --check` passes.
- Repository-wide Ruff currently reports pre-existing findings in `retrieval.py`; no reported finding points to the changed lines.

Fixes open-webui/open-webui#27729
