### PR TITLE
fix: renew the session cleanup lock more often than it expires

### DIFF
--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -176,6 +176,7 @@ YDOC_MANAGER = YdocManager(
 async def periodic_session_pool_cleanup():
     """Reap orphaned SESSION_POOL entries that missed heartbeats (e.g. crashed instance)."""
     retry_delay = random.uniform(WEBSOCKET_REDIS_LOCK_TIMEOUT / 2, WEBSOCKET_REDIS_LOCK_TIMEOUT)
+    renew_interval = min(SESSION_POOL_TIMEOUT, max(WEBSOCKET_REDIS_LOCK_TIMEOUT / 2, 1))
     while True:
         if not session_aquire_func():
             log.debug('Session cleanup lock held by another node. Retrying.')
@@ -183,21 +184,24 @@ async def periodic_session_pool_cleanup():
             continue
 
         try:
+            last_cleanup = 0
             while True:
                 if not session_renew_func():
                     log.warning('Unable to renew session cleanup lock. Retrying cleanup ownership.')
                     break
 
                 now = int(time.time())
-                for sid in list(SESSION_POOL.keys()):
-                    entry = SESSION_POOL.get(sid)
-                    if entry and now - entry.get('last_seen_at', 0) > SESSION_POOL_TIMEOUT:
-                        log.warning(f'Reaping orphaned session {sid} (user {entry.get("id")})')
-                        try:
-                            del SESSION_POOL[sid]
-                        except KeyError:
-                            pass
-                await asyncio.sleep(SESSION_POOL_TIMEOUT)
+                if now - last_cleanup >= SESSION_POOL_TIMEOUT:
+                    last_cleanup = now
+                    for sid in list(SESSION_POOL.keys()):
+                        entry = SESSION_POOL.get(sid)
+                        if entry and now - entry.get('last_seen_at', 0) > SESSION_POOL_TIMEOUT:
+                            log.warning(f'Reaping orphaned session {sid} (user {entry.get("id")})')
+                            try:
+                                del SESSION_POOL[sid]
+                            except KeyError:
+                                pass
+                await asyncio.sleep(renew_interval)
         finally:
             session_release_func()
 


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27762, idle Redis enabled instances warn every 2 minutes because the session cleanup lock expires faster than it is renewed.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable. No new setting or configuration surface.
- [ ] **Dependencies:** No new dependencies.
- [x] **Testing:** The failure was reproduced on the author's live Docker instance (warning every 120.0 seconds; a 10 second TTL trace of the lock key showing it expired and absent for a full minute of every cycle, both in #27762). The fixed loop was verified with a virtual clock simulation of both variants against a faithful fake of the lock's SET NX EX semantics. `ruff format --check` passes; the diff adds zero code comments.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new settings and no dependency changes: one loop in one function is restructured so its renewal cadence is decoupled from its reap cadence.
- [x] **Git Hygiene:** A single commit, +13/-9 in a single file, based on the current `dev`.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

**Problem** (#27762): with `WEBSOCKET_MANAGER=redis`, every idle instance logs

```
WARNING | open_webui.socket.main:periodic_session_pool_cleanup:188 - Unable to renew session cleanup lock. Retrying cleanup ownership.
```

every 2 minutes, forever. Beyond the noise, the session cleanup lock is absent for roughly half of all wall clock time, so the mutual exclusion it exists to provide is missing for half of every cycle on multi node deployments.

**Root Cause**: arithmetic. The loop renews the lock once per iteration and then sleeps the full reap interval (`SESSION_POOL_TIMEOUT` = 120 seconds), but the lock TTL (`WEBSOCKET_REDIS_LOCK_TIMEOUT`) defaults to 60. `RedisLock.renew_lock` only extends a key that still exists and holds this instance's uuid, so after every sleep the key has been expired for a full minute and renewal fails, guaranteed: warn, break, re-acquire, repeat. A live TTL trace of the key (10 second sampling, in the issue) shows the countdown from 60, a full minute of the key not existing, then the fresh acquire. The sibling usage pool cleanup is unaffected because its sleep (3 seconds) is far below the TTL.

**Fix**: decouple the two cadences. The loop now ticks at `WEBSOCKET_REDIS_LOCK_TIMEOUT / 2` (two renewals per TTL, the standard lease pattern) and runs the reap pass only when `SESSION_POOL_TIMEOUT` has elapsed since the last one:

```diff
     retry_delay = random.uniform(WEBSOCKET_REDIS_LOCK_TIMEOUT / 2, WEBSOCKET_REDIS_LOCK_TIMEOUT)
+    renew_interval = min(SESSION_POOL_TIMEOUT, max(WEBSOCKET_REDIS_LOCK_TIMEOUT / 2, 1))
     while True:
         if not session_aquire_func():
             log.debug('Session cleanup lock held by another node. Retrying.')
             await asyncio.sleep(retry_delay)
             continue

         try:
+            last_cleanup = 0
             while True:
                 if not session_renew_func():
                     log.warning('Unable to renew session cleanup lock. Retrying cleanup ownership.')
                     break

                 now = int(time.time())
-                for sid in list(SESSION_POOL.keys()):
-                    ...
-                await asyncio.sleep(SESSION_POOL_TIMEOUT)
+                if now - last_cleanup >= SESSION_POOL_TIMEOUT:
+                    last_cleanup = now
+                    for sid in list(SESSION_POOL.keys()):
+                        ...
+                await asyncio.sleep(renew_interval)
```

Reap behavior is unchanged (first pass immediately after acquiring the lock, then one pass per `SESSION_POOL_TIMEOUT`, exactly as before). The warning becomes what it was meant to be: a signal of genuine lock loss (Redis restart, ownership taken by another node). In non Redis mode the renew functions are constant `True` stubs, so the only change is the loop ticking more often between unchanged reap passes.

**Verification by simulation**: a virtual clock simulation of both loop variants against a faithful fake of the lock's SET NX EX / owner checked renew semantics, 1200 simulated seconds. Current code: 9 renewal failure warnings, lock held for only 49 percent of the time. Fixed loop: 0 warnings, lock held 100 percent of the time, same reap cadence (one pass per ~120 seconds).

### Fixed

- Fixed idle Redis enabled instances logging "Unable to renew session cleanup lock" every 2 minutes: the session cleanup loop slept longer than the lock's TTL, so ownership lapsed every cycle by construction and the lock was absent for half of all wall clock time. The loop now renews at half the TTL and reaps on its original schedule.

---

### Additional Information

- Deployments can silence the warning today without this fix by setting `WEBSOCKET_REDIS_LOCK_TIMEOUT` above 120, at the cost of a crashed lock holder blocking other nodes' cleanup for that long; this PR removes the need for that trade.
- This PR was prepared with AI copilot assistance and reviewed by the author.

### Verification Performed

1. **Reproduced on a live Docker instance** (`:dev` image, `WEBSOCKET_MANAGER=redis`, Valkey backend, default lock timeout): the warning fired every 120.0 seconds while completely idle, and a 10 second TTL trace of `<prefix>:session_cleanup_lock` showed the expiry and the minute long gap every cycle (both traces in #27762).
2. **Simulated both variants** under a virtual clock with faithful lock semantics: 9 warnings and 51 percent lockless time for the current loop over 1200 simulated seconds; 0 warnings, 0 lockless time, and an unchanged reap cadence for the fixed loop.
3. **Confirmed the mitigation arithmetic on the live instance**: raising `WEBSOCKET_REDIS_LOCK_TIMEOUT` above the sleep interval stops the warnings, consistent with the diagnosis.
4. `ruff format --check` passes on the changed file; the diff adds zero code comments.

### Screenshots or Videos

#### Before

<img width="1636" height="1400" alt="image" src="https://github.com/user-attachments/assets/43e8fcfd-bb30-46c1-a23a-da51812c3672" />

#### After

<img width="760" height="524" alt="image" src="https://github.com/user-attachments/assets/4c2f7016-0922-4d1b-904d-b35dfa9fa16e" />

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
