### PR TITLE
perf: use the orjson codec to parse upstream Anthropic stream frames

### DIFF
--- a/backend/open_webui/utils/anthropic.py
+++ b/backend/open_webui/utils/anthropic.py
@@ -9,6 +9,7 @@ from open_webui.env import (
 )
 from open_webui.models.users import UserModel
 from open_webui.utils.headers import include_user_info_headers
+from open_webui.utils.json_codec import JSONCodec
 
 log = logging.getLogger(__name__)
 
@@ -663,8 +664,8 @@ async def openai_stream_to_anthropic_stream(openai_stream_generator, model: str 
                     continue
 
                 try:
-                    data = json.loads(data_string)
-                except (json.JSONDecodeError, TypeError):
+                    data = JSONCodec.loads(data_string)
+                except (ValueError, TypeError):
                     continue
 
                 usage_data = data.get('usage')


### PR DESCRIPTION
`openai_stream_to_anthropic_stream` parses every frame of the upstream SSE stream with stdlib `json`. That is the hottest JSON call in the module, once per chunk for the whole response.

It now goes through `JSONCodec`, which selects orjson when `ENABLE_ORJSON` is set. Only strings and small integers are read out of the parsed frame, and the parsed value is not re-serialized, so there is no round-trip that could alter what reaches the client.

The frame's `except` clause widens from `(json.JSONDecodeError, TypeError)` to `(ValueError, TypeError)`. The codec falls back to engineio's codec, which installs `parse_int=_safe_int` and raises a bare `ValueError` for integer literals longer than 100 characters. The narrower clause would have let that escape and abort an in-flight stream on input that previously just skipped a chunk. `json.JSONDecodeError` is a `ValueError` subclass, so the new clause is a strict superset of the old one.

The SSE frames this module writes keep stdlib `json`, as does the tool-argument parse, which is deliberately left for a separate change.

With `ENABLE_ORJSON` unset, which is the default, `JSONCodec` is stdlib `json` and this call site behaves exactly as before.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
