### PR TITLE
fix: do not auto-open artifacts from the sidebar chat hover preview

### DIFF
--- a/src/lib/components/chat/Messages/ContentRenderer.svelte
+++ b/src/lib/components/chat/Messages/ContentRenderer.svelte
@@ -148,6 +148,7 @@
 
 			if (
 				($settings?.detectArtifacts ?? true) &&
+				!compactPreview &&
 				isArtifact &&
 				hasClosingCodeFence(raw) &&
 				!autoOpenedArtifactIds.has(artifactId) &&


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27772, hovering a sidebar chat whose preview contains an artifact code block closes the Chat Controls pane of the currently open chat.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable. A one line guard with no new setting or configuration surface.
- [ ] **Dependencies:** No new dependencies.
- [x] **Testing:** The bug was reproduced on unmodified `dev` (100 percent reproduction rate) and the fix verified on a live instance by the author: hovering the artifact bearing chat no longer touches the Chat Controls pane, artifact auto open still works in real chats when a model finishes an html or svg code block, and hovering while the Artifacts panel is open in an artifact chat causes no flicker. Prettier passes; no new strings, so zero locale churn.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new settings and no new props: `ContentRenderer` already receives `compactPreview` from the hover preview via `Messages`, `Message`, and `ResponseMessage`; the fix adds it to one existing condition.
- [x] **Git Hygiene:** A single commit, +1/-0 in a single file, based on the current `dev`.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

**Problem** (#27772): with any chat open and the Chat Controls pane visible, hovering a sidebar chat whose preview contains an artifact generating code block (html or svg) closes the Chat Controls pane the moment the preview renders. Reproducible every time.

**Root Cause**: a two store ricochet.

1. The sidebar hover preview renders the full `Messages` tree, which mounts real `ContentRenderer` components. `ContentRenderer`'s artifact auto open path fires `showArtifacts.set(true)` and `showControls.set(true)` whenever a rendered response contains a complete artifact capable code block. Its guards (`detectArtifacts`, desktop, `$chatId`) all hold while any chat is open, so rendering the preview triggers the auto open meant for the active chat.
2. `showArtifacts` mounts `Artifacts.svelte`, whose `artifactContents` subscription fires immediately with the current chat's artifact list. The current chat has no artifacts, so the empty branch runs `showControls.set(false)` and `showArtifacts.set(false)`, closing the pane. (If the current chat does have artifacts, the symptom mutates: the preview hijacks the pane over to the Artifacts tab instead.)

**Fix**: the hover preview already passes `compactPreview={true}` all the way down to `ContentRenderer`, so one guard term stops the preview from emitting the auto open:

```diff
 			if (
 				($settings?.detectArtifacts ?? true) &&
+				!compactPreview &&
 				isArtifact &&
 				hasClosingCodeFence(raw) &&
```

Artifact auto open in real chats is untouched.

**Left as is, deliberately**: the immediate close lives in `Artifacts.svelte`'s reaction to an empty `artifactContents` list. This fix removes the only known path that trips it spuriously; changing that subscription as well would be speculative hardening beyond the reproduced bug.

### Fixed

- Fixed the Chat Controls pane closing by itself when hovering a sidebar chat whose preview contains an artifact generating code block: the read only hover preview no longer triggers the artifact auto open that belongs to the active chat.

---

### Additional Information

- This PR was prepared with AI copilot assistance and reviewed by the author.

### Manual Verification Performed

1. **Reproduced on unmodified `dev`:** chat open, Chat Controls open, hovered a sidebar chat containing a completed html code block; the controls pane closed every single time.
2. **Verified the fix on a live instance:** the same hover leaves the Chat Controls pane untouched.
3. **Verified no regression to the feature the guard sits inside:** in a real chat, a model response finishing an html code block still auto opens the Artifacts panel as before.
4. **Verified the artifact active case:** with an artifact chat open and the Artifacts panel showing, hovering the previewed chat causes no flicker or tab switch.
5. Prettier passes on the changed file; no new strings, so zero locale churn; the diff adds zero code comments.

### Screenshots or Videos

Not applicable in stills (the bug is a pane closing on hover); the reproduction steps take under a minute.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
