### PR TITLE
fix(analytics): clear loading state for incomplete custom date range

### DIFF
--- a/src/lib/components/admin/Analytics/Dashboard.svelte
+++ b/src/lib/components/admin/Analytics/Dashboard.svelte
@@ -168,6 +168,9 @@
 		customEnd;
 		selectedGroupId;
 		loadDashboard();
+	} else {
+		// A half-specified custom range must not leave the spinner running forever.
+		loading = false;
 	}
 
 	onMount(async () => {


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DO NOT DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request

Closes #28125

### Description

When the Analytics period selector is set to **Custom range** without picking both start and end dates, the reactive guard correctly skips `loadDashboard()` to avoid issuing a half-specified query. However, `loading` is initialized to `true` and was never cleared in that branch, leaving the tab stuck on a permanent spinner. Because `selectedPeriod`, `customStart`, and `customEnd` are persisted in `localStorage`, this state survives tab navigation and page reloads.

This PR adds an `else` branch to the reactive guard that sets `loading = false` when the custom range is incomplete, so the date inputs remain visible and usable.

### Changes

- `src/lib/components/admin/Analytics/Dashboard.svelte`: clear `loading` when `selectedPeriod === "custom"` and either date is missing.

# Changelog Entry

### Fixed

- Analytics tab no longer shows an infinite spinner when "Custom range" is selected without dates. (#28125)

---

### Additional Information

- Reproduced against the `dev` branch.
- The fix was verified by inspecting the reactive block and confirming that `loading` is now cleared in the previously empty branch.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
