### PR TITLE
perf: make the websocket heartbeat interval configurable

### DIFF
--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -499,6 +499,13 @@ try:
 except ValueError:
     WEBSOCKET_SERVER_PING_INTERVAL = 25
 
+# Seconds between client heartbeats, capped so last_active_at stays inside the 3 minute active window.
+WEBSOCKET_HEARTBEAT_INTERVAL = os.getenv('WEBSOCKET_HEARTBEAT_INTERVAL', '30')
+try:
+    WEBSOCKET_HEARTBEAT_INTERVAL = min(max(int(WEBSOCKET_HEARTBEAT_INTERVAL), 5), 90)
+except ValueError:
+    WEBSOCKET_HEARTBEAT_INTERVAL = 30
+
 WEBSOCKET_EVENT_CALLER_TIMEOUT = os.getenv('WEBSOCKET_EVENT_CALLER_TIMEOUT', '')
 
 if WEBSOCKET_EVENT_CALLER_TIMEOUT == '':

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -108,6 +108,7 @@ from open_webui.env import (
     SAFE_MODE,
     SCIM_TOKEN,
     VERSION,
+    WEBSOCKET_HEARTBEAT_INTERVAL,
     # Admin Account Runtime Creation
     WEBUI_ADMIN_EMAIL,
     WEBUI_ADMIN_NAME,
@@ -2193,6 +2194,7 @@ async def get_app_config(request: Request):
             'enable_signup': config.get('ui.enable_signup'),
             'enable_login_form': config.get('ui.enable_login_form'),
             'enable_websocket': ENABLE_WEBSOCKET_SUPPORT,
+            'websocket_heartbeat_interval': WEBSOCKET_HEARTBEAT_INTERVAL,
             # --- Authenticated: only consumed by logged-in frontend ---
             **(
                 {

--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -16,6 +16,7 @@ from open_webui.env import (
     GLOBAL_LOG_LEVEL,
     REDIS_KEY_PREFIX,
     WEBSOCKET_EVENT_CALLER_TIMEOUT,
+    WEBSOCKET_HEARTBEAT_INTERVAL,
     WEBSOCKET_MANAGER,
     WEBSOCKET_REDIS_CLUSTER,
     WEBSOCKET_REDIS_LOCK_TIMEOUT,
@@ -102,7 +103,8 @@ else:
 
 # Timeout duration in seconds
 TIMEOUT_DURATION = 3
-SESSION_POOL_TIMEOUT = 120  # seconds without heartbeat before session is reaped
+# Seconds without heartbeat before a session is reaped; the floor covers clients whose bundle beats every 30s.
+SESSION_POOL_TIMEOUT = max(WEBSOCKET_HEARTBEAT_INTERVAL * 4, 120)
 
 # Dictionary to maintain the user pool
 

--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -335,6 +335,7 @@ type Config = {
 		enable_version_update_check: boolean;
 		enable_pyodide_file_persistence?: boolean;
 		folder_max_file_count?: number;
+		websocket_heartbeat_interval?: number;
 	};
 	oauth: {
 		providers: {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -213,13 +213,15 @@
 				}
 			}
 
-			// Send heartbeat every 30 seconds
-			heartbeatInterval = setInterval(() => {
-				if (_socket.connected) {
-					console.log('Sending heartbeat');
-					_socket.emit('heartbeat', {});
-				}
-			}, 30000);
+			heartbeatInterval = setInterval(
+				() => {
+					if (_socket.connected) {
+						console.log('Sending heartbeat');
+						_socket.emit('heartbeat', {});
+					}
+				},
+				($config?.features?.websocket_heartbeat_interval ?? 30) * 1000
+			);
 
 			if (deploymentId !== null) {
 				WEBUI_DEPLOYMENT_ID.set(deploymentId);


### PR DESCRIPTION
Every open tab pings the server every 30 seconds, and that number was hardcoded in the frontend. Each ping costs a Redis read and a Redis write to refresh the session entry plus a database write for the user's last-active timestamp, so a large deployment carries a constant background load that no user action triggered: a few thousand open tabs work out to well over 100 Redis round trips and 100 database writes per second, whether anyone is typing or not.

WEBSOCKET_HEARTBEAT_INTERVAL now sets that interval and the server hands the value to the client in the config response. The default of 30 keeps today's behaviour exactly, and 90 cuts that idle background traffic to a third of it.

Two things bound how far it can go, so the value is clamped to 5-90 seconds. The session reaper derives its timeout from the interval instead of using a fixed 120 seconds, but never drops below that, so clients still running an older frontend bundle keep their 30 second beat and are not reaped while connected. Separately, "active" everywhere else in the app means a last-active timestamp newer than 3 minutes, so an interval anywhere near that would make connected users render as offline, drop out of the active user count, and start receiving away notifications.

Closes #28166

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
