### PR TITLE
fix: make embedded message content inert in the sidebar chat hover preview

### DIFF
--- a/src/lib/components/layout/Sidebar/ChatHoverPreview.svelte
+++ b/src/lib/components/layout/Sidebar/ChatHoverPreview.svelte
@@ -123,7 +123,7 @@
 					</div>
 				{:else if previewReady}
 					<Messages
-						className="flex w-full pt-2 pb-0 [&_.message-listitem]:!mb-1 [&_.message-listitem]:!max-w-none [&_.message-listitem]:!px-3 [&_.pb-18]:!pb-1.5 [&_.markdown-prose]:!text-xs [&_.markdown-prose]:!leading-snug [&_.whitespace-pre-wrap]:!text-xs [&_.whitespace-pre-wrap]:!leading-snug [&_.text-\[0\.9375rem\]]:!text-xs [&_.text-sm]:!text-xs [&_.tool-call-body_pre]:!text-[0.6875rem] [&_.rounded-3xl]:!rounded-2xl [&_.chat-user_.rounded-3xl]:!bg-gray-50 dark:[&_.chat-user_.rounded-3xl]:!bg-gray-800 [&_.px-4]:!px-3 [&_.py-3]:!py-2 [&_.py-1\.5]:!py-1"
+						className="flex w-full pt-2 pb-0 [&_.message-listitem]:!mb-1 [&_.message-listitem]:!max-w-none [&_.message-listitem]:!px-3 [&_.pb-18]:!pb-1.5 [&_.markdown-prose]:!text-xs [&_.markdown-prose]:!leading-snug [&_.whitespace-pre-wrap]:!text-xs [&_.whitespace-pre-wrap]:!leading-snug [&_.text-\[0\.9375rem\]]:!text-xs [&_.text-sm]:!text-xs [&_.tool-call-body_pre]:!text-[0.6875rem] [&_.rounded-3xl]:!rounded-2xl [&_.chat-user_.rounded-3xl]:!bg-gray-50 dark:[&_.chat-user_.rounded-3xl]:!bg-gray-800 [&_.px-4]:!px-3 [&_.py-3]:!py-2 [&_.py-1\.5]:!py-1 [&_button]:!pointer-events-none"
 						chatId={`chat-hover-preview-${chatId}`}
 						user={$user}
 						prompt=""

--- a/src/lib/components/layout/Sidebar/ChatHoverPreview.svelte
+++ b/src/lib/components/layout/Sidebar/ChatHoverPreview.svelte
@@ -123,7 +123,7 @@
 					</div>
 				{:else if previewReady}
 					<Messages
-						className="flex w-full pt-2 pb-0 [&_.message-listitem]:!mb-1 [&_.message-listitem]:!max-w-none [&_.message-listitem]:!px-3 [&_.pb-18]:!pb-1.5 [&_.markdown-prose]:!text-xs [&_.markdown-prose]:!leading-snug [&_.whitespace-pre-wrap]:!text-xs [&_.whitespace-pre-wrap]:!leading-snug [&_.text-\[0\.9375rem\]]:!text-xs [&_.text-sm]:!text-xs [&_.tool-call-body_pre]:!text-[11px] [&_.rounded-3xl]:!rounded-2xl [&_.chat-user_.rounded-3xl]:!bg-gray-50 dark:[&_.chat-user_.rounded-3xl]:!bg-gray-800 [&_.px-4]:!px-3 [&_.py-3]:!py-2 [&_.py-1\.5]:!py-1"
+						className="flex w-full pt-2 pb-0 [&_.message-listitem]:!mb-1 [&_.message-listitem]:!max-w-none [&_.message-listitem]:!px-3 [&_.pb-18]:!pb-1.5 [&_.markdown-prose]:!text-xs [&_.markdown-prose]:!leading-snug [&_.whitespace-pre-wrap]:!text-xs [&_.whitespace-pre-wrap]:!leading-snug [&_.text-\[0\.9375rem\]]:!text-xs [&_.text-sm]:!text-xs [&_.tool-call-body_pre]:!text-[11px] [&_.rounded-3xl]:!rounded-2xl [&_.chat-user_.rounded-3xl]:!bg-gray-50 dark:[&_.chat-user_.rounded-3xl]:!bg-gray-800 [&_.px-4]:!px-3 [&_.py-3]:!py-2 [&_.py-1\.5]:!py-1 [&_button]:!pointer-events-none"
 						chatId={`chat-hover-preview-${chatId}`}
 						user={$user}
 						prompt=""


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27769, clicking an image in the sidebar chat hover preview flashes the fullscreen image viewer open for a fraction of a second before it closes itself.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable. A one line UI fix with no new setting or configuration surface.
- [ ] **Dependencies:** No new dependencies.
- [x] **Testing:** The bug was reproduced on unmodified `dev` and the fix verified on a live instance by the author: clicking an image in the hover preview now does nothing (no flash, no pointer cursor), while the same image in the actual chat still opens the fullscreen viewer normally. Prettier passes; no new strings, so zero locale churn.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new settings, no new props, no dependency changes: one Tailwind arbitrary variant appended to the descendant styling string the component already uses for its embedded messages.
- [x] **Git Hygiene:** A single commit, +1/-1 in a single file, based on the current `dev`.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

**Problem** (#27769): clicking an image inside the sidebar chat hover preview opens the fullscreen image viewer for roughly a quarter of a second, after which it closes by itself. Post filing, the same defect was found on the other interactive elements the preview renders: clicking an inline source pill or the Sources list toggle flashes the citation modal the same way, and the floating Ask and Explain selection buttons leak through as well.

**Root Cause**: the preview card is a `bits-ui` `LinkPreview` (a hover card) rendering the full `Messages` tree. Images render through `common/Image.svelte`, whose wrapping button opens `ImagePreview` as a child component inside the hover card's content. When the fullscreen viewer opens, the pointer no longer counts as hovering the card's trigger or content, so the hover card schedules its close (default close delay 300ms, exactly the observed flash), unmounts its content, and the viewer unmounts with it.

The preview is designed to be inert: it passes `readOnly={true}` and stubs every action handler to a no-op. The clickable elements that leak through (image buttons opening `ImagePreview`, source pills and the Sources toggle opening `CitationModal`, the Ask and Explain selection buttons) all lead somewhere structurally impossible: a modal or viewer parented inside a transient hover card that closes as soon as the pointer state changes.

**Fix**: make every button inside the preview inert, completing the read only design in one stroke instead of chasing each leak individually (the citation surfaces alone span three different button styles with no shared class). The component already restyles its embedded messages via Tailwind arbitrary variants in the `Messages` class string, so the fix is one variant in the same idiom:

```diff
-						... [&_.px-4]:!px-3 [&_.py-3]:!py-2 [&_.py-1\.5]:!py-1"
+						... [&_.px-4]:!px-3 [&_.py-3]:!py-2 [&_.py-1\.5]:!py-1 [&_button]:!pointer-events-none"
```

Scoped entirely to the hover preview: images, sources, and every other control elsewhere keep their normal behavior. The pointer cursor also disappears inside the preview, so the UI no longer promises interactions it cannot deliver.

### Fixed

- Fixed clicking an image, a source pill, or the Sources toggle in the sidebar chat hover preview flashing the corresponding viewer or citation modal open and closed: all buttons inside the preview are now inert, matching the preview's read only design, while the same elements in the actual chat keep their normal behavior.

---

### Additional Information

- This PR was prepared with AI copilot assistance and reviewed by the author.

### Manual Verification Performed

1. **Reproduced on unmodified `dev`:** hovered a chat containing an image, clicked the image in the preview, and watched the fullscreen viewer flash open and self close after ~0.3 seconds.
2. **Verified the fix on a live instance:** clicking the image in the preview does nothing and shows no pointer cursor; the preview stays open and stable.
3. **Verified the source surfaces:** on a live instance, measured the computed style of every button rendered inside an open hover preview containing sources: the inline source pill, the Sources list toggle, and the Ask and Explain selection buttons all compute `pointer-events: none`.
4. **Verified no over-hiding:** opening the same chat and clicking the same image or source opens the viewer or citation modal normally; the variant is scoped to the preview's class string, so nothing outside the preview is affected.
5. Prettier passes on the changed file; no new strings, so zero locale churn; the diff adds zero code comments.

### Screenshots or Videos

Not applicable in stills (the bug is a sub second flash); the reproduction steps take under a minute.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.

