### PR TITLE
fix: deduplicate tool citation markers

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -813,12 +813,33 @@ def get_source_context(sources: list, source_ids: dict = None, include_content: 
         source_ids = {}
     for source in sources:
         for doc, meta in zip(source.get('document', []), source.get('metadata', [])):
-            source_id = meta.get('source') or source.get('source', {}).get('id') or 'N/A'
-            if source_id not in source_ids:
+            source_info = source.get('source', {})
+            source_id = (
+                meta.get('url')
+                or meta.get('file_id')
+                or meta.get('note_id')
+                or meta.get('source')
+                or source_info.get('id')
+                or 'N/A'
+            )
+            if source_id in source_ids:
+                # Tool results are already present in the conversation, so their
+                # source tags are citation markers only. Rendering the same marker
+                # again on every tool iteration wastes context and can emit
+                # conflicting attributes for one numeric citation ID.
+                if not include_content:
+                    continue
+            else:
                 source_ids[source_id] = len(source_ids) + 1
-            src_name = source.get('source', {}).get('name')
-            src_type = source.get('source', {}).get('type')
-            src_rid = source.get('source', {}).get('id')
+            src_name = meta.get('name') or source_info.get('name')
+            src_type = source_info.get('type')
+            src_rid = (
+                meta.get('url')
+                or meta.get('file_id')
+                or meta.get('note_id')
+                or source_info.get('id')
+                or source_id
+            )
             body = doc if include_content else ''
             context_string += (
                 f'<source id="{source_ids[source_id]}"'


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Relates to https://github.com/open-webui/open-webui/discussions/27991.
- [x] **Target branch:** This pull request targets `dev`.
- [x] **Description:** A concise description is provided below.
- [x] **Changelog:** A Keep a Changelog entry is included below.
- [x] **Documentation:** No user-facing documentation change is needed for this bug fix.
- [x] **Dependencies:** No dependencies were added or updated.
- [x] **Testing:** Focused regression checks were run against `get_source_context`.
- [x] **No Unchecked AI Code:** The change was manually reviewed and exercised with focused regression checks.
- [x] **Self-Review:** The diff and generated source context were reviewed.
- [x] **Architecture:** This is a focused correction to existing source-context rendering with no new setting.
- [x] **Git Hygiene:** The pull request is atomic, based on `dev`, and contains one signed-off commit.
- [x] **Title Prefix:** The title uses the `fix:` prefix.

## Description

Native tool calling accumulates citation sources across iterations and renders the accumulated list as marker-only `<source>` tags. `get_source_context` assigned stable numeric IDs, but rendered every occurrence, so repeated search/fetch results produced duplicate empty tags.

The same canonical URL could also receive conflicting `name` and `resource-id` attributes depending on whether it came from `search_web` or `fetch_url`.

This change:

- treats `source_ids` as the set of canonical sources already rendered when building marker-only context;
- skips repeated markers while preserving all content-bearing chunks;
- prefers canonical metadata (`url`, file/note ID, and metadata name) for citation identity and attributes.

The frontend source events are unchanged. This only removes redundant prompt context.

Relates to https://github.com/open-webui/open-webui/discussions/27991.

## Verification

Focused regression checks verified that:

- a repeated URL from `search_web` renders one marker;
- the same URL returned later by `fetch_url` does not render again;
- distinct URLs retain distinct stable IDs;
- rendered resource IDs use the canonical URL rather than `search_web`;
- content-bearing duplicate chunks are preserved.

Also run:

- `python -m compileall -q backend/open_webui/utils/middleware.py`
- `git diff --check`

# Changelog Entry

### Fixed

- Prevented repeated native-tool citation markers from bloating model context and emitting conflicting attributes for the same citation ID.

### Additional Information

- No dependencies, API changes, or user-facing configuration changes.

### Screenshots or Videos

- Not applicable; this changes server-generated model context rather than UI rendering.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.