### PR TITLE
fix: double-encoded user.oauth in the b10670c03dd5 migration

### DIFF
--- a/backend/open_webui/migrations/versions/b10670c03dd5_update_user_table.py
+++ b/backend/open_webui/migrations/versions/b10670c03dd5_update_user_table.py
@@ -185,9 +185,8 @@ def upgrade() -> None:
         for uid, oauth_sub in rows:
             if oauth_sub:
                 provider, sub = oauth_sub.split('@', 1) if '@' in oauth_sub else ('oidc', oauth_sub)
-                conn.execute(
-                    sa.update(_user).where(_user.c.id == uid).values(oauth=json.dumps({provider: {'sub': sub}}))
-                )
+                # no json.dumps here: the column is JSON, SQLAlchemy serializes it
+                conn.execute(sa.update(_user).where(_user.c.id == uid).values(oauth={provider: {'sub': sub}}))
 
     # ── Migrate api_key column → api_key table (only if old column still exists)
     if 'api_key' in user_columns:
@@ -226,10 +225,8 @@ def downgrade() -> None:
 
     for uid, oauth in rows:
         try:
-            data = json.loads(oauth)
-            provider = list(data.keys())[0]
-            sub = data[provider].get('sub')
-            oauth_sub = f'{provider}@{sub}'
+            provider = next(iter(oauth))
+            oauth_sub = f'{provider}@{oauth[provider]["sub"]}'
         except Exception:
             oauth_sub = None
 

--- a/backend/open_webui/migrations/versions/d4a71b6e29c8_repair_double_encoded_user_oauth.py
+++ b/backend/open_webui/migrations/versions/d4a71b6e29c8_repair_double_encoded_user_oauth.py
@@ -1,0 +1,33 @@
+"""Repair double-encoded user.oauth values
+
+Revision ID: d4a71b6e29c8
+Revises: 1ce6ade7d93b
+Create Date: 2026-08-04 12:00:00.000000
+
+"""
+
+import json
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = 'd4a71b6e29c8'
+down_revision = '1ce6ade7d93b'
+branch_labels = None
+depends_on = None
+
+_user = sa.table('user', sa.column('id', sa.Text), sa.column('oauth', sa.JSON))
+
+
+def upgrade():
+    conn = op.get_bind()
+    rows = conn.execute(sa.select(_user.c.id, _user.c.oauth).where(_user.c.oauth.is_not(None))).fetchall()
+
+    for uid, oauth in rows:
+        # b10670c03dd5 used to serialize this column twice, leaving a JSON string instead of an object
+        if isinstance(oauth, str):
+            conn.execute(sa.update(_user).where(_user.c.id == uid).values(oauth=json.loads(oauth)))
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
Instances that had not upgraded since v0.6.41 and then jumped to v0.9.6 or later lose sign-in for every OAuth user, with a 500 and a validation error on the user model. Password sign-in for the same accounts fails identically, because every read path validates the row.

The migration that backfills user.oauth from the legacy oauth_sub column was rewritten from raw SQL to Core DML in May and kept its json.dumps call. The column reference declares sa.JSON, so SQLAlchemy serializes the value a second time and the row ends up holding a JSON string instead of an object. Reading it back yields a str, which the dict-typed field rejects. The mirrored json.loads in downgrade() has the inverse problem and silently nulled oauth_sub for every user.

Binding the dict directly fixes the write. Correcting that migration cannot help a database that already crossed it, since alembic never re-runs a stamped revision, so a follow-up revision un-double-encodes affected rows in place. It is a no-op for rows that were never corrupted.

Fixes #28101

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
