### PR TITLE
chore: bump version examples for software

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -2,7 +2,6 @@ name: Bug Report
 description: Create a detailed bug report to help us improve Open WebUI.
 title: 'issue: '
 labels: ['bug', 'triage']
-assignees: []
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -54,7 +54,7 @@ body:
     id: open-webui-version
     attributes:
       label: Open WebUI Version
-      description: Specify the version (e.g., v0.6.26)
+      description: Specify the version (e.g., v0.11.0)
     validations:
       required: true
 
@@ -62,7 +62,7 @@ body:
     id: ollama-version
     attributes:
       label: Ollama Version (if applicable)
-      description: Specify the version (e.g., v0.2.0, or v0.1.32-rc1)
+      description: Specify the version (e.g., v0.32.5, or v0.32.6-rc0)
     validations:
       required: false
 
@@ -70,7 +70,7 @@ body:
     id: operating-system
     attributes:
       label: Operating System
-      description: Specify the OS (e.g., Windows 10, macOS Sonoma, Ubuntu 22.04, Debian 12)
+      description: Specify the OS (e.g., Windows 11, macOS Tahoe, Ubuntu 26.04, Debian 13)
     validations:
       required: true
 
@@ -78,7 +78,7 @@ body:
     id: browser
     attributes:
       label: Browser (if applicable)
-      description: Specify the browser/version (e.g., Chrome 100.0, Firefox 98.0)
+      description: Specify the browser/version (e.g., Chrome 151.0, Firefox 153.0.3)
     validations:
       required: false
 
@@ -137,8 +137,8 @@ body:
 
       placeholder: |
         Example (include every detail):
-        1. Start with a clean Ubuntu 22.04 install.
-        2. Install Docker v24.0.5 and start the service.
+        1. Start with a clean Ubuntu 26.04 install.
+        2. Install Docker v29.7.1 and start the service.
         3. Clone the Open WebUI repo (git clone ...).
         4. Use the Docker Compose file without modifications.
         5. Open browser Chrome 115.0 in incognito mode.


### PR DESCRIPTION
Older versions might confuse people filing new issues, so newer versions of mentioned software are used as examples.