### PR TITLE
perf: use the orjson codec to parse Jupyter kernel messages

### DIFF
--- a/backend/open_webui/utils/code_interpreter.py
+++ b/backend/open_webui/utils/code_interpreter.py
@@ -7,6 +7,7 @@ from typing import Optional
 import aiohttp
 import websockets
 from open_webui.env import AIOHTTP_CLIENT_ALLOW_REDIRECTS
+from open_webui.utils.json_codec import JSONCodec
 from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
@@ -157,7 +158,7 @@ class JupyterCodeExecuter:
             try:
                 # wait for message
                 message = await asyncio.wait_for(ws.recv(), self.timeout)
-                message_data = json.loads(message)
+                message_data = JSONCodec.loads(message)
                 # msg id not match, skip
                 if message_data.get('parent_header', {}).get('msg_id') != msg_id:
                     continue


### PR DESCRIPTION
The code interpreter parses every message from the Jupyter kernel websocket with stdlib `json`, in a loop that runs for the duration of an execution. Messages carrying large stdout or a base64 image payload are the expensive ones.

It now goes through `JSONCodec`, which selects orjson when `ENABLE_ORJSON` is set. Every consumer of the parsed message reads strings only: `content.text`, `content.data['text/plain']` and `['image/png']`, `content.traceback`, and `content.execution_state`. Jupyter renders large integers into `text/plain` as strings rather than JSON numbers, so no numeric round trip is involved.

The one-shot `execute_request` message this module sends keeps stdlib `json`; it is a small fixed-shape dict sent once per execution.

With `ENABLE_ORJSON` unset, which is the default, `JSONCodec` is stdlib `json` and this call site behaves exactly as before.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
