### PR TITLE
fix: dock the thread reply input below the scroll area instead of inside it

### DIFF
--- a/src/lib/components/channel/Thread.svelte
+++ b/src/lib/components/channel/Thread.svelte
@@ -188,7 +188,7 @@
 			</div>
 		</div>
 
-		<div class=" max-h-full w-full overflow-y-auto" bind:this={messagesContainerElement}>
+		<div class="flex-1 min-h-0 w-full overflow-y-auto" bind:this={messagesContainerElement}>
 			{#if messages !== null}
 				<Messages
 					id={threadId}
@@ -225,25 +225,25 @@
 					<Spinner />
 				</div>
 			{/if}
+		</div>
 
-			<div class=" pb-[1rem] px-2.5 w-full">
-				<MessageInput
-					bind:replyToMessage
-					bind:chatInputElement
-					id={threadId}
-					{channel}
-					disabled={!channel?.write_access}
-					placeholder={!channel?.write_access
-						? $i18n.t('You do not have permission to send messages in this thread.')
-						: $i18n.t('Reply to thread...')}
-					typingUsersClassName="from-gray-50 dark:from-gray-850"
-					{typingUsers}
-					userSuggestions={true}
-					channelSuggestions={true}
-					{onChange}
-					onSubmit={submitHandler}
-				/>
-			</div>
+		<div class=" pb-[1rem] px-2.5 w-full">
+			<MessageInput
+				bind:replyToMessage
+				bind:chatInputElement
+				id={threadId}
+				{channel}
+				disabled={!channel?.write_access}
+				placeholder={!channel?.write_access
+					? $i18n.t('You do not have permission to send messages in this thread.')
+					: $i18n.t('Reply to thread...')}
+				typingUsersClassName="from-gray-50 dark:from-gray-850"
+				{typingUsers}
+				userSuggestions={true}
+				channelSuggestions={true}
+				{onChange}
+				onSubmit={submitHandler}
+			/>
 		</div>
 	</div>
 {/if}


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27767, the thread panel's "Reply to thread..." input scrolls away with the messages instead of staying docked.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable. A layout fix with no new setting or configuration surface.
- [ ] **Dependencies:** No new dependencies.
- [x] **Testing:** The bug was reproduced on unmodified `dev` and the fix verified on a live instance by the author in a thread with over 100 replies: the input stays docked while scrolling the history, opening the thread still lands scrolled to the bottom, replying works, and the typing indicator gradient renders correctly above the docked input. Prettier passes; no new strings, so zero locale churn.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new settings and no dependency changes: the thread panel adopts the exact layout shape the main channel pane already uses.
- [x] **Git Hygiene:** A single commit, +19/-19 in a single file (mostly indentation from the structural move; the substantive change is one class swap and the input block moving outside one closing tag), based on the current `dev`.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

**Problem** (#27767): the "Reply to thread..." input in a channel thread panel scrolls away with the thread messages. In a long thread, scrolling up removes the input from the viewport entirely; replying requires scrolling all the way back down.

**Root Cause**: in `Thread.svelte` the `MessageInput` block is a child of the `overflow-y-auto` messages container, so it is part of the scrolled content. The main channel pane already uses the correct shape: a flex column with the messages in a `flex-1` scrollable region and the input docked below as a sibling.

**Fix**: restructure the thread panel to match its sibling:

```diff
-		<div class=" max-h-full w-full overflow-y-auto" bind:this={messagesContainerElement}>
+		<div class="flex-1 min-h-0 w-full overflow-y-auto" bind:this={messagesContainerElement}>
 			{#if messages !== null}
 				<Messages ... />
 			{/if}
+		</div>

-			<div class=" pb-[1rem] px-2.5 w-full">
-				<MessageInput ... />
-			</div>
-		</div>
+		<div class=" pb-[1rem] px-2.5 w-full">
+			<MessageInput ... />
+		</div>
```

`flex-1 min-h-0` lets the messages region shrink and scroll independently inside the panel's existing flex column while the input stays docked at the bottom. `scrollToBottom` still targets the same bound element (and no longer counts the input's height in `scrollHeight`, which makes it marginally more accurate).

**Behavioral note for review**: in a short thread the input now sits at the bottom of the panel rather than directly under the last message. That matches the main channel pane and the common messaging convention, and it is inherent to docking.

**Overlap note**: #27737 touches the same scroll container line (adding `pt-7` headroom for the straddled hover actions). Whichever of the two merges second needs a one line rebase; both are mine and I will handle it.

### Fixed

- Fixed the channel thread panel's "Reply to thread..." input scrolling out of view with the thread messages: the input is now docked below the scrollable messages region, matching the main channel layout.

---

### Additional Information

**Overlaps with another open PR.** This touches `src/lib/components/channel/Thread.svelte`, which #27737 also modifies, and the two conflict in that file. They are independent channel fixes, one for reply input placement and one for hover action overlap. Either order works; whichever merges second needs a rebase.


- This PR was prepared with AI copilot assistance and reviewed by the author.

### Manual Verification Performed

1. **Reproduced on unmodified `dev`:** in a thread with over 100 replies, scrolling up moved the reply input out of the viewport.
2. **Verified the fix on a live instance:** the input stays docked while scrolling anywhere in the history; opening the thread still lands scrolled to the bottom; sending a reply works; the typing indicator gradient renders correctly above the docked input.
3. **Checked the short thread case:** the input docks to the bottom of the panel, matching the main channel pane's behavior.
4. Prettier passes on the changed file; no new strings, so zero locale churn; the diff adds zero code comments.

### Screenshots or Videos

| Scenario | Before | After |
|---|---|---|
| Long thread, scrolled up in the history | <img width="1168" height="1272" alt="image" src="https://github.com/user-attachments/assets/1d5aebc3-2815-486d-ab10-b02570cd25d5" /> | <img width="1168" height="1272" alt="image" src="https://github.com/user-attachments/assets/bccf71b5-83e9-4462-9238-59650e51862f" /> |
| Short thread | <img width="1168" height="1272" alt="image" src="https://github.com/user-attachments/assets/f38b0fb1-93ba-47fd-9e58-e16d2f7b6b26" /> | <img width="1168" height="1272" alt="image" src="https://github.com/user-attachments/assets/d7e44579-e0bf-484a-8d94-b5b8057a97c7" /> |

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.

