### PR TITLE
fix: generate valid WEBUI_SECRET_KEY in start_windows.bat

### DIFF
--- a/backend/start_windows.bat
+++ b/backend/start_windows.bat
@@ -35,16 +35,21 @@ IF "%WEBUI_SECRET_KEY_LENGTH%" == "" (
 IF "%WEBUI_SECRET_KEY% %WEBUI_JWT_SECRET_KEY%" == " " (
     echo Loading WEBUI_SECRET_KEY from file, not provided as an environment variable.
 
-    IF NOT EXIST "%KEY_FILE%" (
+    IF NOT EXIST "!KEY_FILE!" (
         echo Generating WEBUI_SECRET_KEY
         :: Generate a random value to use as a WEBUI_SECRET_KEY in case the user didn't provide one
-        SET /p WEBUI_SECRET_KEY=<nul
-        FOR /L %%i IN (1,1,%WEBUI_SECRET_KEY_LENGTH%) DO SET /p WEBUI_SECRET_KEY=<!random!>>%KEY_FILE%
+        SET "CHARSET=0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        SET "WEBUI_SECRET_KEY="
+        FOR /L %%i IN (1,1,!WEBUI_SECRET_KEY_LENGTH!) DO (
+            SET /A "INDEX=!RANDOM! %% 62"
+            FOR %%j IN (!INDEX!) DO SET "WEBUI_SECRET_KEY=!WEBUI_SECRET_KEY!!CHARSET:~%%j,1!"
+        )
+        <nul SET /p="!WEBUI_SECRET_KEY!">"!KEY_FILE!"
         echo WEBUI_SECRET_KEY generated
     )
 
-    echo Loading WEBUI_SECRET_KEY from %KEY_FILE%
-    SET /p WEBUI_SECRET_KEY=<%KEY_FILE%
+    echo Loading WEBUI_SECRET_KEY from !KEY_FILE!
+    SET /p WEBUI_SECRET_KEY=<"!KEY_FILE!"
 )
 
 :: Execute uvicorn


### PR DESCRIPTION
The key generation loop redirected input from a non-existent file (`SET /p WEBUI_SECRET_KEY=<!random!>>%KEY_FILE%`), printing "The system cannot find the file specified." once per iteration and leaving the key file empty, so startup failed with "WEBUI_SECRET_KEY is not set".

Build a fixed-length alphanumeric key by indexing into a charset with %RANDOM% and write it once with `<nul set /p`. Also quote the key file path and use delayed expansion so paths with spaces work.

https://github.com/open-webui/open-webui/issues/28060

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
