### PR TITLE
feat: add MiniMax text-to-speech support

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -1612,6 +1612,10 @@ AUDIO_TTS_MISTRAL_API_KEY = os.getenv('AUDIO_TTS_MISTRAL_API_KEY', '')
 
 AUDIO_TTS_MISTRAL_API_BASE_URL = os.getenv('AUDIO_TTS_MISTRAL_API_BASE_URL', 'https://api.mistral.ai/v1')
 
+AUDIO_TTS_MINIMAX_API_KEY = os.getenv('AUDIO_TTS_MINIMAX_API_KEY', '')
+
+AUDIO_TTS_MINIMAX_API_BASE_URL = os.getenv('AUDIO_TTS_MINIMAX_API_BASE_URL', 'https://api.minimax.io/v1')
+
 ####################################
 # WEBUI
 ####################################
@@ -3039,6 +3043,8 @@ DEFAULT_CONFIG = {
     'audio.tts.azure.speech_output_format': AUDIO_TTS_AZURE_SPEECH_OUTPUT_FORMAT,
     'audio.tts.mistral.api_key': AUDIO_TTS_MISTRAL_API_KEY,
     'audio.tts.mistral.api_base_url': AUDIO_TTS_MISTRAL_API_BASE_URL,
+    'audio.tts.minimax.api_key': AUDIO_TTS_MINIMAX_API_KEY,
+    'audio.tts.minimax.api_base_url': AUDIO_TTS_MINIMAX_API_BASE_URL,
     'webui.url': WEBUI_URL,
     'ui.enable_signup': ENABLE_SIGNUP,
     'ui.enable_login_form': ENABLE_LOGIN_FORM,

--- a/backend/open_webui/routers/audio.py
+++ b/backend/open_webui/routers/audio.py
@@ -76,6 +76,17 @@ AZURE_MAX_FILE_SIZE: int = AZURE_MAX_FILE_SIZE_MB * 1024 * 1024
 SPEECH_CACHE_DIR = CACHE_DIR / 'audio' / 'speech'
 SPEECH_CACHE_DIR.mkdir(parents=True, exist_ok=True)
 
+_MINIMAX_TTS_MODELS = (
+    'speech-2.8-hd',
+    'speech-2.8-turbo',
+    'speech-2.6-hd',
+    'speech-2.6-turbo',
+    'speech-02-hd',
+    'speech-02-turbo',
+    'speech-01-hd',
+    'speech-01-turbo',
+)
+
 TTS_CONFIG_KEYS = {
     'OPENAI_API_BASE_URL': 'audio.tts.openai.api_base_url',
     'OPENAI_API_KEY': 'audio.tts.openai.api_key',
@@ -90,6 +101,8 @@ TTS_CONFIG_KEYS = {
     'AZURE_SPEECH_OUTPUT_FORMAT': 'audio.tts.azure.speech_output_format',
     'MISTRAL_API_KEY': 'audio.tts.mistral.api_key',
     'MISTRAL_API_BASE_URL': 'audio.tts.mistral.api_base_url',
+    'MINIMAX_API_KEY': 'audio.tts.minimax.api_key',
+    'MINIMAX_API_BASE_URL': 'audio.tts.minimax.api_base_url',
 }
 
 STT_CONFIG_KEYS = {
@@ -249,6 +262,8 @@ class TTSConfigForm(BaseModel):
     AZURE_SPEECH_OUTPUT_FORMAT: str
     MISTRAL_API_KEY: str
     MISTRAL_API_BASE_URL: str
+    MINIMAX_API_KEY: str = ''
+    MINIMAX_API_BASE_URL: str = ''
 
 
 class STTConfigForm(BaseModel):
@@ -543,6 +558,57 @@ async def _tts_mistral(request, payload, file_path, file_body_path, user):
         await _raise_tts_error(exc, r)
 
 
+async def _tts_minimax(request, payload, file_path, file_body_path, user):
+    """Generate speech via the MiniMax TTS API."""
+    api_key = await Config.get('audio.tts.minimax.api_key')
+    api_base_url = await Config.get('audio.tts.minimax.api_base_url') or 'https://api.minimax.io/v1'
+
+    if not api_key:
+        raise HTTPException(status_code=400, detail='MiniMax API key is required for MiniMax TTS')
+
+    api_base_url = api_base_url.rstrip('/')
+    voice_id = (payload.get('voice') or await Config.get('audio.tts.voice') or '').strip()
+    request_payload = {
+        'model': await Config.get('audio.tts.model') or _MINIMAX_TTS_MODELS[0],
+        'text': payload.get('input', ''),
+        'audio_setting': {'format': 'mp3'},
+    }
+    if voice_id:
+        request_payload['voice_setting'] = {'voice_id': voice_id}
+
+    r = None
+    try:
+        session = await get_session()
+        r = await session.post(
+            url=f'{api_base_url}/t2a_v2',
+            json=request_payload,
+            headers={
+                'Content-Type': 'application/json',
+                'Authorization': f'Bearer {api_key}',
+            },
+            ssl=AIOHTTP_CLIENT_SESSION_SSL,
+        )
+        r.raise_for_status()
+
+        res = await r.json()
+        base_resp = res.get('base_resp') or {}
+        if base_resp.get('status_code', 0) not in (0, '0'):
+            detail = base_resp.get('status_msg') or 'MiniMax TTS request failed'
+            raise HTTPException(status_code=400, detail=f'External: {detail}')
+
+        audio_hex = (res.get('data') or {}).get('audio', '')
+        if not isinstance(audio_hex, str) or not audio_hex:
+            raise ValueError('No audio data in MiniMax TTS response')
+
+        await _write_tts_cache(file_path, bytes.fromhex(audio_hex), file_body_path, payload)
+        return FileResponse(file_path)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        log.exception(exc)
+        await _raise_tts_error(exc, r)
+
+
 # Dispatcher map: engine name -> handler
 _TTS_ENGINES = {
     'openai': _tts_openai,
@@ -550,6 +616,7 @@ _TTS_ENGINES = {
     'azure': _tts_azure,
     'transformers': _tts_transformers,
     'mistral': _tts_mistral,
+    'minimax': _tts_minimax,
 }
 
 
@@ -1325,6 +1392,9 @@ async def get_available_models(request: Request) -> list[dict]:
 
     elif engine == 'mistral':
         available_models = [{'id': 'voxtral-mini-tts-2603'}]
+
+    elif engine == 'minimax':
+        available_models = [{'id': model} for model in _MINIMAX_TTS_MODELS]
 
     return available_models
 

--- a/src/lib/components/admin/Settings/Audio.svelte
+++ b/src/lib/components/admin/Settings/Audio.svelte
@@ -45,6 +45,8 @@
 	let TTS_AZURE_SPEECH_OUTPUT_FORMAT = '';
 	let TTS_MISTRAL_API_KEY = '';
 	let TTS_MISTRAL_API_BASE_URL = '';
+	let TTS_MINIMAX_API_KEY = '';
+	let TTS_MINIMAX_API_BASE_URL = 'https://api.minimax.io/v1';
 
 	let STT_OPENAI_API_BASE_URL = '';
 	let STT_OPENAI_API_KEY = '';
@@ -157,6 +159,8 @@
 				AZURE_SPEECH_OUTPUT_FORMAT: TTS_AZURE_SPEECH_OUTPUT_FORMAT,
 				MISTRAL_API_KEY: TTS_MISTRAL_API_KEY,
 				MISTRAL_API_BASE_URL: TTS_MISTRAL_API_BASE_URL,
+				MINIMAX_API_KEY: TTS_MINIMAX_API_KEY,
+				MINIMAX_API_BASE_URL: TTS_MINIMAX_API_BASE_URL,
 				SPLIT_ON: TTS_SPLIT_ON
 			},
 			stt: {
@@ -212,6 +216,8 @@
 			TTS_AZURE_SPEECH_OUTPUT_FORMAT = res.tts.AZURE_SPEECH_OUTPUT_FORMAT;
 			TTS_MISTRAL_API_KEY = res.tts.MISTRAL_API_KEY;
 			TTS_MISTRAL_API_BASE_URL = res.tts.MISTRAL_API_BASE_URL;
+			TTS_MINIMAX_API_KEY = res.tts.MINIMAX_API_KEY ?? '';
+			TTS_MINIMAX_API_BASE_URL = res.tts.MINIMAX_API_BASE_URL || 'https://api.minimax.io/v1';
 
 			STT_OPENAI_API_BASE_URL = res.stt.OPENAI_API_BASE_URL;
 			STT_OPENAI_API_KEY = res.stt.OPENAI_API_KEY;
@@ -490,6 +496,9 @@
 						} else if (value === 'mistral') {
 							TTS_VOICE = '';
 							TTS_MODEL = 'voxtral-mini-tts-2603';
+						} else if (value === 'minimax') {
+							TTS_VOICE = '';
+							TTS_MODEL = 'speech-2.8-hd';
 						} else {
 							TTS_VOICE = '';
 							TTS_MODEL = '';
@@ -502,6 +511,7 @@
 					<option value="elevenlabs">{$i18n.t('ElevenLabs')}</option>
 					<option value="azure">{$i18n.t('Azure AI Speech')}</option>
 					<option value="mistral">{$i18n.t('MistralAI')}</option>
+					<option value="minimax">MiniMax</option>
 				</SettingsSelect>
 			</AdminSettingRow>
 
@@ -576,6 +586,30 @@
 						/>
 					</AdminSettingField>
 				</div>
+			{:else if TTS_ENGINE === 'minimax'}
+				<div class="grid grid-cols-1 gap-2 sm:grid-cols-2">
+					<AdminSettingField label={$i18n.t('API Base URL')}>
+						<input
+							list="tts-minimax-api-base-url-list"
+							class={inputClass}
+							placeholder={$i18n.t('API Base URL')}
+							bind:value={TTS_MINIMAX_API_BASE_URL}
+							required
+						/>
+						<datalist id="tts-minimax-api-base-url-list">
+							<option value="https://api.minimax.io/v1"></option>
+							<option value="https://api.minimaxi.com/v1"></option>
+						</datalist>
+					</AdminSettingField>
+					<AdminSettingField label={$i18n.t('API Key')}>
+						<SensitiveInput
+							variant="settings"
+							placeholder={$i18n.t('API Key')}
+							bind:value={TTS_MINIMAX_API_KEY}
+							required
+						/>
+					</AdminSettingField>
+				</div>
 			{/if}
 
 			{#if TTS_ENGINE === ''}
@@ -647,7 +681,7 @@
 						placeholder={$i18n.t('Enter additional parameters in JSON format')}
 					/>
 				</AdminSettingField>
-			{:else if TTS_ENGINE === 'elevenlabs' || TTS_ENGINE === 'mistral'}
+			{:else if TTS_ENGINE === 'elevenlabs' || TTS_ENGINE === 'mistral' || TTS_ENGINE === 'minimax'}
 				<div class="grid grid-cols-1 gap-2 sm:grid-cols-2">
 					<AdminSettingField label={$i18n.t('TTS Voice')}>
 						<TTSVoiceInput


### PR DESCRIPTION
Reason: Add MiniMax text-to-speech support through the regional HTTP APIs.

## Changes

- Add persistent MiniMax TTS endpoint and API key settings with global and China endpoint suggestions.
- Route speech requests through `/v1/t2a_v2`, include voice and MP3 audio settings, decode hex-encoded audio responses, and expose the supported speech models.
- Add MiniMax engine controls to the admin audio settings.

## Checks

- `.venv/bin/ruff format --check backend/open_webui/config.py backend/open_webui/routers/audio.py`
- `.venv/bin/ruff check --select E9,F63,F7,F82 backend/open_webui/config.py backend/open_webui/routers/audio.py`
- `python3 -m compileall -q backend/open_webui/config.py backend/open_webui/routers/audio.py`
- `./node_modules/.bin/prettier --check src/lib/components/admin/Settings/Audio.svelte`
- `npm run test:frontend -- --run`
- Secret scan on the committed diff
