### PR TITLE
refactor: place related Interface settings next to each other

### DIFF
--- a/src/lib/components/chat/Settings/Interface.svelte
+++ b/src/lib/components/chat/Settings/Interface.svelte
@@ -850,6 +850,28 @@
 
 			<div>
 				<div class={settingRowClass}>
+					<div id="render-markdown-in-previews-label" class={settingLabelClass}>
+						{$i18n.t('Render Markdown in Previews')}
+					</div>
+
+					<div class={settingControlClass}>
+						<Switch
+							ariaLabelledbyId="render-markdown-in-previews-label"
+							tooltip={true}
+							bind:state={renderMarkdownInPreviews}
+							on:change={() => {
+								saveSettings({ renderMarkdownInPreviews });
+							}}
+						/>
+					</div>
+				</div>
+				<p class={settingDescriptionClass}>
+					{$i18n.t('Format Markdown in previews and compact content surfaces.')}
+				</p>
+			</div>
+
+			<div>
+				<div class={settingRowClass}>
 					<div id="auto-generation-label" class={settingLabelClass}>
 						{$i18n.t('Title Auto-Generation')}
 					</div>
@@ -955,6 +977,28 @@
 				</div>
 				<p class={settingDescriptionClass}>
 					{$i18n.t('Follow assistant responses as they are generated.')}
+				</p>
+			</div>
+
+			<div>
+				<div class={settingRowClass}>
+					<div id="scroll-on-branch-change-label" class={settingLabelClass}>
+						{$i18n.t('Scroll On Branch Change')}
+					</div>
+
+					<div class={settingControlClass}>
+						<Switch
+							ariaLabelledbyId="scroll-on-branch-change-label"
+							tooltip={true}
+							bind:state={scrollOnBranchChange}
+							on:change={() => {
+								saveSettings({ scrollOnBranchChange });
+							}}
+						/>
+					</div>
+				</div>
+				<p class={settingDescriptionClass}>
+					{$i18n.t('Scroll to the active branch when switching response branches.')}
 				</p>
 			</div>
 
@@ -1092,28 +1136,6 @@
 
 			<div>
 				<div class={settingRowClass}>
-					<div id="render-markdown-in-previews-label" class={settingLabelClass}>
-						{$i18n.t('Render Markdown in Previews')}
-					</div>
-
-					<div class={settingControlClass}>
-						<Switch
-							ariaLabelledbyId="render-markdown-in-previews-label"
-							tooltip={true}
-							bind:state={renderMarkdownInPreviews}
-							on:change={() => {
-								saveSettings({ renderMarkdownInPreviews });
-							}}
-						/>
-					</div>
-				</div>
-				<p class={settingDescriptionClass}>
-					{$i18n.t('Format Markdown in previews and compact content surfaces.')}
-				</p>
-			</div>
-
-			<div>
-				<div class={settingRowClass}>
 					<div id="keep-followup-prompts-label" class={settingLabelClass}>
 						{$i18n.t('Display Multi-model Responses in Tabs')}
 					</div>
@@ -1131,28 +1153,6 @@
 				</div>
 				<p class={settingDescriptionClass}>
 					{$i18n.t('Group multi-model responses into tabs.')}
-				</p>
-			</div>
-
-			<div>
-				<div class={settingRowClass}>
-					<div id="scroll-on-branch-change-label" class={settingLabelClass}>
-						{$i18n.t('Scroll On Branch Change')}
-					</div>
-
-					<div class={settingControlClass}>
-						<Switch
-							ariaLabelledbyId="scroll-on-branch-change-label"
-							tooltip={true}
-							bind:state={scrollOnBranchChange}
-							on:change={() => {
-								saveSettings({ scrollOnBranchChange });
-							}}
-						/>
-					</div>
-				</div>
-				<p class={settingDescriptionClass}>
-					{$i18n.t('Scroll to the active branch when switching response branches.')}
 				</p>
 			</div>
 

--- a/src/lib/components/common/InterfaceSettings.svelte
+++ b/src/lib/components/common/InterfaceSettings.svelte
@@ -904,6 +904,29 @@
 
 			<div>
 				<div class={settingRowClass}>
+					<div id="render-markdown-in-previews-label" class={settingLabelClass}>
+						{$i18n.t('Render Markdown in Previews')}
+					</div>
+
+					<div class={settingControlClass}>
+						<Switch
+							ariaLabelledbyId="render-markdown-in-previews-label"
+							tooltip={true}
+							bind:state={renderMarkdownInPreviews}
+							inherited={isDefaultSetting('renderMarkdownInPreviews')}
+							on:change={() => {
+								saveSettings({ renderMarkdownInPreviews });
+							}}
+						/>
+					</div>
+				</div>
+				<p class={settingDescriptionClass}>
+					{$i18n.t('Format Markdown in previews and compact content surfaces.')}
+				</p>
+			</div>
+
+			<div>
+				<div class={settingRowClass}>
 					<div id="auto-generation-label" class={settingLabelClass}>
 						{$i18n.t('Title Auto-Generation')}
 					</div>
@@ -1014,6 +1037,29 @@
 				</div>
 				<p class={settingDescriptionClass}>
 					{$i18n.t('Follow assistant responses as they are generated.')}
+				</p>
+			</div>
+
+			<div>
+				<div class={settingRowClass}>
+					<div id="scroll-on-branch-change-label" class={settingLabelClass}>
+						{$i18n.t('Scroll On Branch Change')}
+					</div>
+
+					<div class={settingControlClass}>
+						<Switch
+							ariaLabelledbyId="scroll-on-branch-change-label"
+							tooltip={true}
+							bind:state={scrollOnBranchChange}
+							inherited={isDefaultSetting('scrollOnBranchChange')}
+							on:change={() => {
+								saveSettings({ scrollOnBranchChange });
+							}}
+						/>
+					</div>
+				</div>
+				<p class={settingDescriptionClass}>
+					{$i18n.t('Scroll to the active branch when switching response branches.')}
 				</p>
 			</div>
 
@@ -1157,29 +1203,6 @@
 
 			<div>
 				<div class={settingRowClass}>
-					<div id="render-markdown-in-previews-label" class={settingLabelClass}>
-						{$i18n.t('Render Markdown in Previews')}
-					</div>
-
-					<div class={settingControlClass}>
-						<Switch
-							ariaLabelledbyId="render-markdown-in-previews-label"
-							tooltip={true}
-							bind:state={renderMarkdownInPreviews}
-							inherited={isDefaultSetting('renderMarkdownInPreviews')}
-							on:change={() => {
-								saveSettings({ renderMarkdownInPreviews });
-							}}
-						/>
-					</div>
-				</div>
-				<p class={settingDescriptionClass}>
-					{$i18n.t('Format Markdown in previews and compact content surfaces.')}
-				</p>
-			</div>
-
-			<div>
-				<div class={settingRowClass}>
 					<div id="keep-followup-prompts-label" class={settingLabelClass}>
 						{$i18n.t('Display Multi-model Responses in Tabs')}
 					</div>
@@ -1198,29 +1221,6 @@
 				</div>
 				<p class={settingDescriptionClass}>
 					{$i18n.t('Group multi-model responses into tabs.')}
-				</p>
-			</div>
-
-			<div>
-				<div class={settingRowClass}>
-					<div id="scroll-on-branch-change-label" class={settingLabelClass}>
-						{$i18n.t('Scroll On Branch Change')}
-					</div>
-
-					<div class={settingControlClass}>
-						<Switch
-							ariaLabelledbyId="scroll-on-branch-change-label"
-							tooltip={true}
-							bind:state={scrollOnBranchChange}
-							inherited={isDefaultSetting('scrollOnBranchChange')}
-							on:change={() => {
-								saveSettings({ scrollOnBranchChange });
-							}}
-						/>
-					</div>
-				</div>
-				<p class={settingDescriptionClass}>
-					{$i18n.t('Scroll to the active branch when switching response branches.')}
 				</p>
 			</div>
 


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Relates to #28128, the proposal to place related Settings > Interface entries next to each other.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable. No setting is added, removed, or renamed.
- [ ] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Verified live by the author in Settings > Interface, in both light and dark mode, toggling each moved setting and confirming its behavior is unchanged.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new settings, no new components, no state changes. Two existing blocks are relocated within the same section.
- [x] **Git Hygiene:** A single commit, +44/-44 in a single file, based on the current `dev`.
- [x] **Title Prefix:** `refactor`

# Changelog Entry

### Description

In the user facing Settings > Interface panel, the `Chat` section lists 29 settings in a flat column. Two pairs of settings that control the same behavior are separated by unrelated entries, so finding one of them does not lead the user to the other:

| Settings | Positions before | Entries between |
|---|---|---|
| `Response Auto-Scroll` and `Scroll On Branch Change` | 16 and 25 | 8 |
| `Render Markdown in Assistant Messages` and `Render Markdown in Previews` | 11 and 23 | 11 |

Both scroll settings control when the view follows content. All three `Render Markdown in ...` settings control where Markdown is formatted, and two of them are already adjacent, so the third sitting twelve rows away reads as an oversight rather than a decision.

This PR moves exactly two blocks:

- `Render Markdown in Previews` now sits directly beneath `Render Markdown in Assistant Messages`, completing the run of three.
- `Scroll On Branch Change` now sits directly beneath `Response Auto-Scroll`.

Every other setting keeps its exact position, and no setting moves between section headings.

### Changed

- Moved `Render Markdown in Previews` and `Scroll On Branch Change` in Settings > Interface so each sits directly beneath the setting it pairs with. No setting was added, removed, renamed, or changed in behavior.

---

### Additional Information

**Overlaps with another open PR.** This reorders entries in `src/lib/components/chat/Settings/Interface.svelte`. #27632 adds a new setting to that same file, so the two conflict. Merging #27632 first is the cleaner order: this reordering is mechanical and is easily regenerated on top of it, whereas rebasing an added setting onto a reordered file is fiddlier.


The change is a pure reordering. No markup, binding, `saveSettings` call, `aria` id, description string, or translation key was altered, and no code comments were added. This is verifiable rather than asserted: sorting the file line by line before and after the change produces byte identical output.

```
diff <(git show upstream/dev:src/lib/components/chat/Settings/Interface.svelte | sort) \
     <(sort src/lib/components/chat/Settings/Interface.svelte)
```

The command returns nothing, so the diff is a permutation of the existing lines and cannot have changed any setting's wiring.

A broader regrouping of the whole panel is possible, and a few settings arguably sit under the wrong heading entirely, for example `Copy Formatted Text` under `UI` while `Auto-Copy Response to Clipboard` sits under `Chat`. That is a much larger and more subjective diff, so it is deliberately left out of this PR and raised in #28128 instead.

This PR was prepared with AI copilot assistance and reviewed by the author.

### Manual Verification Performed

1. Opened Settings > Interface and confirmed `Render Markdown in Previews` now renders directly beneath `Render Markdown in Assistant Messages`, and `Scroll On Branch Change` directly beneath `Response Auto-Scroll`.
2. Confirmed every other setting in the `Chat` section appears in its previous position, and the `UI`, `Input`, `Artifacts`, `Voice`, and `File` sections are untouched.
3. Toggled both moved settings off and on, reloaded the page, and confirmed the values persist and the toggles still drive their behavior: branch switching scrolls or does not scroll, and preview surfaces render Markdown or plain text.
4. Checked the panel in both light and dark mode, and at a narrow viewport, for layout regressions.
5. Ran `npm run format` (the file is reported unchanged) and `npm run build` (succeeds).

### Screenshots or Videos

Before is current `dev`. After is this branch.

| Surface | Before | After |
|---|---|---|
| Settings > Interface, `Chat` section, showing the two Markdown settings and `Render Markdown in Previews` | <img width="1577" height="1068" alt="image" src="https://github.com/user-attachments/assets/40290b7a-8793-4c1e-afaa-f6bbca466e59" /> | <img width="1577" height="1068" alt="image" src="https://github.com/user-attachments/assets/b6698abb-e0c5-4f56-872a-b5d6c43d4b23" /> |
| Settings > Interface, `Chat` section, showing `Response Auto-Scroll` and `Scroll On Branch Change` | <img width="1577" height="1068" alt="image" src="https://github.com/user-attachments/assets/74944d88-9a7c-42f9-939c-e3ca200ef020" />| <img width="1577" height="1068" alt="image" src="https://github.com/user-attachments/assets/98f95c57-f5a3-464b-bf0e-6ab7caabac5b" /> |

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.

