### PR TITLE
fix: derive overview node spacing from rem so branches never overlap

### DIFF
--- a/src/lib/components/chat/Overview/View.svelte
+++ b/src/lib/components/chat/Overview/View.svelte
@@ -64,8 +64,11 @@
 	const drawFlow = async (direction: LayoutDirection) => {
 		const nodeList: Node[] = [];
 		const edgeList: Edge[] = [];
-		const levelOffset = direction === 'vertical' ? 150 : 300;
-		const siblingOffset = direction === 'vertical' ? 250 : 150;
+		const rootFontSize = parseFloat(getComputedStyle(document.documentElement).fontSize) || 16;
+		const nodeWidth = 15 * rootFontSize;
+		const nodeHeight = 5 * rootFontSize;
+		const levelOffset = direction === 'vertical' ? nodeHeight + 70 : nodeWidth + 60;
+		const siblingOffset = direction === 'vertical' ? nodeWidth + 60 : nodeHeight + 70;
 
 		// Map to keep track of node positions at each level
 		let positionMap = new Map<string, PositionMapEntry>();


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27994, Overview graph sibling nodes overlap when a message has multiple branches.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable.
- [ ] **Dependencies:** No new dependencies.
- [x] **Testing:** Verified live on a dev build by measuring the rendered node boxes in the Overview at both a 16px and a 17.6px root font size. Before and after numbers are in Manual Verification below.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new settings. The four spacing values are derived from the node's existing rem based dimensions instead of hardcoded pixels, so the layout stays correct at any root font size. Three of the four values are unchanged at the default 16px root font size.
- [x] **Git Hygiene:** The PR is atomic (a single commit), based on the current `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

**Problem** (#27994): in a chat's Overview graph, sibling message nodes overlap horizontally once a message has more than one branch (after regenerating a response or resending an edited query). The overlap is driven by the document root font size, which Open WebUI's own `UI Scale` setting controls (Settings, then Interface): the cleanest reproduction is to set UI Scale to 1.10x. It looks fine at the default 1.00x, so only some users see it (anyone using UI Scale above about 1.04x, or equivalent browser or OS font scaling).

**Root Cause**: the Overview node box is sized in rem (`w-60` = 15rem, `h-20` = 5rem), so its pixel width scales with the root font size. UI Scale drives that root font size (`src/app.css` applies `font-size: calc(1rem * var(--app-text-scale, 1))` to the root, and the UI Scale slider sets `--app-text-scale`). But `drawFlow` spaces siblings with fixed pixel constants that do not scale:

```js
const levelOffset = direction === 'vertical' ? 150 : 300;
const siblingOffset = direction === 'vertical' ? 250 : 150;
```

In vertical layout, siblings spread horizontally by `siblingOffset` (250px) while the node is 15rem wide. At UI Scale 1.00x (16px root) that node is 240px (10px gap); at 1.10x (17.6px root) it is 264px, wider than 250px, so adjacent siblings overlap by 14px. Any root font size above 250 / 15 = 16.67px overlaps, which is a UI Scale above about 1.04x.

**Fix**: derive the node dimensions from the actual root font size and space nodes relative to those, so the visual gap is constant at any font size:

```diff
-		const levelOffset = direction === 'vertical' ? 150 : 300;
-		const siblingOffset = direction === 'vertical' ? 250 : 150;
+		const rootFontSize = parseFloat(getComputedStyle(document.documentElement).fontSize) || 16;
+		const nodeWidth = 15 * rootFontSize;
+		const nodeHeight = 5 * rootFontSize;
+		const levelOffset = direction === 'vertical' ? nodeHeight + 70 : nodeWidth + 60;
+		const siblingOffset = direction === 'vertical' ? nodeWidth + 60 : nodeHeight + 70;
```

`nodeWidth` and `nodeHeight` mirror the node's `w-60` and `h-20` classes. The cross axis spacing is now node size plus a fixed gap, so siblings can never be spaced closer than the node they render. At the default 16px root font size, three of the four values are unchanged (vertical `levelOffset` 150, horizontal `levelOffset` 300, horizontal `siblingOffset` 150); only vertical `siblingOffset` changes, from 250 (the overlapping value) to 300, which is the fix.

### Fixed

- Fixed sibling nodes overlapping in the chat Overview graph when a message has multiple branches. Node spacing is now derived from the node's rem based size, so branches keep a constant gap regardless of the browser's root font size (previously they overlapped at any root font size above about 16.6px).

---

### Additional Information

- This PR was prepared with AI copilot assistance and reviewed by the author.

### Manual Verification Performed

Measured the rendered `.svelte-flow__node` boxes in the Overview with three sibling branches, vertical layout, at viewport zoom 1.0. UI Scale 1.10x is the setting that reproduces the bug (root font size 17.6px):

- UI Scale 1.00x (16px root), after the fix: node width 240px, sibling spacing 300px, 60px gap, no overlap.
- UI Scale 1.10x (17.6px root), before the fix: node width 264px, sibling spacing 250px, 14px overlap.
- UI Scale 1.10x (17.6px root), after the fix: node width 264px, sibling spacing 324px, 60px gap, no overlap.
- Confirmed the horizontal layout mode (the layout toggle) keeps clear gaps at both scales as well.

### Screenshots or Videos

#### Before

<img width="1766" height="1274" alt="image" src="https://github.com/user-attachments/assets/81a0f710-812c-4b86-ab07-158de6a7ce70" />

<img width="1766" height="1274" alt="image" src="https://github.com/user-attachments/assets/c1724acb-a474-4fb6-93c7-866b09631ab7" />

#### After

<img width="1766" height="1274" alt="image" src="https://github.com/user-attachments/assets/af1d4e55-4d3a-45fd-a4d8-090f8b0833c4" />

<img width="1766" height="1274" alt="image" src="https://github.com/user-attachments/assets/bc3029ac-8f00-4c38-bc91-925d4e2473ca" />

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
