### PR TITLE
feat: add search to the Tools and Skills lists in the Integrations menu

### DIFF
--- a/src/lib/components/chat/MessageInput/IntegrationsMenu.svelte
+++ b/src/lib/components/chat/MessageInput/IntegrationsMenu.svelte
@@ -35,6 +35,7 @@
 	import ChevronRight from '$lib/components/icons/ChevronRight.svelte';
 	import ChevronLeft from '$lib/components/icons/ChevronLeft.svelte';
 	import LinkSlash from '$lib/components/icons/LinkSlash.svelte';
+	import SearchInput from './InputMenu/SearchInput.svelte';
 
 	const i18n = getContext('i18n');
 
@@ -65,6 +66,34 @@
 
 	let tools = null;
 	let skills = null;
+
+	let toolsQuery = '';
+	let skillsQuery = '';
+
+	const matchesQuery = (item, query: string) => {
+		const q = query.trim().toLowerCase();
+		if (!q) {
+			return true;
+		}
+		return (
+			(item?.name ?? '').toLowerCase().includes(q) ||
+			(item?.description ?? '').toLowerCase().includes(q)
+		);
+	};
+
+	$: filteredToolIds = tools
+		? Object.keys(tools).filter((id) => matchesQuery(tools[id], toolsQuery))
+		: [];
+	$: filteredSkillIds = skills
+		? Object.keys(skills).filter((id) => matchesQuery(skills[id], skillsQuery))
+		: [];
+
+	$: if (tab !== 'tools') {
+		toolsQuery = '';
+	}
+	$: if (tab !== 'skills') {
+		skillsQuery = '';
+	}
 
 	$: if (show) {
 		init();
@@ -391,7 +420,13 @@
 						</div>
 					</button>
 
-					{#each Object.keys(tools) as toolId}
+					<SearchInput bind:value={toolsQuery} placeholder={$i18n.t('Search Tools')} />
+
+					{#if filteredToolIds.length === 0}
+						<div class="text-center text-xs text-gray-500 py-3">{$i18n.t('No results found')}</div>
+					{/if}
+
+					{#each filteredToolIds as toolId}
 						<button
 							class="relative flex w-full justify-between gap-2 items-center h-[1.6875rem] px-2 text-[13px] font-normal cursor-pointer rounded-xl hover:bg-gray-50/40 dark:hover:bg-gray-800/40"
 							on:click={async (e) => {
@@ -514,7 +549,13 @@
 						</div>
 					</button>
 
-					{#each Object.keys(skills) as skillId}
+					<SearchInput bind:value={skillsQuery} placeholder={$i18n.t('Search Skills')} />
+
+					{#if filteredSkillIds.length === 0}
+						<div class="text-center text-xs text-gray-500 py-3">{$i18n.t('No results found')}</div>
+					{/if}
+
+					{#each filteredSkillIds as skillId}
 						<button
 							class="relative flex w-full justify-between gap-2 items-center h-[1.6875rem] px-2 text-[13px] font-normal cursor-pointer rounded-xl hover:bg-gray-50/40 dark:hover:bg-gray-800/40"
 							on:click={async () => {


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Relates to #26709, a request for a search input to filter tools in the chat tool selector, to #27764, the proposal to add search to the Tools and Skills lists in the chat input Integrations menu, and to #28108, a community request for search and filtering in the Skills and Tools selector.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable. A UI addition using existing patterns; no new setting or configuration surface.
- [ ] **Dependencies:** No new dependencies.
- [x] **Testing:** Verified live by the author on an instance with 39 tools and 19 skills: filtering by name and by description fragment, toggling a tool while a filter is active, the empty state, the query resetting when switching tabs, and the sibling attachment menu panels unaffected. Prettier passes; `i18n:parse` produces zero locale changes because all three strings already exist as keys.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new settings, no new components, no dependency changes: the existing `SearchInput` component from the attachment menu is reused inside the Integrations menu, and filtering is a client side derivation over the already loaded stores.
- [x] **Git Hygiene:** A single commit, +43/-2 in a single file, based on the current `dev`.
- [x] **Title Prefix:** `feat`

# Changelog Entry

### Description

**Gap** (#27764): every list panel in the chat input's More (+) attachment menu (Attach Files, Attach Notes, Attach Knowledge, Reference Chats) has a search bar. The two list panels in the Integrations menu next to it (Tools and Skills) do not, so on instances with many entries the user scrolls an unsearchable list in a UI that already taught them to expect search one button over.

**Change**: the Tools and Skills tabs of `IntegrationsMenu.svelte` now render the same `SearchInput` component the attachment menu panels use, directly under the tab's back button:

- Filtering is client side over the already loaded stores, matching against name and description. Unlike the Notes panel there is no pagination or server search to integrate: the lists are fully in memory when the menu opens, so filtering is instant with no debounce or request management.
- The standard "No results found" empty state appears when nothing matches.
- The query resets when leaving the tab, so a stale filter never greets the next open.
- The tab header keeps showing the total count, matching how the collapsed menu row displays it.

**Zero new strings**: `Search Tools`, `Search Skills`, and `No results found` all already exist as i18n keys (the workspace Tools and Skills pages use the first two), so `i18n:parse` produces no locale changes.

The toggle wiring, OAuth redirect handling for unauthenticated tools, and valve buttons are untouched; the filter only narrows which rows render.

### Added

- Added a search field to the Tools and Skills lists in the chat input's Integrations menu, matching the search that the attachment menu's Files, Notes, Knowledge, and Reference Chats panels already provide. Filtering is instant and client side, matches name and description, and resets when leaving the tab.

---

### Additional Information

- This PR was prepared with AI copilot assistance and reviewed by the author.

### Manual Verification Performed

1. Filtered the Tools list (39 entries) by name fragments and by a description-only fragment; both match. Same for the Skills list (19 entries).
2. Toggled a tool on and off while a filter was active; selection state and the enabled switches behave exactly as before.
3. Verified the "No results found" state, and that clearing the query restores the full list.
4. Switched between the Tools and Skills tabs and reopened the menu; queries reset, no stale filters.
5. Confirmed the attachment menu panels (Files, Notes, Knowledge, Chats) are unaffected.
6. Prettier passes on the changed file; `i18n:parse` produces zero locale changes; the diff adds zero code comments.

### Screenshots or Videos

#### After: Tools tab with the search field filtering the list

<img width="399" height="403" alt="image" src="https://github.com/user-attachments/assets/ee245af1-380d-4c38-8421-0ce7edf34dd6" />

<img width="399" height="403" alt="image" src="https://github.com/user-attachments/assets/3b873724-3305-4510-82f1-0b5b9183266a" />

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.


