### PR TITLE
fix: stop ORJSONCodec silently discarding stdlib json keyword arguments

### DIFF
--- a/backend/open_webui/utils/json_codec.py
+++ b/backend/open_webui/utils/json_codec.py
@@ -28,18 +28,23 @@ if ENABLE_ORJSON:
         JSONDecodeError = engineio_json.JSONDecodeError
 
         @staticmethod
-        def dumps(obj, *args, **kwargs):
+        def dumps(obj, **kwargs):
+            # orjson can't honour stdlib json kwargs; its output already matches separators=(',', ':').
+            if kwargs and kwargs != {'separators': (',', ':')}:
+                return engineio_json.dumps(obj, **kwargs)
             try:
                 return orjson.dumps(obj).decode('utf-8')
             except (TypeError, ValueError):
-                return engineio_json.dumps(obj, *args, **kwargs)
+                return engineio_json.dumps(obj, **kwargs)
 
         @staticmethod
-        def loads(s, *args, **kwargs):
+        def loads(s, **kwargs):
+            if kwargs:
+                return engineio_json.loads(s, **kwargs)
             try:
                 return orjson.loads(s)
             except (TypeError, ValueError):
-                return engineio_json.loads(s, *args, **kwargs)
+                return engineio_json.loads(s)
 
     # Drop-in for stdlib ``json``: ``JSONCodec.dumps`` / ``JSONCodec.loads``.
     JSONCodec = ORJSONCodec


### PR DESCRIPTION
`*args` is dropped from both signatures. stdlib `json.dumps` and `json.loads` take everything after the first parameter keyword-only, so passing an option positionally was already an invalid call; it now raises `TypeError` rather than being silently ignored.

No existing call site changes behaviour.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
