### PR TITLE
fix: use uuidv4 for new terminal connection ids (save works over HTTP)

### DIFF
--- a/src/lib/components/admin/Settings/Integrations.svelte
+++ b/src/lib/components/admin/Settings/Integrations.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { toast } from 'svelte-sonner';
 	import { createEventDispatcher, onMount, getContext, tick } from 'svelte';
+	import { v4 as uuidv4 } from 'uuid';
 	import { getModels as _getModels } from '$lib/apis';
 	import type { Writable } from 'svelte/store';
 	import type { i18n as i18nType } from 'i18next';
@@ -101,7 +102,7 @@
 	const addTerminalConnection = (server: TerminalConnection) => {
 		terminalConnections = [
 			...terminalConnections,
-			{ ...server, id: server.id ?? crypto.randomUUID() }
+			{ ...server, id: server.id ?? uuidv4() }
 		];
 		saveTerminalServers();
 	};


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** `Closes #28148`
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following Keep a Changelog format is included at the bottom.
- [x] **Documentation:** Not applicable — no user-facing docs changed.
- [x] **Dependencies:** No new dependencies. `uuid` was already a dependency (used across `src/lib/utils/index.ts` etc.).
- [x] **Testing:** Manual reasoning + `svelte-check` run on the changed file (no new errors), `eslint` on the changed file shows only pre-existing issues.
- [x] **No Unchecked AI Code:** This PR was generated with AI assistance and has been manually reviewed and reasoned through; the change is minimal (2 lines) and validated with the project's typecheck/lint tooling.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. No new settings introduced.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses the `fix:` prefix.

# Changelog Entry

### Description

Fixes #28148 — saving a new **Open Terminal** connection from **Admin → Integrations** silently did nothing on setups accessed over plain HTTP (e.g. a Synology NAS on a LAN).

### Root cause

`src/lib/components/admin/Settings/Integrations.svelte` generated the connection id with `crypto.randomUUID()`, which is only available in **secure contexts** (HTTPS or localhost). On plain-HTTP deployments `crypto.randomUUID` is `undefined`, so the Save handler threw a `TypeError` before the connection could be added — the dialog stayed open and the `PUT /api/v1/configs/terminal_servers` request was never sent. The connection **Verify** step worked because it doesn't touch that code path.

### Fix

Replaced `crypto.randomUUID()` with `uuidv4()` from the `uuid` package, which is already a dependency and already used elsewhere in the codebase (`src/lib/utils/index.ts`, chat components). Works in any context.

### Fixed

- New Open Terminal connections can now be saved from Admin → Integrations on HTTP (non-secure-context) deployments.

---

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
