### PR TITLE
refac: apply OAuth role management on the token exchange endpoint

### DIFF
--- a/backend/open_webui/routers/auths.py
+++ b/backend/open_webui/routers/auths.py
@@ -1705,4 +1705,17 @@ async def token_exchange(
             detail='User not found. Please sign in via the web interface first.',
         )
 
+    role = await oauth_manager.get_user_role(user, user_data, deny_on_missing_roles=True)
+    if user.role != role:
+        await Users.update_user_role_by_id(user.id, role, db=db)
+        user.role = role
+        await publish_event(
+            request,
+            EVENTS.USER_ROLE_UPDATED,
+            actor=user,
+            subject_id=user.id,
+            source='oauth',
+            data={'role': role, 'provider': provider},
+        )
+
     return await create_session_response(request, user, db, source='oauth')

--- a/backend/open_webui/routers/auths.py
+++ b/backend/open_webui/routers/auths.py
@@ -1681,4 +1681,9 @@ async def token_exchange(
             detail='User not found. Please sign in via the web interface first.',
         )
 
+    role = await oauth_manager.get_user_role(user, user_data, deny_on_missing_roles=True)
+    if user.role != role:
+        await Users.update_user_role_by_id(user.id, role, db=db)
+        user.role = role
+
     return await create_session_response(request, user, db, source='oauth')

--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -1498,7 +1498,7 @@ class OAuthManager:
             log.error(f'Exception during token refresh for provider {provider}: {e}')
             return None
 
-    async def get_user_role(self, user, user_data):
+    async def get_user_role(self, user, user_data, deny_on_missing_roles=False):
         auth_config = await get_oauth_runtime_config()
         user_count = await Users.get_num_users()
         if user and user_count == 1:
@@ -1550,6 +1550,14 @@ class OAuthManager:
             log.debug('User roles from oauth: %s', oauth_roles)
             log.debug('Accepted user roles: %s', oauth_allowed_roles)
             log.debug('Accepted admin roles: %s', oauth_admin_roles)
+
+            # No ID token here to backfill claims from, so falling back to DEFAULT_USER_ROLE would demote the user.
+            if not oauth_roles and deny_on_missing_roles:
+                log.warning('OAuth role management enabled but no roles resolved for the user; denying token exchange')
+                raise HTTPException(
+                    status.HTTP_403_FORBIDDEN,
+                    detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
+                )
 
             # If roles are present in the token, they must match; otherwise deny access
             if oauth_roles:

--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -1464,7 +1464,7 @@ class OAuthManager:
             log.error(f'Exception during token refresh for provider {provider}: {e}')
             return None
 
-    async def get_user_role(self, user, user_data):
+    async def get_user_role(self, user, user_data, deny_on_missing_roles=False):
         auth_config = await get_oauth_runtime_config()
         user_count = await Users.get_num_users()
         if user and user_count == 1:
@@ -1516,6 +1516,14 @@ class OAuthManager:
             log.debug('User roles from oauth: %s', oauth_roles)
             log.debug('Accepted user roles: %s', oauth_allowed_roles)
             log.debug('Accepted admin roles: %s', oauth_admin_roles)
+
+            # No ID token here to backfill claims from, so falling back to DEFAULT_USER_ROLE would demote the user.
+            if not oauth_roles and deny_on_missing_roles:
+                log.warning('OAuth role management enabled but no roles resolved for the user; denying token exchange')
+                raise HTTPException(
+                    status.HTTP_403_FORBIDDEN,
+                    detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
+                )
 
             # If roles are present in the token, they must match; otherwise deny access
             if oauth_roles:


### PR DESCRIPTION
The endpoint now resolves the user's role through the same role management path the OAuth callback uses, and persists it when it differs.

Where role management is enabled and no roles resolve, the exchange is denied instead of falling back to DEFAULT_USER_ROLE, which would demote an existing user. Deployments whose provider returns roles only in the ID token, or whose OAUTH_ROLES_CLAIM, OAUTH_ALLOWED_ROLES or OAUTH_ADMIN_ROLES configuration is incomplete, will see token exchange rejected where it previously issued a session.

A role change here also publishes USER_ROLE_UPDATED, matching the OAuth callback and the trusted-header sign-in. Without it a demotion applied through token exchange updates the row while the user's live websocket sessions keep serving the old role from the session pool until they reconnect.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
