### PR TITLE
perf: stop scanning every socket.io payload for binary data

### DIFF
--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -5,6 +5,7 @@ import logging
 import random
 import sys
 import time
+from typing import Any
 
 import pycrdt as Y
 import socketio
@@ -66,18 +67,13 @@ def get_room_sid_map(manager, namespace: str, room: str):
 
 
 class JSONOnlyPacket(Packet):
-    """Packet class that keeps every payload JSON-only.
-
-    Client attachments arrive as int lists, the form the Yjs handlers already store and apply,
-    and nothing server-side builds bytes, so python-socketio's recursive per-emit scan for
-    binary is pure overhead. With it off, an emit that does carry bytes raises in encode()
-    instead of being framed as an attachment.
-    """
+    """Packet class for JSON-serializable payloads only, skipping python-socketio's per-emit binary scan."""
 
     uses_binary_events = False
 
     @classmethod
-    def reconstruct_binary(cls, data, attachments):
+    def reconstruct_binary(cls, data: Any, attachments: list[bytes]):
+        """Normalize client attachments to int lists, the form the Yjs handlers store and apply."""
         return super().reconstruct_binary(data, [list(attachment) for attachment in attachments])
 
 

--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -46,6 +46,7 @@ from open_webui.utils.redis import (
     get_redis_connection,
     get_sentinels_from_env,
 )
+from socketio.packet import Packet
 
 logging.basicConfig(stream=sys.stdout, level=GLOBAL_LOG_LEVEL)
 log = logging.getLogger(__name__)
@@ -64,6 +65,22 @@ def get_room_sid_map(manager, namespace: str, room: str):
     return manager.rooms.get(namespace, {}).get(room)
 
 
+class JSONOnlyPacket(Packet):
+    """Packet class that keeps every payload JSON-only.
+
+    Client attachments arrive as int lists, the form the Yjs handlers already store and apply,
+    and nothing server-side builds bytes, so python-socketio's recursive per-emit scan for
+    binary is pure overhead. With it off, an emit that does carry bytes raises in encode()
+    instead of being framed as an attachment.
+    """
+
+    uses_binary_events = False
+
+    @classmethod
+    def reconstruct_binary(cls, data, attachments):
+        return super().reconstruct_binary(data, [list(attachment) for attachment in attachments])
+
+
 if WEBSOCKET_MANAGER == 'redis':
     sentinel_hosts = WEBSOCKET_SENTINEL_HOSTS or ''
     ws_redis_url = (
@@ -76,6 +93,7 @@ if WEBSOCKET_MANAGER == 'redis':
         cors_allowed_origins=SOCKETIO_CORS_ORIGINS,
         async_mode='asgi',
         json=SOCKETIO_JSON,
+        serializer=JSONOnlyPacket,
         transports=(['websocket'] if ENABLE_WEBSOCKET_SUPPORT else ['polling']),
         allow_upgrades=ENABLE_WEBSOCKET_SUPPORT,
         always_connect=True,
@@ -90,6 +108,7 @@ else:
         cors_allowed_origins=SOCKETIO_CORS_ORIGINS,
         async_mode='asgi',
         json=SOCKETIO_JSON,
+        serializer=JSONOnlyPacket,
         transports=(['websocket'] if ENABLE_WEBSOCKET_SUPPORT else ['polling']),
         allow_upgrades=ENABLE_WEBSOCKET_SUPPORT,
         always_connect=True,

--- a/src/lib/components/common/RichTextInput/Collaboration.ts
+++ b/src/lib/components/common/RichTextInput/Collaboration.ts
@@ -154,7 +154,7 @@ export class SocketIOCollaborationProvider {
 										document_id: this.documentId,
 										user_id: this.user?.id,
 										socket_id: this.socket.id,
-										update: Y.encodeStateAsUpdate(this.doc)
+										update: Array.from(Y.encodeStateAsUpdate(this.doc))
 									});
 								} else {
 									console.warn('Yjs document is empty, not sending state.');


### PR DESCRIPTION
Every socket.io event the backend sends was first walked recursively to check whether any value was a bytes object needing binary attachment framing. Open WebUI never emits binary, so the walk always came back empty and the work was thrown away. It has no early exit and allocates at every level, so it scaled with the full size of the message, and the messages are the big ones: chat streaming re-emits the whole assistant message on every update, note collaboration sends document state as a JSON array with one entry per byte. With the Redis manager it ran once per instance per emit on top of that, since every instance builds its own copy of the packet.

The server now installs a Packet subclass with binary events off, through python-socketio's own serializer hook, the same mechanism its msgpack serializer uses. Inbound binary attachments are decoded to int lists rather than refused, so the one frontend path that sends a raw Uint8Array keeps working and handlers can still echo client data straight back out. One scan remains in multi-instance setups: python-socketio's Redis manager calls it on the base Packet class directly, where the serializer hook cannot reach.

Measured per encode:

| payload | before | after |
|---|---|---|
| chat completion re-emit (7.5 KB JSON) | 30 us | 13 us | | collaborative document state (292 KB JSON) | 9.0 ms | 1.7 ms |

With ENABLE_ORJSON=true, where the scan is nearly the whole encode cost: 20 us to 2.3 us, and 7.8 ms to 0.14 ms.

Closes #28164

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
