### PR TITLE
fix: require a date in the calendar event modal and render validation errors as text

### DIFF
--- a/src/lib/apis/calendar/index.ts
+++ b/src/lib/apis/calendar/index.ts
@@ -69,6 +69,14 @@ export type CalendarForm = {
 	access_grants?: { target_type: string; target_id: string; permission: string }[];
 };
 
+const getErrorDetail = (err: any) => {
+	if (Array.isArray(err?.detail)) {
+		return err.detail.map((e: { msg?: string }) => e.msg || JSON.stringify(e)).join(', ');
+	}
+
+	return err?.detail;
+};
+
 // ── Calendars ─────────────────────────────────
 
 export const getCalendars = async (token: string): Promise<CalendarModel[]> => {
@@ -87,7 +95,7 @@ export const getCalendars = async (token: string): Promise<CalendarModel[]> => {
 			return res.json();
 		})
 		.catch((err) => {
-			error = err.detail;
+			error = getErrorDetail(err);
 			console.error(err);
 			return null;
 		});
@@ -116,7 +124,7 @@ export const createCalendar = async (token: string, form: CalendarForm): Promise
 			return res.json();
 		})
 		.catch((err) => {
-			error = err.detail;
+			error = getErrorDetail(err);
 			console.error(err);
 			return null;
 		});
@@ -149,7 +157,7 @@ export const updateCalendar = async (
 			return res.json();
 		})
 		.catch((err) => {
-			error = err.detail;
+			error = getErrorDetail(err);
 			console.error(err);
 			return null;
 		});
@@ -177,7 +185,7 @@ export const deleteCalendar = async (token: string, calendarId: string): Promise
 			return res.json();
 		})
 		.catch((err) => {
-			error = err.detail;
+			error = getErrorDetail(err);
 			console.error(err);
 			return null;
 		});
@@ -208,7 +216,7 @@ export const setDefaultCalendar = async (
 			return res.json();
 		})
 		.catch((err) => {
-			error = err.detail;
+			error = getErrorDetail(err);
 			console.error(err);
 			return null;
 		});
@@ -250,7 +258,7 @@ export const getCalendarEvents = async (
 			return res.json();
 		})
 		.catch((err) => {
-			error = err.detail;
+			error = getErrorDetail(err);
 			console.error(err);
 			return null;
 		});
@@ -282,7 +290,7 @@ export const createCalendarEvent = async (
 			return res.json();
 		})
 		.catch((err) => {
-			error = err.detail;
+			error = getErrorDetail(err);
 			console.error(err);
 			return null;
 		});
@@ -313,7 +321,7 @@ export const getCalendarEventById = async (
 			return res.json();
 		})
 		.catch((err) => {
-			error = err.detail;
+			error = getErrorDetail(err);
 			console.error(err);
 			return null;
 		});
@@ -346,7 +354,7 @@ export const updateCalendarEvent = async (
 			return res.json();
 		})
 		.catch((err) => {
-			error = err.detail;
+			error = getErrorDetail(err);
 			console.error(err);
 			return null;
 		});
@@ -374,7 +382,7 @@ export const deleteCalendarEvent = async (token: string, eventId: string): Promi
 			return res.json();
 		})
 		.catch((err) => {
-			error = err.detail;
+			error = getErrorDetail(err);
 			console.error(err);
 			return null;
 		});
@@ -407,7 +415,7 @@ export const rsvpCalendarEvent = async (
 			return res.json();
 		})
 		.catch((err) => {
-			error = err.detail;
+			error = getErrorDetail(err);
 			console.error(err);
 			return null;
 		});
@@ -445,7 +453,7 @@ export const searchCalendarEvents = async (
 			return res.json();
 		})
 		.catch((err) => {
-			error = err.detail;
+			error = getErrorDetail(err);
 			console.error(err);
 			return null;
 		});

--- a/src/lib/components/calendar/CalendarEventModal.svelte
+++ b/src/lib/components/calendar/CalendarEventModal.svelte
@@ -121,6 +121,11 @@
 			return;
 		}
 
+		if (!startDate) {
+			toast.error($i18n.t('Date is required'));
+			return;
+		}
+
 		loading = true;
 		try {
 			const startNs = dateTimeToNs(startDate, allDay ? '00:00' : startTime);

--- a/src/lib/i18n/locales/en-US/translation.json
+++ b/src/lib/i18n/locales/en-US/translation.json
@@ -708,6 +708,7 @@
 	"Database": "",
 	"Datalab Marker API": "",
 	"Datalab Marker service endpoint used for document parsing.": "",
+	"Date is required": "",
 	"Date Modified": "",
 	"Day": "",
 	"DD/MM/YYYY": "",


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #28133
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable. No configuration surface changes.
- [ ] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Manual tests have been performed to verify the fix works correctly and does not introduce regressions.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new settings. One validation guard and one local error formatting helper.
- [x] **Git Hygiene:** A single commit, +26/-12 across three files, based on the current `dev`.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

Clearing the date in the calendar event modal and submitting produces a red toast reading `[object Object]`, with a 422 from `POST /api/v1/calendars/events/create`. Two separate defects combine to make that happen.

**An invalid request is sent.** `dateTimeToNs` builds the timestamp with:

```js
new Date(`${dateStr}T${timeStr || '00:00'}`).getTime() * NS;
```

With the date cleared, `dateStr` is empty, so this is `new Date("T22:46")`, an Invalid Date. `getTime()` returns `NaN`, and `JSON.stringify` serializes `NaN` as `null`. `CalendarEventForm.start_at` is a required `int`, so the request cannot succeed. `submitHandler` already guards the title but never guarded the date.

**The resulting error cannot be rendered as text.** FastAPI returns validation errors with `detail` as a list, while Open WebUI's own `HTTPException`s return a string. Every wrapper in the calendar API module assigned `err.detail` straight through and rethrew it, and the modal renders errors with ``toast.error(`${err}`)``. Interpolating a list of objects into a template literal yields `[object Object]`. This is why the error path looks fine everywhere else: it only breaks on Pydantic validation errors.

**The changes:**

```diff
  if (!title.trim()) {
      toast.error($i18n.t('Title is required'));
      return;
  }

+ if (!startDate) {
+     toast.error($i18n.t('Date is required'));
+     return;
+ }
```

```diff
+ const getErrorDetail = (err: any) => {
+     if (Array.isArray(err?.detail)) {
+         return err.detail.map((e: { msg?: string }) => e.msg || JSON.stringify(e)).join(', ');
+     }
+
+     return err?.detail;
+ };
```

```diff
  .catch((err) => {
-     error = err.detail;
+     error = getErrorDetail(err);
      console.error(err);
      return null;
  });
```

The guard sits before `loading = true`, so it covers creating and editing alike: both paths built the timestamp from the same value.

The helper is applied to all twelve wrappers in the module rather than only the two reachable from this bug, since any of them can receive the same list shaped `detail`. It mirrors the normalization already present in `src/lib/apis/images/index.ts` and `src/lib/apis/auths/index.ts`, so no new pattern is introduced.

### Fixed

- Submitting the calendar event modal without a date now reports `Date is required` instead of sending a request that cannot succeed. This covers both creating and editing an event.
- Validation errors from the calendar endpoints now surface their messages instead of rendering as `[object Object]`.

---

### Additional Information

`getErrorDetail` returns `undefined` when `detail` is absent, preserving the existing `if (error) throw error` semantics so network level failures still return `null` rather than starting to throw.

Behavior was checked against every input shape the helper can receive:

| Input | Result |
|---|---|
| 422 list, one entry | `Input should be a valid integer` |
| 422 list, two entries | `a, b` |
| list entry without `msg` | `{"type":"x"}` |
| plain string detail | `Calendar not found` |
| object without `detail` | `undefined` |
| `err` itself undefined | `undefined` |

A broader fix is possible, since roughly 260 call sites across the frontend use the same ``toast.error(`${...}`)`` idiom and would show `[object Object]` for any list shaped `detail`. That is a much larger change with a different argument, so it is deliberately out of scope here. #27729 looks like another instance of the same class.

One new `en-US` key is added, `Date is required`, inserted in sorted position. The other locale catalogs are intentionally untouched; missing keys fall back to the English literal.

This PR was prepared with AI copilot assistance and reviewed by the author.

### Manual Verification Performed

1. Opened the Calendar page, entered a title, cleared the date with the picker's `Clear` button, and clicked `Create`. The toast now reads `Date is required`, and no request is sent.
2. Confirmed the same for an existing event: opened it, cleared the date, and saved.
3. Re-entered a date and confirmed the event is created and updated normally, with the correct start time.
4. Submitted with no title and confirmed `Title is required` still takes precedence.
5. Confirmed the `All day` path still saves, and that an event with an end date round trips.
6. Ran `npm run format` (all three files reported unchanged) and `npm run build` (succeeds).

### Screenshots or Videos

Before is current `dev`. After is this branch.

| Surface | Before | After |
|---|---|---|
| Calendar event modal, title entered and date cleared, after clicking `Create` | <img width="2555" height="1277" alt="image" src="https://github.com/user-attachments/assets/0833d3b3-e4ec-4077-8087-8400340a9eec" /> | <img width="2555" height="1277" alt="image" src="https://github.com/user-attachments/assets/2a2eb96c-e7e3-41ea-96ce-107b75e0cb03" /> |

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
