### PR TITLE
fix: normalize OAuth sub claim to str to prevent PostgreSQL type mismatch

### DIFF
--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -1768,6 +1768,10 @@ class OAuthManager:
             if not sub:
                 log.warning(f'OAuth callback failed, sub is missing: {user_data}')
                 raise HTTPException(400, detail=ERROR_MESSAGES.INVALID_CRED)
+            # Normalize to str: some providers (e.g. GitHub) return a numeric id.
+            # Without this, PostgreSQL fails with "operator does not exist: text = integer"
+            # and SQLite containment checks silently miss (int vs str mismatch).
+            sub = str(sub)
 
             oauth_data = {}
             oauth_data[provider] = {


### PR DESCRIPTION
## Summary

Normalize the OAuth `sub` claim to `str` immediately after extraction in `handle_callback`, so providers that return a non-string identifier (e.g. GitHub, whose `/user` API returns `id` as a JSON **number**) no longer crash PostgreSQL or silently fail on SQLite.

## Problem

Fixes #27760.

GitHub's `/user` response includes `id` as a JSON integer. The GitHub provider is registered with `sub_claim: "id"`, so `user_data.get(...)` yields a Python `int`. This `int` is then passed to `Users.get_user_by_oauth_sub()`, which builds:

```python
User.oauth[provider].cast(JSONB)['sub'].astext == sub   # PostgreSQL
User.oauth.contains({provider: {'sub': sub}})            # SQLite
```

- **PostgreSQL**: `.astext` produces `TEXT`, but the `int` parameter binds as `INTEGER`, causing `psycopg.errors.UndefinedFunction: operator does not exist: text = integer`.
- **SQLite**: `json_contains` with an `int` sub never matches a record that was stored with a `str` sub (and vice versa), so the lookup silently returns `None`.

## Fix

A single line: `sub = str(sub)`, placed right after the existing `if not sub` guard and before the value is stored in `oauth_data` or passed to any lookup/signup function.

This is consistent with OIDC providers, where the `sub` claim is always a string per RFC 7519.

## Testing

- Verified the fix logic against the PostgreSQL query path: `astext == str(int_id)` produces a valid `TEXT = TEXT` comparison.
- Verified the SQLite path: `json_contains({...: {'sub': '12345678'}})` matches a record stored with the same string form.
- Checked that the back-channel logout path (line 2167) is unaffected — OIDC JWT `sub` claims are already strings.

## Disclosure

AI copilot assisted with code navigation and the issue report; the fix, its rationale, and all verification were reviewed manually.