### PR TITLE
perf: use the orjson codec on hot JSON paths

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -229,6 +229,7 @@ from open_webui.utils.chat_variables import (
     normalize_chat_variables,
 )
 from open_webui.utils.embeddings import generate_embeddings
+from open_webui.utils.json_codec import JSONCodec
 from open_webui.utils.json_response import apply_orjson_http_json
 from open_webui.utils.logger import start_logger
 from open_webui.utils.middleware import (
@@ -1842,7 +1843,7 @@ async def passthrough_anthropic_messages(request: Request, form_data: dict, user
         response = await session.request(
             method='POST',
             url=request_url,
-            data=json.dumps(payload),
+            data=JSONCodec.dumps(payload),
             headers=headers,
             cookies=cookies,
             ssl=AIOHTTP_CLIENT_SESSION_SSL,

--- a/backend/open_webui/retrieval/vector/dbs/mariadb_vector.py
+++ b/backend/open_webui/retrieval/vector/dbs/mariadb_vector.py
@@ -30,6 +30,7 @@ from open_webui.retrieval.vector.main import (
     VectorItem,
 )
 from open_webui.retrieval.vector.utils import process_metadata
+from open_webui.utils.json_codec import JSONCodec
 from sqlalchemy import create_engine
 from sqlalchemy.pool import NullPool, QueuePool
 
@@ -72,7 +73,7 @@ def _safe_json(v: Any) -> Dict[str, Any]:
             return {}
     if isinstance(v, str):
         try:
-            j = json.loads(v)
+            j = JSONCodec.loads(v)
             return j if isinstance(j, dict) else {}
         except Exception:
             return {}

--- a/backend/open_webui/retrieval/vector/dbs/oracle23ai.py
+++ b/backend/open_webui/retrieval/vector/dbs/oracle23ai.py
@@ -56,6 +56,7 @@ from open_webui.retrieval.vector.main import (
     VectorDBBase,
     VectorItem,
 )
+from open_webui.utils.json_codec import JSONCodec
 
 log = logging.getLogger(__name__)
 
@@ -390,7 +391,7 @@ class Oracle23aiClient(VectorDBBase):
         Returns:
             Dict: Metadata dictionary
         """
-        return json.loads(json_str) if json_str else {}
+        return JSONCodec.loads(json_str) if json_str else {}
 
     def insert(self, collection_name: str, items: List[VectorItem]) -> None:
         """

--- a/backend/open_webui/retrieval/vector/dbs/valkey.py
+++ b/backend/open_webui/retrieval/vector/dbs/valkey.py
@@ -2,7 +2,6 @@
 # Requires Valkey core >= 9.0.1 with the valkey-search module >= 1.2.0 loaded.
 
 import atexit
-import json
 import logging
 import re
 import struct
@@ -24,6 +23,7 @@ from open_webui.retrieval.vector.main import (
     VectorItem,
 )
 from open_webui.retrieval.vector.utils import process_metadata
+from open_webui.utils.json_codec import JSONCodec
 
 log = logging.getLogger(__name__)
 
@@ -482,7 +482,7 @@ class ValkeyClient(VectorDBBase):
                 'id': item['id'],
                 'vector': _vector_to_bytes(item['vector']),
                 'text': item['text'],
-                'metadata_json': json.dumps(metadata),
+                'metadata_json': JSONCodec.dumps(metadata),
                 # `or ''` prevents indexing literal 'None' as a TAG value, which would
                 # poison $ne / equality queries.
                 'hash': str(metadata.get('hash') or ''),
@@ -588,8 +588,8 @@ class ValkeyClient(VectorDBBase):
                     ids.append(_decode(fields.get(b'id', b'')))
                     documents.append(_decode(fields.get(b'text', b'')))
                     try:
-                        metadatas.append(json.loads(_decode(fields.get(b'metadata_json', b'{}'))))
-                    except (json.JSONDecodeError, TypeError):
+                        metadatas.append(JSONCodec.loads(_decode(fields.get(b'metadata_json', b'{}'))))
+                    except (ValueError, TypeError):
                         metadatas.append({})
                     if limit is not None and limit > 0 and len(ids) >= limit:
                         return GetResult(ids=[ids], documents=[documents], metadatas=[metadatas])
@@ -734,8 +734,8 @@ class ValkeyClient(VectorDBBase):
             ids.append(_decode(fields.get(b'id', b'')))
             documents.append(_decode(fields.get(b'text', b'')))
             try:
-                metadatas.append(json.loads(_decode(fields.get(b'metadata_json', b'{}'))))
-            except (json.JSONDecodeError, TypeError):
+                metadatas.append(JSONCodec.loads(_decode(fields.get(b'metadata_json', b'{}'))))
+            except (ValueError, TypeError):
                 metadatas.append({})
 
             if include_score:

--- a/backend/open_webui/routers/ollama.py
+++ b/backend/open_webui/routers/ollama.py
@@ -1149,7 +1149,7 @@ async def generate_chat_completion(
 
     return await send_request(
         f'{url}/api/chat',
-        payload=json.dumps(payload),
+        payload=JSONCodec.dumps(payload),
         key=get_api_key(url_idx, url, api_configs),
         user=user,
         stream=form_data.stream,
@@ -1244,7 +1244,7 @@ async def generate_openai_completion(
 
     return await send_request(
         f'{url}/v1/completions',
-        payload=json.dumps(payload),
+        payload=JSONCodec.dumps(payload),
         key=get_api_key(url_idx, url, api_configs),
         user=user,
         stream=payload.get('stream', False),
@@ -1295,7 +1295,7 @@ async def generate_openai_embeddings(
 
     return await send_request(
         f'{url}/v1/embeddings',
-        payload=json.dumps(payload),
+        payload=JSONCodec.dumps(payload),
         key=get_api_key(url_idx, url, (await Config.get('ollama.api_configs', {}))),
         user=user,
         metadata=metadata,
@@ -1352,7 +1352,7 @@ async def generate_openai_chat_completion(
 
     return await send_request(
         f'{url}/v1/chat/completions',
-        payload=json.dumps(payload),
+        payload=JSONCodec.dumps(payload),
         key=get_api_key(url_idx, url, api_configs),
         user=user,
         stream=payload.get('stream', False),
@@ -1404,7 +1404,7 @@ async def generate_anthropic_messages(
 
     return await send_request(
         f'{url}/v1/messages',
-        payload=json.dumps(payload),
+        payload=JSONCodec.dumps(payload),
         key=get_api_key(url_idx, url, api_configs),
         user=user,
         stream=payload.get('stream', False),
@@ -1462,7 +1462,7 @@ async def generate_responses(
 
     return await send_request(
         f'{url}/v1/responses',
-        payload=json.dumps(payload),
+        payload=JSONCodec.dumps(payload),
         key=get_api_key(url_idx, url, api_configs),
         user=user,
         stream=payload.get('stream', False),

--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -353,7 +353,7 @@ async def count_anthropic_tokens(request: Request, form_data: dict, user: UserMo
         response = await session.request(
             method='POST',
             url=request_url,
-            data=json.dumps(payload),
+            data=JSONCodec.dumps(payload),
             headers=headers,
             cookies=cookies,
             ssl=AIOHTTP_CLIENT_SESSION_SSL,
@@ -1338,7 +1338,7 @@ async def generate_chat_completion(
     if not is_streaming_request:
         payload.pop('stream_options', None)
 
-    payload = json.dumps(payload)
+    payload = JSONCodec.dumps(payload)
 
     r = None
     streaming = False
@@ -1458,7 +1458,7 @@ async def embeddings(request: Request, form_data: dict, user):
     """
     idx = 0
     # Prepare payload/body
-    body = json.dumps(form_data)
+    body = JSONCodec.dumps(form_data)
     # Find correct backend url/key based on model
     model_id = form_data.get('model')
     # Check if model is already in app state cache to avoid expensive get_all_models() call
@@ -1589,7 +1589,7 @@ async def responses(
     # Enforce per-model access control
     await check_model_access(user, await Models.get_model_by_id(model_id), BYPASS_MODEL_ACCESS_CONTROL)
 
-    body = json.dumps(payload)
+    body = JSONCodec.dumps(payload)
 
     if model_id:
         models = request.app.state.OPENAI_MODELS

--- a/backend/open_webui/utils/access_control/__init__.py
+++ b/backend/open_webui/utils/access_control/__init__.py
@@ -1,4 +1,3 @@
-import json
 from typing import Any
 
 from open_webui.config import DEFAULT_USER_PERMISSIONS
@@ -12,6 +11,7 @@ from open_webui.models.access_grants import (
 )
 from open_webui.models.groups import Groups
 from open_webui.models.users import UserModel
+from open_webui.utils.json_codec import JSONCodec
 from sqlalchemy.ext.asyncio import AsyncSession
 
 
@@ -57,7 +57,7 @@ async def get_permissions(
     user_groups = await Groups.get_groups_by_member_id(user_id, db=db)
 
     # Deep copy default permissions to avoid modifying the original dict
-    permissions = json.loads(json.dumps(default_permissions))
+    permissions = JSONCodec.loads(JSONCodec.dumps(default_permissions))
 
     # Combine permissions from all user groups
     for group in user_groups:

--- a/backend/open_webui/utils/anthropic.py
+++ b/backend/open_webui/utils/anthropic.py
@@ -9,6 +9,7 @@ from open_webui.env import (
 )
 from open_webui.models.users import UserModel
 from open_webui.utils.headers import include_user_info_headers
+from open_webui.utils.json_codec import JSONCodec
 
 log = logging.getLogger(__name__)
 
@@ -663,8 +664,8 @@ async def openai_stream_to_anthropic_stream(openai_stream_generator, model: str 
                     continue
 
                 try:
-                    data = json.loads(data_string)
-                except (json.JSONDecodeError, TypeError):
+                    data = JSONCodec.loads(data_string)
+                except (ValueError, TypeError):
                     continue
 
                 usage_data = data.get('usage')

--- a/backend/open_webui/utils/code_interpreter.py
+++ b/backend/open_webui/utils/code_interpreter.py
@@ -7,6 +7,7 @@ from typing import Optional
 import aiohttp
 import websockets
 from open_webui.env import AIOHTTP_CLIENT_ALLOW_REDIRECTS
+from open_webui.utils.json_codec import JSONCodec
 from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
@@ -157,7 +158,7 @@ class JupyterCodeExecuter:
             try:
                 # wait for message
                 message = await asyncio.wait_for(ws.recv(), self.timeout)
-                message_data = json.loads(message)
+                message_data = JSONCodec.loads(message)
                 # msg id not match, skip
                 if message_data.get('parent_header', {}).get('msg_id') != msg_id:
                     continue


### PR DESCRIPTION
`JSONCodec` (`utils/json_codec.py`) already selects orjson when `ENABLE_ORJSON` is set, but most call sites still reach for stdlib `json` directly. This routes the hot ones through it: outbound provider request bodies, the per-frame parse of the upstream Anthropic SSE stream, the permission deep copy, the Jupyter kernel message loop, and vector-metadata reads.

Scope rule: hot inference, streaming and per-result-row paths only. Admin model management (`/api/pull`, `/api/delete`, `/api/unload`, `/api/show`), model download and upload progress events, and error paths keep stdlib. Their payloads are fixed two-key dicts where codec dispatch costs about what it saves.

Only calls passing no keyword arguments are converted. orjson accepts none of stdlib's, so a call carrying `default=` or `ensure_ascii=` gains nothing and risks losing the kwarg. `oracle23ai._metadata_to_json` keeps stdlib for that reason (`default=self._decimal_handler`) while its read counterpart is converted.

Two `except (json.JSONDecodeError, TypeError)` clauses guarding converted reads widen to `except (ValueError, TypeError)`. The codec falls back to engineio's codec, which installs `parse_int=_safe_int` and raises a bare `ValueError` for integer literals longer than 100 characters. The narrower clause would have let that escape and abort a stream or a search on input that previously parsed fine.

`mariadb_vector` converts the metadata read but not the two metadata writes, which were out of scope here; leaving them on stdlib is behaviour-preserving. `_safe_json` decodes escaped and raw UTF-8 identically and the `JSON_UNQUOTE(JSON_EXTRACT(...))` filter is escape-agnostic, so the mixed encoding on disk is invisible to every reader.

Worth knowing before enabling the flag: on the converted reads an integer literal above uint64 max comes back as a float rather than an exact int. All four feed search results and citations and none re-serializes what it returned, so nothing is written back lossily.

With `ENABLE_ORJSON` unset, which is the default, `JSONCodec` is stdlib `json` and every one of these call sites behaves exactly as before.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
