### PR TITLE
correctness fix: escape line separators in orjson output

### DIFF
--- a/backend/open_webui/utils/json_codec.py
+++ b/backend/open_webui/utils/json_codec.py
@@ -17,6 +17,11 @@ from open_webui.env import ENABLE_ORJSON
 if ENABLE_ORJSON:
     import orjson
 
+    # stdlib escapes these, orjson emits them raw, and Python treats all three as
+    # line boundaries: one raw separator splits an SSE frame that a reader
+    # reassembles with ``splitlines()``.
+    LINE_SEPARATOR_ESCAPES = str.maketrans({'\u2028': '\\u2028', '\u2029': '\\u2029', '\x85': '\\u0085'})
+
     class ORJSONCodec:
         """stdlib-``json``-compatible codec backed by orjson.
 
@@ -30,9 +35,12 @@ if ENABLE_ORJSON:
         @staticmethod
         def dumps(obj, *args, **kwargs):
             try:
-                return orjson.dumps(obj).decode('utf-8')
+                serialized = orjson.dumps(obj).decode('utf-8')
             except (TypeError, ValueError):
                 return engineio_json.dumps(obj, *args, **kwargs)
+            if '\u2028' in serialized or '\u2029' in serialized or '\x85' in serialized:
+                return serialized.translate(LINE_SEPARATOR_ESCAPES)
+            return serialized
 
         @staticmethod
         def loads(s, *args, **kwargs):


### PR DESCRIPTION


### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
