### PR TITLE
fix: prevent plugin pip installs from upgrading pinned core dependencies

### DIFF
--- a/backend/open_webui/utils/plugin.py
+++ b/backend/open_webui/utils/plugin.py
@@ -419,6 +419,47 @@ async def get_function_module_from_cache(
 _installed_requirements = set()
 
 
+def _build_constraints_file() -> str | None:
+    """Generate a pip constraints file from currently installed packages.
+
+    This prevents plugin/tool pip installs from upgrading or downgrading
+    packages that Open WebUI already depends on (e.g. cryptography, torch).
+    Replacing native C-extension packages in a running Python process causes
+    crashes that are extremely difficult to diagnose.
+
+    Returns the path to a temporary constraints file, or None on failure.
+    The caller is responsible for cleaning up the file.
+    """
+    try:
+        result = subprocess.run(
+            [sys.executable, '-m', 'pip', 'freeze', '--local'],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if result.returncode != 0:
+            log.warning(
+                'Failed to run pip freeze for constraints; '
+                'proceeding without constraints'
+            )
+            return None
+
+        frozen = result.stdout.strip()
+        if not frozen:
+            return None
+
+        fd, path = tempfile.mkstemp(prefix='owui_constraints_', suffix='.txt')
+        with os.fdopen(fd, 'w') as f:
+            f.write(frozen)
+        return path
+    except Exception:
+        log.warning(
+            'Could not generate pip constraints file; '
+            'proceeding without constraints'
+        )
+        return None
+
+
 def install_frontmatter_requirements(requirements: str):
     global _installed_requirements
     if not ENABLE_PIP_INSTALL_FRONTMATTER_REQUIREMENTS:
@@ -437,10 +478,40 @@ def install_frontmatter_requirements(requirements: str):
             if not new_reqs:
                 return
 
-            log.info(f'Installing requirements: {" ".join(new_reqs)}')
-            subprocess.check_call(
-                [sys.executable, '-m', 'pip', 'install'] + PIP_OPTIONS + new_reqs + PIP_PACKAGE_INDEX_OPTIONS
+            # Generate a constraints file from currently installed packages
+            # to prevent plugin requirements from upgrading/downgrading core
+            # dependencies (e.g. cryptography).  Replacing native C-extension
+            # packages in a live process corrupts loaded shared objects and
+            # causes runtime crashes.
+            constraints_file = _build_constraints_file()
+            constraint_args = (
+                ['--constraint', constraints_file] if constraints_file else []
             )
+
+            log.info(f'Installing requirements: {" ".join(new_reqs)}')
+            try:
+                subprocess.check_call(
+                    [sys.executable, '-m', 'pip', 'install']
+                    + PIP_OPTIONS
+                    + constraint_args
+                    + new_reqs
+                    + PIP_PACKAGE_INDEX_OPTIONS
+                )
+            except subprocess.CalledProcessError:
+                log.error(
+                    f'Failed to install {" ".join(new_reqs)}. '
+                    f'This may be due to a conflict with pinned Open WebUI '
+                    f'dependencies. The tool/function requiring these packages '
+                    f'will not work, but the application will continue normally.'
+                )
+                return
+            finally:
+                if constraints_file:
+                    try:
+                        os.unlink(constraints_file)
+                    except OSError:
+                        pass
+
             _installed_requirements.update(new_reqs)
         except Exception as e:
             log.error(f'Error installing packages: {" ".join(new_reqs)}')


### PR DESCRIPTION
## Linked Issue

Closes #28021 

## Description

Tool/function frontmatter requirements are installed via `pip install` at startup (`install_frontmatter_requirements` in `plugin.py`). If a tool lists a package whose transitive dependencies conflict with pinned Open WebUI dependencies, pip silently replaces them in the running process.

**Example:** A tool with `crawl4ai` in its requirements pulls in `pyOpenSSL>=25.3.0` → `cryptography>=49.0.0`, which uninstalls the pinned `cryptography==48.0.0`. Since the old C-extension `.so` files are already loaded into the Python process, all subsequent code paths using `cryptography` crash, producing HTTP 500 errors on every request.

### Fix

Before running `pip install`, generate a **constraints file** from `pip freeze --local` and pass it via `--constraint` to pip. This prevents pip from upgrading or downgrading any already-installed package while still allowing new packages to be installed.

If a constraint conflict is detected (e.g. `crawl4ai` needs `cryptography>=49` but constraints pin `==48.0.0`), the install **fails cleanly** with a descriptive log message. The offending tool won't work, but the application starts and serves normally.

### Changes

- **New:** `_build_constraints_file()` helper — runs `pip freeze --local`, writes output to a temp file, returns the path
- **Modified:** `install_frontmatter_requirements()` — passes `--constraint <file>` to the pip subprocess, catches `CalledProcessError` with an actionable error message, cleans up temp file in `finally`

### No new dependencies

This uses only `subprocess`, `tempfile`, and `os` — all already imported in the file.

## Checklist

- [x] **Linked Issue/Discussion:** References an existing issue
- [x] **Target branch:** Targets `dev`
- [x] **Changelog:** See below
- [ ] **Documentation:** No docs changes needed (internal behavior change)
- [x] **Dependencies:** No new dependencies
- [x] **Testing:** Manual verification — tool with conflicting requirement now fails cleanly instead of crashing the app
- [x] **No Unchecked AI Code:** Code reviewed and tested
- [x] **Self-Review:** Performed
- [x] **Architecture:** No new settings; graceful fallback if `pip freeze` fails
- [x] **Git Hygiene:** Single atomic commit, rebased on `dev`
- [x] **Title Prefix:** Uses `fix:`

## Changelog

### Fixed

- Prevent plugin/tool `pip install` from upgrading or downgrading pinned core dependencies (e.g. `cryptography`), which could corrupt loaded C-extensions and crash the application with HTTP 500 errors.
