### PR TITLE
docs: show OPENAI_API_BASE_URL for OpenAI-compatible gateways

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,25 @@ This will start the Open WebUI server, which you can access at [http://localhost
   docker run -d -p 3000:8080 -e OPENAI_API_KEY=your_secret_key -v open-webui:/app/backend/data --name open-webui --restart always ghcr.io/open-webui/open-webui:main
   ```
 
+- **OpenAI-compatible gateways / custom base URL**: set `OPENAI_API_BASE_URL` (and the matching key) to any server that speaks the OpenAI HTTP API. Examples:
+
+  ```bash
+  # Official OpenAI (default when OPENAI_API_BASE_URL is unset)
+  docker run -d -p 3000:8080 \
+    -e OPENAI_API_KEY=sk-... \
+    -v open-webui:/app/backend/data --name open-webui --restart always \
+    ghcr.io/open-webui/open-webui:main
+
+  # OpenAI-compatible multi-model gateway (e.g. DaoXE)
+  docker run -d -p 3000:8080 \
+    -e OPENAI_API_BASE_URL=https://api.daoxe.com/v1 \
+    -e OPENAI_API_KEY=sk-... \
+    -v open-webui:/app/backend/data --name open-webui --restart always \
+    ghcr.io/open-webui/open-webui:main
+  ```
+
+  You can also configure base URLs in **Admin → Settings → Connections** after startup. Use a model ID that the target endpoint actually serves (`/v1/models`).
+
 ### Installing Open WebUI with Bundled Ollama Support
 
 This installation method uses a single container image that bundles Open WebUI with Ollama, allowing for a streamlined setup via a single command. Choose the appropriate command based on your hardware setup:


### PR DESCRIPTION
Closes open-webui/docs#1348

# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Closes open-webui/docs#1348
- [x] **Target branch:** `dev`
- [x] **Description:** Document `OPENAI_API_BASE_URL` on the OpenAI-only install path.
- [x] **Changelog:** below
- [x] **Documentation:** README
- [x] **Dependencies:** None
- [x] **Testing:** Env var verified against config.py; docs only
- [x] **No Unchecked AI Code:** Human-reviewed
- [x] **Self-Review:** Done
- [x] **Architecture:** Docs only
- [x] **Git Hygiene:** Single commit on dev
- [x] **Title Prefix:** docs

# Changelog Entry

### Description
- Document `OPENAI_API_BASE_URL` for OpenAI-compatible endpoints on the OpenAI-only Docker install path.

### Added
- README example for custom base URL (official default + compatible gateway example such as DaoXE).
- Note about Admin → Settings → Connections.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.