### PR TITLE
fix: log tool server connectivity failures without a traceback

### DIFF
--- a/backend/open_webui/utils/tools.py
+++ b/backend/open_webui/utils/tools.py
@@ -1439,6 +1439,10 @@ async def get_tool_server_data(url: str, headers: dict | None) -> dict[str, Any]
                         # Fall back to YAML for non-.yml URLs that aren't valid JSON
                         res = yaml.safe_load(text_content)
 
+    except (aiohttp.ClientConnectionError, TimeoutError) as err:
+        error = str(err) or type(err).__name__
+        log.error(f'Could not fetch tool server spec from {url}: {error}')
+        raise Exception(error)
     except Exception as err:
         log.exception(f'Could not fetch tool server spec from {url}')
         if isinstance(err, dict) and 'detail' in err:


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27756, the tool server spec fetch floods logs with a full traceback per attempt when the server is unreachable. Same defect class as #27751, fixed for the terminal proxy in #27755.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable. A logging behavior fix with no new setting or configuration surface.
- [ ] **Dependencies:** No new dependencies.
- [x] **Testing:** The failure was reproduced on the author's live instance with a deliberately unreachable tool server (the log excerpt in #27756 is from that instance), and the fixed branch runs live on the same instance for verification. The exception hierarchy was verified empirically against the installed aiohttp 3.13.5 in the sibling PR #27755 (issubclass checks for all five connectivity classes against `ClientConnectionError`, and `asyncio.TimeoutError is TimeoutError` on Python 3.11). `ruff format --check` passes and `ruff check` reports findings identical to unmodified `dev`.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new settings and no dependency changes: one except branch added ahead of the existing blanket handler in one function.
- [x] **Git Hygiene:** A single commit, +4/-0 in a single file, based on the current `dev`.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

**Problem** (#27756): when a configured OpenAPI tool server is unreachable (DNS failure, container down, network partition), every spec fetch logs a full three-cause chained traceback of roughly 45 lines via `log.exception`, and the same failure is then logged a second time as a single line by the caller (`get_tool_servers_data`). The spec is refetched frequently during normal UI activity, so a tool server that stays down floods the container log continuously.

**Root Cause**: `get_tool_server_data` in `utils/tools.py` handles every failure with a blanket `except Exception` and `log.exception`. For expected connectivity failures the traceback is the same aiohttp connector chain every time and carries no information the message does not.

**Fix**: catch the connectivity classes first and log one line, leaving the blanket handler with its full traceback for genuinely unexpected failures:

```diff
+    except (aiohttp.ClientConnectionError, TimeoutError) as err:
+        error = str(err) or type(err).__name__
+        log.error(f'Could not fetch tool server spec from {url}: {error}')
+        raise Exception(error)
     except Exception as err:
         log.exception(f'Could not fetch tool server spec from {url}')
```

This also brings the function in line with the project's own convention: `routers/ollama.py send_get_request` and `routers/openai.py send_get_request` already log the identical failure mode as one `log.error` line.

**Why these exception classes**: `aiohttp.ClientConnectionError` is the common ancestor of `ClientConnectorDNSError` (the exact class in the reported log), `ClientConnectorError`, `ServerTimeoutError`, `ServerDisconnectedError`, and `ConnectionTimeoutError`, verified empirically against the installed aiohttp 3.13.5 in #27755. The builtin `TimeoutError` covers the total-deadline path of `AIOHTTP_CLIENT_TIMEOUT_TOOL_SERVER_DATA`; since Python 3.11 `asyncio.TimeoutError` is the same class, so no import is needed.

**Why `str(err) or type(err).__name__`**: a bare `TimeoutError` stringifies to an empty string, which would otherwise produce both a log line and a raised error message with no information.

**Caller contract is unchanged**: the function still raises `Exception(error)` with the same message text for connectivity failures, so both callers behave exactly as before. `get_tool_servers_data` still logs its per-server summary line and skips the server, and the connection verification endpoint in `routers/configs.py` still converts the failure into its 400 response.

### Fixed

- Fixed the OpenAPI tool server spec fetch flooding container logs while a tool server is unreachable: expected connectivity failures (DNS, connection refused, timeouts) now log one concise line instead of a full chained traceback per fetch, while unexpected failures keep the full stack.

---

### Additional Information

- Same defect class as the terminal proxy log spam (#27751, fixed in #27755); this addresses the remaining source observed on a live instance.
- This PR was prepared with AI copilot assistance and reviewed by the author.

### Verification Performed

1. **Reproduced on a live instance**: with an OpenAPI tool server configured whose hostname does not resolve, normal UI activity produced the chained traceback plus the duplicate single line on every fetch (full excerpt in #27756).
2. **Fix running live**: the same instance now runs this branch against the same deliberately failing tool server connection.
3. **Exception hierarchy verified empirically** in the project's virtualenv (aiohttp 3.13.5): issubclass checks for all five connectivity classes against `ClientConnectionError`, plus `asyncio.TimeoutError is TimeoutError` returning True on Python 3.11 (documented in #27755).
4. `ruff format --check` passes; `ruff check` on the file reports findings identical to unmodified `dev`; the diff adds zero code comments.

### Screenshots or Videos

Not applicable (backend logging behavior).

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
