### PR TITLE
fix: make native date/time picker icons visible in dark mode

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -731,6 +731,15 @@ body {
 	color: #eee;
 }
 
+/* Make native date/time picker icons visible in dark mode */
+.dark input[type="date"],
+.dark input[type="time"],
+.dark input[type="datetime-local"],
+.dark input[type="month"],
+.dark input[type="week"] {
+	color-scheme: dark;
+}
+
 /* Position the handle relative to each LI */
 .pm-li--with-handle {
 	position: relative;


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) — `Closes #27274`.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [x] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses the `fix:` prefix.

# Changelog Entry

### Description

- Fixes [#27274](https://github.com/open-webui/open-webui/issues/27274) — native `<input type="date">` and `<input type="time">` picker icons are invisible in dark mode because they render dark icons on dark backgrounds.

### Root Cause

Browsers use the OS color scheme to render native date/time picker icons. In dark mode, without an explicit `color-scheme` hint, browsers render dark-colored icons that blend into the dark background.

### Fix

Added a global CSS rule in `src/app.css` that sets `color-scheme: dark` on native date/time inputs when the `.dark` class is active. This forces browsers to render the picker icons with a light color scheme, making them visible on dark backgrounds.

### Affected UI Locations
- Calendar event creation modal
- Settings → Account → Birth Date
- Admin Panel → Analytics → Custom period
- Automations schedule dropdown
- All other date/time inputs across the app

### Added

- `color-scheme: dark` CSS rule for `.dark input[type="date"]`, `input[type="time"]`, `input[type="datetime-local"]`, `input[type="month"]`, and `input[type="week"]` in `src/app.css`

### Fixed

- Native date/time picker icons now visible in dark mode

Closes #27274

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
