### PR TITLE
fix: unwrap image edit request body in images playground

### DIFF
--- a/src/lib/apis/images/index.ts
+++ b/src/lib/apis/images/index.ts
@@ -254,14 +254,12 @@ export const imageEdits = async (
 			...(token && { authorization: `Bearer ${token}` })
 		},
 		body: JSON.stringify({
-			form_data: {
-				image: images,
-				prompt,
-				...(model && { model }),
-				...(size && { size }),
-				...(n && { n }),
-				...(background && { background })
-			}
+			image: images,
+			prompt,
+			...(model && { model }),
+			...(size && { size }),
+			...(n && { n }),
+			...(background && { background })
 		})
 	})
 		.then(async (res) => {


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Relates to #27202 — playground image edit returns 422 because the request body is nested under a `form_data` key while the backend expects a flat `EditImageForm`.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable — no user-facing configuration or docs change; the endpoint contract is unchanged.
- [ ] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Verified the body shape against the backend model. Validating the previous wrapped body `{"form_data": {"image": ..., "prompt": ...}}` against `EditImageForm` reproduces the reported 422 (`missing` on `image` and `prompt`); the flat body this PR sends validates successfully. The component's error surfaced as a toast, matching the reported behavior.
- [x] **No Unchecked AI Code:** This change is a one-line envelope removal, reviewed against the backend route signature (`@router.post('/edit')` with a single non-embedded `form_data: EditImageForm`) and the sibling `imageGenerations` call, which already sends a flat body successfully.
- [x] **Self-Review:** Diff reviewed; only the wrapper layer is removed, no other logic touched.
- [x] **Architecture:** Aligns the playground caller with the existing backend contract and with every other function in `src/lib/apis/images/index.ts`, rather than introducing a new convention.
- [x] **Git Hygiene:** Single atomic commit, based on `dev`, no unrelated changes.
- [x] **Title Prefix:** Uses the `fix:` prefix.

### Description

The Images playground's edit flow (`/playground/images` with one or more source images attached) always failed with a toast like `Field required`, and the backend responded 422 with `loc: ["body", "image"]`.

The root cause is in `src/lib/apis/images/index.ts` `imageEdits()`: it sent the payload nested under an extra `form_data` key:

```json
{"form_data": {"image": "...", "prompt": "..."}}
```

The backend route `edit_images(request, form_data: EditImageForm, ...)` in `backend/open_webui/routers/images.py` declares `form_data` as a single pydantic body parameter without `Body(embed=True)`, so FastAPI expects the whole request body to *be* the `EditImageForm`. The extra wrapper meant the top-level `image` and `prompt` fields were missing, hence the 422.

This change removes the wrapper so the request body is flat:

```json
{"image": "...", "prompt": "...", "model": "...", "size": "...", "n": ..., "background": "..."}
```

This matches `EditImageForm` exactly and is consistent with the sibling `imageGenerations()` call right above it, and with every other function in the same API module, none of which wrap their payloads.

### Added

### Changed

### Deprecated

### Removed

### Fixed

- Fixed the Images playground edit flow 422 error by sending the image edit request body flat instead of nested under a `form_data` key, matching the backend's `EditImageForm` model.

### Security

### Breaking Changes

---

### Additional Information

- Earlier report of the same root cause: Discussion #27202 (`Issue: Image Edit 422 Error with Required Parameters Nested in form_data`).
- The sibling report PR #27203 attempted a server-side unwrap but was auto-closed; this PR fixes it on the frontend caller side, which is the side that introduced the mismatch and keeps the backend contract unchanged for existing direct API consumers.

### Screenshots or Videos

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
