### PR TITLE
fix(oauth): normalize OAuth sub claim to str to prevent PostgreSQL type mismatch

### DIFF
--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -1834,6 +1834,10 @@ class OAuthManager:
             if not sub:
                 log.warning(f'OAuth callback failed, sub is missing: {user_data}')
                 raise HTTPException(400, detail=ERROR_MESSAGES.INVALID_CRED)
+            # Normalize to str: some providers (e.g. GitHub) return a numeric id.
+            # Without this, PostgreSQL fails with "operator does not exist: text = integer"
+            # and SQLite containment checks silently miss (int vs str mismatch).
+            sub = str(sub)
 
             oauth_data = {}
             oauth_data[provider] = {


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) — `Closes #27760`.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [x] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses `fix:`.

# Changelog Entry

### Description

Normalize the OAuth `sub` claim to `str` immediately after extraction in `handle_callback`, so providers that return a non-string identifier (e.g. GitHub, whose `/user` API returns `id` as a JSON number) no longer crash PostgreSQL or silently fail on SQLite.

### Fixed

- Coerce OAuth `sub` claim to string to prevent PostgreSQL type mismatch (`operator does not exist: text = integer`) and SQLite JSON containment lookup misses (`Closes #27760`).

---

### Additional Information

GitHub's `/user` response includes `id` as a JSON integer. The GitHub provider is registered with `sub_claim: "id"`, so `user_data.get(...)` yields a Python `int`. This `int` is then passed to `Users.get_user_by_oauth_sub()`, which builds:

```python
User.oauth[provider].cast(JSONB)['sub'].astext == sub   # PostgreSQL
User.oauth.contains({provider: {'sub': sub}})            # SQLite
```

- **PostgreSQL**: `.astext` produces `TEXT`, but the `int` parameter binds as `INTEGER`, causing `psycopg.errors.UndefinedFunction: operator does not exist: text = integer`.
- **SQLite**: `json_contains` with an `int` sub never matches a record that was stored with a `str` sub (and vice versa), so the lookup silently returns `None`.

Fix: `sub = str(sub)` placed right after extraction.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.