### PR TITLE
perf: use the orjson codec for outbound OpenAI request bodies

### DIFF
--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -353,7 +353,7 @@ async def count_anthropic_tokens(request: Request, form_data: dict, user: UserMo
         response = await session.request(
             method='POST',
             url=request_url,
-            data=json.dumps(payload),
+            data=JSONCodec.dumps(payload),
             headers=headers,
             cookies=cookies,
             ssl=AIOHTTP_CLIENT_SESSION_SSL,
@@ -1338,7 +1338,7 @@ async def generate_chat_completion(
     if not is_streaming_request:
         payload.pop('stream_options', None)
 
-    payload = json.dumps(payload)
+    payload = JSONCodec.dumps(payload)
 
     r = None
     streaming = False
@@ -1458,7 +1458,7 @@ async def embeddings(request: Request, form_data: dict, user):
     """
     idx = 0
     # Prepare payload/body
-    body = json.dumps(form_data)
+    body = JSONCodec.dumps(form_data)
     # Find correct backend url/key based on model
     model_id = form_data.get('model')
     # Check if model is already in app state cache to avoid expensive get_all_models() call
@@ -1589,7 +1589,7 @@ async def responses(
     # Enforce per-model access control
     await check_model_access(user, await Models.get_model_by_id(model_id), BYPASS_MODEL_ACCESS_CONTROL)
 
-    body = json.dumps(payload)
+    body = JSONCodec.dumps(payload)
 
     if model_id:
         models = request.app.state.OPENAI_MODELS


### PR DESCRIPTION
`routers/openai.py` builds the outbound request body with stdlib `json` on four paths: chat completions, the Anthropic token count, embeddings, and responses. Chat completions carries the full conversation including any base64 images, so it is the largest single serialization on an ordinary request.

All four now go through `JSONCodec`, which selects orjson when `ENABLE_ORJSON` is set. Each result is handed straight to aiohttp as `data=`, which encodes `str` as UTF-8 and derives `Content-Length` from the encoded bytes, so raw non-ASCII on the wire is correct. None of the four is hashed, cached, length-measured or persisted. The speech-cache sidecar write and the sha256 cache key over the raw inbound body are untouched, as is the deprecated passthrough proxy.

Compact separators and raw UTF-8 are already what the official `openai-python` and `anthropic-python` clients send to these endpoints, since httpx serializes with `ensure_ascii=False, separators=(',', ':')`.

With `ENABLE_ORJSON` unset, which is the default, `JSONCodec` is stdlib `json` and this call site behaves exactly as before.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
