### PR TITLE
fix: stop the workspace view filter chevron from squashing at narrow widths

### DIFF
--- a/src/lib/components/workspace/common/ViewSelector.svelte
+++ b/src/lib/components/workspace/common/ViewSelector.svelte
@@ -34,7 +34,7 @@
 		>
 			{selectedLabel}
 		</span>
-		<ChevronDown className=" size-3.5" strokeWidth="2.5" />
+		<ChevronDown className=" size-3.5 shrink-0" strokeWidth="2.5" />
 	</svelte:fragment>
 
 	<svelte:fragment slot="item" let:item let:selected>


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #28002, the workspace view filter chevron squashes on narrow viewports.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable.
- [ ] **Dependencies:** No new dependencies.
- [x] **Testing:** Verified live on a dev build at a 414px viewport by measuring the rendered icon before and after; numbers in Manual Verification below.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** One class on the icon, the codebase's standard guard for fixed size visuals in flex rows.
- [x] **Git Hygiene:** The PR is atomic (a single one line commit), based on the current `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

**Problem** (#28002): the chevron in the workspace view filter dropdown (`All` / `Created by you` / `Shared with you` on the Models, Knowledge, Prompts, and Tools pages) squashes into a sliver on small viewports.

**Root Cause**: in `ViewSelector.svelte` the `ChevronDown` is a direct flex child of the Select trigger next to a `w-full ... truncate` label. It has a fixed size class but no `shrink-0`, so when the trigger runs out of room the flex layout compresses the icon instead of letting the label truncate first.

**Fix**:

```diff
-		<ChevronDown className=" size-3.5" strokeWidth="2.5" />
+		<ChevronDown className=" size-3.5 shrink-0" strokeWidth="2.5" />
```

### Fixed

- Fixed the workspace view filter dropdown's chevron squashing into a sliver on narrow viewports: the icon no longer shrinks with the trigger, and the label truncates instead, as intended.

---

### Additional Information

- This PR was prepared with AI copilot assistance and reviewed by the author.

### Manual Verification Performed

1. Reproduced on unmodified `dev` at a 414px viewport on `/workspace/models` and `/workspace/knowledge`: the chevron measured 10.6px wide against its intended square size (about 15.4px at the tested UI scale).
2. With the fix, re-measured the same surfaces: no distorted icons remain (every fixed size icon measures square).
3. The label span keeps `truncate`, so long selected labels shorten gracefully; no layout shift at desktop widths where the trigger never compresses.
4. `npm run format` produces no changes on the file.

### Screenshots or Videos

Not applicable (a few pixel icon distortion; the measurements above are the evidence).

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
