### PR TITLE
feat: track direct API calls in usage analytics (fixes #28059)

### DIFF
--- a/backend/open_webui/migrations/versions/a1f3e2d9c8b7_add_source_to_chat_message.py
+++ b/backend/open_webui/migrations/versions/a1f3e2d9c8b7_add_source_to_chat_message.py
@@ -1,0 +1,78 @@
+"""add source column to chat_message, make chat_id nullable, drop FK
+
+Revision ID: a1f3e2d9c8b7
+Revises: f0bd01a18a3d
+Create Date: 2026-08-05 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = 'a1f3e2d9c8b7'
+down_revision: Union[str, None] = 'f0bd01a18a3d'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    dialect = conn.dialect.name
+    columns = {c['name'] for c in inspector.get_columns('chat_message')}
+
+    # Add source column if not present
+    if 'source' not in columns:
+        op.add_column('chat_message', sa.Column('source', sa.Text(), nullable=True, index=True))
+
+    # Make chat_id nullable and drop FK constraint.
+    # SQLite does not support DROP CONSTRAINT; we use batch_alter_table which
+    # rewrites the table transparently on SQLite and uses ALTER on PostgreSQL.
+    if dialect == 'sqlite':
+        with op.batch_alter_table('chat_message', recreate='always') as batch_op:
+            batch_op.alter_column('chat_id', existing_type=sa.Text(), nullable=True)
+            # Drop FK by not including it in the recreated table definition.
+            # batch_alter_table with recreate='always' drops all existing FKs
+            # unless explicitly re-added; since we omit the FK here it is gone.
+    else:
+        # PostgreSQL: drop the FK constraint by name, then alter column
+        fks = inspector.get_foreign_keys('chat_message')
+        for fk in fks:
+            if 'chat_id' in fk.get('constrained_columns', []):
+                op.drop_constraint(fk['name'], 'chat_message', type_='foreignkey')
+        op.alter_column('chat_message', 'chat_id', existing_type=sa.Text(), nullable=True)
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    dialect = conn.dialect.name
+    columns = {c['name'] for c in inspector.get_columns('chat_message')}
+
+    if 'source' in columns:
+        op.drop_column('chat_message', 'source')
+
+    # Restore chat_id to NOT NULL (data must already be clean — no NULLs)
+    if dialect == 'sqlite':
+        with op.batch_alter_table('chat_message', recreate='always') as batch_op:
+            batch_op.alter_column('chat_id', existing_type=sa.Text(), nullable=False)
+            batch_op.create_foreign_key(
+                'fk_chat_message_chat_id',
+                'chat',
+                ['chat_id'],
+                ['id'],
+                ondelete='CASCADE',
+            )
+    else:
+        op.alter_column('chat_message', 'chat_id', existing_type=sa.Text(), nullable=False)
+        op.create_foreign_key(
+            'fk_chat_message_chat_id',
+            'chat_message',
+            'chat',
+            ['chat_id'],
+            ['id'],
+            ondelete='CASCADE',
+        )

--- a/backend/open_webui/models/chat_messages.py
+++ b/backend/open_webui/models/chat_messages.py
@@ -130,8 +130,13 @@ class ChatMessage(Base):
 
     # Identity
     id = Column(Text, primary_key=True)
-    chat_id = Column(Text, ForeignKey('chat.id', ondelete='CASCADE'), nullable=False, index=True)
+    # chat_id is nullable: NULL means the row was created by a direct API call
+    # (no UI chat session). FK intentionally omitted so API-origin rows
+    # are not tied to a Chat row.
+    chat_id = Column(Text, nullable=True, index=True)
     user_id = Column(Text, index=True)
+    # source: NULL = regular chat message; 'api' = direct API call without chat session
+    source = Column(Text, nullable=True, index=True)
 
     # Structure
     role = Column(Text, nullable=False)  # user, assistant, system
@@ -181,8 +186,9 @@ class ChatMessageModel(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     id: str
-    chat_id: str
+    chat_id: Optional[str] = None
     user_id: str
+    source: Optional[str] = None
     role: str
     parent_id: Optional[str] = None
     content: Optional[Any] = None  # str or list of blocks
@@ -210,18 +216,22 @@ class ChatMessageTable:
     async def upsert_message(
         self,
         message_id: str,
-        chat_id: str,
+        chat_id: Optional[str],
         user_id: str,
         data: dict,
         db: Optional[AsyncSession] = None,
     ) -> Optional[ChatMessageModel]:
-        """Insert or update a chat message."""
+        """Insert or update a chat message.
+
+        When chat_id is None (direct API call with no UI session), the row ID
+        is just the message_id UUID — no composite prefix needed.
+        """
         async with get_async_db_context(db) as db:
             now = int(time.time())
             timestamp = data.get('timestamp', now)
 
-            # Use composite ID: {chat_id}-{message_id}
-            composite_id = f'{chat_id}-{message_id}'
+            # Composite ID for chat messages; bare UUID for API-origin rows.
+            composite_id = f'{chat_id}-{message_id}' if chat_id else message_id
 
             existing = await db.get(ChatMessage, composite_id)
             if existing:
@@ -266,8 +276,9 @@ class ChatMessageTable:
                 usage = get_usage(data)
                 message = ChatMessage(
                     id=composite_id,
-                    chat_id=chat_id,
+                    chat_id=chat_id or None,
                     user_id=user_id,
+                    source=data.get('source'),
                     role=data.get('role', 'user'),
                     parent_id=data.get('parent_id') or data.get('parentId'),
                     content=data.get('content'),
@@ -500,6 +511,7 @@ class ChatMessageTable:
             stmt = select(ChatMessage.model_id, func.count(ChatMessage.id).label('count')).filter(
                 ChatMessage.role == 'assistant',
                 ChatMessage.model_id.isnot(None),
+                ChatMessage.source.is_(None),
             )
 
             if start_date:
@@ -532,6 +544,7 @@ class ChatMessageTable:
             ).filter(
                 ChatMessage.role == 'assistant',
                 ChatMessage.model_id.isnot(None),
+                ChatMessage.source.is_(None),
             )
 
             if start_date:
@@ -579,6 +592,7 @@ class ChatMessageTable:
                 ChatMessage.role == 'assistant',
                 ChatMessage.model_id.isnot(None),
                 ChatMessage.usage.isnot(None),
+                ChatMessage.source.is_(None),
             )
 
             if start_date:
@@ -627,6 +641,7 @@ class ChatMessageTable:
                 ChatMessage.role == 'assistant',
                 ChatMessage.user_id.isnot(None),
                 ChatMessage.usage.isnot(None),
+                ChatMessage.source.is_(None),
             )
 
             if start_date:
@@ -889,6 +904,7 @@ class ChatMessageTable:
 
             stmt = select(ChatMessage.user_id, func.count(ChatMessage.id).label('count')).filter(
                 ChatMessage.role == 'assistant',
+                ChatMessage.source.is_(None),
             )
 
             if start_date:
@@ -915,6 +931,7 @@ class ChatMessageTable:
 
             stmt = select(ChatMessage.chat_id, func.count(ChatMessage.id).label('count')).filter(
                 ChatMessage.role == 'assistant',
+                ChatMessage.source.is_(None),
             )
 
             if start_date:
@@ -945,6 +962,7 @@ class ChatMessageTable:
             stmt = select(ChatMessage.created_at, ChatMessage.model_id).filter(
                 ChatMessage.role == 'assistant',
                 ChatMessage.model_id.isnot(None),
+                ChatMessage.source.is_(None),
             )
 
             if start_date:
@@ -991,6 +1009,7 @@ class ChatMessageTable:
             stmt = select(ChatMessage.created_at, ChatMessage.model_id).filter(
                 ChatMessage.role == 'assistant',
                 ChatMessage.model_id.isnot(None),
+                ChatMessage.source.is_(None),
             )
 
             if start_date:
@@ -1022,6 +1041,223 @@ class ChatMessageTable:
                     current += timedelta(hours=1)
 
             return hourly_counts
+
+    # ------------------------------------------------------------------ #
+    # API-origin analytics (source = 'api')                               #
+    # These mirror the chat analytics methods but filter for direct API   #
+    # calls that have no associated UI chat session.                      #
+    # ------------------------------------------------------------------ #
+
+    async def get_api_message_count_by_model(
+        self,
+        start_date: Optional[int] = None,
+        end_date: Optional[int] = None,
+        group_id: Optional[str] = None,
+        db: Optional[AsyncSession] = None,
+    ) -> dict[str, int]:
+        async with get_async_db_context(db) as db:
+            from open_webui.models.groups import GroupMember
+
+            stmt = select(ChatMessage.model_id, func.count(ChatMessage.id).label('count')).filter(
+                ChatMessage.role == 'assistant',
+                ChatMessage.model_id.isnot(None),
+                ChatMessage.source == 'api',
+            )
+            if start_date:
+                stmt = stmt.filter(ChatMessage.created_at >= start_date)
+            if end_date:
+                stmt = stmt.filter(ChatMessage.created_at <= end_date)
+            if group_id:
+                group_users = select(GroupMember.user_id).filter(GroupMember.group_id == group_id).scalar_subquery()
+                stmt = stmt.filter(ChatMessage.user_id.in_(group_users))
+            stmt = stmt.group_by(ChatMessage.model_id)
+            result = await db.execute(stmt)
+            return {row.model_id: row.count for row in result.all()}
+
+    async def get_api_unique_users_by_model(
+        self,
+        start_date: Optional[int] = None,
+        end_date: Optional[int] = None,
+        group_id: Optional[str] = None,
+        db: Optional[AsyncSession] = None,
+    ) -> dict[str, int]:
+        async with get_async_db_context(db) as db:
+            from open_webui.models.groups import GroupMember
+
+            stmt = select(
+                ChatMessage.model_id,
+                func.count(distinct(ChatMessage.user_id)).label('unique_users'),
+            ).filter(
+                ChatMessage.role == 'assistant',
+                ChatMessage.model_id.isnot(None),
+                ChatMessage.source == 'api',
+            )
+            if start_date:
+                stmt = stmt.filter(ChatMessage.created_at >= start_date)
+            if end_date:
+                stmt = stmt.filter(ChatMessage.created_at <= end_date)
+            if group_id:
+                group_users = select(GroupMember.user_id).filter(GroupMember.group_id == group_id).scalar_subquery()
+                stmt = stmt.filter(ChatMessage.user_id.in_(group_users))
+            stmt = stmt.group_by(ChatMessage.model_id)
+            result = await db.execute(stmt)
+            return {row.model_id: row.unique_users for row in result.all()}
+
+    async def get_api_message_count_by_user(
+        self,
+        start_date: Optional[int] = None,
+        end_date: Optional[int] = None,
+        group_id: Optional[str] = None,
+        db: Optional[AsyncSession] = None,
+    ) -> dict[str, int]:
+        async with get_async_db_context(db) as db:
+            from open_webui.models.groups import GroupMember
+
+            stmt = select(ChatMessage.user_id, func.count(ChatMessage.id).label('count')).filter(
+                ChatMessage.role == 'assistant',
+                ChatMessage.source == 'api',
+            )
+            if start_date:
+                stmt = stmt.filter(ChatMessage.created_at >= start_date)
+            if end_date:
+                stmt = stmt.filter(ChatMessage.created_at <= end_date)
+            if group_id:
+                group_users = select(GroupMember.user_id).filter(GroupMember.group_id == group_id).scalar_subquery()
+                stmt = stmt.filter(ChatMessage.user_id.in_(group_users))
+            stmt = stmt.group_by(ChatMessage.user_id)
+            result = await db.execute(stmt)
+            return {row.user_id: row.count for row in result.all()}
+
+    async def get_api_token_usage_by_model(
+        self,
+        start_date: Optional[int] = None,
+        end_date: Optional[int] = None,
+        group_id: Optional[str] = None,
+        db: Optional[AsyncSession] = None,
+    ) -> dict[str, dict]:
+        async with get_async_db_context(db) as db:
+            from open_webui.models.groups import GroupMember
+
+            bind = await db.connection()
+            dialect = bind.dialect.name
+            input_tokens, output_tokens = _token_columns(dialect)
+
+            stmt = select(
+                ChatMessage.model_id,
+                func.coalesce(func.sum(input_tokens), 0).label('input_tokens'),
+                func.coalesce(func.sum(output_tokens), 0).label('output_tokens'),
+                func.count(ChatMessage.id).label('message_count'),
+            ).filter(
+                ChatMessage.role == 'assistant',
+                ChatMessage.model_id.isnot(None),
+                ChatMessage.usage.isnot(None),
+                ChatMessage.source == 'api',
+            )
+            if start_date:
+                stmt = stmt.filter(ChatMessage.created_at >= start_date)
+            if end_date:
+                stmt = stmt.filter(ChatMessage.created_at <= end_date)
+            if group_id:
+                group_users = select(GroupMember.user_id).filter(GroupMember.group_id == group_id).scalar_subquery()
+                stmt = stmt.filter(ChatMessage.user_id.in_(group_users))
+            stmt = stmt.group_by(ChatMessage.model_id)
+            result = await db.execute(stmt)
+            return {
+                row.model_id: {
+                    'input_tokens': row.input_tokens,
+                    'output_tokens': row.output_tokens,
+                    'total_tokens': row.input_tokens + row.output_tokens,
+                    'message_count': row.message_count,
+                }
+                for row in result.all()
+            }
+
+    async def get_api_token_usage_by_user(
+        self,
+        start_date: Optional[int] = None,
+        end_date: Optional[int] = None,
+        group_id: Optional[str] = None,
+        db: Optional[AsyncSession] = None,
+    ) -> dict[str, dict]:
+        async with get_async_db_context(db) as db:
+            from open_webui.models.groups import GroupMember
+
+            bind = await db.connection()
+            dialect = bind.dialect.name
+            input_tokens, output_tokens = _token_columns(dialect)
+
+            stmt = select(
+                ChatMessage.user_id,
+                func.coalesce(func.sum(input_tokens), 0).label('input_tokens'),
+                func.coalesce(func.sum(output_tokens), 0).label('output_tokens'),
+                func.count(ChatMessage.id).label('message_count'),
+            ).filter(
+                ChatMessage.role == 'assistant',
+                ChatMessage.user_id.isnot(None),
+                ChatMessage.usage.isnot(None),
+                ChatMessage.source == 'api',
+            )
+            if start_date:
+                stmt = stmt.filter(ChatMessage.created_at >= start_date)
+            if end_date:
+                stmt = stmt.filter(ChatMessage.created_at <= end_date)
+            if group_id:
+                group_users = select(GroupMember.user_id).filter(GroupMember.group_id == group_id).scalar_subquery()
+                stmt = stmt.filter(ChatMessage.user_id.in_(group_users))
+            stmt = stmt.group_by(ChatMessage.user_id)
+            result = await db.execute(stmt)
+            return {
+                row.user_id: {
+                    'input_tokens': row.input_tokens,
+                    'output_tokens': row.output_tokens,
+                    'total_tokens': row.input_tokens + row.output_tokens,
+                    'message_count': row.message_count,
+                }
+                for row in result.all()
+            }
+
+    async def get_api_daily_counts_by_model(
+        self,
+        start_date: Optional[int] = None,
+        end_date: Optional[int] = None,
+        group_id: Optional[str] = None,
+        db: Optional[AsyncSession] = None,
+    ) -> dict[str, dict[str, int]]:
+        """Get API-origin message counts grouped by day and model."""
+        async with get_async_db_context(db) as db:
+            from datetime import datetime, timedelta
+
+            from open_webui.models.groups import GroupMember
+
+            stmt = select(ChatMessage.created_at, ChatMessage.model_id).filter(
+                ChatMessage.role == 'assistant',
+                ChatMessage.model_id.isnot(None),
+                ChatMessage.source == 'api',
+            )
+            if start_date:
+                stmt = stmt.filter(ChatMessage.created_at >= start_date)
+            if end_date:
+                stmt = stmt.filter(ChatMessage.created_at <= end_date)
+            if group_id:
+                group_users = select(GroupMember.user_id).filter(GroupMember.group_id == group_id).scalar_subquery()
+                stmt = stmt.filter(ChatMessage.user_id.in_(group_users))
+
+            result = await db.execute(stmt)
+            daily_counts: dict[str, dict[str, int]] = {}
+            for timestamp, model_id in result.all():
+                date_str = datetime.fromtimestamp(_normalize_timestamp(timestamp)).strftime('%Y-%m-%d')
+                daily_counts.setdefault(date_str, {})
+                daily_counts[date_str][model_id] = daily_counts[date_str].get(model_id, 0) + 1
+
+            if start_date and end_date:
+                current = datetime.fromtimestamp(_normalize_timestamp(start_date))
+                end_dt = datetime.fromtimestamp(_normalize_timestamp(end_date))
+                while current <= end_dt:
+                    date_str = current.strftime('%Y-%m-%d')
+                    daily_counts.setdefault(date_str, {})
+                    current += timedelta(days=1)
+
+            return daily_counts
 
 
 ChatMessages = ChatMessageTable()

--- a/backend/open_webui/routers/analytics.py
+++ b/backend/open_webui/routers/analytics.py
@@ -419,3 +419,190 @@ async def get_model_overview(
     tags = [TagEntry(tag=tag, count=count) for tag, count in sorted(tag_counts.items(), key=lambda x: -x[1])[:10]]
 
     return ModelOverviewResponse(history=history, tags=tags)
+
+
+####################
+# API Usage Analytics
+# These endpoints track direct API calls (no UI chat session).
+# Existing chat analytics endpoints above are unaffected.
+####################
+
+
+class ApiModelEntry(BaseModel):
+    model_id: str
+    count: int
+    unique_users: int = 0
+    input_tokens: int = 0
+    output_tokens: int = 0
+    total_tokens: int = 0
+
+
+class ApiModelResponse(BaseModel):
+    models: list[ApiModelEntry]
+
+
+class ApiUserEntry(BaseModel):
+    user_id: str
+    name: Optional[str] = None
+    email: Optional[str] = None
+    count: int
+    input_tokens: int = 0
+    output_tokens: int = 0
+    total_tokens: int = 0
+
+
+class ApiUserResponse(BaseModel):
+    users: list[ApiUserEntry]
+
+
+class ApiSummaryResponse(BaseModel):
+    total_requests: int
+    total_models: int
+    total_users: int
+
+
+class ApiDailyEntry(BaseModel):
+    date: str
+    models: dict[str, int]
+
+
+class ApiDailyResponse(BaseModel):
+    data: list[ApiDailyEntry]
+
+
+class ApiTokenUsageResponse(BaseModel):
+    models: list[TokenUsageEntry]
+    total_input_tokens: int
+    total_output_tokens: int
+    total_tokens: int
+
+
+@router.get('/api/models', response_model=ApiModelResponse)
+async def get_api_model_analytics(
+    start_date: Optional[int] = Query(None, description='Start timestamp (epoch)'),
+    end_date: Optional[int] = Query(None, description='End timestamp (epoch)'),
+    group_id: Optional[str] = Query(None, description='Filter by user group ID'),
+    user=Depends(get_admin_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Get request counts per model for direct API calls."""
+    counts = await ChatMessages.get_api_message_count_by_model(
+        start_date=start_date, end_date=end_date, group_id=group_id, db=db
+    )
+    unique_users = await ChatMessages.get_api_unique_users_by_model(
+        start_date=start_date, end_date=end_date, group_id=group_id, db=db
+    )
+    token_usage = await ChatMessages.get_api_token_usage_by_model(
+        start_date=start_date, end_date=end_date, group_id=group_id, db=db
+    )
+    models = [
+        ApiModelEntry(
+            model_id=model_id,
+            count=count,
+            unique_users=unique_users.get(model_id, 0),
+            **{k: token_usage.get(model_id, {}).get(k, 0) for k in ('input_tokens', 'output_tokens', 'total_tokens')},
+        )
+        for model_id, count in sorted(counts.items(), key=lambda x: -x[1])
+    ]
+    return ApiModelResponse(models=models)
+
+
+@router.get('/api/users', response_model=ApiUserResponse)
+async def get_api_user_analytics(
+    start_date: Optional[int] = Query(None, description='Start timestamp (epoch)'),
+    end_date: Optional[int] = Query(None, description='End timestamp (epoch)'),
+    group_id: Optional[str] = Query(None, description='Filter by user group ID'),
+    limit: int = Query(50, description='Max users to return'),
+    user=Depends(get_admin_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Get request counts and token usage per user for direct API calls."""
+    counts = await ChatMessages.get_api_message_count_by_user(
+        start_date=start_date, end_date=end_date, group_id=group_id, db=db
+    )
+    token_usage = await ChatMessages.get_api_token_usage_by_user(
+        start_date=start_date, end_date=end_date, group_id=group_id, db=db
+    )
+    top_user_ids = [uid for uid, _ in sorted(counts.items(), key=lambda x: -x[1])[:limit]]
+    user_info = {u.id: u for u in await Users.get_users_by_user_ids(top_user_ids, db=db)}
+    users = []
+    for user_id in top_user_ids:
+        u = user_info.get(user_id)
+        tokens = token_usage.get(user_id, {})
+        users.append(
+            ApiUserEntry(
+                user_id=user_id,
+                name=u.name if u else None,
+                email=u.email if u else None,
+                count=counts[user_id],
+                input_tokens=tokens.get('input_tokens', 0),
+                output_tokens=tokens.get('output_tokens', 0),
+                total_tokens=tokens.get('total_tokens', 0),
+            )
+        )
+    return ApiUserResponse(users=users)
+
+
+@router.get('/api/summary', response_model=ApiSummaryResponse)
+async def get_api_summary(
+    start_date: Optional[int] = Query(None, description='Start timestamp (epoch)'),
+    end_date: Optional[int] = Query(None, description='End timestamp (epoch)'),
+    group_id: Optional[str] = Query(None, description='Filter by user group ID'),
+    user=Depends(get_admin_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Get summary statistics for direct API usage."""
+    model_counts = await ChatMessages.get_api_message_count_by_model(
+        start_date=start_date, end_date=end_date, group_id=group_id, db=db
+    )
+    user_counts = await ChatMessages.get_api_message_count_by_user(
+        start_date=start_date, end_date=end_date, group_id=group_id, db=db
+    )
+    return ApiSummaryResponse(
+        total_requests=sum(model_counts.values()),
+        total_models=len(model_counts),
+        total_users=len(user_counts),
+    )
+
+
+@router.get('/api/daily', response_model=ApiDailyResponse)
+async def get_api_daily_stats(
+    start_date: Optional[int] = Query(None, description='Start timestamp (epoch)'),
+    end_date: Optional[int] = Query(None, description='End timestamp (epoch)'),
+    group_id: Optional[str] = Query(None, description='Filter by user group ID'),
+    user=Depends(get_admin_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Get daily API request counts grouped by model."""
+    counts = await ChatMessages.get_api_daily_counts_by_model(
+        start_date=start_date, end_date=end_date, group_id=group_id, db=db
+    )
+    return ApiDailyResponse(
+        data=[ApiDailyEntry(date=date, models=models) for date, models in sorted(counts.items())]
+    )
+
+
+@router.get('/api/tokens', response_model=ApiTokenUsageResponse)
+async def get_api_token_usage(
+    start_date: Optional[int] = Query(None),
+    end_date: Optional[int] = Query(None),
+    group_id: Optional[str] = Query(None, description='Filter by user group ID'),
+    user=Depends(get_admin_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Get token usage aggregated by model for direct API calls."""
+    usage = await ChatMessages.get_api_token_usage_by_model(
+        start_date=start_date, end_date=end_date, group_id=group_id, db=db
+    )
+    models = [
+        TokenUsageEntry(model_id=model_id, **data)
+        for model_id, data in sorted(usage.items(), key=lambda x: -x[1]['total_tokens'])
+    ]
+    total_input = sum(m.input_tokens for m in models)
+    total_output = sum(m.output_tokens for m in models)
+    return ApiTokenUsageResponse(
+        models=models,
+        total_input_tokens=total_input,
+        total_output_tokens=total_output,
+        total_tokens=total_input + total_output,
+    )

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -40,6 +40,7 @@ from open_webui.env import (
     GLOBAL_LOG_LEVEL,
     RAG_SYSTEM_CONTEXT,
 )
+from open_webui.models.chat_messages import ChatMessages
 from open_webui.models.chats import Chats
 from open_webui.models.config import Config
 from open_webui.models.folders import Folders
@@ -3692,6 +3693,23 @@ async def non_streaming_chat_response_handler(response, ctx):
                                 **({'usage': usage} if usage else {}),
                             },
                         )
+                    elif not getattr(request.state, 'internal', False) and usage:
+                        # Direct API call (no UI chat session) — record for analytics.
+                        model_id = form_data.get('model') or metadata.get('model_id') or (metadata.get('model') or {}).get('id')
+                        if model_id and user:
+                            import uuid as _uuid
+                            await ChatMessages.upsert_message(
+                                message_id=str(_uuid.uuid4()),
+                                chat_id=None,
+                                user_id=user.id,
+                                data={
+                                    'role': 'assistant',
+                                    'model_id': model_id,
+                                    'usage': usage,
+                                    'source': 'api',
+                                    'done': True,
+                                },
+                            )
 
                     await publish_chat_finished_event(request, user, metadata, title, content, response_output)
 
@@ -5533,6 +5551,23 @@ async def streaming_chat_response_handler(response, ctx):
                             metadata['chat_id'],
                             metadata['message_id'],
                             {'done': True},
+                        )
+                elif not getattr(request.state, 'internal', False) and usage:
+                    # Direct API call (no UI chat session) — record for analytics.
+                    model_id = form_data.get('model') or metadata.get('model_id') or (metadata.get('model') or {}).get('id')
+                    if model_id and user:
+                        import uuid as _uuid
+                        await ChatMessages.upsert_message(
+                            message_id=str(_uuid.uuid4()),
+                            chat_id=None,
+                            user_id=user.id,
+                            data={
+                                'role': 'assistant',
+                                'model_id': model_id,
+                                'usage': usage,
+                                'source': 'api',
+                                'done': True,
+                            },
                         )
 
                 await publish_chat_finished_event(request, user, metadata, title, ''.join(content_parts), output)

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -3759,6 +3759,25 @@ async def non_streaming_chat_response_handler(response, ctx):
         }
         await outlet_filter_handler(ctx)
 
+    # Direct API call (no UI chat session, no event_emitter) — record for analytics.
+    if not getattr(request.state, 'internal', False) and not save_to_chat:
+        _usage = normalize_usage(response_data.get('usage', {}) or {})
+        _model_id = form_data.get('model') or (metadata.get('model') or {}).get('id')
+        if _usage and _model_id and user:
+            import uuid as _uuid
+            await ChatMessages.upsert_message(
+                message_id=str(_uuid.uuid4()),
+                chat_id=None,
+                user_id=user.id,
+                data={
+                    'role': 'assistant',
+                    'model_id': _model_id,
+                    'usage': _usage,
+                    'source': 'api',
+                    'done': True,
+                },
+            )
+
     if isinstance(response, dict):
         response = merge_events_into_response(response_data, events)
 
@@ -5662,6 +5681,8 @@ async def streaming_chat_response_handler(response, ctx):
                 if event:
                     yield wrap_item(JSONCodec.dumps(event))
 
+            # Accumulate usage from stream chunks for API analytics tracking.
+            _stream_usage = None
             async for data in original_generator:
                 data, _ = await process_filter_functions(
                     request=request,
@@ -5675,11 +5696,33 @@ async def streaming_chat_response_handler(response, ctx):
                 if data:
                     if has_api_outlet_filters:
                         update_assistant_message_from_stream(assistant_message, data)
+                    # Capture usage from the final chunk (stream_options.include_usage)
+                    if isinstance(data, dict) and data.get('usage'):
+                        _stream_usage = data['usage']
                     yield data
 
             if has_api_outlet_filters and assistant_message:
                 ctx['assistant_message'] = assistant_message
                 await outlet_filter_handler(ctx)
+
+            # Direct API call — record usage for analytics after stream completes.
+            if not getattr(request.state, 'internal', False) and not save_to_chat:
+                _usage = normalize_usage(_stream_usage or {})
+                _model_id = form_data.get('model') or (metadata.get('model') or {}).get('id')
+                if _usage and _model_id and user:
+                    import uuid as _uuid
+                    await ChatMessages.upsert_message(
+                        message_id=str(_uuid.uuid4()),
+                        chat_id=None,
+                        user_id=user.id,
+                        data={
+                            'role': 'assistant',
+                            'model_id': _model_id,
+                            'usage': _usage,
+                            'source': 'api',
+                            'done': True,
+                        },
+                    )
 
         return StreamingResponse(
             stream_wrapper(response.body_iterator, events),

--- a/backend/tests/test_api_usage_tracking.py
+++ b/backend/tests/test_api_usage_tracking.py
@@ -1,0 +1,266 @@
+"""
+Tests for API usage tracking via ChatMessage with source='api'.
+
+These tests use an in-memory SQLite DB so no server is required.
+Run with:  pytest backend/tests/test_api_usage_tracking.py -v
+"""
+
+import asyncio
+import time
+import uuid
+from typing import Optional
+
+import pytest
+import pytest_asyncio
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+# ---------------------------------------------------------------------------
+# Minimal in-memory schema — mirrors only what the tests need
+# ---------------------------------------------------------------------------
+
+metadata = sa.MetaData()
+
+chat_message_table = sa.Table(
+    'chat_message',
+    metadata,
+    sa.Column('id', sa.Text, primary_key=True),
+    sa.Column('chat_id', sa.Text, nullable=True),
+    sa.Column('user_id', sa.Text),
+    sa.Column('source', sa.Text, nullable=True),
+    sa.Column('role', sa.Text, nullable=False),
+    sa.Column('parent_id', sa.Text, nullable=True),
+    sa.Column('content', sa.JSON, nullable=True),
+    sa.Column('output', sa.JSON, nullable=True),
+    sa.Column('model_id', sa.Text, nullable=True),
+    sa.Column('files', sa.JSON, nullable=True),
+    sa.Column('sources', sa.JSON, nullable=True),
+    sa.Column('embeds', sa.JSON, nullable=True),
+    sa.Column('meta', sa.JSON, nullable=True),
+    sa.Column('done', sa.Boolean, default=True),
+    sa.Column('status_history', sa.JSON, nullable=True),
+    sa.Column('error', sa.JSON, nullable=True),
+    sa.Column('usage', sa.JSON, nullable=True),
+    sa.Column('context_summary', sa.Text, nullable=True),
+    sa.Column('created_at', sa.BigInteger),
+    sa.Column('updated_at', sa.BigInteger),
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def engine():
+    engine = create_async_engine('sqlite+aiosqlite:///:memory:', echo=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(metadata.create_all)
+    yield engine
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def session(engine):
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with factory() as s:
+        yield s
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _now():
+    return int(time.time())
+
+
+def _usage(inp=100, out=50):
+    return {'input_tokens': inp, 'output_tokens': out, 'total_tokens': inp + out}
+
+
+async def _insert(session: AsyncSession, *, chat_id=None, user_id='u1', model_id='gpt-4o',
+                  source=None, usage=None, created_at=None):
+    msg_id = str(uuid.uuid4())
+    row_id = f'{chat_id}-{msg_id}' if chat_id else msg_id
+    await session.execute(
+        chat_message_table.insert().values(
+            id=row_id,
+            chat_id=chat_id,
+            user_id=user_id,
+            source=source,
+            role='assistant',
+            model_id=model_id,
+            usage=usage or _usage(),
+            done=True,
+            created_at=created_at or _now(),
+            updated_at=_now(),
+        )
+    )
+    await session.commit()
+    return row_id
+
+
+# ---------------------------------------------------------------------------
+# Schema tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_chat_message_allows_null_chat_id(session):
+    """chat_id=NULL must be accepted (no FK constraint)."""
+    row_id = await _insert(session, chat_id=None, source='api')
+    result = await session.execute(
+        sa.select(chat_message_table).where(chat_message_table.c.id == row_id)
+    )
+    row = result.fetchone()
+    assert row is not None
+    assert row.chat_id is None
+    assert row.source == 'api'
+
+
+@pytest.mark.asyncio
+async def test_chat_message_null_source_for_regular_chat(session):
+    """Regular chat rows have source=NULL."""
+    row_id = await _insert(session, chat_id='chat-abc', source=None)
+    result = await session.execute(
+        sa.select(chat_message_table).where(chat_message_table.c.id == row_id)
+    )
+    row = result.fetchone()
+    assert row.source is None
+    assert row.chat_id == 'chat-abc'
+
+
+# ---------------------------------------------------------------------------
+# Analytics filter tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_chat_analytics_excludes_api_rows(session):
+    """Existing analytics (source IS NULL) must not count API rows."""
+    await _insert(session, chat_id='chat-1', source=None, model_id='claude-3')
+    await _insert(session, chat_id='chat-2', source=None, model_id='claude-3')
+    await _insert(session, chat_id=None, source='api', model_id='claude-3')  # API row
+
+    # Simulate existing analytics query: source IS NULL
+    result = await session.execute(
+        sa.select(chat_message_table.c.model_id, sa.func.count().label('cnt'))
+        .where(chat_message_table.c.role == 'assistant')
+        .where(chat_message_table.c.source.is_(None))
+        .group_by(chat_message_table.c.model_id)
+    )
+    row = result.fetchone()
+    assert row is not None
+    assert row.cnt == 2  # only the 2 chat rows, not the API row
+
+
+@pytest.mark.asyncio
+async def test_api_analytics_excludes_chat_rows(session):
+    """API analytics (source='api') must not count chat rows."""
+    await _insert(session, chat_id='chat-1', source=None, model_id='gpt-4o')
+    await _insert(session, chat_id=None, source='api', model_id='gpt-4o')
+    await _insert(session, chat_id=None, source='api', model_id='gpt-4o')
+
+    result = await session.execute(
+        sa.select(chat_message_table.c.model_id, sa.func.count().label('cnt'))
+        .where(chat_message_table.c.role == 'assistant')
+        .where(chat_message_table.c.source == 'api')
+        .group_by(chat_message_table.c.model_id)
+    )
+    row = result.fetchone()
+    assert row is not None
+    assert row.cnt == 2  # only the 2 API rows
+
+
+@pytest.mark.asyncio
+async def test_api_count_by_user(session):
+    """API analytics per-user count is correct."""
+    await _insert(session, chat_id=None, source='api', user_id='alice', model_id='gpt-4o')
+    await _insert(session, chat_id=None, source='api', user_id='alice', model_id='claude-3')
+    await _insert(session, chat_id=None, source='api', user_id='bob', model_id='gpt-4o')
+    await _insert(session, chat_id='chat-1', source=None, user_id='alice', model_id='gpt-4o')  # should NOT count
+
+    result = await session.execute(
+        sa.select(chat_message_table.c.user_id, sa.func.count().label('cnt'))
+        .where(chat_message_table.c.role == 'assistant')
+        .where(chat_message_table.c.source == 'api')
+        .group_by(chat_message_table.c.user_id)
+        .order_by(chat_message_table.c.user_id)
+    )
+    rows = {r.user_id: r.cnt for r in result.fetchall()}
+    assert rows == {'alice': 2, 'bob': 1}
+
+
+@pytest.mark.asyncio
+async def test_token_usage_aggregation(session):
+    """Token sums are correct for API rows only."""
+    await _insert(session, chat_id=None, source='api', user_id='alice',
+                  model_id='gpt-4o', usage=_usage(200, 100))
+    await _insert(session, chat_id=None, source='api', user_id='alice',
+                  model_id='gpt-4o', usage=_usage(300, 150))
+    await _insert(session, chat_id='c1', source=None, user_id='alice',
+                  model_id='gpt-4o', usage=_usage(999, 999))  # chat row — excluded
+
+    # SQLite JSON extraction via json_extract
+    input_col = sa.cast(sa.func.json_extract(chat_message_table.c.usage, '$.input_tokens'), sa.Integer)
+    output_col = sa.cast(sa.func.json_extract(chat_message_table.c.usage, '$.output_tokens'), sa.Integer)
+
+    result = await session.execute(
+        sa.select(
+            sa.func.coalesce(sa.func.sum(input_col), 0).label('total_in'),
+            sa.func.coalesce(sa.func.sum(output_col), 0).label('total_out'),
+        )
+        .where(chat_message_table.c.role == 'assistant')
+        .where(chat_message_table.c.source == 'api')
+        .where(chat_message_table.c.usage.isnot(None))
+    )
+    row = result.fetchone()
+    assert row.total_in == 500
+    assert row.total_out == 250
+
+
+@pytest.mark.asyncio
+async def test_date_range_filter(session):
+    """start_date / end_date filters work for API rows."""
+    t_old = _now() - 10000
+    t_new = _now()
+    await _insert(session, chat_id=None, source='api', created_at=t_old)
+    await _insert(session, chat_id=None, source='api', created_at=t_new)
+
+    cutoff = _now() - 5000
+    result = await session.execute(
+        sa.select(sa.func.count().label('cnt'))
+        .where(chat_message_table.c.source == 'api')
+        .where(chat_message_table.c.created_at >= cutoff)
+    )
+    assert result.scalar() == 1
+
+
+@pytest.mark.asyncio
+async def test_empty_table_returns_zero(session):
+    """Analytics on empty table returns 0, not an error."""
+    result = await session.execute(
+        sa.select(sa.func.count().label('cnt'))
+        .where(chat_message_table.c.source == 'api')
+    )
+    assert result.scalar() == 0
+
+
+@pytest.mark.asyncio
+async def test_mixed_models_api_count(session):
+    """Multiple models are counted independently."""
+    await _insert(session, chat_id=None, source='api', model_id='gpt-4o')
+    await _insert(session, chat_id=None, source='api', model_id='gpt-4o')
+    await _insert(session, chat_id=None, source='api', model_id='claude-3')
+
+    result = await session.execute(
+        sa.select(chat_message_table.c.model_id, sa.func.count().label('cnt'))
+        .where(chat_message_table.c.source == 'api')
+        .group_by(chat_message_table.c.model_id)
+        .order_by(chat_message_table.c.model_id)
+    )
+    rows = {r.model_id: r.cnt for r in result.fetchall()}
+    assert rows == {'claude-3': 1, 'gpt-4o': 2}

--- a/backend/tests/test_e2e_api_tracking.py
+++ b/backend/tests/test_e2e_api_tracking.py
@@ -1,0 +1,428 @@
+"""
+End-to-end tests for API usage tracking via ChatMessage with source='api'.
+
+Tests ORM model methods directly against an in-memory SQLite database with
+get_async_db_context patched to avoid the real DB connection.
+
+Covers:
+  - upsert_message with chat_id=None stores source='api', chat_id=NULL
+  - Chat analytics methods exclude source='api' rows  (source IS NULL filter)
+  - API analytics methods include only source='api' rows
+  - Token aggregation correctness for both chat and API paths
+  - Date range filtering for API rows
+  - Daily/hourly count methods isolation
+
+Run with:  pytest backend/tests/test_e2e_api_tracking.py -v
+"""
+
+import asyncio
+import time
+import uuid
+from contextlib import asynccontextmanager
+from typing import Optional
+from unittest.mock import patch
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+# ── env setup must happen before open_webui imports ──────────────────────────
+import os
+os.environ.setdefault('WEBUI_SECRET_KEY', 'test-secret-key-for-unit-tests')
+# DATABASE_URL intentionally not overridden: the default file-based SQLite URL
+# is compatible with the pool_size args in internal/db.py.  The global engine
+# is irrelevant because every test patches get_async_db_context to use an
+# isolated in-memory engine instead.
+# ─────────────────────────────────────────────────────────────────────────────
+
+from open_webui.models.chat_messages import Base, ChatMessage, ChatMessages  # noqa: E402
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Fixtures
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest_asyncio.fixture
+async def engine():
+    eng = create_async_engine('sqlite+aiosqlite:///:memory:', echo=False)
+    async with eng.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield eng
+    await eng.dispose()
+
+
+@pytest_asyncio.fixture
+async def session_factory(engine):
+    return async_sessionmaker(engine, expire_on_commit=False)
+
+
+@pytest_asyncio.fixture
+async def db_patch(session_factory):
+    """
+    Patch get_async_db_context in chat_messages so all ORM calls
+    use the test in-memory engine instead of the real one.
+    """
+    @asynccontextmanager
+    async def _ctx(db: Optional[AsyncSession] = None):
+        async with session_factory() as s:
+            yield s
+
+    with patch('open_webui.models.chat_messages.get_async_db_context', _ctx):
+        yield
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _now():
+    return int(time.time())
+
+
+def _usage(inp=100, out=50):
+    return {'input_tokens': inp, 'output_tokens': out, 'total_tokens': inp + out}
+
+
+async def _insert_chat(model_id='claude-3', user_id='u1', chat_id=None, usage=None):
+    """Insert a regular chat message (source=NULL)."""
+    chat_id = chat_id or str(uuid.uuid4())
+    return await ChatMessages.upsert_message(
+        message_id=str(uuid.uuid4()),
+        chat_id=chat_id,
+        user_id=user_id,
+        data={
+            'role': 'assistant',
+            'model_id': model_id,
+            'usage': usage or _usage(),
+            'done': True,
+        },
+    )
+
+
+async def _insert_api(model_id='gpt-4o', user_id='u1', usage=None, created_at=None):
+    """Insert a direct API call row (source='api', chat_id=NULL)."""
+    msg = await ChatMessages.upsert_message(
+        message_id=str(uuid.uuid4()),
+        chat_id=None,
+        user_id=user_id,
+        data={
+            'role': 'assistant',
+            'model_id': model_id,
+            'usage': usage or _usage(),
+            'source': 'api',
+            'done': True,
+        },
+    )
+    return msg
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 1. upsert_message behaviour
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_upsert_api_row_has_null_chat_id_and_api_source(db_patch):
+    """upsert_message(chat_id=None, source='api') → chat_id=NULL, source='api'."""
+    row = await _insert_api(model_id='gpt-4o', user_id='alice')
+    assert row is not None
+    assert row.chat_id is None
+    assert row.source == 'api'
+    assert row.model_id == 'gpt-4o'
+    assert row.user_id == 'alice'
+
+
+@pytest.mark.asyncio
+async def test_upsert_chat_row_has_chat_id_and_null_source(db_patch):
+    """upsert_message(chat_id=<uuid>) → source=NULL (regular chat)."""
+    cid = str(uuid.uuid4())
+    row = await _insert_chat(model_id='claude-3', chat_id=cid)
+    assert row is not None
+    assert row.chat_id == cid
+    assert row.source is None
+
+
+@pytest.mark.asyncio
+async def test_api_row_id_is_bare_message_uuid(db_patch):
+    """API rows use bare UUID as ID (no composite chat_id prefix)."""
+    msg_id = str(uuid.uuid4())
+    row = await ChatMessages.upsert_message(
+        message_id=msg_id,
+        chat_id=None,
+        user_id='u1',
+        data={'role': 'assistant', 'model_id': 'gpt-4o', 'source': 'api', 'done': True},
+    )
+    assert row.id == msg_id  # bare UUID, not "{chat_id}-{msg_id}"
+
+
+@pytest.mark.asyncio
+async def test_chat_row_id_is_composite(db_patch):
+    """Chat rows use composite {chat_id}-{message_id} as row ID."""
+    cid = str(uuid.uuid4())
+    mid = str(uuid.uuid4())
+    row = await ChatMessages.upsert_message(
+        message_id=mid,
+        chat_id=cid,
+        user_id='u1',
+        data={'role': 'assistant', 'model_id': 'gpt-4o', 'done': True},
+    )
+    assert row.id == f'{cid}-{mid}'
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 2. Chat analytics exclude API rows
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_chat_model_count_excludes_api_rows(db_patch):
+    """get_message_count_by_model must not count API rows."""
+    await _insert_chat(model_id='claude-3')
+    await _insert_chat(model_id='claude-3')
+    await _insert_api(model_id='claude-3')   # must be excluded
+
+    counts = await ChatMessages.get_message_count_by_model()
+    assert counts.get('claude-3') == 2
+
+
+@pytest.mark.asyncio
+async def test_chat_user_count_excludes_api_rows(db_patch):
+    """get_message_count_by_user must not count API rows."""
+    await _insert_chat(model_id='gpt-4o', user_id='alice')
+    await _insert_api(model_id='gpt-4o', user_id='alice')  # must be excluded
+
+    counts = await ChatMessages.get_message_count_by_user()
+    assert counts.get('alice') == 1
+
+
+@pytest.mark.asyncio
+async def test_chat_token_usage_excludes_api_rows(db_patch):
+    """get_token_usage_by_model must not include API token usage."""
+    await _insert_chat(model_id='gpt-4o')
+    await _insert_api(model_id='gpt-4o', usage=_usage(999, 999))  # must be excluded
+
+    usage = await ChatMessages.get_token_usage_by_model()
+    gpt_usage = usage.get('gpt-4o', {})
+    assert gpt_usage.get('input_tokens') == 100   # only chat row's 100
+    assert gpt_usage.get('output_tokens') == 50   # only chat row's 50
+
+
+@pytest.mark.asyncio
+async def test_chat_daily_counts_exclude_api_rows(db_patch):
+    """get_daily_message_counts_by_model must not include API rows."""
+    await _insert_chat(model_id='gpt-4o')
+    await _insert_api(model_id='gpt-4o')   # must be excluded
+
+    daily = await ChatMessages.get_daily_message_counts_by_model()
+    # Sum all counts across all days — should only be 1 (the chat row)
+    total = sum(sum(m.values()) for m in daily.values())
+    assert total == 1
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 3. API analytics include only API rows
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_api_model_count_excludes_chat_rows(db_patch):
+    """get_api_message_count_by_model must not count chat rows."""
+    await _insert_chat(model_id='gpt-4o')    # must be excluded
+    await _insert_api(model_id='gpt-4o')
+    await _insert_api(model_id='gpt-4o')
+
+    counts = await ChatMessages.get_api_message_count_by_model()
+    assert counts.get('gpt-4o') == 2
+
+
+@pytest.mark.asyncio
+async def test_api_user_count_excludes_chat_rows(db_patch):
+    """get_api_message_count_by_user must not count chat rows."""
+    await _insert_chat(model_id='gpt-4o', user_id='alice')  # must be excluded
+    await _insert_api(model_id='gpt-4o', user_id='alice')
+    await _insert_api(model_id='gpt-4o', user_id='bob')
+
+    counts = await ChatMessages.get_api_message_count_by_user()
+    assert counts == {'alice': 1, 'bob': 1}
+
+
+@pytest.mark.asyncio
+async def test_api_unique_users_per_model(db_patch):
+    """get_api_unique_users_by_model counts distinct users for API rows only."""
+    await _insert_api(model_id='gpt-4o', user_id='alice')
+    await _insert_api(model_id='gpt-4o', user_id='alice')   # duplicate — same user
+    await _insert_api(model_id='gpt-4o', user_id='bob')
+    await _insert_chat(model_id='gpt-4o', user_id='carol')  # must be excluded
+
+    unique = await ChatMessages.get_api_unique_users_by_model()
+    assert unique.get('gpt-4o') == 2  # alice + bob only
+
+
+@pytest.mark.asyncio
+async def test_api_token_usage_excludes_chat_rows(db_patch):
+    """get_api_token_usage_by_model sums only API-origin token usage."""
+    await _insert_api(model_id='gpt-4o', usage=_usage(200, 100))
+    await _insert_api(model_id='gpt-4o', usage=_usage(300, 150))
+    await _insert_chat(model_id='gpt-4o', usage=_usage(999, 999))   # must be excluded
+
+    usage = await ChatMessages.get_api_token_usage_by_model()
+    gpt_usage = usage.get('gpt-4o', {})
+    assert gpt_usage.get('input_tokens') == 500
+    assert gpt_usage.get('output_tokens') == 250
+    assert gpt_usage.get('total_tokens') == 750
+
+
+@pytest.mark.asyncio
+async def test_api_token_usage_by_user(db_patch):
+    """get_api_token_usage_by_user aggregates per user for API rows only."""
+    await _insert_api(model_id='gpt-4o', user_id='alice', usage=_usage(100, 50))
+    await _insert_api(model_id='gpt-4o', user_id='alice', usage=_usage(200, 100))
+    await _insert_chat(model_id='gpt-4o', user_id='alice')  # must be excluded
+
+    usage = await ChatMessages.get_api_token_usage_by_user()
+    alice = usage.get('alice', {})
+    assert alice.get('input_tokens') == 300
+    assert alice.get('output_tokens') == 150
+
+
+@pytest.mark.asyncio
+async def test_api_daily_counts_exclude_chat_rows(db_patch):
+    """get_api_daily_counts_by_model must not include chat rows."""
+    await _insert_api(model_id='gpt-4o')
+    await _insert_api(model_id='gpt-4o')
+    await _insert_chat(model_id='gpt-4o')   # must be excluded
+
+    daily = await ChatMessages.get_api_daily_counts_by_model()
+    total = sum(sum(m.values()) for m in daily.values())
+    assert total == 2
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 4. Isolation: mixed models
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_mixed_models_tracked_independently(db_patch):
+    """API and chat counts are correct across multiple models simultaneously."""
+    # Chat rows
+    await _insert_chat(model_id='claude-3')
+    await _insert_chat(model_id='claude-3')
+    await _insert_chat(model_id='gpt-4o')
+    # API rows
+    await _insert_api(model_id='gpt-4o')
+    await _insert_api(model_id='gpt-4o')
+    await _insert_api(model_id='claude-3')
+
+    chat_counts = await ChatMessages.get_message_count_by_model()
+    api_counts = await ChatMessages.get_api_message_count_by_model()
+
+    assert chat_counts == {'claude-3': 2, 'gpt-4o': 1}
+    assert api_counts == {'gpt-4o': 2, 'claude-3': 1}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 5. Date range filtering
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_api_date_range_filter(db_patch, session_factory):
+    """start_date/end_date correctly filter API rows."""
+    t_old = _now() - 10_000
+    t_new = _now()
+
+    # Manually insert rows with controlled timestamps via raw ORM
+    async with session_factory() as s:
+        s.add(ChatMessage(
+            id=str(uuid.uuid4()),
+            chat_id=None,
+            user_id='u1',
+            source='api',
+            role='assistant',
+            model_id='gpt-4o',
+            done=True,
+            created_at=t_old,
+            updated_at=t_old,
+        ))
+        s.add(ChatMessage(
+            id=str(uuid.uuid4()),
+            chat_id=None,
+            user_id='u1',
+            source='api',
+            role='assistant',
+            model_id='gpt-4o',
+            done=True,
+            created_at=t_new,
+            updated_at=t_new,
+        ))
+        await s.commit()
+
+    cutoff = _now() - 5_000
+    counts = await ChatMessages.get_api_message_count_by_model(start_date=cutoff)
+    # Only the new row should be counted
+    assert counts.get('gpt-4o') == 1
+
+
+@pytest.mark.asyncio
+async def test_chat_date_range_filter(db_patch, session_factory):
+    """start_date/end_date correctly filter chat rows."""
+    t_old = _now() - 10_000
+    t_new = _now()
+    cid = str(uuid.uuid4())
+
+    async with session_factory() as s:
+        s.add(ChatMessage(
+            id=f'{cid}-old',
+            chat_id=cid,
+            user_id='u1',
+            source=None,
+            role='assistant',
+            model_id='claude-3',
+            done=True,
+            created_at=t_old,
+            updated_at=t_old,
+        ))
+        s.add(ChatMessage(
+            id=f'{cid}-new',
+            chat_id=cid,
+            user_id='u1',
+            source=None,
+            role='assistant',
+            model_id='claude-3',
+            done=True,
+            created_at=t_new,
+            updated_at=t_new,
+        ))
+        await s.commit()
+
+    cutoff = _now() - 5_000
+    counts = await ChatMessages.get_message_count_by_model(start_date=cutoff)
+    assert counts.get('claude-3') == 1
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 6. Empty DB edge cases
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_empty_db_api_counts_return_empty(db_patch):
+    """All API analytics methods return empty dicts on empty DB."""
+    assert await ChatMessages.get_api_message_count_by_model() == {}
+    assert await ChatMessages.get_api_message_count_by_user() == {}
+    assert await ChatMessages.get_api_unique_users_by_model() == {}
+    assert await ChatMessages.get_api_token_usage_by_model() == {}
+    assert await ChatMessages.get_api_token_usage_by_user() == {}
+    assert await ChatMessages.get_api_daily_counts_by_model() == {}
+
+
+@pytest.mark.asyncio
+async def test_empty_db_chat_counts_return_empty(db_patch):
+    """All chat analytics methods return empty dicts on empty DB."""
+    assert await ChatMessages.get_message_count_by_model() == {}
+    assert await ChatMessages.get_message_count_by_user() == {}
+    assert await ChatMessages.get_token_usage_by_model() == {}
+    assert await ChatMessages.get_daily_message_counts_by_model() == {}

--- a/src/lib/apis/analytics/index.ts
+++ b/src/lib/apis/analytics/index.ts
@@ -240,6 +240,80 @@ export const getTokenUsage = async (
 	return res;
 };
 
+// ------------------------------------------------------------------ //
+// API-origin analytics (source = 'api')                               //
+// ------------------------------------------------------------------ //
+
+const _apiFetch = async (token: string, path: string, params: URLSearchParams) => {
+	const res = await fetch(`${WEBUI_API_BASE_URL}/analytics/${path}?${params.toString()}`, {
+		method: 'GET',
+		headers: {
+			Accept: 'application/json',
+			'Content-Type': 'application/json',
+			authorization: `Bearer ${token}`
+		}
+	})
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			console.error(err);
+			return null;
+		});
+	return res;
+};
+
+const _apiParams = (
+	startDate: number | null,
+	endDate: number | null,
+	groupId: string | null = null,
+	extra: Record<string, string> = {}
+) => {
+	const p = new URLSearchParams();
+	if (startDate) p.append('start_date', startDate.toString());
+	if (endDate) p.append('end_date', endDate.toString());
+	if (groupId) p.append('group_id', groupId);
+	for (const [k, v] of Object.entries(extra)) p.append(k, v);
+	return p;
+};
+
+export const getApiModelAnalytics = (
+	token: string,
+	startDate: number | null = null,
+	endDate: number | null = null,
+	groupId: string | null = null
+) => _apiFetch(token, 'api/models', _apiParams(startDate, endDate, groupId));
+
+export const getApiUserAnalytics = (
+	token: string,
+	startDate: number | null = null,
+	endDate: number | null = null,
+	limit: number = 50,
+	groupId: string | null = null
+) => _apiFetch(token, 'api/users', _apiParams(startDate, endDate, groupId, { limit: limit.toString() }));
+
+export const getApiSummary = (
+	token: string,
+	startDate: number | null = null,
+	endDate: number | null = null,
+	groupId: string | null = null
+) => _apiFetch(token, 'api/summary', _apiParams(startDate, endDate, groupId));
+
+export const getApiDailyStats = (
+	token: string,
+	startDate: number | null = null,
+	endDate: number | null = null,
+	groupId: string | null = null
+) => _apiFetch(token, 'api/daily', _apiParams(startDate, endDate, groupId));
+
+export const getApiTokenUsage = (
+	token: string,
+	startDate: number | null = null,
+	endDate: number | null = null,
+	groupId: string | null = null
+) => _apiFetch(token, 'api/tokens', _apiParams(startDate, endDate, groupId));
+
 export const getModelChats = async (
 	token: string = '',
 	modelId: string,

--- a/src/lib/components/admin/Analytics/Dashboard.svelte
+++ b/src/lib/components/admin/Analytics/Dashboard.svelte
@@ -6,7 +6,12 @@
 		getModelAnalytics,
 		getUserAnalytics,
 		getDailyStats,
-		getTokenUsage
+		getTokenUsage,
+		getApiSummary,
+		getApiModelAnalytics,
+		getApiUserAnalytics,
+		getApiDailyStats,
+		getApiTokenUsage
 	} from '$lib/apis/analytics';
 	import { getGroups } from '$lib/apis/groups';
 	import Spinner from '$lib/components/common/Spinner.svelte';
@@ -43,6 +48,9 @@
 	// User group filter
 	let groups: Array<{ id: string; name: string }> = [];
 	let selectedGroupId: string | null = null;
+
+	// Source filter: 'chat' = UI chat sessions, 'api' = direct API calls
+	let selectedSource: 'chat' | 'api' = 'chat';
 
 	const getDateRange = (period: string): { start: number | null; end: number | null } => {
 		const now = Math.floor(Date.now() / 1000);
@@ -119,15 +127,38 @@
 		try {
 			const { start, end } = getDateRange(selectedPeriod);
 			const granularity = selectedPeriod === '24h' ? 'hourly' : 'daily';
+			const isApi = selectedSource === 'api';
 			const [summaryRes, modelsRes, usersRes, dailyRes, tokensRes] = await Promise.all([
-				getSummary(localStorage.token, start, end, selectedGroupId),
-				getModelAnalytics(localStorage.token, start, end, selectedGroupId),
-				getUserAnalytics(localStorage.token, start, end, 50, selectedGroupId),
-				getDailyStats(localStorage.token, start, end, granularity, selectedGroupId),
-				getTokenUsage(localStorage.token, start, end, selectedGroupId)
+				isApi
+					? getApiSummary(localStorage.token, start, end, selectedGroupId)
+					: getSummary(localStorage.token, start, end, selectedGroupId),
+				isApi
+					? getApiModelAnalytics(localStorage.token, start, end, selectedGroupId)
+					: getModelAnalytics(localStorage.token, start, end, selectedGroupId),
+				isApi
+					? getApiUserAnalytics(localStorage.token, start, end, 50, selectedGroupId)
+					: getUserAnalytics(localStorage.token, start, end, 50, selectedGroupId),
+				isApi
+					? getApiDailyStats(localStorage.token, start, end, selectedGroupId)
+					: getDailyStats(localStorage.token, start, end, granularity, selectedGroupId),
+				isApi
+					? getApiTokenUsage(localStorage.token, start, end, selectedGroupId)
+					: getTokenUsage(localStorage.token, start, end, selectedGroupId)
 			]);
 
-			summary = summaryRes ?? summary;
+			if (summaryRes) {
+				if (isApi) {
+					// API summary has total_requests/total_models/total_users (no total_chats)
+					summary = {
+						total_messages: summaryRes.total_requests ?? 0,
+						total_chats: 0,
+						total_models: summaryRes.total_models ?? 0,
+						total_users: summaryRes.total_users ?? 0
+					};
+				} else {
+					summary = summaryRes;
+				}
+			}
 
 			const modelsMap = new Map($models.map((m) => [m.id, m.name || m.id]));
 			modelStats = (modelsRes?.models ?? []).map((entry) => ({
@@ -167,6 +198,7 @@
 		customStart;
 		customEnd;
 		selectedGroupId;
+		selectedSource;
 		loadDashboard();
 	}
 
@@ -246,6 +278,13 @@
 				{/each}
 			</select>
 		{/if}
+		<select
+			bind:value={selectedSource}
+			class="w-fit pr-8 rounded-sm px-2 text-xs bg-transparent outline-none text-right"
+		>
+			<option value="chat">{$i18n.t('Chat')}</option>
+			<option value="api">{$i18n.t('API')}</option>
+		</select>
 		{#if selectedPeriod === 'custom'}
 			<input
 				type="date"
@@ -287,7 +326,7 @@
 			><span class="font-normal text-gray-900 dark:text-gray-300"
 				>{summary.total_messages.toLocaleString()}</span
 			>
-			{$i18n.t('messages')}</span
+			{selectedSource === 'api' ? $i18n.t('requests') : $i18n.t('messages')}</span
 		>
 		<Tooltip content={$i18n.t('Token counts are estimates and may not reflect actual API usage')}>
 			<span class="cursor-help"
@@ -297,12 +336,14 @@
 				{$i18n.t('tokens')}</span
 			>
 		</Tooltip>
-		<span
-			><span class="font-normal text-gray-900 dark:text-gray-300"
-				>{summary.total_chats.toLocaleString()}</span
+		{#if selectedSource !== 'api'}
+			<span
+				><span class="font-normal text-gray-900 dark:text-gray-300"
+					>{summary.total_chats.toLocaleString()}</span
+				>
+				{$i18n.t('chats')}</span
 			>
-			{$i18n.t('chats')}</span
-		>
+		{/if}
 		<span
 			><span class="font-normal text-gray-900 dark:text-gray-300">{summary.total_users}</span>
 			{$i18n.t('users')}</span
@@ -409,24 +450,26 @@
 									{/if}
 								</div>
 							</th>
-							<th
-								scope="col"
-								class="px-2.5 py-2 cursor-pointer select-none text-right"
-								on:click={() => toggleModelSort('chats')}
-							>
-								<div class="flex gap-1.5 items-center justify-end">
-									{$i18n.t('Chats')}
-									{#if modelOrderBy === 'chats'}
-										<span class="font-normal">
-											{#if modelDirection === 'asc'}<ChevronUp
-													className="size-2"
-												/>{:else}<ChevronDown className="size-2" />{/if}
-										</span>
-									{:else}
-										<span class="invisible"><ChevronUp className="size-2" /></span>
-									{/if}
-								</div>
-							</th>
+							{#if selectedSource !== 'api'}
+								<th
+									scope="col"
+									class="px-2.5 py-2 cursor-pointer select-none text-right"
+									on:click={() => toggleModelSort('chats')}
+								>
+									<div class="flex gap-1.5 items-center justify-end">
+										{$i18n.t('Chats')}
+										{#if modelOrderBy === 'chats'}
+											<span class="font-normal">
+												{#if modelDirection === 'asc'}<ChevronUp
+														className="size-2"
+													/>{:else}<ChevronDown className="size-2" />{/if}
+											</span>
+										{:else}
+											<span class="invisible"><ChevronUp className="size-2" /></span>
+										{/if}
+									</div>
+								</th>
+							{/if}
 							<th
 								scope="col"
 								class="px-2.5 py-2 cursor-pointer select-none text-right"
@@ -490,7 +533,9 @@
 								</td>
 								<td class="px-3 py-1 text-right">{model.count.toLocaleString()}</td>
 								<td class="px-3 py-1 text-right">{(model.unique_users ?? 0).toLocaleString()}</td>
-								<td class="px-3 py-1 text-right">{(model.unique_chats ?? 0).toLocaleString()}</td>
+								{#if selectedSource !== 'api'}
+									<td class="px-3 py-1 text-right">{(model.unique_chats ?? 0).toLocaleString()}</td>
+								{/if}
 								<td class="px-3 py-1 text-right"
 									>{formatNumber(tokenStats[model.model_id]?.total_tokens ?? 0)}</td
 								>
@@ -503,7 +548,7 @@
 						{/each}
 						{#if sortedModels.length === 0}
 							<tr
-								><td colspan="7" class="px-3 py-2 text-center text-gray-400"
+								><td colspan={selectedSource === 'api' ? 6 : 7} class="px-3 py-2 text-center text-gray-400"
 									>{$i18n.t('No data')}</td
 								></tr
 							>
@@ -616,6 +661,8 @@
 	</div>
 
 	<div class="text-gray-500 text-xs mt-1.5 text-right">
-		ⓘ {$i18n.t('Message counts are based on assistant responses.')}
+		ⓘ {selectedSource === 'api'
+			? $i18n.t('API requests are direct calls without a chat session.')
+			: $i18n.t('Message counts are based on assistant responses.')}
 	</div>
 {/if}


### PR DESCRIPTION
## Summary

Fixes #28059 — direct calls to `/api/chat/completions` and `/api/v1/chat/completions` (no UI chat session) are now recorded in analytics and surfaced in a new **API** tab in the admin dashboard.

- **New `source` column** on `chat_message`: `NULL` = regular chat message, `'api'` = direct API call. Migration drops the FK on `chat_id` (making it nullable) and adds `source TEXT NULL`.
- **All existing chat analytics** filter `source IS NULL` — no change to current numbers.
- **New API analytics endpoints** (`/api/v1/analytics/api/models`, `/api/v1/analytics/api/users`, `/api/v1/analytics/api/summary`, `/api/v1/analytics/api/daily`, `/api/v1/analytics/api/tokens`) — admin-only, filter `source = 'api'`.
- **Middleware fix**: tracking code placed *outside* the `if event_emitter:` guard in both `non_streaming_chat_response_handler` and `streaming_chat_response_handler`. Pure API calls have `event_emitter = None`, so the original placement was never reached.
- **Dashboard Source dropdown**: admin analytics page gains a Chat / API toggle; the API view hides the "Chats" column and relabels metrics appropriately.

## Commits

1. `c9390d8e` — feat: models, migration, analytics router, frontend API types + dashboard dropdown
2. `4f9148d4` — fix: record API-origin usage outside event_emitter guard (the actual tracking was silently skipped for pure API calls)
3. `694a9d35` — test: 28 ORM-level tests covering upsert, source isolation, token aggregation, date filtering, edge cases

## Test plan

- [ ] Run `pytest backend/tests/test_api_usage_tracking.py backend/tests/test_e2e_api_tracking.py` — 28 tests pass
- [ ] Make a direct API call: `curl -X POST /api/chat/completions -H "Authorization: Bearer <key>" -d '{"model":"...", "messages":[...]}'`
- [ ] Check Admin → Analytics → switch Source to **API** — request should appear with token counts
- [ ] Verify existing Chat analytics numbers unchanged after API calls
- [ ] Apply migration on PostgreSQL and SQLite