### PR TITLE
fix: add OAuth persistent configuration check to admin routes

### DIFF
--- a/backend/open_webui/routers/auths.py
+++ b/backend/open_webui/routers/auths.py
@@ -1440,13 +1440,23 @@ def oauth_config_updates(data: dict) -> dict:
     }
 
 
+def _require_oauth_persistent_config():
+    if not Config.OAUTH_PERSISTENT_ENABLED:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail='OAuth admin configuration is disabled. Set ENABLE_OAUTH_PERSISTENT_CONFIG=true to enable.',
+        )
+
+
 @router.get('/admin/config/oauth', response_model=OAuthConfigForm)
 async def get_oauth_config(request: Request, user=Depends(get_admin_user)):
+    _require_oauth_persistent_config()
     return await get_oauth_config_values()
 
 
 @router.post('/admin/config/oauth', response_model=OAuthConfigForm)
 async def update_oauth_config(request: Request, form_data: OAuthConfigForm, user=Depends(get_admin_user)):
+    _require_oauth_persistent_config()
     await Config.upsert(oauth_config_updates(form_data.model_dump(exclude_none=True)))
     return await get_oauth_config_values()
 


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** https://github.com/open-webui/open-webui/discussions/28104
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [x] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **BREAKING CHANGE**: Changes affecting backward compatibility
  - **build**: Build system or dependency changes
  - **ci**: CI/CD workflow changes
  - **chore**: Refactoring, cleanup, or non-functional changes
  - **docs**: Documentation additions or updates
  - **feat**: New features or enhancements
  - **fix**: Bug fixes or corrections
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvements
  - **refactor**: Code restructuring
  - **style**: Formatting changes (whitespace, semicolons, etc.)
  - **test**: Test additions or corrections
  - **WIP**: Work in progress

# Changelog Entry

### Description

- Hide the admin OAuth/OIDC settings UI when OAuth persistent config is disabled, so SSO cannot appear editable when changes will not survive a restart.

### Changed

- Admin OAuth config GET/POST endpoints (`/api/v1/auths/admin/config/oauth`) now require `ENABLE_OAUTH_PERSISTENT_CONFIG=true`. When disabled (the default), the endpoints return 404 and the Authentication settings page hides the OAuth/OIDC section via the existing `{#if oauthConfig}` guard.

### Fixed

- Misleading admin UX where OAuth/OIDC settings were editable in the UI even though `ENABLE_OAUTH_PERSISTENT_CONFIG` defaulted to `false`, so saves only updated in-memory defaults and were lost on restart.

---

### Additional Information

- Reuses the existing `ENABLE_OAUTH_PERSISTENT_CONFIG` env flag; no new setting introduced.
- To show and persist OAuth settings from the admin panel, set `ENABLE_OAUTH_PERSISTENT_CONFIG=true`.
- When the flag is off, OAuth continues to be configured via environment variables as before.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.