### PR TITLE
fix: process queued chat messages sequentially

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -67,6 +67,7 @@
 	} from '$lib/utils';
 	import { AudioQueue } from '$lib/utils/audio';
 	import { createTemporaryChatId, isTemporaryChatId } from '$lib/utils/chatId';
+	import { dequeueChatRequest } from '$lib/utils/chatQueue';
 	import { getOutputText } from './Messages/structuredOutput';
 
 	import {
@@ -2157,20 +2158,13 @@
 	const processNextInQueue = async (targetChatId: string) => {
 		if (processingQueueChats.has(targetChatId)) return;
 
-		const queue = $chatRequestQueues[targetChatId];
-		if (!queue || queue.length === 0) return;
+		const { queues, request } = dequeueChatRequest($chatRequestQueues, targetChatId);
+		if (!request) return;
 
 		processingQueueChats.add(targetChatId);
 		try {
-			const combinedPrompt = queue.map((m) => m.prompt).join('\n\n');
-			const combinedFiles = queue.flatMap((m) => m.files);
-
-			chatRequestQueues.update((q) => {
-				const { [targetChatId]: _, ...rest } = q;
-				return rest;
-			});
-
-			await submitPrompt(combinedPrompt, combinedFiles);
+			chatRequestQueues.set(queues);
+			await submitPrompt(request.prompt, request.files);
 		} finally {
 			processingQueueChats.delete(targetChatId);
 		}

--- a/src/lib/utils/chatQueue.test.ts
+++ b/src/lib/utils/chatQueue.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { dequeueChatRequest, type ChatRequestQueues } from './chatQueue';
+
+describe('dequeueChatRequest', () => {
+	it('dequeues only the oldest request and preserves later requests', () => {
+		const queues: ChatRequestQueues = {
+			chat: [
+				{ id: 'first', prompt: 'First prompt', files: [{ id: 'first-file' }] },
+				{ id: 'second', prompt: 'Second prompt', files: [{ id: 'second-file' }] }
+			],
+			other: [{ id: 'other', prompt: 'Other chat', files: [] }]
+		};
+
+		const result = dequeueChatRequest(queues, 'chat');
+
+		expect(result.request).toEqual(queues.chat[0]);
+		expect(result.queues).toEqual({
+			chat: [queues.chat[1]],
+			other: queues.other
+		});
+		expect(queues.chat).toHaveLength(2);
+	});
+
+	it('removes the chat queue after dequeuing its last request', () => {
+		const queues: ChatRequestQueues = {
+			chat: [{ id: 'only', prompt: 'Only prompt', files: [] }]
+		};
+
+		expect(dequeueChatRequest(queues, 'chat')).toEqual({
+			queues: {},
+			request: queues.chat[0]
+		});
+	});
+
+	it('leaves queues unchanged when the chat has no pending request', () => {
+		const queues: ChatRequestQueues = {};
+
+		expect(dequeueChatRequest(queues, 'chat')).toEqual({
+			queues,
+			request: null
+		});
+	});
+});

--- a/src/lib/utils/chatQueue.ts
+++ b/src/lib/utils/chatQueue.ts
@@ -1,0 +1,28 @@
+export type ChatQueueRequest = {
+	id: string;
+	prompt: string;
+	files: any[];
+};
+
+export type ChatRequestQueues = Record<string, ChatQueueRequest[]>;
+
+export const dequeueChatRequest = (
+	queues: ChatRequestQueues,
+	chatId: string
+): { queues: ChatRequestQueues; request: ChatQueueRequest | null } => {
+	const [request, ...remainingQueue] = queues[chatId] ?? [];
+
+	if (!request) {
+		return { queues, request: null };
+	}
+
+	if (remainingQueue.length > 0) {
+		return {
+			queues: { ...queues, [chatId]: remainingQueue },
+			request
+		};
+	}
+
+	const { [chatId]: _, ...remainingQueues } = queues;
+	return { queues: remainingQueues, request };
+};


### PR DESCRIPTION
## Summary

- process queued chat requests one at a time in FIFO order
- keep each request's files scoped to that request
- preserve later queue entries until the preceding response completes
- add focused unit coverage for dequeue order and queue isolation

## Root cause

`processNextInQueue()` currently joins every pending prompt with blank lines, flattens all attached files, removes the entire chat queue, and submits one combined turn. When more than one message is queued during generation, the individual entries therefore disappear as soon as the active response completes.

This conflicts with the serial behavior requested in #10843 and makes separately queued instructions indistinguishable in chat history.

## Reproduction

1. Start a response with message queueing enabled.
2. While it is generating, queue two distinct messages.
3. Let the active response finish.
4. Observe that both queue entries disappear and one combined user message is submitted.

With this change, only the oldest entry is removed and submitted. The second entry remains visible and is processed after the first queued response completes.

## Validation

- `npm run test:frontend -- --run` - 5 tests passed
- targeted Prettier check - passed
- `npm run build` - passed

The repository-wide `npm run check` currently reports pre-existing diagnostics on `dev`; no diagnostic pointed to the changed files.
