### PR TITLE
perf: index group_member on (user_id, group_id)

### DIFF
--- a/backend/open_webui/migrations/versions/1ce6ade7d93b_add_group_member_user_id_index.py
+++ b/backend/open_webui/migrations/versions/1ce6ade7d93b_add_group_member_user_id_index.py
@@ -1,0 +1,28 @@
+"""Add group_member user_id index
+
+Revision ID: 1ce6ade7d93b
+Revises: f0bd01a18a3d
+Create Date: 2026-07-31 03:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = '1ce6ade7d93b'
+down_revision = 'f0bd01a18a3d'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    existing_indexes = {idx['name'] for idx in inspector.get_indexes('group_member')}
+
+    if 'ix_group_member_user_id_group_id' not in existing_indexes:
+        op.create_index('ix_group_member_user_id_group_id', 'group_member', ['user_id', 'group_id'])
+
+
+def downgrade():
+    op.drop_index('ix_group_member_user_id_group_id', table_name='group_member')

--- a/backend/open_webui/models/groups.py
+++ b/backend/open_webui/models/groups.py
@@ -13,6 +13,7 @@ from sqlalchemy import (
     BigInteger,
     Column,
     ForeignKey,
+    Index,
     String,
     Text,
     and_,
@@ -72,6 +73,8 @@ class GroupModel(BaseModel):
 
 class GroupMember(Base):
     __tablename__ = 'group_member'
+    # The table's (group_id, user_id) unique constraint cannot serve user_id lookups.
+    __table_args__ = (Index('ix_group_member_user_id_group_id', 'user_id', 'group_id'),)
 
     id = Column(Text, unique=True, primary_key=True)
     group_id = Column(


### PR DESCRIPTION
Permission checks are the most repeated database work in a request, and every one of them asks the same question: which groups is this user in. Today that question cannot use an index.

`group_member` has only its primary key and a `(group_id, user_id)` unique constraint. That constraint leads on `group_id`, so a lookup by `user_id` has to walk the entire membership table, every time. `Groups.get_groups_by_member_id` sits under `has_permission`, `has_access`, `check_model_access` and the `AccessGrants` fallbacks, so an ordinary chat completion pays that walk several times before the model is even called, and the admin user list pays it once per row.

The cost scales with total memberships across all users rather than with the size of any one user's, so it stays invisible on a small instance and then arrives all at once on a large one.

Measured on SQLite, timing the real join from `get_groups_by_member_id`:

| memberships | before | after |
|---|---|---|
| 5,000 | 0.04 ms | 0.03 ms |
| 50,000 | 0.10 ms | 0.04 ms |
| 200,000 | 1.33 ms | 0.04 ms |
| 500,000 | 2.94 ms | 0.04 ms |

The after column is flat because the lookup becomes a seek instead of a scan. Concretely: on a deployment with 500k memberships, say 10,000 users in 50 groups each, one chat completion currently spends roughly 15 ms of database time answering the same question over and over. Afterwards it is under 0.2 ms. On a small install you will not be able to measure the difference, and that is fine, the point is that the curve stops bending.

The index is `(user_id, group_id)`. The trailing column makes those lookups index-only, since `group_id` is the column they select. Queries that lead on `group_id`, such as `get_group_user_ids_by_id` and the `chat_messages` subqueries, are already served by the existing unique constraint and are unaffected.

What to expect when the migration runs: on PostgreSQL this is a plain `CREATE INDEX`, which takes a SHARE lock, so reads continue while writes to `group_member` block until it completes. The table holds one row per membership, so expect sub-second even on the numbers above. `CONCURRENTLY` cannot be used here because the migration runner wraps the upgrade in a transaction, and it is not warranted at this table size.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
