### PR TITLE
feat: add a per-file reindex action to knowledge bases

### DIFF
--- a/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
+++ b/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
@@ -893,6 +893,28 @@
 		}
 	};
 
+	let reindexingFileIds = [];
+
+	const reindexFileHandler = async (fileId: string) => {
+		if (reindexingFileIds.includes(fileId)) {
+			return;
+		}
+
+		reindexingFileIds = [...reindexingFileIds, fileId];
+
+		try {
+			const res = await updateFileFromKnowledgeById(localStorage.token, id, fileId);
+			if (res) {
+				toast.success($i18n.t('File reindexed.'));
+				getItemsPage();
+			}
+		} catch (e) {
+			toast.error(`${e}`);
+		} finally {
+			reindexingFileIds = reindexingFileIds.filter((reindexedId) => reindexedId !== fileId);
+		}
+	};
+
 	let debounceTimeout = null;
 	let mediaQuery;
 
@@ -1591,6 +1613,8 @@
 													deleteFileHandler(fileId);
 												}}
 												onRename={(fileId, name) => renameFileHandler(fileId, name)}
+												onReindex={(fileId) => reindexFileHandler(fileId)}
+												{reindexingFileIds}
 												onNavigateDirectory={(dirId) => navigateToDirectory(dirId)}
 												onRenameDirectory={(id, name) => renameDirectoryHandler(id, name)}
 												onDeleteDirectory={(id) => confirmDeleteDirectory(id)}

--- a/src/lib/components/workspace/Knowledge/KnowledgeBase/Files.svelte
+++ b/src/lib/components/workspace/Knowledge/KnowledgeBase/Files.svelte
@@ -18,6 +18,7 @@
 	import DropdownMenu from '$lib/components/common/DropdownMenu.svelte';
 	import DocumentPage from '$lib/components/icons/DocumentPage.svelte';
 	import EllipsisHorizontal from '$lib/components/icons/EllipsisHorizontal.svelte';
+	import ArrowPath from '$lib/components/icons/ArrowPath.svelte';
 	import Download from '$lib/components/icons/Download.svelte';
 	import GarbageBin from '$lib/components/icons/GarbageBin.svelte';
 	import Pencil from '$lib/components/icons/Pencil.svelte';
@@ -28,10 +29,12 @@
 	export let selectedFileId = null;
 	export let files = [];
 	export let directories = [];
+	export let reindexingFileIds = [];
 
 	export let onClick = (fileId) => {};
 	export let onDelete = (fileId) => {};
 	export let onRename = (fileId: string, name: string) => {};
+	export let onReindex = (fileId: string) => {};
 	export let onNavigateDirectory = (directoryId: string) => {};
 	export let onRenameDirectory = (id: string, name: string) => {};
 	export let onDeleteDirectory = (id: string) => {};
@@ -89,7 +92,7 @@
 			}}
 		>
 			<div class="flex items-center">
-				{#if file?.status !== 'uploading'}
+				{#if file?.status !== 'uploading' && !reindexingFileIds.includes(file?.id ?? file?.tempId)}
 					<button
 						class="p-1 rounded-full transition"
 						type="button"
@@ -206,6 +209,16 @@
 								>
 									<Download className="size-3.5" />
 									{$i18n.t('Download')}
+								</button>
+								<button
+									type="button"
+									class="select-none flex h-[1.6875rem] w-full cursor-pointer items-center gap-2 rounded-xl bg-transparent px-2 text-xs transition hover:text-gray-900 dark:hover:text-gray-100"
+									on:click={() => {
+										onReindex(file?.id ?? file?.tempId);
+									}}
+								>
+									<ArrowPath className="size-3.5" />
+									{$i18n.t('Reindex')}
 								</button>
 								<button
 									type="button"

--- a/src/lib/i18n/locales/en-US/translation.json
+++ b/src/lib/i18n/locales/en-US/translation.json
@@ -1229,6 +1229,7 @@
 	"File moved.": "",
 	"File name": "",
 	"File not found.": "",
+	"File reindexed.": "",
 	"File removed successfully.": "",
 	"File renamed.": "",
 	"File size should not exceed {{maxSize}} MB.": "",


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Discussed in #28093. Split out of #26211, which bundled three unrelated concerns; this PR carries only the per-file reindex action. Relates to #28093 and #26211
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** No documentation changes needed.
- [x] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Manual tests have been performed to verify the feature works correctly and does not introduce regressions.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new settings and no backend changes. The action reuses the existing endpoint.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **feat**: New features or enhancements

# Changelog Entry

### Description

- Reindexing a single file in a knowledge base is already supported on the backend, but nothing in the UI calls it. `PUT /knowledge/{id}/file/update` deletes that file's vectors and re-embeds it, `updateFileFromKnowledgeById` exists in the API client, and `KnowledgeBase.svelte` already imports that function. The import is currently unused.
- Reindexing does exist in the UI at instance scope: `Reindex Knowledge Base Vectors` in Admin Settings > Documents > Danger Zone, which calls `POST /knowledge/reindex`. That endpoint is admin only and iterates every knowledge base and every file. So repairing one badly extracted file means either rebuilding every knowledge file on the instance, or removing that file from the knowledge base and adding it back by hand. Someone who manages a knowledge base without being an admin has no reindex path at all.
- This adds the missing granular action: a **Reindex** entry in the per-file menu, wired to the endpoint that already exists. It does not change or replace the instance-wide admin action, and there are no backend changes.

### Added

- A `Reindex` entry in the knowledge base file menu, next to Download and Delete.
- A progress indication while a file is reindexing: the file row shows the same spinner already used for files that are uploading, and a `File reindexed.` toast on completion.

---

### Additional Information

**Why this is UI only.** `update_file_from_knowledge_by_id` awaits `process_file` directly, and nothing in the retrieval path schedules background work, so the request blocks until embedding finishes and the HTTP response is the completion signal. That is why the toast reports completion rather than start, and why the spinner is driven by the in-flight request rather than by polling a status endpoint.

**Concurrency.** Reindex requests are tracked per file id, so a second click on a file that is already reindexing is ignored, and reindexing two different files at once shows a spinner on each. The tracking is cleared in a `finally` block, so a failed request clears its spinner rather than stranding it.

**Relationship to #26211.** That PR bundles three separate concerns: removal of unlinked pending files, this per-file reindex action, and a cap on the pending poll timer. Splitting the reindex action out leaves each reviewable on its own. The hunks here are not copied verbatim from that PR: the file menu buttons were restyled on `dev` since it was opened, so the new button matches the current classes, and the handler is a named function alongside `renameFileHandler` and `deleteFileHandler` rather than an inline closure.

**Distinct from #13225.** That PR adds instance-wide reindexing across memories, files and knowledge bases, and its only UI surface is `admin/Settings/Documents.svelte`. It does not add a per-file action, and it shares no files with this change.

**Manual verification performed:**

1. Opened a knowledge base, opened the per-file menu, and confirmed the Reindex entry appears alongside Download and Delete.
2. Triggered a reindex on a file and confirmed the file row shows a spinner for the duration and a `File reindexed.` toast on completion.
3. Confirmed the file list refreshes afterwards.
4. Clicked Reindex repeatedly on the same file and confirmed only one request is issued.
5. Confirmed no backend changes were required: the action calls the existing endpoint unmodified.

**Verified on both vector backends.** The steps above were carried out with Chroma. The same action was then exercised against pgvector (`halfvec(2560)`, ollama embeddings) at the API level, reindexing a single file inside a knowledge base of four:

| | Before | After |
|---|---|---|
| Chunks for that file in the knowledge base collection | 338 | 338 |
| Chunk ids carried over | | 0 |
| Total chunks in the collection | 352 | 352 |
| Vector dimensions | 2560 | 2560 |

Zero ids survived, so the delete and re-embed cycle genuinely ran, while the collection total stayed flat and the other three files were untouched. Worth stating separately because the delete step goes through a per-backend vector client implementation, so a Chroma result does not imply a pgvector one.

### Screenshots or Videos

Before is current `dev`. After is this branch.

| Surface | Before | After |
|---|---|---|
| Knowledge base, per-file menu | <img width="2328" height="531" alt="image" src="https://github.com/user-attachments/assets/8a4233b6-2d21-4626-82a4-a24ed0494ce9" /> | <img width="2328" height="531" alt="image" src="https://github.com/user-attachments/assets/e0e5b9d5-ab7e-46b5-afc3-549f59fec11d" /> |
| File row while reindexing | **N/A** | <img width="2328" height="531" alt="image" src="https://github.com/user-attachments/assets/8902ccd5-d838-4390-a2e2-7f98d7c44e39" /> |

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.


