### PR TITLE
fix: default loose function tools to strict:false in Responses API conversion

### DIFF
--- a/PR_27750.md
+++ b/PR_27750.md
@@ -1,0 +1,84 @@
+# Pull Request Checklist
+
+**Before submitting, make sure you've checked the following:**
+
+- [x] **Linked Issue/Discussion:** `Closes #27750`
+- [x] **Target branch:** The pull request targets the `dev` branch.
+- [x] **Description:** A concise description of the changes is provided below.
+- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
+- [ ] **Documentation:** No docs change needed (internal payload-conversion fix).
+- [ ] **Dependencies:** No new or updated dependencies.
+- [x] **Testing:** Manual verification of the three strict cases performed (see below).
+- [x] **No Unchecked AI Code:** Human-reviewed and manually tested.
+- [x] **Self-Review:** Performed.
+- [x] **Architecture:** Smart default (non-strict) preferred over a new setting.
+- [x] **Git Hygiene:** Atomic, rebased on `dev`.
+- [x] **Title Prefix:** `fix:`
+
+**Suggested PR title:** `fix: default loose function tools to strict:false in Responses API conversion`
+
+# Changelog Entry
+
+### Description
+
+- When Open WebUI converts a Chat Completions payload to the Responses API format
+  (`convert_to_responses_payload()` in `backend/open_webui/routers/openai.py`), it
+  only copied a tool's `strict` flag when the source tool already had one. Loose
+  function tools derived from Chat Completions / MCP / OpenAPI definitions carry no
+  tool-level `strict`, so the tool was sent to `/v1/responses` with `strict` omitted.
+  The Responses API then treats the tool as strict, materializes every optional
+  property (empty string, `false`, `0`, empty array) and can populate
+  mutually-exclusive filters together. Open WebUI forwards those generated arguments
+  to the tool unchanged, which can make the tool reject the call — whereas the same
+  tool over `/v1/chat/completions` returns only the intended arguments.
+
+### Fixed
+
+- Loose function tools are now defaulted to `strict: false` during Responses API
+  conversion, restoring omission semantics for optional parameters and matching
+  Chat Completions behavior. Explicit `strict: true` and `strict: false` from the
+  source tool are preserved; already-native Responses tools are left unchanged.
+
+---
+
+### Additional Information
+
+The change is a one-line default:
+
+```python
+# before
+if 'strict' in func:
+    converted_tool['strict'] = func['strict']
+
+# after
+converted_tool['strict'] = func.get('strict', False)
+```
+
+Behavior across the three cases:
+
+| Source tool          | Before          | After           |
+|----------------------|-----------------|-----------------|
+| `strict` absent      | omitted (→ strict on API side) | `strict: false` |
+| `strict: true`       | `true`          | `true` (preserved) |
+| `strict: false`      | `false`         | `false` (preserved) |
+
+`strict: true` is intentionally *not* used as the default — it would require
+rewriting each schema (all properties required, `additionalProperties: false`,
+nullable optionals), which is out of scope for this fix.
+
+Scope: `convert_to_responses_payload()` is the only place in the Responses
+conversion path that constructs tool dicts. Tools already in native Responses
+shape (no `function` key) pass through the untouched `else` branch.
+
+Manual verification (four cases, incl. a native tool):
+
+```
+{'type': 'function', 'name': 'a', 'strict': False}   # loose  -> false
+{'type': 'function', 'name': 'b', 'strict': True}    # strict:true  -> preserved
+{'type': 'function', 'name': 'c', 'strict': False}   # strict:false -> preserved
+{'type': 'function', 'name': 'd', 'strict': True}    # native -> untouched
+```
+
+### Contributor License Agreement
+
+- [ ] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -1141,8 +1141,15 @@ def convert_to_responses_payload(payload: dict) -> dict:
                         converted_tool['description'] = func['description']
                     if 'parameters' in func:
                         converted_tool['parameters'] = func['parameters']
-                    if 'strict' in func:
-                        converted_tool['strict'] = func['strict']
+                    # Default loose (Chat Completions / MCP / OpenAPI-derived)
+                    # function tools to non-strict. Without an explicit
+                    # strict:false, the Responses API materializes every
+                    # optional property (empty string, false, 0, empty array)
+                    # and can populate mutually-exclusive filters together,
+                    # which Open WebUI then forwards to the tool unchanged.
+                    # Preserve an explicit strict:true / strict:false from the
+                    # source tool.
+                    converted_tool['strict'] = func.get('strict', False)
                 converted_tools.append(converted_tool)
             else:
                 # Already in correct format or unknown format, pass through


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** `Closes #27750`
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** No docs change needed (internal payload-conversion fix).
- [ ] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Manual verification of the three strict cases performed (see below).
- [x] **No Unchecked AI Code:** Human-reviewed and manually tested.
- [x] **Self-Review:** Performed.
- [x] **Architecture:** Smart default (non-strict) preferred over a new setting.
- [x] **Git Hygiene:** Atomic, rebased on `dev`.
- [x] **Title Prefix:** `fix:`

**Suggested PR title:** `fix: default loose function tools to strict:false in Responses API conversion`

# Changelog Entry

### Description

- When Open WebUI converts a Chat Completions payload to the Responses API format
  (`convert_to_responses_payload()` in `backend/open_webui/routers/openai.py`), it
  only copied a tool's `strict` flag when the source tool already had one. Loose
  function tools derived from Chat Completions / MCP / OpenAPI definitions carry no
  tool-level `strict`, so the tool was sent to `/v1/responses` with `strict` omitted.
  The Responses API then treats the tool as strict, materializes every optional
  property (empty string, `false`, `0`, empty array) and can populate
  mutually-exclusive filters together. Open WebUI forwards those generated arguments
  to the tool unchanged, which can make the tool reject the call — whereas the same
  tool over `/v1/chat/completions` returns only the intended arguments.

### Fixed

- Loose function tools are now defaulted to `strict: false` during Responses API
  conversion, restoring omission semantics for optional parameters and matching
  Chat Completions behavior. Explicit `strict: true` and `strict: false` from the
  source tool are preserved; already-native Responses tools are left unchanged.

---

### Additional Information

The change is a one-line default:

```python
# before
if 'strict' in func:
    converted_tool['strict'] = func['strict']

# after
converted_tool['strict'] = func.get('strict', False)
```

Behavior across the three cases:

| Source tool          | Before          | After           |
|----------------------|-----------------|-----------------|
| `strict` absent      | omitted (→ strict on API side) | `strict: false` |
| `strict: true`       | `true`          | `true` (preserved) |
| `strict: false`      | `false`         | `false` (preserved) |

`strict: true` is intentionally *not* used as the default — it would require
rewriting each schema (all properties required, `additionalProperties: false`,
nullable optionals), which is out of scope for this fix.

Scope: `convert_to_responses_payload()` is the only place in the Responses
conversion path that constructs tool dicts. Tools already in native Responses
shape (no `function` key) pass through the untouched `else` branch.

Manual verification (four cases, incl. a native tool):

```
{'type': 'function', 'name': 'a', 'strict': False}   # loose  -> false
{'type': 'function', 'name': 'b', 'strict': True}    # strict:true  -> preserved
{'type': 'function', 'name': 'c', 'strict': False}   # strict:false -> preserved
{'type': 'function', 'name': 'd', 'strict': True}    # native -> untouched
```

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
