### PR TITLE
fix: prevent plugin pip installs from upgrading pinned core dependencies

### DIFF
--- a/backend/open_webui/utils/plugin.py
+++ b/backend/open_webui/utils/plugin.py
@@ -419,6 +419,47 @@ async def get_function_module_from_cache(
 _installed_requirements = set()
 
 
+def _build_constraints_file() -> str | None:
+    """Generate a pip constraints file from currently installed packages.
+
+    This prevents plugin/tool pip installs from upgrading or downgrading
+    packages that Open WebUI already depends on (e.g. cryptography, torch).
+    Replacing native C-extension packages in a running Python process causes
+    crashes that are extremely difficult to diagnose.
+
+    Returns the path to a temporary constraints file, or None on failure.
+    The caller is responsible for cleaning up the file.
+    """
+    try:
+        result = subprocess.run(
+            [sys.executable, '-m', 'pip', 'freeze', '--local'],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if result.returncode != 0:
+            log.warning(
+                'Failed to run pip freeze for constraints; '
+                'proceeding without constraints'
+            )
+            return None
+
+        frozen = result.stdout.strip()
+        if not frozen:
+            return None
+
+        fd, path = tempfile.mkstemp(prefix='owui_constraints_', suffix='.txt')
+        with os.fdopen(fd, 'w') as f:
+            f.write(frozen)
+        return path
+    except Exception:
+        log.warning(
+            'Could not generate pip constraints file; '
+            'proceeding without constraints'
+        )
+        return None
+
+
 def install_frontmatter_requirements(requirements: str):
     global _installed_requirements
     if not ENABLE_PIP_INSTALL_FRONTMATTER_REQUIREMENTS:
@@ -437,10 +478,40 @@ def install_frontmatter_requirements(requirements: str):
             if not new_reqs:
                 return
 
-            log.info(f'Installing requirements: {" ".join(new_reqs)}')
-            subprocess.check_call(
-                [sys.executable, '-m', 'pip', 'install'] + PIP_OPTIONS + new_reqs + PIP_PACKAGE_INDEX_OPTIONS
+            # Generate a constraints file from currently installed packages
+            # to prevent plugin requirements from upgrading/downgrading core
+            # dependencies (e.g. cryptography).  Replacing native C-extension
+            # packages in a live process corrupts loaded shared objects and
+            # causes runtime crashes.
+            constraints_file = _build_constraints_file()
+            constraint_args = (
+                ['--constraint', constraints_file] if constraints_file else []
             )
+
+            log.info(f'Installing requirements: {" ".join(new_reqs)}')
+            try:
+                subprocess.check_call(
+                    [sys.executable, '-m', 'pip', 'install']
+                    + PIP_OPTIONS
+                    + constraint_args
+                    + new_reqs
+                    + PIP_PACKAGE_INDEX_OPTIONS
+                )
+            except subprocess.CalledProcessError:
+                log.error(
+                    f'Failed to install {" ".join(new_reqs)}. '
+                    f'This may be due to a conflict with pinned Open WebUI '
+                    f'dependencies. The tool/function requiring these packages '
+                    f'will not work, but the application will continue normally.'
+                )
+                return
+            finally:
+                if constraints_file:
+                    try:
+                        os.unlink(constraints_file)
+                    except OSError:
+                        pass
+
             _installed_requirements.update(new_reqs)
         except Exception as e:
             log.error(f'Error installing packages: {" ".join(new_reqs)}')


### PR DESCRIPTION

<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — Closes #28019. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

# Changelog Entry

### Description

Tool/function frontmatter requirements are installed via `pip install` at startup (`install_frontmatter_requirements` in `plugin.py`). If a tool lists a package whose transitive dependencies conflict with pinned Open WebUI dependencies, pip silently replaces them in the running process.

**Example:** A tool with `crawl4ai` in its requirements pulls in `pyOpenSSL>=25.3.0` → `cryptography>=49.0.0`, which uninstalls the pinned `cryptography==48.0.0`. Since the old C-extension `.so` files are already loaded into the Python process, all subsequent code paths using `cryptography` crash, producing HTTP 500 errors on every request.

**Fix:** Before running `pip install`, generate a constraints file from `pip freeze --local` and pass it via `--constraint` to pip. This prevents pip from upgrading or downgrading any already-installed package. If a constraint conflict is detected, the install fails cleanly with a descriptive log message — the offending tool won't work, but the application starts and serves normally.

### Added

- `_build_constraints_file()` helper in `plugin.py` — runs `pip freeze --local`, writes output to a temp file, returns the path

### Changed

- `install_frontmatter_requirements()` now passes `--constraint <file>` to the pip subprocess, catches `CalledProcessError` with an actionable error message, and cleans up the temp file in `finally`

### Deprecated

- N/A

### Removed

- N/A

### Fixed

- Prevent plugin/tool `pip install` from upgrading or downgrading pinned core dependencies (e.g. `cryptography`), which could corrupt loaded C-extensions and crash the application with HTTP 500 errors.

### Security

- N/A

### Breaking Changes

- N/A

---

### Additional Information

- No new dependencies — uses only `subprocess`, `tempfile`, and `os`, all already imported in the file.
- Graceful fallback: if `pip freeze` fails for any reason, the install proceeds without constraints (same behavior as before).

### Screenshots or Videos

- N/A (backend-only change)

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
