### PR TITLE
feat: add knowledge base upload limits (max file count / size)

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -972,6 +972,10 @@ RAG_FILE_MAX_COUNT = int(os.getenv('RAG_FILE_MAX_COUNT')) if os.getenv('RAG_FILE
 
 RAG_FILE_MAX_SIZE = int(os.getenv('RAG_FILE_MAX_SIZE')) if os.getenv('RAG_FILE_MAX_SIZE') else None
 
+RAG_KNOWLEDGE_MAX_COUNT = int(os.getenv('RAG_KNOWLEDGE_MAX_COUNT')) if os.getenv('RAG_KNOWLEDGE_MAX_COUNT') else None
+
+RAG_KNOWLEDGE_MAX_SIZE = int(os.getenv('RAG_KNOWLEDGE_MAX_SIZE')) if os.getenv('RAG_KNOWLEDGE_MAX_SIZE') else None
+
 RAG_FILE_CONTENT_SEARCH_MAX_CHARS = int(os.getenv('RAG_FILE_CONTENT_SEARCH_MAX_CHARS', str(64 * 1024 * 1024)))
 
 FILE_IMAGE_COMPRESSION_WIDTH = (
@@ -2878,6 +2882,8 @@ DEFAULT_CONFIG = {
     'rag.full_context': RAG_FULL_CONTEXT,
     'rag.file.max_count': RAG_FILE_MAX_COUNT,
     'rag.file.max_size': RAG_FILE_MAX_SIZE,
+    'rag.knowledge.max_count': RAG_KNOWLEDGE_MAX_COUNT,
+    'rag.knowledge.max_size': RAG_KNOWLEDGE_MAX_SIZE,
     'file.image_compression_width': FILE_IMAGE_COMPRESSION_WIDTH,
     'file.image_compression_height': FILE_IMAGE_COMPRESSION_HEIGHT,
     'rag.file.allowed_extensions': RAG_ALLOWED_FILE_EXTENSIONS,

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -2150,6 +2150,8 @@ async def get_app_config(request: Request):
         'audio.stt.engine',
         'rag.file.max_size',
         'rag.file.max_count',
+        'rag.knowledge.max_size',
+        'rag.knowledge.max_count',
         'file.image_compression_width',
         'file.image_compression_height',
         'user.permissions',
@@ -2258,6 +2260,10 @@ async def get_app_config(request: Request):
                         'width': config.get('file.image_compression_width'),
                         'height': config.get('file.image_compression_height'),
                     },
+                },
+                'knowledge': {
+                    'max_size': config.get('rag.knowledge.max_size'),
+                    'max_count': config.get('rag.knowledge.max_count'),
                 },
                 'permissions': {**(config.get('user.permissions') or {})},
                 'google_drive': {

--- a/backend/open_webui/models/knowledge.py
+++ b/backend/open_webui/models/knowledge.py
@@ -705,6 +705,18 @@ class KnowledgeTable:
         except Exception:
             return []
 
+    async def get_file_count_by_id(
+        self, knowledge_id: str, db: Optional[AsyncSession] = None
+    ) -> int:
+        try:
+            async with get_async_db_context(db) as db:
+                result = await db.execute(
+                    select(func.count()).select_from(KnowledgeFile).filter_by(knowledge_id=knowledge_id)
+                )
+                return result.scalar() or 0
+        except Exception:
+            return 0
+
     async def add_file_to_knowledge_by_id(
         self,
         knowledge_id: str,

--- a/backend/open_webui/routers/files.py
+++ b/backend/open_webui/routers/files.py
@@ -53,6 +53,7 @@ log = logging.getLogger(__name__)
 router = APIRouter()
 
 
+from open_webui.routers.knowledge import enforce_knowledge_upload_limits
 from open_webui.utils.access_control.files import has_access_to_file
 from open_webui.utils.json_codec import JSONCodec
 
@@ -224,6 +225,10 @@ async def process_uploaded_file(
                             f'{knowledge_id}: user {user.id} lacks write access'
                         )
                     else:
+                        await enforce_knowledge_upload_limits(
+                            knowledge_id, (file_item.meta or {}).get('size', 0), db=db_session,
+                        )
+
                         # Keep the generic file status stream open until the
                         # KB-specific vector write and durable link both finish.
                         await Files.update_file_data_by_id(file_item.id, {'status': 'processing'}, db=db_session)
@@ -389,6 +394,30 @@ async def upload_file_handler(
                 status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
                 detail=ERROR_MESSAGES.FILE_TOO_LARGE(size=f'{max_size} MB'),
             )
+
+        # Enforce KB upload limits before any extraction/embedding work, not just
+        # before the final link — a file destined to be rejected shouldn't pay for
+        # text extraction or vector embedding first.
+        knowledge_id = file_metadata.get('knowledge_id')
+        if knowledge_id:
+            knowledge = await Knowledges.get_knowledge_by_id(id=knowledge_id, db=db)
+            can_write = bool(knowledge) and (
+                knowledge.user_id == user.id
+                or user.role == 'admin'
+                or await AccessGrants.has_access(
+                    user_id=user.id,
+                    resource_type='knowledge',
+                    resource_id=knowledge.id,
+                    permission='write',
+                    db=db,
+                )
+            )
+            if can_write:
+                try:
+                    await enforce_knowledge_upload_limits(knowledge_id, len(contents), db=db)
+                except ValueError as e:
+                    await asyncio.to_thread(Storage.delete_file, file_path)
+                    raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 
         # SHA-256 of raw uploaded bytes for incremental sync diffing.
         # If the client pre-computed and sent file_hash, use that.

--- a/backend/open_webui/routers/knowledge.py
+++ b/backend/open_webui/routers/knowledge.py
@@ -1367,6 +1367,23 @@ async def get_knowledge_files_by_id(
 ############################
 
 
+async def enforce_knowledge_upload_limits(knowledge_id: str, file_size: int, db: AsyncSession) -> None:
+    """
+    Raise ValueError if adding a file of `file_size` bytes to `knowledge_id`
+    would exceed the configured global knowledge base upload limits
+    (Admin Settings → Documents → Max Knowledge Base Files / Max Knowledge Base File Size).
+    """
+    max_count = await Config.get('rag.knowledge.max_count')
+    if max_count is not None and max_count != 0:
+        current_count = await Knowledges.get_file_count_by_id(knowledge_id, db=db)
+        if current_count >= max_count:
+            raise ValueError(f'Knowledge base file limit reached ({max_count} files maximum).')
+
+    max_size = await Config.get('rag.knowledge.max_size')
+    if max_size is not None and max_size != 0 and file_size > max_size * 1024 * 1024:
+        raise ValueError(f'File size exceeds the {max_size} MB limit for knowledge base uploads.')
+
+
 class KnowledgeFileIdForm(BaseModel):
     file_id: str
     directory_id: Optional[str] = None
@@ -1424,6 +1441,11 @@ async def add_file_to_knowledge_by_id(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
             )
+
+    try:
+        await enforce_knowledge_upload_limits(id, (file.meta or {}).get('size', 0), db=db)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 
     # Add content to the vector database
     try:
@@ -2030,6 +2052,26 @@ async def add_files_to_knowledge_batch(
     log.info('files/batch/add - %s files', len(form_data))
     file_ids = [form.file_id for form in form_data]
     files = await Files.get_files_by_ids(file_ids, db=db)
+
+    max_count = await Config.get('rag.knowledge.max_count')
+    if max_count is not None and max_count != 0:
+        current_count = await Knowledges.get_file_count_by_id(id, db=db)
+        if current_count + len(files) > max_count:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f'Knowledge base file limit exceeded: adding {len(files)} file(s) would exceed the {max_count} file maximum (currently {current_count}).',
+            )
+
+    max_size = await Config.get('rag.knowledge.max_size')
+    if max_size is not None and max_size != 0:
+        oversized = [
+            f.filename for f in files if f.meta and f.meta.get('size', 0) > max_size * 1024 * 1024
+        ]
+        if oversized:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f'File(s) exceed the {max_size} MB limit for knowledge base uploads: {", ".join(oversized)}',
+            )
 
     # Verify all requested files were found
     found_ids = {file.id for file in files}

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -315,6 +315,8 @@ RETRIEVAL_CONFIG_KEYS = {
     'JINA_API_BASE_URL': 'web.search.jina_api_base_url',
     'JINA_API_KEY': 'web.search.jina_api_key',
     'KAGI_SEARCH_API_KEY': 'web.search.kagi_search_api_key',
+    'KNOWLEDGE_MAX_COUNT': 'rag.knowledge.max_count',
+    'KNOWLEDGE_MAX_SIZE': 'rag.knowledge.max_size',
     'LINKUP_API_KEY': 'web.search.linkup_api_key',
     'LINKUP_SEARCH_PARAMS': 'web.search.linkup_search_params',
     'MINERU_API_KEY': 'rag.mineru_api_key',
@@ -683,6 +685,8 @@ async def get_rag_config(request: Request, user=Depends(get_admin_user)):
         # File upload settings
         'FILE_MAX_SIZE': config.FILE_MAX_SIZE,
         'FILE_MAX_COUNT': config.FILE_MAX_COUNT,
+        'KNOWLEDGE_MAX_SIZE': config.KNOWLEDGE_MAX_SIZE,
+        'KNOWLEDGE_MAX_COUNT': config.KNOWLEDGE_MAX_COUNT,
         'FILE_IMAGE_COMPRESSION_WIDTH': config.FILE_IMAGE_COMPRESSION_WIDTH,
         'FILE_IMAGE_COMPRESSION_HEIGHT': config.FILE_IMAGE_COMPRESSION_HEIGHT,
         'ALLOWED_FILE_EXTENSIONS': config.ALLOWED_FILE_EXTENSIONS,
@@ -922,6 +926,8 @@ class ConfigForm(BaseModel):
     # File upload settings
     FILE_MAX_SIZE: Union[int, str | None] = None
     FILE_MAX_COUNT: Union[int, str | None] = None
+    KNOWLEDGE_MAX_SIZE: Union[int, str | None] = None
+    KNOWLEDGE_MAX_COUNT: Union[int, str | None] = None
     FILE_IMAGE_COMPRESSION_WIDTH: Union[int, str | None] = None
     FILE_IMAGE_COMPRESSION_HEIGHT: Union[int, str | None] = None
     ALLOWED_FILE_EXTENSIONS: list[str | None] = None
@@ -1216,6 +1222,10 @@ async def update_rag_config(request: Request, form_data: ConfigForm, user=Depend
         config.FILE_MAX_SIZE = None if form_data.FILE_MAX_SIZE == '' else form_data.FILE_MAX_SIZE
     if form_data.FILE_MAX_COUNT is not None:
         config.FILE_MAX_COUNT = None if form_data.FILE_MAX_COUNT == '' else form_data.FILE_MAX_COUNT
+    if form_data.KNOWLEDGE_MAX_SIZE is not None:
+        config.KNOWLEDGE_MAX_SIZE = None if form_data.KNOWLEDGE_MAX_SIZE == '' else form_data.KNOWLEDGE_MAX_SIZE
+    if form_data.KNOWLEDGE_MAX_COUNT is not None:
+        config.KNOWLEDGE_MAX_COUNT = None if form_data.KNOWLEDGE_MAX_COUNT == '' else form_data.KNOWLEDGE_MAX_COUNT
     if form_data.FILE_IMAGE_COMPRESSION_WIDTH is not None:
         config.FILE_IMAGE_COMPRESSION_WIDTH = (
             None if form_data.FILE_IMAGE_COMPRESSION_WIDTH == '' else form_data.FILE_IMAGE_COMPRESSION_WIDTH
@@ -1390,6 +1400,8 @@ async def update_rag_config(request: Request, form_data: ConfigForm, user=Depend
         # File upload settings
         'FILE_MAX_SIZE': config.FILE_MAX_SIZE,
         'FILE_MAX_COUNT': config.FILE_MAX_COUNT,
+        'KNOWLEDGE_MAX_SIZE': config.KNOWLEDGE_MAX_SIZE,
+        'KNOWLEDGE_MAX_COUNT': config.KNOWLEDGE_MAX_COUNT,
         'FILE_IMAGE_COMPRESSION_WIDTH': config.FILE_IMAGE_COMPRESSION_WIDTH,
         'FILE_IMAGE_COMPRESSION_HEIGHT': config.FILE_IMAGE_COMPRESSION_HEIGHT,
         'ALLOWED_FILE_EXTENSIONS': config.ALLOWED_FILE_EXTENSIONS,

--- a/src/lib/components/admin/Settings/Documents.svelte
+++ b/src/lib/components/admin/Settings/Documents.svelte
@@ -258,6 +258,8 @@
 			// can distinguish "clear this field" from "don't change this field"
 			FILE_MAX_SIZE: RAGConfig.FILE_MAX_SIZE ?? '',
 			FILE_MAX_COUNT: RAGConfig.FILE_MAX_COUNT ?? '',
+			KNOWLEDGE_MAX_SIZE: RAGConfig.KNOWLEDGE_MAX_SIZE ?? '',
+			KNOWLEDGE_MAX_COUNT: RAGConfig.KNOWLEDGE_MAX_COUNT ?? '',
 			FILE_IMAGE_COMPRESSION_WIDTH: RAGConfig.FILE_IMAGE_COMPRESSION_WIDTH ?? '',
 			FILE_IMAGE_COMPRESSION_HEIGHT: RAGConfig.FILE_IMAGE_COMPRESSION_HEIGHT ?? '',
 			ALLOWED_FILE_EXTENSIONS: RAGConfig.ALLOWED_FILE_EXTENSIONS.split(',')
@@ -1436,6 +1438,37 @@
 							type="number"
 							placeholder={$i18n.t('Leave empty for unlimited')}
 							bind:value={RAGConfig.FILE_MAX_COUNT}
+							autocomplete="off"
+							min="0"
+						/>
+					</AdminSettingField>
+				</div>
+
+				<div class="grid grid-cols-1 gap-x-3 gap-y-2.5 sm:grid-cols-2">
+					<AdminSettingField
+						label={$i18n.t('Max Knowledge Base File Size')}
+						description={$i18n.t(
+							'Maximum file size in MB for knowledge base uploads. Leave empty for unlimited.'
+						)}
+					>
+						<input
+							class={inputClass}
+							type="number"
+							placeholder={$i18n.t('Leave empty for unlimited')}
+							bind:value={RAGConfig.KNOWLEDGE_MAX_SIZE}
+							autocomplete="off"
+							min="0"
+						/>
+					</AdminSettingField>
+					<AdminSettingField
+						label={$i18n.t('Max Knowledge Base Files')}
+						description={$i18n.t('Maximum number of files allowed per knowledge base.')}
+					>
+						<input
+							class={inputClass}
+							type="number"
+							placeholder={$i18n.t('Leave empty for unlimited')}
+							bind:value={RAGConfig.KNOWLEDGE_MAX_COUNT}
 							autocomplete="off"
 							min="0"
 						/>

--- a/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
+++ b/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
@@ -406,17 +406,19 @@
 			return null;
 		}
 
-		if (
-			($config?.file?.max_size ?? null) !== null &&
-			file.size > ($config?.file?.max_size ?? 0) * 1024 * 1024
-		) {
-			console.log('File exceeds max size limit:', {
-				fileSize: file.size,
-				maxSize: ($config?.file?.max_size ?? 0) * 1024 * 1024
-			});
+		const knowledgeMaxSize = $config?.knowledge?.max_size ?? null;
+		if (knowledgeMaxSize !== null && file.size > knowledgeMaxSize * 1024 * 1024) {
 			toast.error(
-				$i18n.t(`File size should not exceed {{maxSize}} MB.`, {
-					maxSize: $config?.file?.max_size
+				$i18n.t(`File size should not exceed {{maxSize}} MB.`, { maxSize: knowledgeMaxSize })
+			);
+			return;
+		}
+
+		const knowledgeMaxCount = $config?.knowledge?.max_count ?? null;
+		if (knowledgeMaxCount !== null && (fileItemsTotal ?? 0) >= knowledgeMaxCount) {
+			toast.error(
+				$i18n.t(`Knowledge base file limit reached ({{maxCount}} files maximum).`, {
+					maxCount: knowledgeMaxCount
 				})
 			);
 			return;
@@ -602,12 +604,48 @@
 		return currentPath && path ? `${currentPath}/${path}` : currentPath || path;
 	};
 
+	// Mirrors the backend's enforce_knowledge_upload_limits: same source values
+	// ($config.knowledge), same semantics (0/null = unlimited). This is a UX
+	// fast-path only — the backend is still the source of truth.
+	const checkKnowledgeUploadLimits = (entries: DirectoryManifestEntry[]): boolean => {
+		const knowledgeMaxCount = $config?.knowledge?.max_count ?? null;
+		if (knowledgeMaxCount !== null && (fileItemsTotal ?? 0) + entries.length > knowledgeMaxCount) {
+			toast.error(
+				$i18n.t('Knowledge base file limit exceeded: adding {{count}} file(s) would exceed the {{maxCount}} file maximum.', {
+					count: entries.length,
+					maxCount: knowledgeMaxCount
+				})
+			);
+			return false;
+		}
+
+		const knowledgeMaxSize = $config?.knowledge?.max_size ?? null;
+		if (knowledgeMaxSize !== null) {
+			const oversized = entries.filter((entry) => entry.size > knowledgeMaxSize * 1024 * 1024);
+			if (oversized.length > 0) {
+				toast.error(
+					$i18n.t('File(s) exceed the {{maxSize}} MB limit for knowledge base uploads: {{files}}', {
+						maxSize: knowledgeMaxSize,
+						files: oversized.map((entry) => entry.filename).join(', ')
+					})
+				);
+				return false;
+			}
+		}
+
+		return true;
+	};
+
 	const uploadDirectoryEntries = async (entries: DirectoryFileEntry[]) => {
 		if (!knowledge) return;
 
 		try {
 			syncing = $i18n.t('Computing checksums ({{count}} files)', { count: entries.length });
 			const manifest = await buildDirectoryManifest(entries);
+
+			if (!checkKnowledgeUploadLimits(manifest)) {
+				return;
+			}
 
 			syncing = $i18n.t('Comparing with knowledge base...');
 			const diff = await syncKnowledgeDiff(
@@ -628,6 +666,7 @@
 
 			const directoryIdByPath = await createMissingDirectories(diff);
 
+			const failures: string[] = [];
 			let uploadedCount = 0;
 			for (const entry of manifest) {
 				uploadedCount++;
@@ -639,7 +678,7 @@
 				});
 
 				const fileObject = new File([entry.file], entry.filename, { type: entry.file.type });
-				await uploadFile(localStorage.token, fileObject, {
+				const uploadedFile = await uploadFile(localStorage.token, fileObject, {
 					knowledge_id: knowledge.id,
 					file_hash: entry.checksum,
 					directory_id: entry.path
@@ -649,9 +688,21 @@
 					toast.error(`${e}`);
 					return null;
 				});
+
+				if (uploadedFile?.error) {
+					failures.push(`${displayPath}: ${uploadedFile.error}`);
+				}
 			}
 
-			toast.success($i18n.t('File uploaded successfully'));
+			if (failures.length > 0) {
+				toast.error(
+					$i18n.t('{{count}} file(s) failed to upload:', { count: failures.length }) +
+						' ' +
+						failures.join('; ')
+				);
+			} else {
+				toast.success($i18n.t('File uploaded successfully'));
+			}
 			init();
 		} catch (e) {
 			toast.error(`${e}`);
@@ -706,6 +757,11 @@
 					diff.modified.some((m: any) => m.filename === entry.filename && m.path === entry.path)
 			);
 
+			if (!checkKnowledgeUploadLimits(filesToUpload)) {
+				return;
+			}
+
+			const failures: string[] = [];
 			let uploadedCount = 0;
 			for (const entry of filesToUpload) {
 				uploadedCount++;
@@ -717,14 +773,28 @@
 				});
 
 				const fileObject = new File([entry.file], entry.filename, { type: entry.file.type });
-				await uploadFile(localStorage.token, fileObject, {
+				const uploadedFile = await uploadFile(localStorage.token, fileObject, {
 					knowledge_id: knowledge.id,
 					file_hash: entry.checksum,
 					directory_id: entry.path ? directoryIdByPath[entry.path] : null
-				}).catch(() => null);
+				}).catch((e) => {
+					toast.error(`${e}`);
+					return null;
+				});
+
+				if (uploadedFile?.error) {
+					failures.push(`${displayPath}: ${uploadedFile.error}`);
+				}
 			}
 
 			// ── 7. Report ──
+			if (failures.length > 0) {
+				toast.error(
+					$i18n.t('{{count}} file(s) failed to upload:', { count: failures.length }) +
+						' ' +
+						failures.join('; ')
+				);
+			}
 			toast.success(
 				$i18n.t(
 					'Sync complete: {{added}} added, {{modified}} modified, {{deleted}} deleted, {{unmodified}} unmodified',

--- a/src/lib/components/workspace/Models/Knowledge.svelte
+++ b/src/lib/components/workspace/Models/Knowledge.svelte
@@ -114,18 +114,10 @@
 				extension: file.name.split('.').at(-1)
 			});
 
-			if (
-				($config?.file?.max_size ?? null) !== null &&
-				file.size > ($config?.file?.max_size ?? 0) * 1024 * 1024
-			) {
-				console.log('File exceeds max size limit:', {
-					fileSize: file.size,
-					maxSize: ($config?.file?.max_size ?? 0) * 1024 * 1024
-				});
+			const knowledgeMaxSize = $config?.knowledge?.max_size ?? null;
+			if (knowledgeMaxSize !== null && file.size > knowledgeMaxSize * 1024 * 1024) {
 				toast.error(
-					$i18n.t(`File size should not exceed {{maxSize}} MB.`, {
-						maxSize: $config?.file?.max_size
-					})
+					$i18n.t(`File size should not exceed {{maxSize}} MB.`, { maxSize: knowledgeMaxSize })
 				);
 				return;
 			}


### PR DESCRIPTION
Adds `RAG_KNOWLEDGE_MAX_COUNT` and `RAG_KNOWLEDGE_MAX_SIZE` to global admin settings (Admin Settings → Documents → Files) capping how many files a knowledge base may hold and the max size per file. Applies uniformly to every user, including admins, and to every way of adding a file to a knowledge base: manual upload, one-shot directory import, incremental directory sync, and the API — all funnel through a single `enforce_knowledge_upload_limits()` check, applied before storage, text extraction, or embedding so a rejected file doesn't pay for any of that work. The frontend pre-checks the same limits client-side for fast feedback, but the backend is the source of truth.

# Changelog Entry

### Added

- Admins can now cap how many files a knowledge base may hold and the max size per file, via `RAG_KNOWLEDGE_MAX_COUNT` and `RAG_KNOWLEDGE_MAX_SIZE` (MB), configurable in Admin Panel → Settings → Documents → Files as `Max Knowledge Base Files` / `Max Knowledge Base File Size`, alongside the existing `Max Upload Size` / `Max Upload Count`. `0` or empty means unlimited. Global settings, applied uniformly to every user including admins.

---

### Additional Information

- Related discussions: https://github.com/open-webui/open-webui/discussions/24075, https://github.com/open-webui/open-webui/discussions/24845
- Docs updated in a companion [PR to the Docs Repository](https://github.com/open-webui/docs/pull/1342)
- Manually tested against a local dev stack (source-built image) with `Max Knowledge Base Files=2` / `Max Knowledge Base File Size=25`: confirmed the 3rd file and oversized files are rejected via the manual upload button, the one-shot directory import, incremental directory sync, and a direct API call — and that this applies to admin accounts too, since the limit is global with no per-role exemption.

### Screenshots or Videos

Admin Settings → Documents → Files, showing the new fields:
<img width="1231" height="434" alt="image" src="https://github.com/user-attachments/assets/8df1493d-33fb-4ef8-9fa2-89de60511602" />
Rejection when uploading more than the configured file count via the manual upload button:
<img width="383" height="162" alt="image" src="https://github.com/user-attachments/assets/44e015c1-4432-4ce4-9bef-3d3f765ea0a2" />
Rejection when uploading a directory that exceeds the configured file count:
<img width="385" height="93" alt="image" src="https://github.com/user-attachments/assets/4d2a3621-9ecb-4545-9112-9a4532d40b7e" />

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
