### PR TITLE
fix: prevent profile preview avatars from squashing on narrow viewports

### DIFF
--- a/src/lib/components/channel/Messages/Message/ProfilePreview.svelte
+++ b/src/lib/components/channel/Messages/Message/ProfilePreview.svelte
@@ -44,7 +44,7 @@
 </script>
 
 <LinkPreview.Root openDelay={0} closeDelay={200} bind:open={openPreview}>
-	<LinkPreview.Trigger class="flex items-center">
+	<LinkPreview.Trigger class="flex shrink-0 items-center">
 		<button
 			type="button"
 			class=" cursor-pointer no-underline! font-normal!"


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

## Summary

Relates to #27999

This PR fixes the avatar distortion issue on narrow mobile viewports by preventing the `LinkPreview.Trigger` wrapper from shrinking inside flex containers.

The fix adds the `shrink-0` Tailwind utility class to the shared `ProfilePreview` component, ensuring profile avatars retain their circular shape across all screen sizes.

## Testing

- Reproduced the issue using a 414px mobile viewport in Chrome DevTools.
- Verified avatars remain circular after the change.
- Confirmed desktop behavior is unchanged.

---

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Relates to #27999
- [x] **Target branch:** This PR targets the `dev` branch.
- [x] **Description:** A concise description has been provided.
- [x] **Changelog:** Added below.
- [ ] **Documentation:** No documentation changes required.
- [ ] **Dependencies:** No dependency changes.
- [x] **Testing:** Manual testing completed.
- [x] **No Unchecked AI Code:** Changes were manually reviewed and tested.
- [x] **Self-Review:** Completed.
- [x] **Architecture:** No architectural changes introduced.
- [x] **Git Hygiene:** Single logical commit, rebased on `dev`.
- [x] **Title Prefix:** Uses the `fix` prefix.

# Changelog Entry

### Description

- Prevent avatar wrappers from shrinking in flex layouts on narrow viewports.

### Added

- None.

### Changed

- Added the `shrink-0` utility class to `LinkPreview.Trigger` in `ProfilePreview.svelte`.

### Deprecated

- None.

### Removed

- None.

### Fixed

- Fixed profile avatars being compressed into vertical ovals on mobile devices.

### Security

- None.

### Breaking Changes

- None.

---

### Additional Information

This change affects the shared `ProfilePreview` component, ensuring avatar dimensions remain consistent wherever the component is used.

### Screenshots or Videos

- Before: Avatar compressed into an oval on a 414px viewport.
- After: Avatar remains circular on the same viewport.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.