### PR TITLE
chore: remove dead json imports

### DIFF
--- a/backend/open_webui/models/channels.py
+++ b/backend/open_webui/models/channels.py
@@ -1,4 +1,3 @@
-import json
 import secrets
 import time
 import uuid

--- a/backend/open_webui/models/chat_messages.py
+++ b/backend/open_webui/models/chat_messages.py
@@ -1,4 +1,3 @@
-import json
 import time
 import uuid
 from collections import Counter

--- a/backend/open_webui/models/groups.py
+++ b/backend/open_webui/models/groups.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import time
 import uuid

--- a/backend/open_webui/models/knowledge.py
+++ b/backend/open_webui/models/knowledge.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import time
 import uuid

--- a/backend/open_webui/models/messages.py
+++ b/backend/open_webui/models/messages.py
@@ -1,4 +1,3 @@
-import json
 import time
 import uuid
 from typing import Optional

--- a/backend/open_webui/models/notes.py
+++ b/backend/open_webui/models/notes.py
@@ -1,4 +1,3 @@
-import json
 import time
 import uuid
 from functools import lru_cache

--- a/backend/open_webui/models/prompt_history.py
+++ b/backend/open_webui/models/prompt_history.py
@@ -1,7 +1,6 @@
 """Prompt history model for version tracking."""
 
 import difflib
-import json
 import time
 import uuid
 from typing import Optional

--- a/backend/open_webui/retrieval/vector/dbs/opengauss.py
+++ b/backend/open_webui/retrieval/vector/dbs/opengauss.py
@@ -2,7 +2,6 @@
 NOTE: This vector database integration is community-supported and maintained on a best-effort basis.
 """
 
-import json
 import logging
 import re
 from typing import Any, Dict, List, Optional

--- a/backend/open_webui/routers/channels.py
+++ b/backend/open_webui/routers/channels.py
@@ -1,6 +1,5 @@
 import base64
 import io
-import json
 import logging
 from typing import Optional
 

--- a/backend/open_webui/routers/chats.py
+++ b/backend/open_webui/routers/chats.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
 from typing import Optional
 from uuid import uuid4

--- a/backend/open_webui/routers/models.py
+++ b/backend/open_webui/routers/models.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import base64
 import io
-import json
 import logging
 import posixpath
 from typing import Optional

--- a/backend/open_webui/routers/notes.py
+++ b/backend/open_webui/routers/notes.py
@@ -1,4 +1,3 @@
-import json
 import logging
 from typing import Optional
 from uuid import uuid4

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
 import mimetypes
 import os

--- a/backend/open_webui/tools/knowledge_fs.py
+++ b/backend/open_webui/tools/knowledge_fs.py
@@ -8,7 +8,6 @@ Re-exported through builtin.py for consistent imports.
 """
 
 import contextvars
-import json
 import logging
 import re
 import shlex


### PR DESCRIPTION
Fourteen modules import `json` without using it. Ruff flags every one with F401, and a word-boundary search for `json` in each file matches only the import line itself, including inside strings, comments and annotations.

Two exclusions, both deliberate. Migration files are left alone: the import is equally dead there, but those files are frozen history and not worth the churn. `models/chats.py` has the same dead import and is handled in its own change, so it is skipped here to avoid two changes touching the same line.

No behaviour change.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
