### PR TITLE
fix: stop the analytics dashboard spinning when a custom range has no dates

### DIFF
--- a/src/lib/components/admin/Analytics/Dashboard.svelte
+++ b/src/lib/components/admin/Analytics/Dashboard.svelte
@@ -160,9 +160,12 @@
 		loading = false;
 	};
 
+	$: awaitingCustomRange = selectedPeriod === 'custom' && !(customStart && customEnd);
+
 	// Reload when the period, group, or custom range changes.
-	// In custom mode, wait until both dates are set to avoid a half-specified query.
-	$: if (selectedPeriod === 'custom' ? customStart && customEnd : selectedPeriod) {
+	$: if (awaitingCustomRange) {
+		loading = false;
+	} else if (selectedPeriod) {
 		// reference customStart/customEnd so this block reruns when they change
 		customStart;
 		customEnd;
@@ -281,7 +284,7 @@
 />
 
 <!-- Summary stats -->
-{#if !loading}
+{#if !loading && !awaitingCustomRange}
 	<div class="flex gap-3 text-xs text-gray-500 dark:text-gray-400 px-0.5 pb-2">
 		<span
 			><span class="font-normal text-gray-900 dark:text-gray-300"
@@ -342,6 +345,10 @@
 {#if loading}
 	<div class="my-10 flex justify-center">
 		<Spinner className="size-5" />
+	</div>
+{:else if awaitingCustomRange}
+	<div class="my-10 text-center text-xs text-gray-500 dark:text-gray-400">
+		{$i18n.t('Select a start and end date to view analytics.')}
 	</div>
 {:else}
 	<div class="grid md:grid-cols-2 gap-4">

--- a/src/lib/i18n/locales/en-US/translation.json
+++ b/src/lib/i18n/locales/en-US/translation.json
@@ -2343,6 +2343,7 @@
 	"Select a pipeline url": "",
 	"Select a reranking model engine": "",
 	"Select a role": "",
+	"Select a start and end date to view analytics.": "",
 	"Select a theme": "",
 	"Select a tool": "",
 	"Select a voice": "",


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #28125
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** No documentation changes needed.
- [x] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Manual tests have been performed to verify the fix works correctly and does not introduce regressions.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new settings. The change is local UI state only.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

# Changelog Entry

### Description

- Selecting `Custom range` in Admin Settings > Analytics without picking dates leaves the tab showing a spinner that never resolves, hiding the dashboard entirely. The selection is persisted in `localStorage`, so it survives leaving the tab and reloading the page.
- `loading` starts as `true` and is only cleared at the end of `loadDashboard()`. The reactive block that calls it deliberately declines to run while a custom range is half specified, which is correct, but nothing then clears `loading`. Waiting for input and loading render identically, and there is no path out of the waiting state.

### Fixed

- The Analytics dashboard no longer spins indefinitely when `Custom range` is selected without dates. The waiting state is now distinct from the loading state and prompts for the missing dates instead.

---

### Additional Information

The guard is preserved rather than removed, so a half specified range still does not produce a query. The condition is extracted into `awaitingCustomRange` and used in three places: to clear `loading` when waiting, to suppress the summary stats row so it does not render a line of zeroes, and to render a short prompt in place of the dashboard body.

**Manual verification performed:**

1. Selected `Custom range` without dates, navigated to another settings tab, and returned. The tab now shows the prompt instead of a permanent spinner.
2. Reloaded the page with that state already persisted in `localStorage` and confirmed it recovers rather than spinning.
3. Set both dates and confirmed the dashboard loads normally.
4. Switched back to a preset period such as `Last 7 days` and confirmed it loads normally.
5. Confirmed the summary stats row is hidden while waiting, rather than showing zeroes.

### Screenshots or Videos

Before is current `dev`. After is this branch.

| Surface | Before | After |
|---|---|---|
| Admin Settings > Analytics, `Custom range` selected with no dates, after leaving and returning to the tab | <img width="1577" height="1068" alt="image" src="https://github.com/user-attachments/assets/0b2c5be7-3a0c-4de0-9325-c7f6f4997ecf" /> | <img width="1577" height="1068" alt="image" src="https://github.com/user-attachments/assets/648ee0cc-bc87-4062-a032-63014bedad46" /> |

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
