### PR TITLE
fix: filter due timers in SQL instead of loading every pending timer each poll

### DIFF
--- a/backend/open_webui/utils/timers.py
+++ b/backend/open_webui/utils/timers.py
@@ -13,7 +13,7 @@ from typing import Literal
 from uuid import uuid4
 
 from fastapi import Request
-from sqlalchemy import select
+from sqlalchemy import BigInteger, cast, select
 from starlette.datastructures import Headers
 
 from open_webui.internal.db import get_async_db
@@ -170,19 +170,21 @@ async def create_timer(
 async def claim_due_timers(now_ns: int, limit: int = 10) -> list[tuple[str, str]]:
     """Claim due timers by moving them from pending to running."""
     async with get_async_db() as db:
+        timer_at = cast(Chat.meta['timer_at'].as_string(), BigInteger)
         stmt = (
             select(Chat)
             .where(Chat.meta['internal'].as_boolean().is_(True))
             .where(Chat.meta['type'].as_string() == 'timer')
             .where(Chat.meta['status'].as_string() == 'pending')
+            .where(timer_at <= now_ns)
+            .order_by(timer_at)
+            .limit(limit)
         )
         if db.bind.dialect.name == 'postgresql':
             stmt = stmt.with_for_update(skip_locked=True)
 
         result = await db.execute(stmt)
-        rows = [row for row in result.scalars().all() if int((row.meta or {}).get('timer_at') or 0) <= now_ns]
-        rows.sort(key=lambda row: int((row.meta or {}).get('timer_at') or 0))
-        rows = rows[:limit]
+        rows = result.scalars().all()
 
         claimed = []
         for row in rows:


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27782, the timer scheduler loads every pending timer from the database once per second, filtering in Python.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable. Same query semantics, expressed in SQL.
- [ ] **Dependencies:** No new dependencies.
- [x] **Testing:** The due filter expression was executed against both supported dialects with nanosecond scale values: SQLite in memory via SQLAlchemy, and PostgreSQL 18 (the pgvector image, throwaway container). Both return exactly the due rows, exclude future ones, and exclude rows with a missing timer_at. The compiled SQL was inspected for both dialects to confirm the BIGINT cast renders correctly (a plain as_integer() would render a 4 byte INTEGER cast on PostgreSQL and overflow on nanosecond values). ruff format passes; the diff adds zero code comments.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new settings and no dependency changes: the claim query gains a WHERE, an ORDER BY, and a LIMIT, in the same JSON field idiom the query already uses.
- [x] **Git Hygiene:** A single commit, +6/-4 in a single file, based on the current `dev`.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

**Problem** (#27782): `claim_due_timers` polls every second and selects every pending timer row, applying the due filter, sort, and limit in Python. Every pending timer's full chat row (including its JSON payload) is fetched and deserialized once per second per instance even when nothing is due; on PostgreSQL, `FOR UPDATE SKIP LOCKED` locks all pending rows per poll instead of just the claimed batch, so a concurrently polling instance skips due timers too; and a missing `timer_at` counts as due immediately.

**Fix**: push the filter, sort, and limit into SQL:

```diff
     async with get_async_db() as db:
+        timer_at = cast(Chat.meta['timer_at'].as_string(), BigInteger)
         stmt = (
             select(Chat)
             .where(Chat.meta['internal'].as_boolean().is_(True))
             .where(Chat.meta['type'].as_string() == 'timer')
             .where(Chat.meta['status'].as_string() == 'pending')
+            .where(timer_at <= now_ns)
+            .order_by(timer_at)
+            .limit(limit)
         )
         if db.bind.dialect.name == 'postgresql':
             stmt = stmt.with_for_update(skip_locked=True)

         result = await db.execute(stmt)
-        rows = [row for row in result.scalars().all() if int((row.meta or {}).get('timer_at') or 0) <= now_ns]
-        rows.sort(key=lambda row: int((row.meta or {}).get('timer_at') or 0))
-        rows = rows[:limit]
+        rows = result.scalars().all()
```

The explicit BIGINT cast matters: nanosecond timestamps overflow the 4 byte INTEGER that `.as_integer()` renders on PostgreSQL. With the limit in SQL, `FOR UPDATE SKIP LOCKED` now locks at most `limit` rows per poll. A pending row with a missing `timer_at` is now never claimed instead of being claimed immediately, which is the safer reading of a malformed row (it cannot occur through `create_timer`, which always sets the field).

### Fixed

- Fixed the timer scheduler fetching every pending timer chat from the database once per second and filtering in Python: due filtering, ordering, and the claim limit now run in SQL on both SQLite and PostgreSQL, and the PostgreSQL claim locks only the batch being claimed instead of every pending timer.

---

### Additional Information

- This PR was prepared with AI copilot assistance and reviewed by the author.

### Verification Performed

1. **SQLite**: executed the new expression in memory via SQLAlchemy with nanosecond values; returns exactly the due row, excludes the future row and the row with no timer_at.
2. **PostgreSQL 18**: executed the compiled SQL in a throwaway container of the pgvector image with the same fixture; identical results.
3. **Compiled SQL inspected for both dialects**: the expression renders `CAST(... AS BIGINT)` on both; the `.as_integer()` alternative was checked and rejected because it renders `CAST(... AS INTEGER)` on PostgreSQL, which overflows on nanosecond values.
4. `ruff format --check` passes; the diff adds zero code comments.

### Screenshots or Videos

Not applicable (backend query behavior; the dialect verification above is the evidence).

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
