### PR TITLE
fix: stop the calendar update tool from nulling every omitted field

### DIFF
--- a/backend/open_webui/tools/builtin.py
+++ b/backend/open_webui/tools/builtin.py
@@ -4278,16 +4278,17 @@ async def update_calendar_event(
             if reminder_minutes is not None:
                 meta = {'alert_minutes': reminder_minutes}
 
-        form = CalendarEventUpdateForm(
-            title=title,
-            description=description,
-            start_at=start_ns,
-            end_at=end_ns,
-            all_day=all_day,
-            location=location,
-            is_cancelled=is_cancelled,
-            meta=meta,
-        )
+        update_fields = {
+            'title': title,
+            'description': description,
+            'start_at': start_ns,
+            'end_at': end_ns,
+            'all_day': all_day,
+            'location': location,
+            'is_cancelled': is_cancelled,
+            'meta': meta,
+        }
+        form = CalendarEventUpdateForm(**{k: v for k, v in update_fields.items() if v is not None})
 
         updated = await CalendarEvents.update_event_by_id(event_id, form)
         if not updated:


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27776, the `update_calendar_event` builtin tool nulls every omitted field, breaking all partial updates.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable. Restores the tool's documented contract; no new surface.
- [ ] **Dependencies:** No new dependencies.
- [x] **Testing:** Verified by executing both construction styles against the form's field definitions: the previous construction marks eight fields as set on a title only update (including `start_at: None` headed for a NOT NULL column); the fixed construction yields exactly the provided fields, and explicit `False` values (un-cancelling, `all_day=False`) still pass through. `ruff format --check` passes; the diff adds zero code comments.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new settings and no dependency changes: one form construction in one builtin tool.
- [x] **Git Hygiene:** A single commit, +11/-10 in a single file, based on the current `dev`.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

**Problem** (#27776): the `update_calendar_event` builtin tool promises "Only provided fields are changed; omitted fields stay the same", but any call that omits fields marks all of them for update with `NULL`. A title only rename attempts `start_at = NULL`, `all_day = NULL`, `is_cancelled = NULL` (NOT NULL columns, so the update fails with an integrity error) and would silently erase `description` and `location`. Every partial update through the tool either fails or destroys data.

**Root Cause**: the tool constructs `CalendarEventUpdateForm` with every parameter passed explicitly. Pydantic counts constructor supplied fields as "set" even when the value is `None`, so the `model_dump(exclude_unset=True)` in `update_event_by_id` returns all of them and the update loop writes each `None` into the row. The HTTP route is unaffected because FastAPI populates only the keys actually sent.

**Fix**: build the form from only the provided parameters, which is exactly the docstring's contract for this tool (a `None` parameter means "not provided"):

```diff
-        form = CalendarEventUpdateForm(
-            title=title,
-            description=description,
-            start_at=start_ns,
-            end_at=end_ns,
-            all_day=all_day,
-            location=location,
-            is_cancelled=is_cancelled,
-            meta=meta,
-        )
+        update_fields = {
+            'title': title,
+            'description': description,
+            'start_at': start_ns,
+            'end_at': end_ns,
+            'all_day': all_day,
+            'location': location,
+            'is_cancelled': is_cancelled,
+            'meta': meta,
+        }
+        form = CalendarEventUpdateForm(**{k: v for k, v in update_fields.items() if v is not None})
```

Explicit `False` values still pass through (the filter drops only `None`), so un-cancelling an event and switching `all_day` off keep working.

### Fixed

- Fixed the `update_calendar_event` builtin tool nulling every omitted field on partial updates: renaming an event through chat no longer fails with a database integrity error or erases the event's description, location, and times. Only the fields the model actually provides are changed, matching the tool's documented behavior.

---

### Additional Information

- This PR was prepared with AI copilot assistance and reviewed by the author.

### Verification Performed

1. **Reproduced the defect at the semantics level:** constructing the form tool style with only `title` provided yields eight fields in the `exclude_unset` dump, including `start_at: None`, `all_day: None`, and `is_cancelled: None`; the model layer's update loop then writes those into NOT NULL columns.
2. **Verified the fix:** the filtered construction yields exactly the provided fields for title only, start only, and cancel plus reminder updates.
3. **Verified no over-filtering:** explicit `False` for `all_day` and `is_cancelled` passes through, so the two boolean transitions the tool documents remain expressible.
4. `ruff format --check` passes; the diff adds zero code comments.

### Screenshots or Videos

Not applicable (builtin tool behavior; the construction dumps above are the evidence).

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
