### PR TITLE
perf: use the orjson codec for outbound Ollama request bodies

### DIFF
--- a/backend/open_webui/routers/ollama.py
+++ b/backend/open_webui/routers/ollama.py
@@ -1149,7 +1149,7 @@ async def generate_chat_completion(
 
     return await send_request(
         f'{url}/api/chat',
-        payload=json.dumps(payload),
+        payload=JSONCodec.dumps(payload),
         key=get_api_key(url_idx, url, api_configs),
         user=user,
         stream=form_data.stream,
@@ -1244,7 +1244,7 @@ async def generate_openai_completion(
 
     return await send_request(
         f'{url}/v1/completions',
-        payload=json.dumps(payload),
+        payload=JSONCodec.dumps(payload),
         key=get_api_key(url_idx, url, api_configs),
         user=user,
         stream=payload.get('stream', False),
@@ -1295,7 +1295,7 @@ async def generate_openai_embeddings(
 
     return await send_request(
         f'{url}/v1/embeddings',
-        payload=json.dumps(payload),
+        payload=JSONCodec.dumps(payload),
         key=get_api_key(url_idx, url, (await Config.get('ollama.api_configs', {}))),
         user=user,
         metadata=metadata,
@@ -1352,7 +1352,7 @@ async def generate_openai_chat_completion(
 
     return await send_request(
         f'{url}/v1/chat/completions',
-        payload=json.dumps(payload),
+        payload=JSONCodec.dumps(payload),
         key=get_api_key(url_idx, url, api_configs),
         user=user,
         stream=payload.get('stream', False),
@@ -1404,7 +1404,7 @@ async def generate_anthropic_messages(
 
     return await send_request(
         f'{url}/v1/messages',
-        payload=json.dumps(payload),
+        payload=JSONCodec.dumps(payload),
         key=get_api_key(url_idx, url, api_configs),
         user=user,
         stream=payload.get('stream', False),
@@ -1462,7 +1462,7 @@ async def generate_responses(
 
     return await send_request(
         f'{url}/v1/responses',
-        payload=json.dumps(payload),
+        payload=JSONCodec.dumps(payload),
         key=get_api_key(url_idx, url, api_configs),
         user=user,
         stream=payload.get('stream', False),


### PR DESCRIPTION
`routers/ollama.py` serializes the outbound body with stdlib `json` on six inference paths: `/api/chat`, the OpenAI-compatible completions and chat completions proxies, embeddings, the Anthropic messages proxy, and responses. All six carry a full conversation or an embedding batch.

They now go through `JSONCodec`, which selects orjson when `ENABLE_ORJSON` is set. Every one is passed to `send_request`, which hands it to aiohttp as `data=`; aiohttp encodes `str` as UTF-8 and derives `Content-Length` from the encoded bytes. None is hashed, cached, length-measured or persisted.

Admin model management keeps stdlib: `/api/unload`, `/api/pull`, `/api/delete` and `/api/show` serialize fixed one- or two-key dicts, as do the blob download and upload progress events and the error frames. Codec dispatch on those costs about what it saves.

With `ENABLE_ORJSON` unset, which is the default, `JSONCodec` is stdlib `json` and this call site behaves exactly as before.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
