### PR TITLE
fix: discard unsaved group settings and key the groups list

### DIFF
--- a/src/lib/components/admin/Users/Groups.svelte
+++ b/src/lib/components/admin/Users/Groups.svelte
@@ -176,7 +176,7 @@
 
 		{#if filteredGroups.length !== 0}
 			<div class="mt-1 grid grid-cols-1">
-				{#each filteredGroups as group, idx}
+				{#each filteredGroups as group, idx (group.id)}
 					<GroupItem {group} {setGroups} {defaultPermissions} />
 					{#if idx < filteredGroups.length - 1}
 						<hr class="border-gray-50 dark:border-gray-850/40" />

--- a/src/lib/components/admin/Users/Groups/EditGroupModal.svelte
+++ b/src/lib/components/admin/Users/Groups/EditGroupModal.svelte
@@ -96,7 +96,7 @@
 				features: { ...DEFAULT_PERMISSIONS.features, ...loadedPermissions.features },
 				settings: { ...DEFAULT_PERMISSIONS.settings, ...loadedPermissions.settings }
 			};
-			data = group?.data ?? {};
+			data = structuredClone(group?.data ?? {});
 
 			userCount = group?.member_count ?? 0;
 		}


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #28075. The member count refresh this branch originally also carried is dropped in favor of #28074, which was opened first and solves it more simply.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable.
- [ ] **Dependencies:** No new dependencies.
- [x] **Testing:** Both changes were reproduced on unmodified `dev` and verified on a live instance by the author. Details in Manual Verification below.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new settings, props, or components. One clone at initialization and one keyed each block, both following patterns already used in the frontend.
- [x] **Git Hygiene:** Two commits, one per change, based on the current `dev`, with no unrelated changes.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

Two state handling defects around the Edit User Group modal, both independent of the member count refresh in #28074.

**Problem 1** (#28075): changing `Who can share to this group` and closing the modal without saving leaves the abandoned value in place. Reopening shows it, and a later save of an unrelated field writes it to the database.

**Root Cause 1**: `init()` assigns `data = group?.data ?? {}`, a reference rather than a copy, so the modal's `data` and the group object held by the groups list are the same object. The share control in `General.svelte` then mutates it with `data.config = {...}`, writing through to the list. Permissions are immune because `init()` rebuilds them from fresh spreads, and Name and Description are strings copied by value, which is why only this field misbehaves.

**Fix 1**: clone the group's data when the modal initializes, so edits stay local until Save. `structuredClone` is already the cloning idiom used across the frontend:

```diff
-			data = group?.data ?? {};
+			data = structuredClone(group?.data ?? {});
```

**Problem 2**: the groups list renders `GroupItem` from an unkeyed each block, so Svelte reuses component instances positionally. When the list reorders while a modal is open, the still open modal can be rebound to a different group: it keeps displaying the original group's name and permissions while writing to another one.

This is reachable on current `dev`. `submitHandler` awaits `onSubmit`, which calls `setGroups()`, before setting `show = false`, so saving a rename while the list is sorted by name refetches and reorders the list before the modal closes.

**Fix 2**: key the each block by group id, so instances follow their group rather than their position:

```diff
-				{#each filteredGroups as group, idx}
+				{#each filteredGroups as group, idx (group.id)}
```

### Fixed

- Fixed unsaved changes to `Who can share to this group` persisting after closing the Edit User Group modal without saving, and being silently written to the database by a later save of an unrelated field.
- Fixed the admin groups list reusing component instances positionally, which could rebind an open Edit User Group modal to a different group when the list reordered.

---

### Additional Information

- This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- This branch originally also fixed the stale member count from #28072. @kim-seokjin opened #28074 for that shortly before, with a simpler approach in a single file, so that work is dropped here and #28074 should be preferred for it. The two changes remaining in this PR do not overlap with it.
- Fix 2 was found while testing an earlier iteration of the member count refresh. Refreshing the list on every membership toggle reordered the member sorted list under the open modal, and the unkeyed each block then rebound the modal to a different group, so toggles began hitting the wrong group. That approach was abandoned, but the keying weakness it exposed is real on its own and is fixed here.

### Manual Verification Performed

1. **Reproduced #28075 on unmodified `dev`:** changed the share setting, closed the modal without saving, reopened, and saw the abandoned value. A page refresh reverted it, confirming it was never persisted and the modal was showing stale local state.
2. **Verified the silent persistence path:** changed the share setting, closed without saving, reopened, changed only the Name, clicked Save, then refreshed. Before the fix the abandoned share value was written to the database alongside the name. After the fix the share setting keeps its saved value.
3. **Confirmed the reference semantics** by simulating both `init()` strategies against the real mutation the share control performs. The reference assignment leaves the abandoned value visible on reopen and mutates the list's group object; the clone leaves both correct.
4. **Verified Fix 2:** with the list sorted so that a save reorders it, an open modal now stays bound to the group named in its header.
5. `npm run format` produces no changes and `npm run build` passes. The diff adds no code comments.

### Screenshots or Videos

Not applicable. Both are state behavior rather than visual, and the reproduction steps above take under a minute each.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
