### PR TITLE
fix: default loose function tools to strict:false in Responses API conversion

### DIFF
--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -1141,8 +1141,8 @@ def convert_to_responses_payload(payload: dict) -> dict:
                         converted_tool['description'] = func['description']
                     if 'parameters' in func:
                         converted_tool['parameters'] = func['parameters']
-                    if 'strict' in func:
-                        converted_tool['strict'] = func['strict']
+                    # Default loose tools to non-strict; preserve explicit strict.
+                    converted_tool['strict'] = func.get('strict', False)
                 converted_tools.append(converted_tool)
             else:
                 # Already in correct format or unknown format, pass through


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** `Closes #27750`
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** No docs change needed (internal payload-conversion fix).
- [ ] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Manually verified the three strict cases (absent / true / false) produce the expected `strict` value; native Responses tools pass through unchanged.
- [x] **No Unchecked AI Code:** Human-reviewed and manually tested.
- [x] **Self-Review:** Performed.
- [x] **Architecture:** Smart default (non-strict) preferred over a new setting.
- [x] **Git Hygiene:** Atomic single-file change, rebased on `dev`.
- [x] **Title Prefix:** `fix:`

# Changelog Entry

### Description

- Converting a loose Chat Completions / MCP / OpenAPI-derived function tool to the
  Responses API dropped omission semantics for optional params.
  `convert_to_responses_payload()` only copied `strict` when the source tool already
  had it, so loose tools reached `/v1/responses` with `strict` omitted. The Responses
  API then materializes every optional property (empty string, `false`, `0`, empty
  array) and can populate mutually-exclusive filters together; Open WebUI forwards
  those generated arguments to the tool unchanged, which can make the tool reject the
  call. The same tool over `/v1/chat/completions` returns only the intended arguments.

### Fixed

- Default loose function tools to `strict: false` during Responses API conversion,
  restoring omission semantics for optional parameters. Explicit `strict: true` /
  `strict: false` from the source tool is preserved; already-native Responses tools
  are unchanged.

---

### Additional Information

One-line change in `convert_to_responses_payload()`:

```python
# before: strict copied only when present
if 'strict' in func:
    converted_tool['strict'] = func['strict']
# after: default loose tools to non-strict, preserve explicit strict
converted_tool['strict'] = func.get('strict', False)
```

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
