### PR TITLE
fix: hide Ports section when terminal is disabled

### DIFF
--- a/src/lib/components/chat/FileNav.svelte
+++ b/src/lib/components/chat/FileNav.svelte
@@ -1472,7 +1472,7 @@
 		</div>
 
 		<!-- Port detection -->
-		{#if selectedTerminal && !selectedFile && previewPort === null}
+		{#if selectedTerminal && terminalEnabled && !selectedFile && previewPort === null}
 			<div class="shrink-0 border-t border-gray-100 dark:border-gray-800">
 				<PortList
 					baseUrl={selectedTerminal.url}


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27830
- [x] **Target branch:** This pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following Keep a Changelog format is included below.
- [ ] **Documentation:** No documentation changes are required for this UI bug fix.
- [ ] **Dependencies:** No new dependencies were added or updated.
- [x] **Testing:** Manual testing was performed to verify the fix and ensure no regressions.
- [x] **No Unchecked AI Code:** The code changes have been reviewed and manually tested.
- [x] **Self-Review:** A self-review has been completed.
- [x] **Architecture:** The fix uses the existing `terminalEnabled` state and does not introduce new configuration or architectural changes.
- [x] **Git Hygiene:** This PR contains a single logical change and is based on the latest `dev` branch.
- [x] **Title Prefix:** This PR uses the `fix:` prefix.

# Changelog Entry

## Description

This PR fixes the File Navigator so that the **Ports** section is only rendered when the terminal feature is enabled. Previously, the Ports panel remained visible even when `OPEN_TERMINAL_ENABLE_TERMINAL=false`, resulting in a confusing UI for deployments where terminal functionality is intentionally disabled.

## Added

- N/A

## Changed

- Updated the conditional rendering of the `PortList` component in `src/lib/components/chat/FileNav.svelte` to also check the existing `terminalEnabled` flag.

## Deprecated

- N/A

## Removed

- N/A

## Fixed

- Fixed the File Navigator to hide the **Ports** section when the terminal feature is disabled.

## Security

- N/A

## Breaking Changes

- None.

## Additional Information

### Testing Performed

- Verified that the **Ports** section is displayed when `OPEN_TERMINAL_ENABLE_TERMINAL=true`.
- Verified that the **Ports** section is hidden when `OPEN_TERMINAL_ENABLE_TERMINAL=false`.
- Confirmed that existing File Navigator behavior remains unchanged when the terminal feature is enabled.

### Screenshots or Videos

- Not included (UI change is limited to conditional rendering of an existing panel).

## Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.