### PR TITLE
fix: wire markUnreadHandler in Search chats modal

### DIFF
--- a/src/lib/components/layout/SearchModal.svelte
+++ b/src/lib/components/layout/SearchModal.svelte
@@ -14,7 +14,8 @@
 		archiveChatById,
 		updateChatById,
 		updateChatFolderIdById,
-		getAllTags
+		getAllTags,
+		markChatUnreadById
 	} from '$lib/apis/chats';
 	import Spinner from '../common/Spinner.svelte';
 
@@ -139,6 +140,17 @@
 				toast.success($i18n.t('Chat moved successfully'));
 			}
 		}
+	};
+
+	const markUnreadHandler = async (id) => {
+		const res = await markChatUnreadById(localStorage.token, id).catch((error) => {
+			toast.error(`${error}`);
+			return null;
+		});
+		if (!res) return;
+
+		await refreshSidebar();
+		await searchHandler();
 	};
 
 	const renameHandler = async (id) => {
@@ -820,6 +832,9 @@
 													menuChatId = chat.id;
 													menuChatTitle = chat.title;
 													showDeleteConfirm = true;
+												}}
+												markUnreadHandler={() => {
+													markUnreadHandler(chat.id);
 												}}
 												onClose={() => {}}
 												onPinChange={async () => {


### PR DESCRIPTION
## Summary

The "Mark as unread" option in the Search chats modal was a no-op because `ChatMenu` wasn't receiving the `markUnreadHandler` prop.

## Changes

- `src/lib/components/layout/SearchModal.svelte`: Import `markChatUnreadById`, add `markUnreadHandler` function that calls the API and refreshes sidebar + search results, and pass it to `ChatMenu`

## Testing

1. Open Search chats modal
2. Click the three-dot menu on any chat
3. Click "Mark as unread"
4. Verify the chat is marked unread in the sidebar and the search results refresh

Closes #28135
