### PR TITLE
fix: use the local date for the event modal's default start and end

### DIFF
--- a/src/lib/components/calendar/CalendarEventModal.svelte
+++ b/src/lib/components/calendar/CalendarEventModal.svelte
@@ -100,10 +100,10 @@
 				endTime = nsToTimeStr(endNs);
 			} else {
 				const now = new Date();
-				startDate = now.toISOString().slice(0, 10);
+				startDate = nsToDateStr(now.getTime() * NS);
 				startTime = now.toTimeString().slice(0, 5);
 				const later = new Date(now.getTime() + 60 * 60 * 1000);
-				endDate = later.toISOString().slice(0, 10);
+				endDate = nsToDateStr(later.getTime() * NS);
 				endTime = later.toTimeString().slice(0, 5);
 			}
 			allDay = false;


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27778, the create event modal defaults to tomorrow's date every evening for users west of UTC.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable. A two line correctness fix.
- [ ] **Dependencies:** No new dependencies.
- [x] **Testing:** Verified by executing the default population code under `TZ=America/New_York` with a fixed 21:30 clock: before the fix `startDate` reads the next day; after, it reads today, and the end default still rolls to tomorrow when the one hour offset genuinely crosses local midnight. Prettier passes; no new strings, so zero locale churn.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new settings and no new helpers: the fix reuses the component's own `nsToDateStr` local date formatter, defined a few lines above.
- [x] **Git Hygiene:** A single commit, +2/-2 in a single file, based on the current `dev`.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

**Problem** (#27778): opening the create event modal without a preselected slot in the evening (any timezone west of UTC) prefills tomorrow's date with today's local time. At 21:30 EDT the prefill reads July 31, 21:30 while it is July 30; submitting creates the event 24 hours in the future. East of UTC the same defect prefills yesterday in the early morning.

**Root Cause**: the defaults mix timezones between the date and the time. `toISOString()` renders the UTC date (already tomorrow during the evening west of UTC) while `toTimeString()` renders local time; the pair is recombined as a local datetime on submit.

**Fix**: use the component's own local date helper for both date defaults:

```diff
 			} else {
 				const now = new Date();
-				startDate = now.toISOString().slice(0, 10);
+				startDate = nsToDateStr(now.getTime() * NS);
 				startTime = now.toTimeString().slice(0, 5);
 				const later = new Date(now.getTime() + 60 * 60 * 1000);
-				endDate = later.toISOString().slice(0, 10);
+				endDate = nsToDateStr(later.getTime() * NS);
 				endTime = later.toTimeString().slice(0, 5);
 			}
```

`nsToDateStr` is defined a few lines above in the same component and formats via local getters, matching how every other date in the modal is produced.

### Fixed

- Fixed the create event modal prefilling tomorrow's date (with today's time) when opened in the evening for users west of UTC, and yesterday's date in the early morning east of UTC: the default date now uses local time like the rest of the modal.

---

### Additional Information

- This PR was prepared with AI copilot assistance and reviewed by the author.

### Verification Performed

1. **Reproduced:** executed the default population code under `TZ=America/New_York` with a fixed 21:30 clock; `startDate` evaluated to the next day's date while `startTime` read 21:30.
2. **Verified the fix:** the same clock yields today's date for both start and end defaults.
3. **Verified the midnight edge:** at 23:30 local, the plus one hour end default correctly lands on tomorrow's date.
4. Prettier passes; no new strings, so zero locale churn; the diff adds zero code comments.

### Screenshots or Videos

Not applicable (a prefilled date field; the reproduction takes under a minute in the evening).

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
