### PR TITLE
fix: accept null unused embedding provider fields

### DIFF
--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -481,13 +481,13 @@ class OpenAIConfigForm(BaseModel):
 
 class OllamaConfigForm(BaseModel):
     url: str
-    key: str
+    key: str | None = None
 
 
 class AzureOpenAIConfigForm(BaseModel):
-    url: str
-    key: str
-    version: str
+    url: str | None = None
+    key: str | None = None
+    version: str | None = None
 
 
 class EmbeddingModelUpdateForm(BaseModel):
@@ -540,12 +540,16 @@ async def update_embedding_config(request: Request, form_data: EmbeddingModelUpd
 
             if form_data.ollama_config is not None:
                 config.RAG_OLLAMA_BASE_URL = form_data.ollama_config.url
-                config.RAG_OLLAMA_API_KEY = form_data.ollama_config.key
+                if form_data.ollama_config.key is not None:
+                    config.RAG_OLLAMA_API_KEY = form_data.ollama_config.key
 
             if form_data.azure_openai_config is not None:
-                config.RAG_AZURE_OPENAI_BASE_URL = form_data.azure_openai_config.url
-                config.RAG_AZURE_OPENAI_API_KEY = form_data.azure_openai_config.key
-                config.RAG_AZURE_OPENAI_API_VERSION = form_data.azure_openai_config.version
+                if form_data.azure_openai_config.url is not None:
+                    config.RAG_AZURE_OPENAI_BASE_URL = form_data.azure_openai_config.url
+                if form_data.azure_openai_config.key is not None:
+                    config.RAG_AZURE_OPENAI_API_KEY = form_data.azure_openai_config.key
+                if form_data.azure_openai_config.version is not None:
+                    config.RAG_AZURE_OPENAI_API_VERSION = form_data.azure_openai_config.version
 
         request.app.state.ef = get_ef(
             config.RAG_EMBEDDING_ENGINE,


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Closes #27729.
- [x] **Target branch:** This pull request targets the `dev` branch.
- [x] **Description:** A concise description is provided below.
- [x] **Changelog:** A Keep a Changelog entry is included below.
- [x] **Documentation:** No documentation changes are required for this bug fix.
- [x] **Dependencies:** No dependencies were added or updated.
- [x] **Testing:** The reported payload was validated against the production Pydantic model definitions before and after the fix.
- [x] **No Unchecked AI Code:** The change underwent human review and direct validation against the reported reproduction.
- [x] **Self-Review:** The final diff was reviewed for scope and project conventions.
- [x] **Architecture:** The fix uses the existing backend validation boundary and introduces no settings or UI state.
- [x] **Git Hygiene:** The PR is atomic, rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The title uses the `fix` prefix.

## Description

Saving OpenAI RAG embedding settings returned HTTP 422 when the frontend included unused Ollama or Azure OpenAI configuration values as `null`.

The provider config objects were optional, but their nested fields were validated as required strings. This change:

- accepts `null` for the Ollama API key and Azure OpenAI URL, key, and version;
- skips `None` values when updating stored provider settings, avoiding accidental overwrites;
- keeps OpenAI URL/key, Ollama URL, and the top-level embedding engine/model required.

The fix belongs at the backend validation boundary so every API client receives consistent behavior.

# Changelog Entry

### Description

- Allow RAG embedding settings to be saved when unused provider fields are null.

### Added

- None.

### Changed

- Inactive provider settings are preserved when their submitted values are null.

### Deprecated

- None.

### Removed

- None.

### Fixed

- Fixed HTTP 422 responses when saving OpenAI embedding settings with null Ollama or Azure OpenAI fields.

### Security

- None.

### Breaking Changes

- None.

---

### Additional Information

- Baseline `dev` rejects the exact payload from #27729 with `ValidationError`.
- The patched production model accepts it while still rejecting payloads missing the required embedding engine.
- `git diff --check` passes.
- No new dependencies.

Closes #27729

### Screenshots or Videos

- Not applicable; this is a backend request-validation fix.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
