### PR TITLE
fix: reject COUNT rules without DTSTART so limited automations cannot run forever

### DIFF
--- a/backend/open_webui/constants.py
+++ b/backend/open_webui/constants.py
@@ -118,6 +118,9 @@ class ERROR_MESSAGES(str, Enum):
     AUTOMATION_TOO_FREQUENT = lambda interval='': f'Schedule too frequent. Minimum interval is {interval} seconds.'
     AUTOMATION_INVALID_RRULE = lambda err='': f'Invalid RRULE: {err}'
     AUTOMATION_NO_FUTURE_RUNS = 'RRULE has no future occurrences'
+    AUTOMATION_COUNT_REQUIRES_DTSTART = (
+        'RRULE with COUNT requires an explicit DTSTART line to anchor the occurrence window'
+    )
 
     FEATURE_DISABLED = lambda name='': f'{name} is disabled'
     INPUT_TOO_LONG = lambda size='': f'Input prompt exceeds maximum length of {size}'

--- a/backend/open_webui/utils/automations.py
+++ b/backend/open_webui/utils/automations.py
@@ -124,6 +124,9 @@ def validate_rrule(s: str, tz: str = None) -> None:
     clock so that near-future schedules are not incorrectly rejected
     on servers whose system clock is ahead (e.g. UTC vs US timezones).
     """
+    upper = s.upper()
+    if 'COUNT=' in upper and 'DTSTART' not in upper:
+        raise ValueError(ERROR_MESSAGES.AUTOMATION_COUNT_REQUIRES_DTSTART)
     zi = _resolve_tz(tz)
     now = datetime.now(zi).replace(tzinfo=None) if zi else datetime.now()
     try:


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27780, automations with COUNT but no DTSTART never stop running because every claim reanchors the rule.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable. A validation rule with a self explaining error message.
- [ ] **Dependencies:** No new dependencies.
- [x] **Testing:** The runaway behavior was proven by simulating the scheduler's per claim reparse with a controlled clock against the real parsing code: a `COUNT=3` rule without DTSTART fired 10 times across 10 simulated days with no exhaustion, while the identical rule with DTSTART exhausted after exactly 3. The fix was verified with a six case validation matrix: both unanchored COUNT shapes rejected with the new message, all four documented shapes (anchored COUNT, documented one shot, plain recurring, interval based sub daily) still accepted. `ruff format --check` passes; the diff adds zero code comments.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new settings and no dependency changes: one guard in `validate_rrule`, the single choke point shared by the HTTP create/update routes and the builtin create/update tools, plus one error message constant.
- [x] **Git Hygiene:** A single commit, +6/-0 across two files, based on the current `dev`.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

**Problem** (#27780): an automation whose RRULE contains `COUNT` but no `DTSTART` line never stops running. A "run 3 times" schedule executes daily forever, silently consuming model calls and creating chats. This is exactly the rule shape a model produces through the `create_automation` builtin tool when asked to run something a limited number of times, since the tool's examples only pair DTSTART with COUNT=1 and models freely recombine the pieces.

**Root Cause**: upcoming runs are recomputed by reparsing the stored RRULE string on every scheduler claim. Without a `DTSTART`, `dateutil.rrulestr` defaults the anchor to the moment of parsing, so each claim restarts the COUNT window at "now": the N occurrence budget can never be spent. Proven with a controlled clock simulation against the real parsing code: `RRULE:FREQ=DAILY;BYHOUR=9;BYMINUTE=0;COUNT=3` fired 10 times across 10 simulated days with no end, while the same rule with a DTSTART exhausted correctly after exactly 3 runs. `UNTIL` rules are unaffected (absolute cutoff), which is why only COUNT needs anchoring.

**Fix**: reject the unanchorable shape at validation time, in the choke point every create and update path already goes through:

```diff
+    upper = s.upper()
+    if 'COUNT=' in upper and 'DTSTART' not in upper:
+        raise ValueError(ERROR_MESSAGES.AUTOMATION_COUNT_REQUIRES_DTSTART)
     zi = _resolve_tz(tz)
```

with

```diff
     AUTOMATION_NO_FUTURE_RUNS = 'RRULE has no future occurrences'
+    AUTOMATION_COUNT_REQUIRES_DTSTART = (
+        'RRULE with COUNT requires an explicit DTSTART line to anchor the occurrence window'
+    )
```

The message states exactly what to add, so a model calling the builtin tool retries with a corrected rule. The automation editor UI always emits DTSTART with its one shot rules, so no UI path is affected. Existing stored rules are untouched by validation; an affected automation stops the moment its owner pauses or edits it, at which point the corrected validation applies.

### Fixed

- Fixed automations with a COUNT limited schedule but no DTSTART running forever: the scheduler reanchors such rules on every claim, restarting the occurrence budget indefinitely. These rules are now rejected at creation and update time with an error message stating that COUNT requires an explicit DTSTART.

---

### Additional Information

- This PR was prepared with AI copilot assistance and reviewed by the author.

### Verification Performed

1. **Proved the runaway:** simulated the scheduler's per claim reparse cycle with a controlled clock injected into the parser: 10 fires across 10 simulated days for `COUNT=3` without DTSTART, no exhaustion; exactly 3 fires then exhaustion for the identical rule with DTSTART.
2. **Verified the fix with a six case matrix:** `RRULE:FREQ=DAILY;BYHOUR=9;COUNT=3` and `RRULE:FREQ=HOURLY;COUNT=5` rejected with the new message; anchored COUNT, the documented one shot (`DTSTART:...\nRRULE:FREQ=DAILY;COUNT=1`), plain recurring, and interval based sub daily rules all still accepted.
3. **Checked every caller:** `validate_rrule` is invoked by the HTTP create and update routes and by the builtin `create_automation` and `update_automation` tools, so all creation surfaces are covered by the single guard.
4. `ruff format --check` passes on both changed files; the diff adds zero code comments.

### Screenshots or Videos

Not applicable (backend scheduling behavior; the simulation output above is the evidence).

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
