### PR TITLE
fix(openai): pin strict=false when converting loose tools to the Responses API (#27750)

### DIFF
--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -978,8 +978,11 @@ def convert_to_responses_payload(payload: dict) -> dict:
                         converted_tool['description'] = func['description']
                     if 'parameters' in func:
                         converted_tool['parameters'] = func['parameters']
-                    if 'strict' in func:
-                        converted_tool['strict'] = func['strict']
+                    # Responses API function tools default to strict=true, while Chat
+                    # Completions tools default to strict=false. Loose tools (MCP- or
+                    # OpenAPI-derived) omit the field, so pin it explicitly instead of
+                    # dropping it, otherwise optional properties stop being omittable.
+                    converted_tool['strict'] = bool(func.get('strict', False))
                 converted_tools.append(converted_tool)
             else:
                 # Already in correct format or unknown format, pass through


### PR DESCRIPTION
## What

`convert_to_responses_payload()` only forwarded `strict` when the source Chat Completions tool already carried the key:

```python
if 'strict' in func:
    converted_tool['strict'] = func['strict']
```

The Responses API defaults function tools to `strict: true`, while Chat Completions defaults to `strict: false`. MCP- and OpenAPI-derived tools commonly ship loose schemas with no tool-level `strict`, so dropping the key silently promoted them to strict mode once converted.

With strict semantics the model stops treating optional properties as omittable and materializes them as `""`, `0`, `false` or `[]` — including mutually exclusive ones (e.g. `year` alongside `date_from`/`date_to`). Open WebUI then forwards those generated arguments to the tool unchanged, and search/filter tools either return wrong results or reject the call.

## Change

One line in `backend/open_webui/routers/openai.py`: set `strict` explicitly from the source tool, defaulting to `False`.

```python
converted_tool['strict'] = bool(func.get('strict', False))
```

Tools that opt in to `strict: true` are unaffected; only tools that never specified it change, and they change to the Chat Completions default they already had.

## Verification

Ran the real `convert_to_responses_payload` (extracted via `ast`, no other module imports) on a payload with three tools — a loose one, one with `strict: true`, one with `strict: false`:

| tool | before | after |
|---|---|---|
| `search` (no `strict`) | *key absent* → Responses defaults to `true` | `strict: false` |
| `strict_tool` (`strict: true`) | `strict: true` | `strict: true` |
| `explicit_false` (`strict: false`) | `strict: false` | `strict: false` |

Formatting/lint checked with the CI configuration (`ruff>=0.15.5`, repo `pyproject.toml` with `quote-style = "single"`, `line-length = 120`):

- `ruff format --check` → `1 file already formatted`
- `ruff check --select=F --ignore=F401,F403,F405,F541,F811,F841` → `All checks passed!`

Fixes #27750

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
