### PR TITLE
fix: wire up Mark as unread in the Search chats modal

### DIFF
--- a/src/lib/components/layout/SearchModal.svelte
+++ b/src/lib/components/layout/SearchModal.svelte
@@ -14,6 +14,7 @@
 		archiveChatById,
 		updateChatById,
 		updateChatFolderIdById,
+		markChatUnreadById,
 		getAllTags
 	} from '$lib/apis/chats';
 	import Spinner from '../common/Spinner.svelte';
@@ -84,6 +85,17 @@
 		if (res) {
 			await refreshSidebar();
 			await searchHandler();
+		}
+	};
+
+	const markUnreadHandler = async (id) => {
+		const res = await markChatUnreadById(localStorage.token, id).catch((error) => {
+			toast.error(`${error}`);
+			return null;
+		});
+
+		if (res) {
+			await refreshSidebar();
 		}
 	};
 
@@ -815,6 +827,9 @@
 												}}
 												renameHandler={() => {
 													renameHandler(chat.id);
+												}}
+												markUnreadHandler={() => {
+													markUnreadHandler(chat.id);
 												}}
 												deleteHandler={() => {
 													menuChatId = chat.id;


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #28135
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable. No configuration surface changes.
- [ ] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Manual tests have been performed to verify the fix works correctly and does not introduce regressions.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new settings and no new components. An existing handler prop is supplied by a consumer that was missing it.
- [x] **Git Hygiene:** A single commit, +15/-0 in a single file, based on the current `dev`.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

`Mark as unread` in the Search chats modal does nothing: the menu closes, no request is sent, no error is reported, and the sidebar is unchanged. The same action from a chat's three dot menu in the sidebar works.

**Root cause.** `ChatMenu` declares the handler with a silent no-op default:

```js
export let markUnreadHandler: Function = () => {};
```

and renders the menu entry unconditionally, without checking that a handler was supplied. `ChatMenu` has two consumers. `Sidebar/ChatItem.svelte` passes the prop; `layout/SearchModal.svelte` wires up eight handlers (share, move, clone, archive, rename, delete, `onClose`, `onPinChange`) but omits this one. The click therefore invokes the empty default, and because the default is silent rather than absent, the entry still renders and looks functional.

**The fix** supplies the missing handler in `SearchModal`, following the same shape as every other mutating handler in that file:

```js
const markUnreadHandler = async (id) => {
	const res = await markChatUnreadById(localStorage.token, id).catch((error) => {
		toast.error(`${error}`);
		return null;
	});

	if (res) {
		await refreshSidebar();
	}
};
```

`refreshSidebar` is the modal's existing helper and calls `refreshChatList`, which re-fetches `last_read_at`. That value is what `ChatItem` derives its `unread` state from, so the sidebar updates with no additional plumbing. A failed request now raises a toast instead of failing silently.

The change is additive: an import, the handler, and the prop passed to `ChatMenu`, placed after `renameHandler` so the prop order matches the order the entries appear in the menu.

### Fixed

- `Mark as unread` now works in the Search chats modal and updates the sidebar, matching the behavior of the same action in the sidebar's own chat menu.

---

### Additional Information

The no-op default is what allowed this to ship unnoticed, and it would hide the same omission in any future consumer of `ChatMenu`. Rendering the entry only when a handler is supplied would surface it instead, but that changes the component's contract for every consumer and every menu entry that uses the same pattern, so it is deliberately left out of this PR.

This PR was prepared with AI copilot assistance and reviewed by the author.

### Manual Verification Performed

1. Opened the Search chats modal, chose `Mark as unread` from a chat's three dot menu, and confirmed the chat is now shown unread in the sidebar behind the modal.
2. Confirmed a request is sent to `POST /api/v1/chats/{id}/unread`, where previously none was.
3. Opened the marked chat and confirmed it returns to read, and that the unread indicator clears.
4. Used `Mark as unread` from the sidebar's own chat menu and confirmed that path still behaves exactly as before.
5. Exercised the modal's other menu actions (rename, clone, archive, pin, delete) and confirmed no regressions.
6. Ran `npm run format` (file reported unchanged) and `npm run build` (succeeds).

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
