### PR TITLE
fix: keep references to lifespan background tasks so they are not garbage collected

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -373,12 +373,12 @@ async def lifespan(app: FastAPI):
         limiter = anyio.to_thread.current_default_thread_limiter()
         limiter.total_tokens = THREAD_POOL_SIZE
 
-    asyncio.create_task(periodic_usage_pool_cleanup())
-    asyncio.create_task(periodic_session_pool_cleanup())
+    app.state.periodic_usage_pool_cleanup = asyncio.create_task(periodic_usage_pool_cleanup())
+    app.state.periodic_session_pool_cleanup = asyncio.create_task(periodic_session_pool_cleanup())
 
     from open_webui.utils.automations import scheduler_worker_loop
 
-    asyncio.create_task(scheduler_worker_loop(app))
+    app.state.scheduler_worker_loop = asyncio.create_task(scheduler_worker_loop(app))
 
     if await Config.get('models.base_models_cache'):
         try:
@@ -458,6 +458,10 @@ async def lifespan(app: FastAPI):
 
     if hasattr(app.state, 'redis_task_command_listener'):
         app.state.redis_task_command_listener.cancel()
+
+    app.state.periodic_usage_pool_cleanup.cancel()
+    app.state.periodic_session_pool_cleanup.cancel()
+    app.state.scheduler_worker_loop.cancel()
 
     await publish_event(app, EVENTS.SYSTEM_SHUTDOWN_COMPLETED, source='system')
 


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #28052
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** No user-facing behaviour changes, so nothing to document.
- [ ] **Dependencies:** No dependency changes.
- [ ] **Testing:** See "What I verified and what I did not" below. I did not check this box because I have not run a live instance through a full startup/shutdown cycle.
- [ ] **No Unchecked AI Code:** Not checked, deliberately. See the note below.
- [x] **Self-Review:** A self-review of the code has been performed.
- [x] **Architecture:** No new settings; this follows a pattern already present six lines above the change.
- [x] **Git Hygiene:** Single atomic commit, branched from `dev` @ `2d18727`.
- [x] **Title Prefix:** `fix`

### On the AI-code checkbox

This patch was written with an AI coding agent. I have left the "No Unchecked AI Code" box unchecked rather than check it inaccurately, since it asks for thorough human review **and** manual testing and the manual-testing half has not happened. Everything under "What I verified" below was done mechanically and is reproducible by you in a couple of minutes. If that is not enough for this repo, closing this is completely reasonable and I would rather you close it than merge something unverified.

### Description

Three background tasks started in `lifespan` had their handles discarded:

```python
asyncio.create_task(periodic_usage_pool_cleanup())
asyncio.create_task(periodic_session_pool_cleanup())
asyncio.create_task(scheduler_worker_loop(app))
```

The event loop keeps only a **weak** reference to a task, so a task whose only referent is the loop can be garbage collected while suspended at an `await` ([asyncio docs](https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task): *"Save a reference to the result of this function, to avoid a task disappearing mid-execution"*).

All three are `while True` loops intended to run for the process lifetime (`socket/main.py:205`, `socket/main.py:176`, `utils/automations.py:203`). If one is collected, the symptom is silent: pool entries stop being cleaned up, or automations and calendar alerts stop firing, with nothing logged.

This is very likely an oversight rather than a decision, because the correct pattern is already in the same function six lines above:

```python
app.state.redis_task_command_listener = asyncio.create_task(redis_task_command_listener(app))
```

and it is cancelled in the shutdown half. The other three got neither. This applies the same treatment to them.

### What I verified and what I did not

Verified:

- `ruff format --check` and `ruff check` at the pinned `v0.15.5` from `.pre-commit-config.yaml`. The file reports **13 lint errors both before and after** this change, so the count is unchanged and none are introduced here. Formatting passes.
- `python -m py_compile` on the changed file.
- The unconditional `.cancel()` calls are safe. `yield` is at line 450 and the shutdown statements are plain code after it, not inside a `finally`, so a startup failure before line 376 skips them entirely. The three assignments are unconditional and sit before the `yield`, and calling an `async def` only builds a coroutine and cannot raise, so by the time shutdown runs all three attributes exist.
- `.cancel()` on an already-finished task is a no-op that returns `False`, so cancelling at shutdown cannot raise here.

Not verified:

- I have not run a live Open WebUI instance through startup and shutdown. The change is confined to reference-keeping and shutdown cancellation, but I am stating the limit rather than implying coverage I do not have.

---

# Changelog Entry

### Description

- Keeps strong references to the three lifespan background tasks so they cannot be garbage collected mid-execution, and cancels them on shutdown alongside the existing `redis_task_command_listener`.

### Fixed

- Fixed `periodic_usage_pool_cleanup`, `periodic_session_pool_cleanup` and `scheduler_worker_loop` being eligible for garbage collection while running, which could silently stop session/usage pool cleanup and the automation and calendar-alert scheduler.
- These three tasks are now cancelled on application shutdown instead of being left running.

---

### Additional Information

- Closes #28052, which has the full reasoning and the file/line references.

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
