### PR TITLE
fix: preserve HTML entities in structured output embeds

### DIFF
--- a/src/lib/components/chat/Messages/Markdown/ConsecutiveDetailsGroup.svelte
+++ b/src/lib/components/chat/Messages/Markdown/ConsecutiveDetailsGroup.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { decode } from 'html-entities';
 	import { getContext } from 'svelte';
 	import { slide } from 'svelte/transition';
 	import { quintOut } from 'svelte/easing';
@@ -11,6 +10,10 @@
 	import Sparkles from '$lib/components/icons/Sparkles.svelte';
 	import CheckCircle from '$lib/components/icons/CheckCircle.svelte';
 	import FullHeightIframe from '$lib/components/common/FullHeightIframe.svelte';
+	import {
+		decodeToolCallAttribute,
+		parseToolCallAttribute
+	} from '$lib/components/common/toolCallAttributes';
 
 	import { settings } from '$lib/stores';
 
@@ -32,16 +35,9 @@
 	export let messageDone = true;
 	export let allowEmbeds = true;
 	export let compactPreview = false;
+	export let htmlEncodedAttributes = true;
 
 	let open = $settings?.expandDetails ?? false;
-
-	function parseJSONString(str: string) {
-		try {
-			return parseJSONString(JSON.parse(str));
-		} catch (e) {
-			return str;
-		}
-	}
 
 	$: toolCallCount = tokens.filter((t) => t?.attributes?.type === 'tool_calls').length;
 	$: reasoningCount = tokens.filter((t) => t?.attributes?.type === 'reasoning').length;
@@ -58,15 +54,14 @@
 		const result: Array<{ name: string; embed: string; args: string }> = [];
 		for (const t of tokens) {
 			if (t?.attributes?.type !== 'tool_calls') continue;
-			const raw = decode(t.attributes?.embeds ?? '');
 			try {
-				const parsed = parseJSONString(raw);
+				const parsed = parseToolCallAttribute(t.attributes?.embeds ?? '', htmlEncodedAttributes);
 				if (Array.isArray(parsed) && parsed.length > 0) {
 					for (const embed of parsed) {
 						result.push({
 							name: t.attributes?.name ?? '',
 							embed,
-							args: decode(t.attributes?.arguments ?? '')
+							args: decodeToolCallAttribute(t.attributes?.arguments ?? '', htmlEncodedAttributes)
 						});
 					}
 				}

--- a/src/lib/components/chat/Messages/StructuredOutputRenderer.svelte
+++ b/src/lib/components/chat/Messages/StructuredOutputRenderer.svelte
@@ -70,6 +70,7 @@
 			id={`${id}-${displayItem.id}`}
 			tokens={displayItem.tokens}
 			messageDone={done}
+			htmlEncodedAttributes={false}
 			{compactPreview}
 		>
 			<div slot="content">
@@ -80,6 +81,7 @@
 							attributes={detailToken.attributes}
 							resultContent={detailToken.text}
 							grouped={true}
+							htmlEncodedAttributes={false}
 							open={$settings?.expandDetails ?? false}
 							className="w-full"
 							buttonClassName={detailButtonClassName}
@@ -127,6 +129,7 @@
 				id={`${id}-${displayItem.id}-tool-call`}
 				attributes={detailToken.attributes}
 				resultContent={detailToken.text}
+				htmlEncodedAttributes={false}
 				open={$settings?.expandDetails ?? false}
 				className="w-full space-y-2"
 				buttonClassName={detailButtonClassName}

--- a/src/lib/components/chat/Messages/StructuredOutputRenderer.test.ts
+++ b/src/lib/components/chat/Messages/StructuredOutputRenderer.test.ts
@@ -1,0 +1,89 @@
+import { encode } from 'html-entities';
+import { render } from 'svelte/server';
+import { readable } from 'svelte/store';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import ToolCallDisplay from '$lib/components/common/ToolCallDisplay.svelte';
+
+import StructuredOutputRenderer from './StructuredOutputRenderer.svelte';
+import type { OutputItem } from './structuredOutput';
+
+const EMBED_HTML = '<html><body><p>&quot;</p></body></html>';
+const context = new Map([['i18n', readable({ t: (value: string) => value })]]);
+
+beforeAll(() => {
+	vi.stubGlobal('window', {
+		addEventListener: () => {},
+		removeEventListener: () => {}
+	});
+});
+
+afterAll(() => {
+	vi.unstubAllGlobals();
+});
+
+function renderOutput(output: OutputItem[]) {
+	return render(StructuredOutputRenderer, {
+		props: {
+			id: 'message',
+			output,
+			done: true,
+			renderMarkdown: false
+		},
+		context
+	}).body;
+}
+
+function toolCall(callId: string): OutputItem {
+	return {
+		type: 'function_call',
+		call_id: callId,
+		name: 'rich_ui',
+		status: 'completed',
+		arguments: '{}'
+	};
+}
+
+function toolOutput(callId: string): OutputItem {
+	return {
+		type: 'function_call_output',
+		call_id: callId,
+		embeds: [EMBED_HTML]
+	};
+}
+
+describe('StructuredOutputRenderer', () => {
+	it('keeps decoding legacy HTML-encoded embed attributes', () => {
+		const body = render(ToolCallDisplay, {
+			props: {
+				id: 'legacy',
+				attributes: {
+					name: 'rich_ui',
+					done: 'true',
+					embeds: encode(JSON.stringify([EMBED_HTML]))
+				}
+			},
+			context
+		}).body;
+
+		expect(body).toContain('legacy-tool-call-embed-0');
+	});
+
+	it('renders a structured embed containing an HTML entity', () => {
+		const body = renderOutput([toolCall('call-1'), toolOutput('call-1')]);
+
+		expect(body).toContain('tool-call-embed-0');
+	});
+
+	it('renders grouped structured embeds containing HTML entities', () => {
+		const body = renderOutput([
+			toolCall('call-1'),
+			toolOutput('call-1'),
+			toolCall('call-2'),
+			toolOutput('call-2')
+		]);
+
+		expect(body).toContain('detail-group-0-embed-0');
+		expect(body).toContain('detail-group-0-embed-1');
+	});
+});

--- a/src/lib/components/common/ToolCallDisplay.svelte
+++ b/src/lib/components/common/ToolCallDisplay.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { decode } from 'html-entities';
 	import { v4 as uuidv4 } from 'uuid';
 
 	import { getContext } from 'svelte';
@@ -15,6 +14,11 @@
 	import CheckCircle from '../icons/CheckCircle.svelte';
 	import Image from './Image.svelte';
 	import FullHeightIframe from './FullHeightIframe.svelte';
+	import {
+		decodeToolCallAttribute,
+		parseJSONString,
+		parseToolCallAttribute
+	} from './toolCallAttributes';
 	import { settings } from '$lib/stores';
 
 	export let id: string = '';
@@ -31,6 +35,7 @@
 
 	export let open = false;
 	export let grouped = false;
+	export let htmlEncodedAttributes = true;
 	export let className = '';
 
 	const RESULT_PREVIEW_LIMIT = 10000;
@@ -41,22 +46,6 @@
 		'w-fit py-1 text-[0.9375rem] text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 transition';
 
 	const componentId = id || uuidv4();
-
-	function parseJSONString(str: string) {
-		// Iteratively unwrap nested JSON-encoded strings. Same result as the previous
-		// recursive form, but without the stack-overflow-and-recover path it hit on
-		// scalar values (e.g. JSON.parse('5') -> 5 -> infinite self-recursion).
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		let value: any = str;
-		while (typeof value === 'string') {
-			try {
-				value = JSON.parse(value);
-			} catch {
-				break;
-			}
-		}
-		return value;
-	}
 
 	function formatJSONString(str: string) {
 		try {
@@ -85,11 +74,14 @@
 
 	export let resultContent: string = '';
 
-	$: result = resultContent || decode(attributes?.result ?? '');
-	$: files = parseJSONString(decode(attributes?.files ?? ''));
-	$: embeds = parseJSONString(decode(attributes?.embeds ?? ''));
+	$: result =
+		resultContent || decodeToolCallAttribute(attributes?.result ?? '', htmlEncodedAttributes);
+	$: files = parseToolCallAttribute(attributes?.files ?? '', htmlEncodedAttributes);
+	$: embeds = parseToolCallAttribute(attributes?.embeds ?? '', htmlEncodedAttributes);
 	$: args =
-		open || (Array.isArray(embeds) && embeds.length > 0) ? decode(attributes?.arguments ?? '') : '';
+		open || (Array.isArray(embeds) && embeds.length > 0)
+			? decodeToolCallAttribute(attributes?.arguments ?? '', htmlEncodedAttributes)
+			: '';
 	$: isDone = attributes?.done === 'true';
 	$: isExecuting = attributes?.done && attributes?.done !== 'true';
 

--- a/src/lib/components/common/toolCallAttributes.ts
+++ b/src/lib/components/common/toolCallAttributes.ts
@@ -1,0 +1,22 @@
+import { decode } from 'html-entities';
+
+export function decodeToolCallAttribute(value: string, htmlEncoded = true): string {
+	return htmlEncoded ? decode(value) : value;
+}
+
+export function parseJSONString(value: string) {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	let parsed: any = value;
+	while (typeof parsed === 'string') {
+		try {
+			parsed = JSON.parse(parsed);
+		} catch {
+			break;
+		}
+	}
+	return parsed;
+}
+
+export function parseToolCallAttribute(value: string, htmlEncoded = true) {
+	return parseJSONString(decodeToolCallAttribute(value, htmlEncoded));
+}


### PR DESCRIPTION
# Pull Request Checklist

- [x] Closes #28085
- [x] Targets `dev`
- [x] No dependency or documentation changes
- [x] Focused regression tests included
- [x] Atomic change and self-review completed

# Changelog Entry

### Description

- Preserve literal HTML entities inside Rich UI embeds from structured model output.

### Added

- SSR regression coverage for legacy encoded attributes and single/grouped structured embeds.

### Changed

- Tool-call parsing now distinguishes HTML-encoded legacy attributes from raw structured-output attributes.

### Fixed

- Structured Rich UI embeds no longer disappear when embedded HTML contains entities such as `&quot;`.

---

### Additional Information

- `npx vitest run src/lib/components/chat/Messages/StructuredOutputRenderer.test.ts` (3 passed)
- Targeted ESLint and Prettier checks
- `git diff --check`
- `npm run build`
- Full `svelte-check` remains blocked by the repository's existing error baseline; the new helper/imports and structured-output prop uses add no diagnostics.
- No API, persistence, or save-contract behavior changes.

### Screenshots or Videos

- Not applicable; deterministic SSR assertions cover both affected render paths.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
