### PR TITLE
refac: keep external connections until their last knowledge base is removed

### DIFF
--- a/backend/open_webui/routers/knowledge.py
+++ b/backend/open_webui/routers/knowledge.py
@@ -1721,7 +1721,12 @@ async def delete_knowledge_by_id(
     # Clean up vector DB
     if is_external_knowledge(knowledge):
         connection_id = (knowledge.meta or {}).get('external', {}).get('connection_id')
-        if connection_id:
+        # Connections are admin-owned and shared across knowledge bases
+        if (
+            connection_id
+            and user.role == 'admin'
+            and await _count_external_connection_mappings(connection_id, db=db) <= 1
+        ):
             connections = [
                 connection for connection in await _get_external_connections() if connection.get('id') != connection_id
             ]

--- a/backend/open_webui/routers/knowledge.py
+++ b/backend/open_webui/routers/knowledge.py
@@ -1715,7 +1715,12 @@ async def delete_knowledge_by_id(
     # Clean up vector DB
     if is_external_knowledge(knowledge):
         connection_id = (knowledge.meta or {}).get('external', {}).get('connection_id')
-        if connection_id:
+        # Connections are admin-owned and shared across knowledge bases
+        if (
+            connection_id
+            and user.role == 'admin'
+            and await _count_external_connection_mappings(connection_id, db=db) <= 1
+        ):
             connections = [
                 connection for connection in await _get_external_connections() if connection.get('id') != connection_id
             ]


### PR DESCRIPTION
Deleting an external knowledge base now clears its connection only when an admin removes the last knowledge base referencing it, matching the connection delete route.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
