### PR TITLE
fix: expand recurring events in the user's timezone instead of the server's

### DIFF
--- a/backend/open_webui/utils/calendar.py
+++ b/backend/open_webui/utils/calendar.py
@@ -32,12 +32,24 @@ def expand_recurring_event(
     if not rrule_str:
         return [event_dict]
 
-    range_start_dt = datetime.fromtimestamp(range_start_ns / 1_000_000_000)
-    range_end_dt = datetime.fromtimestamp(range_end_ns / 1_000_000_000)
+    tzinfo = None
+    if tz:
+        try:
+            tzinfo = ZoneInfo(tz)
+        except Exception:
+            tzinfo = None
+
+    def _to_wall(ns: int) -> datetime:
+        if tzinfo:
+            return datetime.fromtimestamp(ns / 1_000_000_000, tz=tzinfo).replace(tzinfo=None)
+        return datetime.fromtimestamp(ns / 1_000_000_000)
+
+    range_start_dt = _to_wall(range_start_ns)
+    range_end_dt = _to_wall(range_end_ns)
     scan_start = range_start_dt - timedelta(days=1)
 
     original_start_ns = event_dict['start_at']
-    original_start_dt = datetime.fromtimestamp(original_start_ns / 1_000_000_000)
+    original_start_dt = _to_wall(original_start_ns)
 
     try:
         # Anchor to the event's real start so day-of-week / day-of-month are correct
@@ -53,12 +65,8 @@ def expand_recurring_event(
     dt = rule.after(scan_start, inc=True)
 
     while dt and dt < range_end_dt and len(instances) < max_instances:
-        if tz:
-            try:
-                dt_tz = dt.replace(tzinfo=ZoneInfo(tz))
-                instance_start_ns = int(dt_tz.timestamp() * 1_000_000_000)
-            except Exception:
-                instance_start_ns = int(dt.timestamp() * 1_000_000_000)
+        if tzinfo:
+            instance_start_ns = int(dt.replace(tzinfo=tzinfo).timestamp() * 1_000_000_000)
         else:
             instance_start_ns = int(dt.timestamp() * 1_000_000_000)
 


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27774, recurring calendar events render shifted by the server/user timezone offset, including the original occurrence.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable. A correctness fix with no new setting or configuration surface.
- [ ] **Dependencies:** No new dependencies.
- [x] **Testing:** Verified by executing the expansion function under a `TZ=UTC` process (the Docker condition): before the fix, a daily 14:00 America/New_York event expands to 18:00 instances; after the fix, all instances are 14:00, wall clock time stays stable across the November 2026 DST fall back, and an invalid timezone string falls back to the previous server local behavior. `ruff format --check` passes; the diff adds zero code comments.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new settings and no dependency changes: one function resolves the user's zone once and uses it consistently for all wall clock conversions.
- [x] **Git Hygiene:** A single commit, +17/-9 in a single file, based on the current `dev`.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

**Problem** (#27774): every expanded occurrence of a recurring event, including the occurrence on the original day, is shifted by the offset between the server's timezone and the user's timezone. On a UTC container (every Docker deployment), a 14:00 America/New_York daily event renders at 18:00 on every day. Non recurring events are unaffected. The bug is invisible on setups where the server process runs in the user's timezone, which is how it survives development testing.

**Root Cause**: `expand_recurring_event` mixes two timezones. It derives wall clock datetimes with `datetime.fromtimestamp(ns / 1e9)` (server local), anchors the RRULE at that server wall time, then localizes each generated occurrence with `dt.replace(tzinfo=ZoneInfo(tz))`, stamping server wall times as user wall times. Since `GET /calendar/events` replaces an rrule event entirely with its expanded instances, even the original occurrence displays wrong.

**Fix**: resolve the user's zone once, derive every wall clock value in that zone, and localize instances back with the same zone:

```diff
+    tzinfo = None
+    if tz:
+        try:
+            tzinfo = ZoneInfo(tz)
+        except Exception:
+            tzinfo = None
+
+    def _to_wall(ns: int) -> datetime:
+        if tzinfo:
+            return datetime.fromtimestamp(ns / 1_000_000_000, tz=tzinfo).replace(tzinfo=None)
+        return datetime.fromtimestamp(ns / 1_000_000_000)
+
-    range_start_dt = datetime.fromtimestamp(range_start_ns / 1_000_000_000)
-    range_end_dt = datetime.fromtimestamp(range_end_ns / 1_000_000_000)
+    range_start_dt = _to_wall(range_start_ns)
+    range_end_dt = _to_wall(range_end_ns)
     ...
-        if tz:
-            try:
-                dt_tz = dt.replace(tzinfo=ZoneInfo(tz))
-                instance_start_ns = int(dt_tz.timestamp() * 1_000_000_000)
-            except Exception:
-                instance_start_ns = int(dt.timestamp() * 1_000_000_000)
-        else:
+        if tzinfo:
+            instance_start_ns = int(dt.replace(tzinfo=tzinfo).timestamp() * 1_000_000_000)
+        else:
             instance_start_ns = int(dt.timestamp() * 1_000_000_000)
```

Because the recurrence now expands in the user's wall space and localizes per occurrence, occurrences keep their wall clock time across DST transitions (a 14:00 daily event stays 14:00 through the fall back), which is the standard calendar semantic. When no user timezone is set, or the string is invalid, behavior is unchanged from before (server local expansion).

### Fixed

- Fixed recurring calendar events rendering shifted by the server/user timezone offset (for example, a 14:00 daily event showing at 18:00 for a New York user on a UTC container). Expansion now happens in the user's timezone, and occurrences keep their wall clock time across DST transitions.

---

### Additional Information

- This PR was prepared with AI copilot assistance and reviewed by the author.

### Verification Performed

1. **Reproduced under Docker conditions without a deployment:** executed the expansion function verbatim under a `TZ=UTC` process with `tz='America/New_York'`; a daily event stored at 14:00 New York expanded to instances at 18:00 New York on every day, including the original one.
2. **Verified the fix in the same harness:** all instances at 14:00 New York.
3. **Verified DST behavior:** a daily 14:00 event spanning the November 1, 2026 fall back keeps 14:00 wall clock time on every occurrence.
4. **Verified fallback:** an invalid timezone string degrades to the previous server local behavior instead of raising.
5. `ruff format --check` passes; the diff adds zero code comments.

### Screenshots or Videos

Not applicable (backend time computation; the harness output above is the evidence).

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
