### PR TITLE
perf: take the orjson fast path for ensure_ascii=False callers

### DIFF
--- a/backend/open_webui/utils/json_codec.py
+++ b/backend/open_webui/utils/json_codec.py
@@ -16,25 +16,36 @@ from open_webui.env import ENABLE_ORJSON
 if ENABLE_ORJSON:
     import orjson
 
-    # stdlib escapes these, orjson emits them raw, and Python treats all three as
-    # line boundaries: one raw separator splits an SSE frame that a reader
-    # reassembles with ``splitlines()``.
+    # orjson emits these raw and Python treats all three as line boundaries: one raw
+    # separator splits an SSE frame reassembled with ``splitlines()``. Escaped even
+    # where stdlib would not.
     LINE_SEPARATOR_ESCAPES = str.maketrans({'\u2028': '\\u2028', '\u2029': '\\u2029', '\x85': '\\u0085'})
+
+    # Module-level because CPython rebuilds these dicts on every call.
+    FAST_PATH_KWARGS = ({'separators': (',', ':')}, {'ensure_ascii': False})
 
     class ORJSONCodec:
         """stdlib-``json``-compatible codec backed by orjson.
 
-        Anything orjson rejects (non-str dict keys, ints beyond 64 bits, ``NaN``
-        literals) falls back to engineio's stdlib-based codec, which keeps its
-        oversized-integer guard for untrusted client payloads.
+        The fast path is not byte-for-byte stdlib: it is always compact, formats
+        floats orjson's way (``1e16``, not ``1e+16``), and is raw UTF-8 apart from
+        the three line separators escaped above, so a ``separators`` caller loses
+        stdlib's ASCII escaping and an ``ensure_ascii=False`` caller loses its
+        spacing. ``dumps`` also serializes ``datetime``/``UUID``/dataclasses that
+        stdlib refuses, and encodes ``NaN``/``Infinity`` as ``null``. ``loads``
+        decodes integers above ``2**64-1`` or below ``-2**63`` as ``float`` and does
+        not enforce engineio's 100-digit integer-literal limit.
+
+        What orjson does reject (non-str dict keys and oversized ints on ``dumps``,
+        the ``NaN``/``Infinity`` literals on ``loads``) falls back to engineio's
+        stdlib-based codec, and with it stdlib's formatting.
         """
 
         JSONDecodeError = engineio_json.JSONDecodeError
 
         @staticmethod
         def dumps(obj, *args, **kwargs):
-            # orjson can't honor stdlib json options; compact separators are its default.
-            if args or (kwargs and kwargs != {'separators': (',', ':')}):
+            if args or (kwargs and kwargs not in FAST_PATH_KWARGS):
                 return engineio_json.dumps(obj, *args, **kwargs)
             try:
                 serialized = orjson.dumps(obj).decode('utf-8')


### PR DESCRIPTION
`ENABLE_ORJSON` is meant to swap the JSON codec app-wide, but 59 of the 379 `JSONCodec.dumps` sites never reach orjson: they pass `ensure_ascii=False`, and the codec routes any kwarg other than compact separators to stdlib. Those 59 are every builtin tool result, so the tool path still pays stdlib speed with the flag on.

**orjson always emits raw UTF-8**, which is what `ensure_ascii=False` asks for, **so it can take the fast path**. No call site changes.

| payload | before | after |
| --- | --- | --- |
| 20-result tool output | 18.57 us | 3.77 us |
| small dict | 1316 ns | 229 ns |

Output is equal by value, not byte for byte: orjson is compact and formats floats its own way. 40k fuzzed payloads gave zero value differences, the 320 sites already on the fast path are unchanged, and the flag-off path is untouched.

The docstring claimed `NaN` falls back to engineio. It does not, orjson encodes it as `null` without raising, so that branch is unreachable. Corrected along with the other divergences a caller actually sees.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
