### PR TITLE
docs: show OPENAI_API_BASE_URL for OpenAI-compatible gateways

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,25 @@ This will start the Open WebUI server, which you can access at [http://localhost
   docker run -d -p 3000:8080 -e OPENAI_API_KEY=your_secret_key -v open-webui:/app/backend/data --name open-webui --restart always ghcr.io/open-webui/open-webui:main
   ```
 
+- **OpenAI-compatible gateways / custom base URL**: set `OPENAI_API_BASE_URL` (and the matching key) to any server that speaks the OpenAI HTTP API. Examples:
+
+  ```bash
+  # Official OpenAI (default when OPENAI_API_BASE_URL is unset)
+  docker run -d -p 3000:8080 \
+    -e OPENAI_API_KEY=sk-... \
+    -v open-webui:/app/backend/data --name open-webui --restart always \
+    ghcr.io/open-webui/open-webui:main
+
+  # OpenAI-compatible multi-model gateway (e.g. DaoXE)
+  docker run -d -p 3000:8080 \
+    -e OPENAI_API_BASE_URL=https://api.daoxe.com/v1 \
+    -e OPENAI_API_KEY=sk-... \
+    -v open-webui:/app/backend/data --name open-webui --restart always \
+    ghcr.io/open-webui/open-webui:main
+  ```
+
+  You can also configure base URLs in **Admin → Settings → Connections** after startup. Use a model ID that the target endpoint actually serves (`/v1/models`).
+
 ### Installing Open WebUI with Bundled Ollama Support
 
 This installation method uses a single container image that bundles Open WebUI with Ollama, allowing for a streamlined setup via a single command. Choose the appropriate command based on your hardware setup:


### PR DESCRIPTION
<!--
1. Target the `dev` branch.
2. Do NOT delete the CLA section at the bottom.
-->

# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Docs-only clarification of an existing env var (`OPENAI_API_BASE_URL` already supported in `backend/open_webui/config.py`). No separate issue — this documents behavior users already hit when wiring OpenAI-compatible endpoints. Happy to open a discussion if required.
- [x] **Target branch:** `dev`
- [x] **Description:** Document `OPENAI_API_BASE_URL` on the OpenAI-only install path with a concrete compatible-gateway example (DaoXE) and point to Admin → Connections.
- [x] **Changelog:** See below.
- [x] **Documentation:** README only (runtime docs live in open-webui/docs; this is the install entrypoint most users see first).
- [x] **Dependencies:** None.
- [x] **Testing:** Verified env var name against `backend/open_webui/config.py`; no runtime code change.
- [x] **No Unchecked AI Code:** Human-reviewed docs edit.
- [x] **Self-Review:** Done.
- [x] **Architecture:** Docs only; no new settings.
- [x] **Git Hygiene:** Single docs commit on `dev`.
- [x] **Title Prefix:** docs

# Changelog Entry

### Description

- Document how to point the OpenAI-only Docker install at an OpenAI-compatible base URL via `OPENAI_API_BASE_URL`.

### Added

- README example for `OPENAI_API_BASE_URL` (official OpenAI default + compatible gateway example).
- Note that Admin → Settings → Connections can configure base URLs after startup.

### Changed

- N/A

### Deprecated

- N/A

### Removed

- N/A

### Fixed

- N/A (docs gap only)

### Security

- N/A

### Breaking Changes

- N/A

### Additional Information

- Backend already honors `OPENAI_API_BASE_URL` / `OPENAI_API_BASE_URLS`; README previously only showed `OPENAI_API_KEY`.
- DaoXE is one concrete multi-model gateway example; pattern is vendor-neutral.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.