### PR TITLE
fix: place model editor capability checkboxes directly before their labels

### DIFF
--- a/src/lib/components/workspace/Models/BuiltinTools.svelte
+++ b/src/lib/components/workspace/Models/BuiltinTools.svelte
@@ -78,12 +78,7 @@
 	<div class="mb-1.5 text-xs text-gray-400 dark:text-gray-600">{$i18n.t('Builtin Tools')}</div>
 	<div class="grid grid-cols-1 gap-x-5 gap-y-1 sm:grid-cols-2 lg:grid-cols-3">
 		{#each allTools as tool}
-			<div class="flex min-h-6 items-center justify-between gap-2.5">
-				<div class="min-w-0 text-xs text-gray-600 dark:text-gray-400">
-					<Tooltip content={marked.parse(toolLabels[tool].description)}>
-						<span class="truncate">{$i18n.t(toolLabels[tool].label)}</span>
-					</Tooltip>
-				</div>
+			<div class="flex min-h-6 items-center gap-2.5">
 				<Checkbox
 					ariaLabel={$i18n.t(toolLabels[tool].label)}
 					state={builtinTools[tool] !== false ? 'checked' : 'unchecked'}
@@ -96,6 +91,11 @@
 						builtinTools = builtinTools;
 					}}
 				/>
+				<div class="min-w-0 text-xs text-gray-600 dark:text-gray-400">
+					<Tooltip content={marked.parse(toolLabels[tool].description)}>
+						<span class="truncate">{$i18n.t(toolLabels[tool].label)}</span>
+					</Tooltip>
+				</div>
 			</div>
 		{/each}
 	</div>

--- a/src/lib/components/workspace/Models/Capabilities.svelte
+++ b/src/lib/components/workspace/Models/Capabilities.svelte
@@ -80,12 +80,7 @@
 	<div class="mb-1.5 text-xs text-gray-400 dark:text-gray-600">{$i18n.t('Capabilities')}</div>
 	<div class="grid grid-cols-1 gap-x-5 gap-y-1 sm:grid-cols-2 lg:grid-cols-3">
 		{#each visibleCapabilities as capability}
-			<div class="flex min-h-6 items-center justify-between gap-2.5">
-				<div class="min-w-0 text-xs text-gray-600 dark:text-gray-400">
-					<Tooltip content={marked.parse(capabilityLabels[capability].description)}>
-						<span class="truncate">{$i18n.t(capabilityLabels[capability].label)}</span>
-					</Tooltip>
-				</div>
+			<div class="flex min-h-6 items-center gap-2.5">
 				<Checkbox
 					ariaLabel={$i18n.t(capabilityLabels[capability].label)}
 					state={capabilities[capability] ? 'checked' : 'unchecked'}
@@ -93,6 +88,11 @@
 						capabilities[capability] = e.detail === 'checked';
 					}}
 				/>
+				<div class="min-w-0 text-xs text-gray-600 dark:text-gray-400">
+					<Tooltip content={marked.parse(capabilityLabels[capability].description)}>
+						<span class="truncate">{$i18n.t(capabilityLabels[capability].label)}</span>
+					</Tooltip>
+				</div>
 			</div>
 		{/each}
 	</div>

--- a/src/lib/components/workspace/Models/DefaultFeatures.svelte
+++ b/src/lib/components/workspace/Models/DefaultFeatures.svelte
@@ -29,12 +29,7 @@
 	<div class="mb-1.5 text-xs text-gray-400 dark:text-gray-600">{$i18n.t('Default Features')}</div>
 	<div class="grid grid-cols-1 gap-x-5 gap-y-1 sm:grid-cols-2 lg:grid-cols-3">
 		{#each availableFeatures as feature}
-			<div class="flex min-h-6 items-center justify-between gap-2.5">
-				<div class="min-w-0 text-xs text-gray-600 dark:text-gray-400">
-					<Tooltip content={marked.parse(featureLabels[feature].description)}>
-						<span class="truncate">{$i18n.t(featureLabels[feature].label)}</span>
-					</Tooltip>
-				</div>
+			<div class="flex min-h-6 items-center gap-2.5">
 				<Checkbox
 					ariaLabel={$i18n.t(featureLabels[feature].label)}
 					state={featureIds.includes(feature) ? 'checked' : 'unchecked'}
@@ -46,6 +41,11 @@
 						}
 					}}
 				/>
+				<div class="min-w-0 text-xs text-gray-600 dark:text-gray-400">
+					<Tooltip content={marked.parse(featureLabels[feature].description)}>
+						<span class="truncate">{$i18n.t(featureLabels[feature].label)}</span>
+					</Tooltip>
+				</div>
 			</div>
 		{/each}
 	</div>


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27771, checkbox alignment in the Model Editor "Capabilities" section.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable, visual layout adjustment only.
- [ ] **Dependencies:** No new dependencies.
- [x] **Testing:** Verified live on a local dev build: all three sections render checkbox before label with the checkbox directly adjacent to its text, and toggling still works (checked, unchecked, checked round trip). The production build passes and `npm run format` produces no changes. Details in Manual Verification below.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new settings and no logic changes: each row's existing checkbox and label are reordered inside the same flex container, matching the leading checkbox pattern already used by the neighboring Tools and Filters selectors in the same editor.
- [x] **Git Hygiene:** The PR is atomic (one logical change), based on the current `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

**Problem** (#27771): in the Model Editor, the Capabilities checkboxes sit in a detached column at the far right edge of each grid cell instead of next to their labels. With the responsive 2 or 3 column grid on wide screens, a checkbox ends up floating in the middle of the panel, closer to the next column's label than to its own, so it is hard to tell at a glance which checkbox belongs to which item.

**Root Cause**: each row uses `justify-between`, which pushes the label to the left edge and the checkbox to the right edge of the grid cell. The gap between them grows with the cell width, and in a multi column grid the right edge of one cell visually abuts the left edge of the next.

**Fix**: place each checkbox directly in front of its label, exactly as the issue proposes. The row keeps its existing container, sizing, tooltip, and truncation behavior; only `justify-between` is dropped and the order of the two children is swapped:

```diff
-			<div class="flex min-h-6 items-center justify-between gap-2.5">
-				<div class="min-w-0 text-xs text-gray-600 dark:text-gray-400">
-					<Tooltip content={marked.parse(capabilityLabels[capability].description)}>
-						<span class="truncate">{$i18n.t(capabilityLabels[capability].label)}</span>
-					</Tooltip>
-				</div>
-				<Checkbox ... />
+			<div class="flex min-h-6 items-center gap-2.5">
+				<Checkbox ... />
+				<div class="min-w-0 text-xs text-gray-600 dark:text-gray-400">
+					<Tooltip content={marked.parse(capabilityLabels[capability].description)}>
+						<span class="truncate">{$i18n.t(capabilityLabels[capability].label)}</span>
+					</Tooltip>
+				</div>
 			</div>
```

The same detached column layout is shared verbatim by the two sibling sections directly below Capabilities in the same editor, so all three are updated identically for consistency:

- `src/lib/components/workspace/Models/Capabilities.svelte`
- `src/lib/components/workspace/Models/DefaultFeatures.svelte`
- `src/lib/components/workspace/Models/BuiltinTools.svelte`

The leading checkbox arrangement also matches the pattern the Model Editor already uses for selected Tools and Filters chips (`ToolsSelector.svelte`, `FiltersSelector.svelte`), so the editor becomes internally consistent rather than mixing both styles.

These three components are also rendered by the admin panel's Model Defaults section (Admin Settings > Models > Model Defaults, via `admin/Settings/Models/ModelDefaultsPanel.svelte`), so that surface picks up the same aligned layout from this diff with no additional changes.

No logic, state handling, i18n strings, or accessibility attributes changed: the `Checkbox` keeps its `ariaLabel`, the label keeps its tooltip and `truncate`, and the diff is a pure reorder of 6 lines per file (+18/-18 total across the three files).

### Fixed

- Fixed checkboxes in the Capabilities, Default Features, and Builtin Tools sections being detached from their labels, both in the Model Editor and in the admin panel's Model Defaults section (which renders the same components): each checkbox now sits directly in front of its label instead of floating at the far edge of the grid cell, making the checkbox to label mapping unambiguous in multi column layouts.

---

### Additional Information

- This PR was prepared with AI copilot assistance and reviewed by the author.

### Manual Verification Performed

1. Opened the Model Editor on a local dev build and confirmed via DOM inspection that every row in Capabilities, Default Features, and Builtin Tools now renders `checkbox -> label`, with the checkbox sitting flush against its label instead of at the far edge of the grid cell (previously the checkbox sat at the cell's right edge; it now sits at the left, roughly 370px away from that edge in a 3 column layout).
2. Toggled a capability checkbox through a full round trip (checked, unchecked, checked) and confirmed state updates still work; no handler, state, i18n, or aria code was touched by the diff.
3. Confirmed the label keeps its tooltip wrapper and `truncate` class, and the row keeps its `min-h-6` sizing, so tooltip and truncation behavior are structurally unchanged.
4. No color related classes were added or removed, so light and dark mode rendering is unaffected by construction.
5. Confirmed the admin panel's Model Defaults section (Admin Settings > Models > Model Defaults) renders the same three components and shows the same corrected layout, with toggles still working (screenshots below).
6. `npm run format` produces no changes; `npm run build` passes.

### Screenshots or Videos

| Surface | Before | After |
|---|---|---|
| Model Editor (Capabilities, Default Features, Builtin Tools) | <img width="2326" height="688" alt="Model editor before, checkboxes detached at the far edge of each grid cell" src="https://github.com/user-attachments/assets/fb2f6bb1-a59c-4843-b2c3-b90dc237c5fc" /> | <img width="2326" height="688" alt="Model editor after, each checkbox directly in front of its label" src="https://github.com/user-attachments/assets/01c5d579-8cb9-4cf2-bf26-b0ddd095383b" /> |
| Admin Settings > Models > Model Defaults (same components) | <img width="1578" height="686" alt="Admin Model Defaults before, checkboxes detached at the far edge of each grid cell" src="https://github.com/user-attachments/assets/e08b26c4-c200-4f7b-886c-942f455e8742" /> | <img width="1578" height="686" alt="Admin Model Defaults after, each checkbox directly in front of its label" src="https://github.com/user-attachments/assets/36ae7353-1f83-435b-8919-227f32cb72d9" /> |

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.

