### PR TITLE
fix(tools): apply function_names filter when loading openapi tool server specs

### DIFF
--- a/backend/open_webui/utils/tools.py
+++ b/backend/open_webui/utils/tools.py
@@ -363,6 +363,7 @@ async def get_tools(request: Request, tool_ids: list[str], user: UserModel, extr
                     type = splits[1]
                     server_id = splits[2]
 
+                function_names = None
                 server_id_splits = server_id.split('|')
                 if len(server_id_splits) == 2:
                     server_id = server_id_splits[0]
@@ -404,6 +405,8 @@ async def get_tools(request: Request, tool_ids: list[str], user: UserModel, extr
 
                     for spec in specs:
                         function_name = spec['name']
+                        if function_names and function_name not in function_names:
+                            continue
                         if function_name_filter_list:
                             if not is_string_allowed(function_name, function_name_filter_list):
                                 # Skip this function


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Linked Issue/Discussion:** This PR addresses OpenAPI tool server function selection logic in `open_webui/utils/tools.py`.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** Fixes `function_names` filter when loading OpenAPI tool server specs in `get_tools()` when `server_id` contains a pipe (`server_id|func1,func2`).
- [x] **Testing:** Verified logic in tool server spec filtering.
- [x] **No Unchecked AI Code:** Thoroughly reviewed and tested.

# Changelog Entry

### Fixed

- Fix `function_names` filter when loading OpenAPI tool server specs in `get_tools()` when `server_id` contains a pipe (`server_id|func1,func2`).

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.