### PR TITLE
perf: avoid a redundant full-string encode per chat row in sanitize_data_for_db

### DIFF
--- a/backend/open_webui/utils/json_codec.py
+++ b/backend/open_webui/utils/json_codec.py
@@ -48,3 +48,16 @@ if ENABLE_ORJSON:
 else:
     JSONCodec = stdlib_json
     SOCKETIO_JSON = engineio_json
+
+
+def dumps_utf8(obj) -> bytes:
+    """Serialize to UTF-8 bytes, raising on lone surrogates.
+
+    ``JSONCodec.dumps`` cannot stand in: its stdlib fallback escapes them via ``ensure_ascii``.
+    """
+    if ENABLE_ORJSON:
+        try:
+            return orjson.dumps(obj)
+        except (TypeError, ValueError):
+            pass
+    return stdlib_json.dumps(obj, ensure_ascii=False).encode('utf-8')

--- a/backend/open_webui/utils/misc.py
+++ b/backend/open_webui/utils/misc.py
@@ -15,6 +15,7 @@ from typing import Callable, Optional, Sequence, Union
 import aiohttp
 import mimeparse
 from open_webui.env import CHAT_STREAM_RESPONSE_CHUNK_MAX_BUFFER_SIZE
+from open_webui.utils.json_codec import dumps_utf8
 
 log = logging.getLogger(__name__)
 SURROGATE_RE = re.compile('[\ud800-\udfff]')
@@ -811,7 +812,7 @@ def _strip_null_bytes_deep(obj):
 def sanitize_data_for_db(obj):
     """Recursively sanitize all strings in a data structure for database storage.
 
-    Performs a fast pre-check: serializes the structure once and scans for
+    Performs a fast pre-check: serializes the structure and scans for
     null bytes or invalid UTF-8 surrogates. If none are found, the
     original object is returned immediately, skipping the expensive
     recursive walk.
@@ -819,12 +820,8 @@ def sanitize_data_for_db(obj):
     if isinstance(obj, str):
         return sanitize_text_for_db(obj)
     # Fast path: check for null bytes and surrogate code points in the serialized form.
-    # json.dumps is implemented in C and much faster than a Python-level
-    # recursive walk over every leaf string.
     try:
-        serialized = json.dumps(obj, ensure_ascii=False)
-        if '\\u0000' not in serialized:
-            serialized.encode('utf-8')
+        if b'\\u0000' not in dumps_utf8(obj):
             return obj
     except (TypeError, ValueError, UnicodeEncodeError):
         pass


### PR DESCRIPTION
`sanitize_data_for_db` runs on every chat read and write. Its fast path serialized the entire chat object, scanned the result for escaped null bytes, then encoded the whole string to UTF-8 to surface lone surrogates, and discarded both. The cost is O(chat size), so it grows with conversation length, and `_sanitize_chat_row` pays it twice per invocation, once on the title and once on the whole chat blob.

The serialize step now goes through a new `dumps_utf8` helper in `utils/json_codec.py`, which returns UTF-8 bytes directly and uses orjson when `ENABLE_ORJSON` is set. The null-byte scan becomes a bytes search and the separate encode disappears, because orjson raises on lone surrogates and the stdlib path still encodes.

Both predicates the discarded string existed to test are preserved. Both backends escape NUL as a six-character JSON escape regardless of `ensure_ascii`, so the byte pattern is identical, and both signal a lone surrogate with an exception the caller already catches, `orjson.JSONEncodeError` being a `TypeError` subclass and stdlib raising `UnicodeEncodeError`. `ensure_ascii=False` has to stay on the stdlib path: with it on, a lone surrogate is escaped to the literal text `\ud800`, the encode then succeeds, and the function would return the object unsanitized, defeating the bug it exists to prevent.

orjson is only an accelerator here, never an authority on whether serialization failed. It rejects input stdlib accepts, including non-str dict keys, integers past 64 bits, and container nesting past 253 levels, so whatever it refuses is retried with stdlib rather than counted as a failure. Without that retry a chat nested past 253 levels would fall through to the recursive walk and raise `RecursionError` on a request that currently succeeds.

With `ENABLE_ORJSON` unset, which is the default, the work is unchanged: one dumps, one encode, one scan, same escaping.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
