### PR TITLE
perf: read the model pool with one HGETALL instead of one HGET per model

### DIFF
--- a/backend/open_webui/routers/tasks.py
+++ b/backend/open_webui/routers/tasks.py
@@ -117,7 +117,7 @@ async def generate_title(request: Request, form_data: dict, user=Depends(get_ver
 
     if getattr(request.state, 'direct', False) and hasattr(request.state, 'model'):
         models = {
-            **request.app.state.MODELS,
+            **dict(request.app.state.MODELS.items()),
             request.state.model['id']: request.state.model,
         }
     else:
@@ -201,7 +201,7 @@ async def generate_follow_ups(request: Request, form_data: dict, user=Depends(ge
 
     if getattr(request.state, 'direct', False) and hasattr(request.state, 'model'):
         models = {
-            **request.app.state.MODELS,
+            **dict(request.app.state.MODELS.items()),
             request.state.model['id']: request.state.model,
         }
     else:
@@ -271,7 +271,7 @@ async def generate_chat_tags(request: Request, form_data: dict, user=Depends(get
 
     if getattr(request.state, 'direct', False) and hasattr(request.state, 'model'):
         models = {
-            **request.app.state.MODELS,
+            **dict(request.app.state.MODELS.items()),
             request.state.model['id']: request.state.model,
         }
     else:
@@ -335,7 +335,7 @@ async def generate_chat_tags(request: Request, form_data: dict, user=Depends(get
 async def generate_image_prompt(request: Request, form_data: dict, user=Depends(get_verified_user)):
     if getattr(request.state, 'direct', False) and hasattr(request.state, 'model'):
         models = {
-            **request.app.state.MODELS,
+            **dict(request.app.state.MODELS.items()),
             request.state.model['id']: request.state.model,
         }
     else:
@@ -417,7 +417,7 @@ async def generate_queries(request: Request, form_data: dict, user=Depends(get_v
 
     if getattr(request.state, 'direct', False) and hasattr(request.state, 'model'):
         models = {
-            **request.app.state.MODELS,
+            **dict(request.app.state.MODELS.items()),
             request.state.model['id']: request.state.model,
         }
     else:
@@ -498,7 +498,7 @@ async def generate_autocompletion(request: Request, form_data: dict, user=Depend
 
     if getattr(request.state, 'direct', False) and hasattr(request.state, 'model'):
         models = {
-            **request.app.state.MODELS,
+            **dict(request.app.state.MODELS.items()),
             request.state.model['id']: request.state.model,
         }
     else:
@@ -562,7 +562,7 @@ async def generate_autocompletion(request: Request, form_data: dict, user=Depend
 async def generate_emoji(request: Request, form_data: dict, user=Depends(get_verified_user)):
     if getattr(request.state, 'direct', False) and hasattr(request.state, 'model'):
         models = {
-            **request.app.state.MODELS,
+            **dict(request.app.state.MODELS.items()),
             request.state.model['id']: request.state.model,
         }
     else:
@@ -628,7 +628,7 @@ async def generate_emoji(request: Request, form_data: dict, user=Depends(get_ver
 async def generate_moa_response(request: Request, form_data: dict, user=Depends(get_verified_user)):
     if getattr(request.state, 'direct', False) and hasattr(request.state, 'model'):
         models = {
-            **request.app.state.MODELS,
+            **dict(request.app.state.MODELS.items()),
             request.state.model['id']: request.state.model,
         }
     else:

--- a/backend/open_webui/utils/chat.py
+++ b/backend/open_webui/utils/chat.py
@@ -316,7 +316,7 @@ async def chat_completed(request: Request, form_data: dict, user: Any):
 
     if getattr(request.state, 'direct', False) and hasattr(request.state, 'model'):
         models = {
-            **request.app.state.MODELS,
+            **dict(request.app.state.MODELS.items()),
             request.state.model['id']: request.state.model,
         }
     else:

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2347,7 +2347,7 @@ async def process_chat_payload(request, form_data, user, metadata, model):
     if is_saved_chat_id(chat_id) and user_message_id:
         if getattr(request.state, 'direct', False) and hasattr(request.state, 'model'):
             compaction_models = {
-                **request.app.state.MODELS,
+                **dict(request.app.state.MODELS.items()),
                 request.state.model['id']: request.state.model,
             }
         else:


### PR DESCRIPTION
Every background task on an ordinary chat turn (title generation, tags, follow-up, autocomplete, query generation) reads the model list out of Redis one model at a time, and freezes the worker while it does.

**Today.** `request.app.state.MODELS` is a `RedisDict` backed by a Redis hash. Unpacking it with `{**pool}` goes through the mapping protocol, so Python calls `keys()` once and then `__getitem__` once per key. That is one HKEYS followed by one HGET per model. The client is synchronous, so they land back to back on the event loop thread.

**After.** `RedisDict.items()` is a single HGETALL, so `dict(pool.items())` returns the same mapping in one command.

| deployment with 200 models | before | after |
|---|---|---|
| Redis commands per call | 201 (1 HKEYS + 200 HGET) | 1 (HGETALL) |
| at 0.2 ms RTT, Redis on the same host | ~40 ms | ~0.2 ms |
| at 1 ms RTT, managed Redis across an AZ | ~200 ms | ~1 ms |

The command counts are measured. The times are simply that count multiplied by your Redis round-trip latency, so they scale with where Redis lives and how many models you have. The part that matters is not the latency of this one request: because the client is synchronous, that is time the worker spends unable to serve anybody else, so every other user's stream on that worker stops for the duration.

`utils/chat.py:184` already does exactly this and carries a comment explaining why. The other ten call sites were missed, so this applies the same fix to them.

**Behaviour is unchanged.** The merged mapping is identical, the explicitly added direct model still overrides a pool entry with the same id, and when Redis is not configured the pool is a plain dict where `dict(d.items())` and `{**d}` are equivalent.

**It also closes a race.** `RedisDict.set` writes with HSET and then HDELs the now-stale keys. A key returned by HKEYS could therefore be deleted before its HGET arrived, raising `KeyError` out of the dict literal and failing the request. In practice that meant a chat request could fail outright if it landed during a model-list refresh, and a request that survived could still see a mix of pre- and post-refresh entries. HGETALL is atomic, so callers now always get one coherent snapshot.

**What to expect after merging:** nothing to configure and no migration. On a small instance with a handful of models you will not notice. The saving grows with model count and with Redis latency, and it is largest exactly when the instance is busiest.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
