### PR TITLE
docs(readme): show OPENAI_API_BASE_URL for OpenAI-compatible gateways

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,18 @@ This will start the Open WebUI server, which you can access at [http://localhost
   docker run -d -p 3000:8080 -e OPENAI_API_KEY=your_secret_key -v open-webui:/app/backend/data --name open-webui --restart always ghcr.io/open-webui/open-webui:main
   ```
 
+- **OpenAI-compatible gateways / custom base URL**: set `OPENAI_API_BASE_URL` (and the matching key) to any server that speaks the OpenAI HTTP API. Examples:
+
+  ```bash
+  # Official OpenAI (default when OPENAI_API_BASE_URL is unset)
+  docker run -d -p 3000:8080     -e OPENAI_API_KEY=sk-...     -v open-webui:/app/backend/data --name open-webui --restart always     ghcr.io/open-webui/open-webui:main
+
+  # OpenAI-compatible multi-model gateway (e.g. DaoXE)
+  docker run -d -p 3000:8080     -e OPENAI_API_BASE_URL=https://api.daoxe.com/v1     -e OPENAI_API_KEY=sk-...     -v open-webui:/app/backend/data --name open-webui --restart always     ghcr.io/open-webui/open-webui:main
+  ```
+
+  You can also configure base URLs in **Admin → Settings → Connections** after startup. Use a model ID that the target endpoint actually serves (`/v1/models`).
+
 ### Installing Open WebUI with Bundled Ollama Support
 
 This installation method uses a single container image that bundles Open WebUI with Ollama, allowing for a streamlined setup via a single command. Choose the appropriate command based on your hardware setup:


### PR DESCRIPTION
## Summary
The OpenAI-only install snippet in the README only set `OPENAI_API_KEY`. The backend already supports `OPENAI_API_BASE_URL` / `OPENAI_API_BASE_URLS` for any OpenAI-compatible endpoint.

This PR documents:
- How to point the container at a custom base URL
- A concrete multi-model gateway example (DaoXE)
- That Admin → Settings → Connections can also configure this after startup
- Reminder to use a model ID the target actually serves

## Test plan
- [ ] README renders correctly
- [ ] Env var names match `backend/open_webui/config.py` (`OPENAI_API_BASE_URL`)
- [ ] Example is optional / not presented as required