### PR TITLE
fix: record an error state when a timer's chat completion raises

### DIFF
--- a/backend/open_webui/utils/timers.py
+++ b/backend/open_webui/utils/timers.py
@@ -405,7 +405,11 @@ async def execute_due_timer(app, timer_id: str, claim_id: str | None = None) -> 
         )
         request.state.token = None
         request.state.enable_api_keys = False
-        await app.state.CHAT_COMPLETION_HANDLER(request, form_data, user=user)
+        try:
+            await app.state.CHAT_COMPLETION_HANDLER(request, form_data, user=user)
+        except Exception as exc:
+            log.exception(f'Timer {timer_id} completion failed')
+            await _set_timer_state(timer_id, 'error', timer_error=str(exc)[:500])
 
 
 async def _set_timer_state(timer_id: str, status: str, **fields) -> None:


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27783, a timer whose chat completion raises is recorded as completed and the failure is silently swallowed.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable. Error handling for an existing path.
- [ ] **Dependencies:** No new dependencies.
- [x] **Testing:** The failure mode is structural: `execute_due_timer` runs as a fire and forget asyncio task, marks the timer completed before invoking the completion handler, and calls the handler bare, so any exception raised by the handler (model resolution, access, payload validation) vanishes into the task. The guard logs the exception and records the error state through the existing `_set_timer_state` helper, which is exercised by the function's other error paths. ruff format passes; the diff adds zero code comments.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new settings and no dependency changes: one try/except around the handler call, using the module's existing state helper and logger.
- [x] **Git Hygiene:** A single commit, +5/-1 in a single file, based on the current `dev`.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

**Problem** (#27783): when a timer fires and its chat completion raises (for example, the timer's model was deleted between setting and firing), the exception disappears. `execute_due_timer` marks the timer `completed` before invoking the handler, runs as a fire and forget task, and calls the handler with no exception handling: the parent chat keeps an assistant message stuck in its pending state, nothing is logged at error level, and the timer's stored state claims success.

**Fix**: guard the handler call, log the failure, and record it on the timer:

```diff
         request.state.token = None
         request.state.enable_api_keys = False
-        await app.state.CHAT_COMPLETION_HANDLER(request, form_data, user=user)
+        try:
+            await app.state.CHAT_COMPLETION_HANDLER(request, form_data, user=user)
+        except Exception as exc:
+            log.exception(f'Timer {timer_id} completion failed')
+            await _set_timer_state(timer_id, 'error', timer_error=str(exc)[:500])
```

Failures the completion pipeline already handles internally (provider errors during streaming, which it writes into the assistant message) are untouched; the guard only catches what previously escaped. Reordering the `completed` stamp to after the handler would widen the parent chat lock scope, so the error state is recorded after the fact instead, which corrects the stored outcome either way.

### Fixed

- Fixed timers whose chat completion raises being recorded as completed with the failure silently swallowed: the exception is now logged and the timer records an error state with the failure message.

---

### Additional Information

- This PR was prepared with AI copilot assistance and reviewed by the author.

### Verification Performed

1. The guarded call reuses `_set_timer_state`, the same helper every other error path in `execute_due_timer` uses (missing parent chat, missing task message, missing user, missing model context), so the state transition is an already exercised path.
2. Confirmed the completion pipeline's internal streaming error handling is unaffected: it does not raise for provider errors, so the new except only fires for exceptions that previously escaped into the fire and forget task.
3. `ruff format --check` passes; the diff adds zero code comments.

### Screenshots or Videos

Not applicable (backend error handling).

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
