### PR TITLE
refactor: walk chat message history by map key

### DIFF
--- a/backend/open_webui/utils/misc.py
+++ b/backend/open_webui/utils/misc.py
@@ -139,18 +139,13 @@ def get_message_list(messages_map, message_id):
     message_list = []
     visited_message_ids = set()
 
-    while current_message:
-        message_id = current_message.get('id')
-        if message_id in visited_message_ids:
-            # Cycle detected, break to prevent infinite loop
-            break
-
-        if message_id is not None:
-            visited_message_ids.add(message_id)
-
+    # Track the map keys, not the messages' own 'id' field: a message may omit it
+    while current_message and message_id not in visited_message_ids:
+        visited_message_ids.add(message_id)
         message_list.append(current_message)
-        parent_id = current_message.get('parentId')  # Use .get() for safety
-        current_message = messages_map.get(parent_id) if parent_id else None
+
+        message_id = current_message.get('parentId')
+        current_message = messages_map.get(message_id) if message_id else None
 
     message_list.reverse()
     return message_list


### PR DESCRIPTION
`get_message_list` moves through `messages_map` by key but tracked each message's own `id` field, which the message body does not have to carry. Track the key instead.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
