### PR TITLE
fix(groups): isolate unsaved modal data

### DIFF
--- a/src/lib/components/admin/Users/Groups/EditGroupModal.svelte
+++ b/src/lib/components/admin/Users/Groups/EditGroupModal.svelte
@@ -96,7 +96,13 @@
 				features: { ...DEFAULT_PERMISSIONS.features, ...loadedPermissions.features },
 				settings: { ...DEFAULT_PERMISSIONS.settings, ...loadedPermissions.settings }
 			};
-			data = group?.data ?? {};
+			// Keep edits local to the modal. General.svelte updates data.config in
+			// place, so sharing the group's object would leak unsaved changes back
+			// into the groups list.
+			data = {
+				...(group?.data ?? {}),
+				config: { ...(group?.data?.config ?? {}) }
+			};
 
 			userCount = group?.member_count ?? 0;
 		}


### PR DESCRIPTION
Fixes #28075

---

Clone the group's data and nested config when EditGroupModal initializes. General.svelte mutates data.config in place, so sharing the original object causes discarded modal edits to leak into the groups list and later saves.

Tests: ran git diff --check; the change is limited to modal initialization.