### PR TITLE
fix: open original files from knowledge collections

### DIFF
--- a/src/lib/components/workspace/Knowledge/KnowledgeBase/Files.svelte
+++ b/src/lib/components/workspace/Knowledge/KnowledgeBase/Files.svelte
@@ -90,16 +90,18 @@
 		>
 			<div class="flex items-center">
 				{#if file?.status !== 'uploading'}
-					<button
-						class="p-1 rounded-full transition"
-						type="button"
-						on:click={() => {
-							let fileId = file?.id ?? file?.tempId;
-							onClick(fileId);
-						}}
-					>
-						<DocumentPage className="size-3.5" />
-					</button>
+					<Tooltip content={$i18n.t('Open file')}>
+						<button
+							class="p-1 rounded-full hover:bg-gray-100 dark:hover:bg-gray-850 transition"
+							type="button"
+							on:click={() => {
+								let fileId = file?.id ?? file?.tempId;
+								window.open(`${WEBUI_BASE_URL}/api/v1/files/${fileId}/content`, '_blank');
+							}}
+						>
+							<DocumentPage className="size-3.5" />
+						</button>
+					</Tooltip>
 				{:else}
 					<Spinner className="size-3.5" />
 				{/if}


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Closes #28086 and relates to #28103.
- [x] **Target branch:** This pull request targets `dev`.
- [x] **Description:** A concise description of the change is provided below.
- [x] **Changelog:** A changelog entry is included below.
- [x] **Documentation:** No documentation changes are required for this bug fix.
- [x] **Dependencies:** No dependencies were added or updated.
- [x] **Testing:** Manual testing was performed and the existing frontend tests passed.
- [x] **No Unchecked AI Code:** The change was manually reviewed and tested.
- [x] **Self-Review:** The code and final diff were reviewed.
- [x] **Architecture:** No new settings, backend changes, or architectural changes were introduced.
- [x] **Git Hygiene:** The PR is atomic, rebased on `dev`, and contains no unrelated changes.
- [x] **Title Prefix:** The title uses the `fix` prefix.

# Changelog Entry

### Description

- Restores the original-file action for files displayed inside knowledge collections.
- The filename continues to open the extracted-text drawer, while the document icon now opens the uploaded file in a new tab.

### Added

- None.

### Changed

- Restored the document icon hover styling and the localized `Open file` tooltip.

### Deprecated

- None.

### Removed

- None.

### Fixed

- Fixed the document icon in knowledge collections opening the extracted-text drawer instead of the original uploaded file.

### Security

- None.

### Breaking Changes

- None.

---

### Additional Information

- Closes #28086
- Relates to discussion #28103
- No backend, API, database, migration, dependency, or permission changes were required.
- The existing `/api/v1/files/{fileId}/content` endpoint is used.

### Testing

- Confirmed clicking the filename opens the extracted-text view.
- Confirmed clicking the document icon opens the original PDF in a new tab.
- Confirmed only one tab opens per click.
- Confirmed the opened URL uses `/api/v1/files/{fileId}/content`.
- Confirmed the existing overflow Download action remains functional.
- Existing frontend tests were run successfully during validation.
- Ran targeted formatting checks and `git diff --check`.
- `npm run check` still reports the repository’s existing baseline diagnostics.

### Screenshots or Videos

- Not included. The change was manually verified locally:
  - clicking the filename opens the extracted-text view;
  - clicking the document icon opens the original PDF in a new tab.
  
### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.