### PR TITLE
fix: enforce the image generation flag on the legacy chat feature path

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -1720,6 +1720,19 @@ async def chat_image_generation_handler(request: Request, form_data: dict, extra
 
             system_message_content = f'<context>Image generation was attempted but failed. The system is currently unable to generate the image. Tell the user that the following error occurred: {error_message}</context>'
 
+    elif not await Config.get('image_generation.enable'):
+        await __event_emitter__(
+            {
+                'type': 'status',
+                'data': {
+                    'description': 'Image generation is disabled',
+                    'done': True,
+                },
+            }
+        )
+
+        system_message_content = '<context>Image generation was requested but the feature is currently disabled by the administrator, so no image was created. Let the user know that image generation is currently unavailable.</context>'
+
     else:
         # Create image(s)
         if await Config.get('image_generation.prompt.enable'):

--- a/src/lib/components/admin/Settings/Images.svelte
+++ b/src/lib/components/admin/Settings/Images.svelte
@@ -150,8 +150,9 @@
 		});
 
 		if (res) {
+			backendConfig.set(await getBackendConfig());
+
 			if (res.ENABLE_IMAGE_GENERATION) {
-				backendConfig.set(await getBackendConfig());
 				getModels();
 			}
 

--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -2144,7 +2144,7 @@
 												{/if}
 											{/each}
 
-											{#if webSearchEnabled}
+											{#if webSearchEnabled && showWebSearchButton}
 												<Tooltip content={$i18n.t('Web Search')} placement="top">
 													<button
 														on:click|preventDefault={() => (webSearchEnabled = !webSearchEnabled)}
@@ -2162,7 +2162,7 @@
 												</Tooltip>
 											{/if}
 
-											{#if imageGenerationEnabled}
+											{#if imageGenerationEnabled && showImageGenerationButton}
 												<Tooltip content={$i18n.t('Image')} placement="top">
 													<button
 														on:click|preventDefault={() =>
@@ -2180,7 +2180,7 @@
 												</Tooltip>
 											{/if}
 
-											{#if codeInterpreterEnabled}
+											{#if codeInterpreterEnabled && showCodeInterpreterButton}
 												<Tooltip content={$i18n.t('Code Interpreter')} placement="top">
 													<button
 														aria-label={codeInterpreterEnabled


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27758, the chat Image toggle still generates images after an admin disables Image Generation. Fixes #26842, the originally reported symptom: the image generation button not disappearing after the admin disables the feature.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable. Enforcement of an existing admin setting; no new setting or configuration surface.
- [ ] **Dependencies:** No new dependencies.
- [x] **Testing:** All three parts were reproduced on unmodified `dev` and verified fixed on a live instance by the author: the server side bypass (image generated with the feature disabled), the admin session's Image entry surviving a disable in the Integrations menu, and the active Image pill surviving a disable and a page refresh. Details in the verification section. `ruff format --check` and Prettier pass; the diff adds zero code comments; no new strings, so zero locale churn.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new settings and no dependency changes: one new branch in one backend handler, one conditional made unconditional in the admin Images settings save path, and three render conditions tightened in the message input.
- [x] **Git Hygiene:** Three commits, one per concern, +18/-4 across three files, based on the current `dev`.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

**Problem** (#27758, symptom reported in #26842): after an admin turns off **Admin Panel > Settings > Images > Image Generation**:

1. A chat session opened before the change could still **generate images** through the chat input's `Image` toggle until a refresh, and any API client sending `features: {"image_generation": true}` could do the same regardless of UI state.
2. In the admin's own session, the `Image` entry stayed in the Integrations menu even though disabling Web Search or Code Interpreter removes their entries immediately.
3. If the `Image` toggle had been enabled, its active pill next to the input survived the disable and even a full page refresh.

**Root Cause, part 1 (server side)**: the three entry points into image generation gate inconsistently.

| entry point | global flag | user permission |
|---|---|---|
| `POST /api/v1/images/generations` (`routers/images.py`) | checked | checked |
| native function calling tool injection (`utils/tools.py`) | checked | checked |
| legacy chat feature path (`utils/middleware.py`) | **not checked** | checked (admins bypass) |

The legacy path re-checks the `features.image_generation` permission and then calls `chat_image_generation_handler`, which invokes the internal `image_generations()` worker directly. The internal workers are deliberately unguarded; `routers/images.py` documents the contract above the edit endpoint: "callers (edit_image tool, chat middleware) gate themselves and call image_edits()". The handler's own edit branch honors that contract (`await Config.get('images.edit.enable')`), but its create branch had no corresponding check.

**Root Cause, part 2 (admin session UI)**: the Web and Code Execution settings tabs call `config.set(await getBackendConfig())` unconditionally in their save handlers, which is why their menu entries disappear immediately. The Images tab refreshed the config store only inside `if (res.ENABLE_IMAGE_GENERATION)`, a one way refresh: enabling updated the UI, disabling never did. This also explains the reporter's observation in #26842 that toggling web search "fixed" the stuck image button: the web tab's unconditional refetch pulled in the corrected image flag as a side effect.

**Root Cause, part 3 (active pill)**: the chat input restores toggle state (`imageGenerationEnabled` and siblings) from the saved input draft on load, and the active pills rendered on that local state alone. A pill enabled before the feature was disabled therefore persisted across refreshes, visually promising a feature that no longer exists. The sibling Web Search and Code Interpreter pills had the identical latent defect.

**Fix** (one commit per part):

1. `utils/middleware.py`: gate the create branch of `chat_image_generation_handler` on `image_generation.enable`, mirroring the edit branch beside it. When the flag is off, the status indicator completes ("Image generation is disabled", so the "Creating image" spinner does not hang) and the model receives a context message telling it to inform the user, matching the shape of the existing failure branch. The edit path is unchanged and remains governed by its own `images.edit.enable` flag, exactly as the native function calling path treats the two flags independently.

```diff
+    elif not await Config.get('image_generation.enable'):
+        await __event_emitter__(
+            {
+                'type': 'status',
+                'data': {
+                    'description': 'Image generation is disabled',
+                    'done': True,
+                },
+            }
+        )
+
+        system_message_content = '<context>Image generation was requested but the feature is currently disabled by the administrator, so no image was created. Let the user know that image generation is currently unavailable.</context>'
+
     else:
         # Create image(s)
```

2. `admin/Settings/Images.svelte`: refresh the config store unconditionally on save, keeping only the model list reload behind the enabled check. This brings the Images tab in line with the Web and Code Execution tabs, so the admin's session hides the `Image` entry the moment the feature is disabled.

```diff
 		if (res) {
+			backendConfig.set(await getBackendConfig());
+
 			if (res.ENABLE_IMAGE_GENERATION) {
-				backendConfig.set(await getBackendConfig());
 				getModels();
 			}
```

3. `chat/MessageInput.svelte`: render each active feature pill only while its feature is actually available, reusing the existing `show*` conditions (admin flag, user permission, and model capability). The underlying draft state is preserved, so re-enabling the feature brings the pill back still active.

```diff
-											{#if webSearchEnabled}
+											{#if webSearchEnabled && showWebSearchButton}
...
-											{#if imageGenerationEnabled}
+											{#if imageGenerationEnabled && showImageGenerationButton}
...
-											{#if codeInterpreterEnabled}
+											{#if codeInterpreterEnabled && showCodeInterpreterButton}
```

**Defense in depth**: the outgoing chat payload already clamps `features.image_generation` to false when the config says the feature is disabled, so sessions that received the updated config never even request generation. The middleware gate covers the clients that clamp cannot reach: sessions whose config predates the change and API callers that construct the payload themselves. Sessions of other users still learn about the change on their next config fetch; the server side gate is what guarantees they cannot generate in the meantime.

### Fixed

- Fixed the legacy chat image generation path ignoring the admin Image Generation setting: a stale session or any API client sending the image_generation feature flag could still generate images after an admin disabled the feature instance wide. The chat now completes the status indicator with "Image generation is disabled" and the model informs the user.
- Fixed the admin Images settings only refreshing the session's config when enabling image generation, so disabling it now removes the Image entry from the chat Integrations menu immediately, matching the Web Search and Code Interpreter settings tabs.
- Fixed active Web Search, Image, and Code Interpreter pills in the chat input persisting (even across page refreshes, via the saved input draft) after the corresponding feature was disabled or became unavailable.

---

### Additional Information

- This PR was prepared with AI copilot assistance and reviewed by the author.

### Manual Verification Performed

1. **Reproduced all three defects on unmodified `dev`:** generated an image via the chat toggle with the feature disabled (while the direct REST endpoint correctly refused with 403); watched the Integrations menu keep its `Image` entry after disabling (while Web Search and Code Interpreter entries disappear immediately when their features are disabled); and watched an active `Image` pill survive the disable and a full page refresh.
2. **Verified the server side gate:** with the feature disabled and a session whose config predates the change, sending a prompt with the toggle enabled produces a completed "Image generation is disabled" status and a normal text reply with no image.
3. **Verified the admin session UI:** disabling Image Generation now removes the `Image` entry from the Integrations menu immediately, and re-enabling restores it, matching the behavior of the Web Search and Code Interpreter toggles.
4. **Verified the pill behavior:** an active `Image` pill disappears when the feature is disabled, stays gone across a refresh, and returns still active when the feature is re-enabled. Confirmed the Web Search pill still renders and works normally while its feature is enabled, so the added conditions do not over-hide.
5. **Verified re-enablement end to end:** turning the admin setting back on restores generation through the chat toggle without a restart.
6. `ruff format --check` and Prettier pass on the changed files; the diff adds zero code comments; no new strings, so zero locale churn.

### Screenshots or Videos

Each scenario is captured with the corresponding feature's admin setting toggled off (rows 1 to 3: **Image Generation** under Images; row 4: **Web Search**; row 5: **Code Interpreter**).

| Scenario | Before | After |
|---|---|---|
| Chat request with the `Image` toggle enabled (stale session) | <img width="2555" height="1280" alt="image" src="https://github.com/user-attachments/assets/9457f488-bef0-4625-a756-c10499ec661d" /> | <img width="2555" height="1280" alt="image" src="https://github.com/user-attachments/assets/2f0a3df2-5c79-4d02-a759-ec5f806394d9" /> |
| Integrations menu in the admin's session, immediately after disabling | <img width="394" height="246" alt="image" src="https://github.com/user-attachments/assets/36e2f27b-d6a1-4e11-a744-7a2f03f23a23" /> | <img width="394" height="246" alt="image" src="https://github.com/user-attachments/assets/283cfa7f-0691-4717-9831-67fa8ec480b9" /> |
| Active `Image` pill next to the input, after disabling and refreshing | <img width="385" height="206" alt="image" src="https://github.com/user-attachments/assets/7f3f4752-19f8-4181-9211-b3c612d9dc83" /> | <img width="422" height="229" alt="image" src="https://github.com/user-attachments/assets/1f0a7223-fb87-411a-a998-d5477002a721" /> |
| Active `Web Search` pill next to the input, after disabling Web Search globally | <img width="422" height="229" alt="image" src="https://github.com/user-attachments/assets/946283a1-a3fa-4301-a55f-5328ed0cc126" /> | <img width="422" height="229" alt="image" src="https://github.com/user-attachments/assets/9c04f2d6-57cb-4b57-b0fd-a1a56ed74f72" /> |
| Active `Code Interpreter` pill next to the input, after disabling Code Interpreter globally | <img width="422" height="229" alt="image" src="https://github.com/user-attachments/assets/c7d366e9-a9f8-4d58-81c4-944e0e804f98" /> | <img width="422" height="229" alt="image" src="https://github.com/user-attachments/assets/156372b8-15c6-46da-88f1-83f0cc785c76" /> |

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.

