### PR TITLE
fix: stop profile preview avatars from squashing in narrow flex rows

### DIFF
--- a/src/lib/components/channel/Messages/Message/ProfilePreview.svelte
+++ b/src/lib/components/channel/Messages/Message/ProfilePreview.svelte
@@ -44,7 +44,7 @@
 </script>
 
 <LinkPreview.Root openDelay={0} closeDelay={200} bind:open={openPreview}>
-	<LinkPreview.Trigger class="flex items-center">
+	<LinkPreview.Trigger class="flex shrink-0 items-center">
 		<button
 			type="button"
 			class=" cursor-pointer no-underline! font-normal!"


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27999, admin Users list profile images squash into ovals on narrow viewports.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable.
- [ ] **Dependencies:** No new dependencies.
- [x] **Testing:** Verified live on a dev build at a 414px viewport by measuring the rendered avatar boxes before and after; numbers in Manual Verification below. Also reproduced originally on an iPhone 13 Pro running Open WebUI as a PWA.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** One class added to the shared component's trigger element, protecting every consumer at once instead of patching each call site.
- [x] **Git Hygiene:** The PR is atomic (a single one line commit), based on the current `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

**Problem** (#27999): on narrow viewports (mobile browsers and the PWA), the avatars in the admin panel's Users list squash into vertical ovals, each row by a different amount, so the column also looks misaligned. Desktop widths render correctly.

**Root Cause**: the avatars are wrapped in the shared `ProfilePreview` component, whose `LinkPreview.Trigger` renders with `class="flex items-center"` and no `shrink-0`. The trigger, not the `img`, is the row's flex child, so when the Name cell runs out of room the trigger compresses. Tailwind's preflight gives images `max-width: 100%`, so the avatar's width clamps to the squashed trigger while its explicit height class keeps the full height, producing the oval. Compression varies with each row's name length, hence the per row misalignment. The `img` already carries `flex-shrink-0` and `object-cover` from the earlier avatar squash fix, but that protects the wrong element: the wrapper between the row and the image is what gets squashed.

**Fix**: one class on the shared trigger:

```diff
-	<LinkPreview.Trigger class="flex items-center">
+	<LinkPreview.Trigger class="flex shrink-0 items-center">
```

All four consumers of `ProfilePreview` (admin Users list, channel messages, channel info member list, workspace member selector) wrap only avatar images, never truncating text, so the change is safe on every surface and protects them all from the same class of squash.

### Fixed

- Fixed profile images in the admin panel's Users list (and every other surface using the shared profile preview trigger) squashing into vertical ovals on narrow viewports: the preview trigger no longer shrinks with the row, so avatars stay round and aligned at any width.

---

### Additional Information

- This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Manual Verification Performed

1. **Reproduced on unmodified `dev`** at a 414px viewport (iPhone XR emulation) in Admin Settings > Users: avatar heights all 26.8px with widths ranging from 18.9px to 23.2px depending on the row's name length; only the row with the shortest content stayed round. Also observed on an iPhone 13 Pro running the PWA.
2. **Verified the fix live**: after the change, every avatar in the same list measures 26.8px by 26.8px at the same viewport, round and aligned across all rows.
3. Confirmed the consumer audit: all four `ProfilePreview` call sites wrap only avatar images, so `shrink-0` on the trigger cannot suppress any intended truncation.
4. Desktop rendering is unchanged (the trigger was never squashed at desktop widths).
5. `npm run format` produces no changes on the file.

### Screenshots or Videos

#### Before

<img width="773" height="981" alt="image" src="https://github.com/user-attachments/assets/05f6d5dd-5626-4106-967f-24666a2b793b" />

#### After

<img width="773" height="981" alt="image" src="https://github.com/user-attachments/assets/40f90e85-3450-4694-a2e3-93ab9d90389d" />

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
