### PR TITLE
fix: show error icon when a tool call result contains an error

### DIFF
--- a/src/lib/components/chat/Messages/Markdown/ConsecutiveDetailsGroup.svelte
+++ b/src/lib/components/chat/Messages/Markdown/ConsecutiveDetailsGroup.svelte
@@ -10,7 +10,9 @@
 	import WrenchSolid from '$lib/components/icons/WrenchSolid.svelte';
 	import Sparkles from '$lib/components/icons/Sparkles.svelte';
 	import CheckCircle from '$lib/components/icons/CheckCircle.svelte';
+	import ErrorCircle from '$lib/components/icons/ErrorCircle.svelte';
 	import FullHeightIframe from '$lib/components/common/FullHeightIframe.svelte';
+	import { isToolResultError } from '$lib/components/common/toolCallUtils';
 
 	import { settings } from '$lib/stores';
 
@@ -19,6 +21,7 @@
 	export let id = '';
 	export let tokens: Array<{
 		summary?: string;
+		text?: string;
 		attributes?: {
 			type?: string;
 			name?: string;
@@ -50,6 +53,16 @@
 		tokens.some((t) => t?.attributes?.done !== undefined && t?.attributes?.done !== 'true');
 
 	$: codeInterpreterCount = tokens.filter((t) => t?.attributes?.type === 'code_interpreter').length;
+
+	// True when any completed tool call in the group returned an error payload
+	// (e.g. {"error": "403 Client Error: ..."}), so the group summary can show a
+	// warning icon instead of a success check.
+	$: hasError = tokens.some((t) => {
+		if (t?.attributes?.type !== 'tool_calls') return false;
+		if (t?.attributes?.done !== 'true') return false;
+		const text = decode(t?.text ?? '').replace(/<summary>.*?<\/summary>/gi, '').trim();
+		return isToolResultError(text);
+	});
 
 	// Collect all embeds from tool_calls tokens
 	$: allEmbeds = (() => {
@@ -127,6 +140,10 @@
 			{#if hasPending}
 				<div>
 					<Spinner className="size-4" />
+				</div>
+			{:else if toolCallCount > 0 && hasError}
+				<div class="text-red-500 dark:text-red-400">
+					<ErrorCircle className="size-4" strokeWidth="2" />
 				</div>
 			{:else if toolCallCount > 0}
 				<div class="text-emerald-500 dark:text-emerald-400">

--- a/src/lib/components/common/ToolCallDisplay.svelte
+++ b/src/lib/components/common/ToolCallDisplay.svelte
@@ -13,9 +13,11 @@
 	import Spinner from './Spinner.svelte';
 	import WrenchSolid from '../icons/WrenchSolid.svelte';
 	import CheckCircle from '../icons/CheckCircle.svelte';
+	import ErrorCircle from '../icons/ErrorCircle.svelte';
 	import Image from './Image.svelte';
 	import FullHeightIframe from './FullHeightIframe.svelte';
 	import { settings } from '$lib/stores';
+	import { isToolResultError } from './toolCallUtils';
 
 	export let id: string = '';
 	export let attributes: {
@@ -95,6 +97,7 @@
 
 	$: parsedArgs = parseArguments(args);
 	$: parsedResult = parseJSONString(result);
+	$: isError = isDone && isToolResultError(result);
 </script>
 
 <div {id} class={className}>
@@ -135,6 +138,10 @@
 				{#if isExecuting}
 					<div>
 						<Spinner className="size-4" />
+					</div>
+				{:else if isDone && isError}
+					<div class="text-red-500 dark:text-red-400">
+						<ErrorCircle className="size-4" strokeWidth="2" />
 					</div>
 				{:else if isDone}
 					<div class="text-emerald-500 dark:text-emerald-400">

--- a/src/lib/components/common/toolCallUtils.test.ts
+++ b/src/lib/components/common/toolCallUtils.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { isToolResultError, parseToolResult } from './toolCallUtils';
+
+describe('parseToolResult', () => {
+	it('unwraps nested JSON-encoded strings', () => {
+		expect(parseToolResult('{"error":"x"}')).toEqual({ error: 'x' });
+		// Double-encoded payload: a JSON string containing a JSON string.
+		expect(parseToolResult('"{\\"error\\":\\"x\\"}"')).toEqual({ error: 'x' });
+	});
+
+	it('returns scalars without looping forever', () => {
+		expect(parseToolResult('5')).toBe(5);
+		expect(parseToolResult('null')).toBe(null);
+		expect(parseToolResult('true')).toBe(true);
+		expect(parseToolResult(5)).toBe(5);
+	});
+
+	it('returns non-JSON strings as-is', () => {
+		expect(parseToolResult('not json')).toBe('not json');
+		expect(parseToolResult('')).toBe('');
+	});
+});
+
+describe('isToolResultError', () => {
+	it('detects a JSON-encoded object with a non-empty error string', () => {
+		expect(isToolResultError('{"error":"403 Client Error: Forbidden for url: ..."}')).toBe(true);
+		expect(isToolResultError({ error: 'boom' })).toBe(true);
+	});
+
+	it('ignores empty / null / non-string error fields', () => {
+		expect(isToolResultError('{"error":""}')).toBe(false);
+		expect(isToolResultError('{"error":null}')).toBe(false);
+		expect(isToolResultError('{"error":0}')).toBe(false);
+		expect(isToolResultError('{"error":false}')).toBe(false);
+		expect(isToolResultError({ error: null })).toBe(false);
+	});
+
+	it('ignores non-error payloads', () => {
+		expect(isToolResultError('{"results":[1,2,3]}')).toBe(false);
+		expect(isToolResultError('{"query":"cats"}')).toBe(false);
+		expect(isToolResultError('just text')).toBe(false);
+		expect(isToolResultError('')).toBe(false);
+		expect(isToolResultError(null)).toBe(false);
+		expect(isToolResultError(undefined)).toBe(false);
+		expect(isToolResultError([])).toBe(false);
+	});
+});

--- a/src/lib/components/common/toolCallUtils.ts
+++ b/src/lib/components/common/toolCallUtils.ts
@@ -1,0 +1,37 @@
+/**
+ * Iteratively unwrap nested JSON-encoded strings.
+ *
+ * The naive recursive form (`return parse(JSON.parse(str))`) recurses forever
+ * on scalar values such as `JSON.parse('5') -> 5`, because `JSON.parse(5)` is
+ * `JSON.parse('5')` again. Unwrapping in a `while` loop avoids that
+ * stack-overflow-and-recover path.
+ */
+export function parseToolResult(value: string | unknown): unknown {
+	let current: unknown = value;
+	while (typeof current === 'string') {
+		try {
+			current = JSON.parse(current);
+		} catch {
+			break;
+		}
+	}
+	return current;
+}
+
+/**
+ * A tool call result is considered an error when the (possibly JSON-encoded)
+ * payload is an object that carries a non-empty `error` string — the shape the
+ * Open WebUI backend uses for tool failures such as
+ * `{"error": "403 Client Error: Forbidden for url: ..."}`.
+ *
+ * Empty/null/non-string `error` fields are ignored so that normal results that
+ * happen to include an `error: null` or `error: 0` field are not misreported.
+ */
+export function isToolResultError(value: string | unknown): boolean {
+	const parsed = parseToolResult(value);
+	if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+		return false;
+	}
+	const error = (parsed as Record<string, unknown>).error;
+	return typeof error === 'string' && error.trim().length > 0;
+}

--- a/src/lib/components/icons/ErrorCircle.svelte
+++ b/src/lib/components/icons/ErrorCircle.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	export let className = 'size-4';
+	export let strokeWidth = '1.5';
+</script>
+
+<svg
+	aria-hidden="true"
+	xmlns="http://www.w3.org/2000/svg"
+	fill="none"
+	viewBox="0 0 24 24"
+	stroke-width={strokeWidth}
+	stroke="currentColor"
+	class={className}
+>
+	<path
+		stroke-linecap="round"
+		stroke-linejoin="round"
+		d="M12 9v4M12 16.992v.008M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
+	/>
+</svg>


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Discussion: https://github.com/open-webui/open-webui/discussions/28046 · `Closes #28016`
- [x] **Target branch:** targets `dev`.
- [x] **Description:** provided below.
- [x] **Changelog:** Keep a Changelog entry included below.
- [ ] **Documentation:** No docs change needed for a UI status-icon fix.
- [x] **Dependencies:** No new dependencies added.
- [x] **Testing:** Unit tests added and verified; manual reasoning against the issue reproduction.
- [x] **No Unchecked AI Code:** AI-assisted, but every change was human-reviewed and the error-detection logic manually verified (see disclosure).
- [x] **Self-Review:** Performed.
- [x] **Architecture:** No new settings; local reactive state; purely additive.
- [x] **Git Hygiene:** Atomic, one commit, branched from `dev`.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

Tool call results that carry an error (e.g. `{"error": "403 Client Error: Forbidden for url: ..."}`) were always rendered with a green ✅ success check, hiding failures until the result was expanded. This renders a red error icon when a completed tool call's result is an error payload.

### Added

- `ErrorCircle` icon component (mirrors the existing `CheckCircle` heroicons style).
- `toolCallUtils.ts` with `isToolResultError()` — a dependency-free helper that safely parses a (possibly JSON-encoded / double-encoded) tool result and reports an error only when it is an object with a **non-empty string** `error` field (the shape the backend uses for tool failures). Vitest test included.

### Fixed

- Tool-call status icon now reflects errors: a completed call whose result is an error payload shows a red `ErrorCircle` instead of a green `CheckCircle`, both on the per-call "View Result from {name}" button (`ToolCallDisplay.svelte`) and the grouped "Explored {n} {name}" summary (`ConsecutiveDetailsGroup.svelte`). Fixes #28016.

### Behavior

| Result payload | Before | After |
|---|---|---|
| `{"error": "403 Client Error: Forbidden for url: ..."}` | green ✅ | red ⚠️ |
| `{"error": ""}` / `{"error": null}` / `{"error": 0}` | green ✅ | green ✅ (not an error) |
| `{"results": [...]}` / `{"query": "..."}` / plain text | green ✅ | green ✅ |

---

### Additional Information

- Purely additive (0 deletions), scoped strictly to the tool-call status icon.
- Edge case: some tools may include a string `error` field in a *successful* result. Detection is scoped to a **non-empty string** `error` to limit false positives; happy to switch to a more precise backend signal if one exists.
- No result-label text or i18n strings changed; only the icon + color reflect the error state.

### Verification

- `toolCallUtils.test.ts` (vitest) covers parse/unwrap and error-detection cases.
- The actual `toolCallUtils.ts` was also verified directly with Node's built-in TS stripping (19/19 assertions pass), since `node_modules` isn't installed in my sandbox.

### AI assistance disclosure

I used AI assistance to locate the bug and draft the fix/tests, then human-reviewed every change and manually verified the error-detection logic against the reproduction.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
