### PR TITLE
perf: make THREAD_POOL_SIZE bound asyncio's thread pool as well

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -7,6 +7,7 @@ import mimetypes
 import os
 import sys
 import time
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager
 from uuid import uuid4
 
@@ -337,6 +338,14 @@ async def lifespan(app: FastAPI):
     # This allows sync functions to schedule work on the main loop without blocking health checks
     app.state.main_loop = asyncio.get_running_loop()
 
+    if THREAD_POOL_SIZE and THREAD_POOL_SIZE > 0:
+        anyio.to_thread.current_default_thread_limiter().total_tokens = THREAD_POOL_SIZE
+
+        # asyncio offloads bypass the limiter; set their pool before the first offload creates the stock one
+        app.state.main_loop.set_default_executor(
+            ThreadPoolExecutor(max_workers=THREAD_POOL_SIZE, thread_name_prefix='owui_offload')
+        )
+
     app.state.instance_id = INSTANCE_ID
     start_logger()
 
@@ -371,10 +380,6 @@ async def lifespan(app: FastAPI):
 
     if app.state.redis is not None:
         app.state.redis_task_command_listener = asyncio.create_task(redis_task_command_listener(app))
-
-    if THREAD_POOL_SIZE and THREAD_POOL_SIZE > 0:
-        limiter = anyio.to_thread.current_default_thread_limiter()
-        limiter.total_tokens = THREAD_POOL_SIZE
 
     asyncio.create_task(periodic_usage_pool_cleanup())
     asyncio.create_task(periodic_session_pool_cleanup())


### PR DESCRIPTION
THREAD_POOL_SIZE only raised the AnyIO capacity limiter, but most blocking work is offloaded with asyncio.to_thread, which uses asyncio's own default pool. That pool is hard-capped at min(32, cpu_count + 4) and no setting could change it, so on a busy instance every vector DB call, storage read, LDAP bind and password verification competed for at most 32 slots regardless of what the operator configured. Slow object storage was enough to hold up RAG for every other user while CPU and memory looked idle. It could not be sized down either: os.cpu_count() reports the host's cores rather than the container's limit, so each container sized this pool off the whole machine.

The knob now sizes asyncio's default executor too, so it covers both offload paths and the documented behaviour becomes the actual behaviour. It is applied before the first startup offload, since otherwise the stock pool gets created and then orphaned. Leaving it unset changes nothing. Replacing the executor was preferred over converting the ~100 asyncio.to_thread call sites to AnyIO, which is a large mechanical diff for the same result. The value now sizes two independent pools, so the per-process thread ceiling is twice THREAD_POOL_SIZE; both fill lazily, so nothing is preallocated and an idle ceiling still costs nothing.

Measured with 400 concurrent 50 ms blocking offloads on 24 cores at THREAD_POOL_SIZE=2000, asyncio.to_thread went from 0.76s (effective concurrency 26) to 0.10s (205), matching run_in_threadpool on the same workload.

Fixes #28168

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
