### PR TITLE
fix: crash when selecting a knowledge base in folder settings for folders without a files key

### DIFF
--- a/src/lib/components/workspace/Models/Knowledge.svelte
+++ b/src/lib/components/workspace/Models/Knowledge.svelte
@@ -31,7 +31,7 @@
 	let showItemModal = false;
 	let selectedItemIdx = null;
 
-	$: if (selectedItems === null) {
+	$: if (!selectedItems) {
 		selectedItems = [];
 	}
 

--- a/src/lib/components/workspace/Models/Knowledge.svelte
+++ b/src/lib/components/workspace/Models/Knowledge.svelte
@@ -27,7 +27,7 @@
 	let filesInputElement = null;
 	let inputFiles = null;
 
-	$: if (selectedItems === null) {
+	$: if (!selectedItems) {
 		selectedItems = [];
 	}
 


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27982, selecting a knowledge base in folder settings crashes when the folder's data has no `files` key.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable.
- [ ] **Dependencies:** No new dependencies.
- [x] **Testing:** Manually verified by the author on a live instance: the exact crash was reproduced on an affected folder before the fix, and after the fix the same steps attach the knowledge item with no console error. Full details in Manual Verification below.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new settings and no new state: the component's existing normalization guard is loosened by one comparison so it covers the whole class of empty bindings instead of only `null`.
- [x] **Git Hygiene:** The PR is atomic (a single one line commit), based on the current `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

**Problem** (#27982): clicking Select Knowledge in a folder's Edit modal and choosing a knowledge base throws an uncaught TypeError and attaches nothing, for any folder whose stored `data` object exists but has no `files` key (for example a folder that only ever had a system prompt saved, from before folder knowledge support):

```
Uncaught TypeError: can't access property "find", selectedItems() is undefined
    select Knowledge.svelte:182
```

**Root Cause**: `FolderModal.svelte` initializes `data = folder.data || {...}`, so a truthy `data` without a `files` key passes through and `<Knowledge bind:selectedItems={data.files} />` binds `undefined`. The shared knowledge section component already normalizes empty bindings, but its guard checks `selectedItems === null` only, which `undefined` does not satisfy, so the select handler dereferences `undefined`:

```js
if (!selectedItems.find((k) => k.id === item.id)) {
```

**Fix**: loosen the existing guard to cover the whole falsy class:

```diff
-	$: if (selectedItems === null) {
+	$: if (!selectedItems) {
 		selectedItems = [];
 	}
```

Because `selectedItems` is a two way binding, the normalization also writes `files: []` back into the folder's `data`, so saving the folder heals it to the current shape. The guard equally protects the component's other consumer (the model editor) and any future parent. Arrays are truthy in JavaScript (including `[]`), so populated and empty selections are unaffected.

Scope: one line in `src/lib/components/workspace/Models/Knowledge.svelte`.

### Fixed

- Fixed an uncaught TypeError (`selectedItems() is undefined`) that prevented attaching knowledge bases in folder settings for folders whose stored data predates folder knowledge support (a `data` object without a `files` key): the knowledge section now normalizes an undefined selection binding to an empty array, and saving the folder persists the corrected shape.

---

### Additional Information

**Overlaps with other open PRs.** This touches `src/lib/components/workspace/Models/Knowledge.svelte`, which #26296 and #27686 also modify, and the three conflict with each other in that file. This is the smallest of the three, so taking it first keeps the rebases on the other two small.


- This PR was prepared with AI copilot assistance and reviewed by the author.
- Related but distinct: #27801 tracks the inability to preview knowledge already attached to a folder; this PR only fixes the selection crash.

### Manual Verification Performed

1. Reproduced the crash first: created a folder via the API with `data: { "system_prompt": "legacy folder shape" }` (confirmed stored without a `files` key), opened Edit Folder, clicked Select Knowledge, and clicked a knowledge item. The TypeError above fired and nothing was attached. Also hit organically on a long lived folder on a live instance.
2. With the fix, repeated the same steps on the same folder shape: no console error, and the selected item appeared as a chip in the modal.
3. Clicked Save and re-fetched the folder via the API: `data.files` now contains the selected item and the pre-existing `system_prompt` value is preserved unchanged.
4. Regression check on the other consumer: the model editor's Knowledge section still attaches and removes items normally (its parent always passes an array, and arrays, including empty ones, are truthy, so the loosened guard never rewrites them).
5. `npm run format` produces no changes on the file.

### Screenshots or Videos

Not applicable (console error before, no error after; the behavior is described in the verification steps).

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.

