### PR TITLE
perf: use the orjson codec to parse MariaDB vector metadata

### DIFF
--- a/backend/open_webui/retrieval/vector/dbs/mariadb_vector.py
+++ b/backend/open_webui/retrieval/vector/dbs/mariadb_vector.py
@@ -30,6 +30,7 @@ from open_webui.retrieval.vector.main import (
     VectorItem,
 )
 from open_webui.retrieval.vector.utils import process_metadata
+from open_webui.utils.json_codec import JSONCodec
 from sqlalchemy import create_engine
 from sqlalchemy.pool import NullPool, QueuePool
 
@@ -72,7 +73,7 @@ def _safe_json(v: Any) -> Dict[str, Any]:
             return {}
     if isinstance(v, str):
         try:
-            j = json.loads(v)
+            j = JSONCodec.loads(v)
             return j if isinstance(j, dict) else {}
         except Exception:
             return {}


### PR DESCRIPTION
`_safe_json` parses the metadata of every result row returned by search and get. It now goes through `JSONCodec`, which selects orjson when `ENABLE_ORJSON` is set.

Only the read is converted. The two metadata writes stay on stdlib, which is behaviour-preserving and keeps this change to a single call site. Nothing depends on the two matching: `_safe_json` decodes escaped and raw UTF-8 to the same object, and the query filter uses `JSON_UNQUOTE(JSON_EXTRACT(...))`, which MariaDB evaluates against the parsed value rather than the stored text. So a mix of old and new rows reads identically and no migration is needed.

The surrounding `except Exception` is unchanged and already covers every exception either backend can raise.

With `ENABLE_ORJSON` unset, which is the default, `JSONCodec` is stdlib `json` and this call site behaves exactly as before.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
