### PR TITLE
perf: drop unused database session dependencies from seven endpoints

### DIFF
--- a/backend/open_webui/routers/knowledge.py
+++ b/backend/open_webui/routers/knowledge.py
@@ -641,10 +641,7 @@ async def _count_external_connection_mappings(connection_id: str, db: Optional[A
 
 
 @router.get('/external/connections', response_model=ExternalKnowledgeConnectionListResponse)
-async def get_external_knowledge_connections(
-    user=Depends(get_admin_user),
-    db: AsyncSession = Depends(get_async_session),
-):
+async def get_external_knowledge_connections(user=Depends(get_admin_user)):
     connections = [_sanitize_external_connection(connection) for connection in await _get_external_connections()]
     return ExternalKnowledgeConnectionListResponse(items=connections, total=len(connections))
 
@@ -674,7 +671,6 @@ async def create_external_knowledge_connection(
 async def get_external_knowledge_connection(
     id: str,
     user=Depends(get_admin_user),
-    db: AsyncSession = Depends(get_async_session),
 ):
     connection = await _get_external_connection(id)
     if not connection:
@@ -741,7 +737,6 @@ async def delete_external_knowledge_connection(
 async def test_external_knowledge_connection(
     id: str,
     user=Depends(get_admin_user),
-    db: AsyncSession = Depends(get_async_session),
 ):
     connection = await _get_external_connection(id)
     if not connection:
@@ -839,7 +834,6 @@ async def test_external_knowledge_retrieval(
     id: str,
     form_data: ExternalKnowledgeRetrieveTestForm,
     user=Depends(get_admin_user),
-    db: AsyncSession = Depends(get_async_session),
 ):
     connection = await _get_external_connection(id)
     if not connection:

--- a/backend/open_webui/routers/users.py
+++ b/backend/open_webui/routers/users.py
@@ -470,7 +470,6 @@ async def get_default_user_permissions_defaults(user=Depends(get_admin_user)):
 async def get_user_settings_by_session_user(
     raw: bool = False,
     user=Depends(get_verified_user),
-    db: AsyncSession = Depends(get_async_session),
 ):
     # user already fetched by get_verified_user — no need to refetch
     if raw:
@@ -569,7 +568,6 @@ async def update_user_settings_by_session_user(
 async def get_user_status_by_session_user(
     request: Request,
     user=Depends(get_verified_user),
-    db: AsyncSession = Depends(get_async_session),
 ):
     if not await Config.get('users.enable_status'):
         raise HTTPException(
@@ -619,7 +617,7 @@ async def update_user_status_by_session_user(
 
 
 @router.get('/user/info', response_model=dict | None)
-async def get_user_info_by_session_user(user=Depends(get_verified_user), db: AsyncSession = Depends(get_async_session)):
+async def get_user_info_by_session_user(user=Depends(get_verified_user)):
     # user already fetched by get_verified_user — no need to refetch
     return user.info
 


### PR DESCRIPTION
Seven route handlers declare a request-scoped database session as a FastAPI dependency and then never touch it. Three of them are `GET /api/v1/users/user/settings`, `/user/status` and `/user/info`, which the frontend hits on every page load, and all three carry a comment saying the user object is already available, so the parameter is leftover from the refactor that removed the refetch. The other four are admin-only external-knowledge connection endpoints that read their data from the config store.

Measured on a route with and without the dependency, 20k requests, best of 5:

| | µs per request |
| --- | --- |
| no dependency | 16.18 |
| unused session dependency | 62.85 |

The dependency costs about three times as much as everything else the request does put together. It is worth being precise about why, because the obvious guess is wrong: this is not database I/O and not connection pool pressure. SQLAlchemy connects lazily, so a session that is never used checks out zero connections, verified by watching the pool's counter stay at zero across the request. The cost is FastAPI resolving an extra async-generator dependency onto the request's exit stack, plus constructing and closing the session object.

Deleting the seven parameters is the whole change. An AST scan over the backend finds exactly these seven handlers before and none after.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
