### PR TITLE
fix(analytics): clear loading state for incomplete custom date range

### DIFF
--- a/src/lib/components/admin/Analytics/Dashboard.svelte
+++ b/src/lib/components/admin/Analytics/Dashboard.svelte
@@ -168,6 +168,9 @@
 		customEnd;
 		selectedGroupId;
 		loadDashboard();
+	} else {
+		// A half-specified custom range must not leave the spinner running forever.
+		loading = false;
 	}
 
 	onMount(async () => {


### PR DESCRIPTION
Fixes #28125

When the Analytics period selector is set to Custom range without picking both start and end dates, the reactive guard correctly avoids calling loadDashboard() so it does not issue a half-specified query. However, loading is initialized to true and was never cleared in that branch, leaving the tab stuck on a permanent spinner. The state persists across tab navigation because selectedPeriod and the custom date strings are stored in localStorage.

This change adds an else branch to the reactive guard that sets loading = false when customStart or customEnd is missing, so the date inputs remain visible and usable.

### Verification
- Open Admin Settings > Analytics.
- Select Custom range without choosing dates.
- Navigate away and return, or reload the component.
- The spinner now resolves and the date pickers remain usable.
- Selecting both dates triggers the normal dashboard load.