### PR TITLE
fix: log terminal proxy connectivity failures as single lines and handle client disconnects

### DIFF
--- a/backend/open_webui/routers/terminals.py
+++ b/backend/open_webui/routers/terminals.py
@@ -22,6 +22,7 @@ from open_webui.utils.auth import get_verified_user
 from open_webui.utils.terminals import get_terminal_server_url
 from open_webui.utils.tools import bearer_auth_header, normalize_bearer_token
 from starlette.background import BackgroundTask
+from starlette.requests import ClientDisconnect
 
 log = logging.getLogger(__name__)
 
@@ -153,13 +154,14 @@ async def proxy_terminal(
     if content_type:
         headers['Content-Type'] = content_type
 
-    body = await request.body()
     session = aiohttp.ClientSession(
         timeout=aiohttp.ClientTimeout(total=300, connect=10),
         trust_env=True,
     )
 
     try:
+        body = await request.body()
+
         upstream_response = await session.request(
             method=request.method,
             url=target_url,
@@ -200,6 +202,13 @@ async def proxy_terminal(
 
         return Response(content=response_body, status_code=status_code, headers=filtered_headers)
 
+    except ClientDisconnect:
+        await session.close()
+        return Response(status_code=499)
+    except (aiohttp.ClientConnectionError, TimeoutError) as error:
+        await session.close()
+        log.error('Terminal proxy error: %s', str(error) or type(error).__name__)
+        return JSONResponse({'error': f'Terminal proxy error: {error}'}, status_code=502)
     except Exception as error:
         await session.close()
         log.exception('Terminal proxy error: %s', error)


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27751, the terminal proxy floods logs with full tracebacks when the terminal server is unreachable.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable. A logging behavior fix with no new setting or configuration surface.
- [ ] **Dependencies:** No new dependencies.
- [x] **Testing:** Both failure modes were reproduced and the fix verified in a standalone uvicorn harness running the exact handler pattern against the project's installed dependency versions (aiohttp 3.13.5, starlette, uvicorn). Details in the verification section below. `ruff format --check` passes and `ruff check` reports zero findings beyond what `dev` already has on this file.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new settings and no dependency changes: one handler in one router gains two targeted except branches, and one line moves inside the try block.
- [x] **Git Hygiene:** A single commit, +10/-1 in a single file, based on the current `dev`.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

**Problem** (from #27751): when a configured terminal server is unreachable, the container log is flooded with full multi-frame tracebacks, roughly one per proxy attempt, while the UI retries continuously. A few minutes of terminal downtime produces enormous logs. Two distinct sources, both in `routers/terminals.py`:

1. The proxy's `except Exception` handler answers the request cleanly with a 502 but logs it with `log.exception`, so every expected connectivity failure (DNS resolution failure, connection refused, timeout) emits the entire stack even though the message alone carries all the information.
2. `body = await request.body()` sits outside the try block. When the client aborts an in-flight request, which happens constantly while the terminal is down and the UI is retrying, `starlette.requests.ClientDisconnect` escapes the handler entirely and uvicorn logs `Exception in ASGI application` with a second full traceback, returning a 500 for a client that has already gone away.

**Fix**

1. The body read moves inside the try block, and `ClientDisconnect` gets its own handler: close the session and return a 499 without logging, since the client cannot receive a response and nothing failed server side. (499 is the de facto "client closed request" status; the response is never delivered.)
2. Expected connectivity failures get their own handler that logs one line via `log.error` and returns the same 502 JSON as before:

```python
    except ClientDisconnect:
        await session.close()
        return Response(status_code=499)
    except (aiohttp.ClientConnectionError, TimeoutError) as error:
        await session.close()
        log.error('Terminal proxy error: %s', str(error) or type(error).__name__)
        return JSONResponse({'error': f'Terminal proxy error: {error}'}, status_code=502)
    except Exception as error:
        await session.close()
        log.exception('Terminal proxy error: %s', error)
        return JSONResponse({'error': f'Terminal proxy error: {error}'}, status_code=502)
```

Genuinely unexpected exceptions still fall through to the existing `log.exception` branch with the full stack, so debuggability for real bugs is unchanged.

**Why these exception classes**: verified empirically against the installed aiohttp 3.13.5 that `aiohttp.ClientConnectionError` is the common ancestor of every connectivity class named in the issue (`ClientConnectorDNSError`, `ClientConnectorError`, `ServerTimeoutError`, `ServerDisconnectedError`, `ConnectionTimeoutError`). The builtin `TimeoutError` additionally covers the total-deadline timeout path; since Python 3.11 `asyncio.TimeoutError` is the same class, so no `asyncio` import is needed (this also keeps ruff's UP041 rule happy, which flags the aliased form).

**Why `str(error) or type(error).__name__`**: a bare `TimeoutError` stringifies to an empty string, so logging the message alone would produce a line that says nothing; the class name is the fallback.

**Not included**: the issue's optional suggestion to rate limit or dedupe repeated identical failures per terminal id. With one concise line per attempt instead of a 60-frame traceback, the volume drops by roughly two orders of magnitude; if per-line dedup is still wanted on top, it is a separable follow-up.

**Response semantics are unchanged** for everything except the client-disconnect case, which previously surfaced as an unhandled 500 and now returns a quiet 499 to a peer that is no longer listening.

### Fixed

- Fixed the terminal proxy flooding container logs while a terminal server is unreachable: expected connectivity failures (DNS, connection refused, timeouts) now log one concise line instead of a full traceback per retry, and a client aborting an in-flight proxied request no longer escapes as an unhandled ASGI exception with a second traceback.

---

### Additional Information

- This PR was prepared with AI copilot assistance and reviewed by the author.

### Verification Performed

1. **Reproduced both spam sources**: a standalone FastAPI/uvicorn harness exposing two routes with identical proxy logic to an unreachable upstream, one in the current `dev` shape and one in the fixed shape, running on the project's installed aiohttp 3.13.5, starlette, and uvicorn.
2. **Unreachable upstream**: the `dev` shape logged a three-cause chained traceback of roughly 50 lines per request (ending in `aiohttp.client_exceptions.ClientConnectorDNSError`, the exact class from the issue) alongside the 502. The fixed shape logged exactly one line, `Terminal proxy error: Cannot connect to host ... [Domain name not found]`, with the same 502.
3. **Client abort mid-request**: driven by a raw socket sending a partial body with a large declared Content-Length and then closing. The `dev` shape produced uvicorn's `Exception in ASGI application` traceback ending in `starlette.requests.ClientDisconnect`. The fixed shape logged nothing and produced no unhandled exception.
4. **Exception hierarchy checked empirically** in the project's virtualenv (`issubclass` checks for all five aiohttp connectivity classes against `ClientConnectionError`, plus `asyncio.TimeoutError is TimeoutError` returning True on Python 3.11).
5. `ruff format --check` passes; `ruff check` on the file reports the identical finding count as unmodified `dev` (the pre-existing complexity and UP041 findings elsewhere in the file are untouched).

### Screenshots or Videos

Not applicable (backend logging behavior).

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
