### PR TITLE
fix: double-encoded oauth JSON in b10670c03dd5 user table migration

### DIFF
--- a/backend/open_webui/migrations/versions/b10670c03dd5_update_user_table.py
+++ b/backend/open_webui/migrations/versions/b10670c03dd5_update_user_table.py
@@ -186,7 +186,7 @@ def upgrade() -> None:
             if oauth_sub:
                 provider, sub = oauth_sub.split('@', 1) if '@' in oauth_sub else ('oidc', oauth_sub)
                 conn.execute(
-                    sa.update(_user).where(_user.c.id == uid).values(oauth=json.dumps({provider: {'sub': sub}}))
+                    sa.update(_user).where(_user.c.id == uid).values(oauth={provider: {'sub': sub}})
                 )
 
     # ── Migrate api_key column → api_key table (only if old column still exists)
@@ -226,7 +226,7 @@ def downgrade() -> None:
 
     for uid, oauth in rows:
         try:
-            data = json.loads(oauth)
+            data = oauth
             provider = list(data.keys())[0]
             sub = data[provider].get('sub')
             oauth_sub = f'{provider}@{sub}'

--- a/backend/open_webui/migrations/versions/e6c5542b66b9_fix_double_encoded_user_oauth.py
+++ b/backend/open_webui/migrations/versions/e6c5542b66b9_fix_double_encoded_user_oauth.py
@@ -1,0 +1,58 @@
+"""fix double-encoded user oauth
+
+Revision b10670c03dd5 migrated the legacy `oauth_sub` column into the new
+`oauth` JSON column by writing `json.dumps({...})` (a string) into a
+column already typed `sa.JSON()`. SQLAlchemy's JSON type serializes
+whatever Python value it's given, so the pre-serialized string was
+serialized a second time, leaving affected rows with `oauth` holding a
+JSON string (e.g. '{"oidc": {"sub": "..."}}') instead of a JSON object.
+That breaks `UserModel.oauth: dict | None` validation on OAuth login for
+any instance upgraded from a version that still had `oauth_sub`.
+
+This migration re-parses any string-valued `oauth` cell back into its
+underlying dict, fixing the double encoding in place. Rows that were
+never double-encoded (already a dict, or null) are left untouched, so
+this is idempotent and safe to run more than once.
+
+Revision ID: e6c5542b66b9
+Revises: 1ce6ade7d93b
+Create Date: 2026-08-04 14:00:05.328172
+
+"""
+
+import json
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'e6c5542b66b9'
+down_revision: str | None = '1ce6ade7d93b'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_user = sa.table('user', sa.column('id', sa.Text), sa.column('oauth', sa.JSON))
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    rows = conn.execute(sa.select(_user.c.id, _user.c.oauth).where(_user.c.oauth.is_not(None))).fetchall()
+
+    for uid, oauth in rows:
+        if not isinstance(oauth, str):
+            continue
+
+        try:
+            parsed = json.loads(oauth)
+        except Exception:
+            continue
+
+        if isinstance(parsed, dict):
+            conn.execute(sa.update(_user).where(_user.c.id == uid).values(oauth=parsed))
+
+
+def downgrade() -> None:
+    # Data repair only; nothing structural to revert.
+    pass


### PR DESCRIPTION
## Summary

- Fixes `b10670c03dd5`'s `oauth_sub` -> `oauth` backfill, which wrote `json.dumps({...})` into a column already typed `sa.JSON()`, causing SQLAlchemy to serialize the value a second time. Affected rows end up with `user.oauth` holding a JSON string instead of a JSON object, which fails `UserModel.oauth: dict | None` validation and breaks sign-in (500) for any instance upgraded from a version that still had `oauth_sub` populated (e.g. any SSO/OIDC user).
- Fixes the mirrored bug in the same migration's `downgrade()`, which called `json.loads()` on a value SQLAlchemy had already deserialized into a dict, raising a silently-swallowed `TypeError` on every row and losing `oauth_sub` data on downgrade.
- Adds a follow-up migration (`e6c5542b66b9`) that repairs already-corrupted `oauth` values in place on instances that already ran the buggy migration. It's a no-op for rows that were never double-encoded, so it's safe to run on any instance.

Closes #28101

## Test plan

- [x] Verified against a throwaway SQLite DB: seeded a `user` row with the legacy `oauth_sub` column populated, ran the fixed `b10670c03dd5.upgrade()`, and confirmed `oauth` lands as a proper dict (not a re-serialized string).
- [x] Simulated a row already corrupted by the old buggy migration and confirmed the new repair migration un-double-encodes it.
- [x] Confirmed the repair migration is idempotent (safe to run twice, and a no-op on already-correct rows).
- [x] Confirmed the migration graph has a single head after rebasing onto `dev` (`e6c5542b66b9` now chains after `1ce6ade7d93b`, dev's current head, not the stale `f0bd01a18a3d`).