### PR TITLE
fix: refresh the frontend config after saving admin interface settings

### DIFF
--- a/src/lib/components/admin/Settings.svelte
+++ b/src/lib/components/admin/Settings.svelte
@@ -462,8 +462,11 @@
 					/>
 				{:else if selectedTab === 'interface'}
 					<Interface
-						on:save={() => {
+						on:save={async () => {
 							toast.success($i18n.t('Settings saved successfully!'));
+
+							await tick();
+							await config.set(await getBackendConfig());
 						}}
 					/>
 				{:else if selectedTab === 'audio'}

--- a/src/lib/components/chat/SettingsModal.svelte
+++ b/src/lib/components/chat/SettingsModal.svelte
@@ -1246,11 +1246,7 @@
 			{:else if selectedTab === 'admin:code-execution'}
 				<AdminCodeExecution saveHandler={adminConfigSaveHandler} />
 			{:else if selectedTab === 'admin:interface'}
-				<AdminInterface
-					on:save={() => {
-						toast.success($i18n.t('Settings saved successfully!'));
-					}}
-				/>
+				<AdminInterface on:save={adminConfigSaveHandler} />
 			{:else if selectedTab === 'admin:audio'}
 				<AdminAudio
 					saveHandler={() => {


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) - Closes #28082 
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

# Changelog Entry

### Description

- Saving on the admin Interface tab persists the value and `/api/config` returns it, but the running SPA keeps the value it loaded at page load, because the Interface tab is the only admin settings tab that never refreshes the frontend `config` store after a save. It only shows a success toast.
- Every other tab that feeds `$config` refreshes it, either through the shared save handler (General, Documents, Web Search, Code Execution) or internally in the component (Connections, Audio, General). Images refreshes only when image generation is enabled, which is a separate pre-existing issue and is left alone here.
- The gap exists on both surfaces that render the admin Interface tab: the `/admin/settings/interface` page and the settings modal.
- The observable consequence today is `ENABLE_AUTOCOMPLETE_GENERATION`, consumed at `MessageInput.svelte` as `$config?.features?.enable_autocomplete_generation && ($settings?.promptAutocomplete ?? false)`. Turning it off in the admin panel leaves autocomplete running for any user who already has the per-user prompt autocomplete setting enabled, until they reload.
- The most direct way to see the gap without depending on a feature: open the browser Network tab, save on the Interface tab, and note that no `GET /api/config` request follows. Doing the same on General or Web Search fires one.

### Fixed

- The admin Interface tab now refreshes the frontend config store after a save, on both the admin settings page and the settings modal, matching the tabs that already do this, so the setting takes effect without a page reload.

---

### Additional Information

The `config` store is populated in `src/routes/+layout.svelte` on page load, on the auth page, and by the admin save handlers listed above. No other path updates it, so before this change a reload was the only way to pick up an admin Interface tab save.

An earlier revision of this description claimed `ENABLE_FOLLOW_UP_GENERATION` was also affected. That was wrong and has been corrected: follow-up generation is not exposed through `/api/config` at all and has no frontend consumer, so it is gated entirely server-side and cannot go stale this way.

The change reuses the exact handler shape already present in the sibling branches of the same `{#if}` block:

```js
await tick();
await config.set(await getBackendConfig());
```

`tick` and `getBackendConfig` were already imported in this file, so no new imports were needed.

### Contributor License Agreement

- [X] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.

