### PR TITLE
fix(oauth): require provider-verified email before merging accounts by email

### DIFF
--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -1841,6 +1841,10 @@ class OAuthManager:
             # Email extraction
             email_claim = auth_config.OAUTH_EMAIL_CLAIM
             email = user_data.get(email_claim, '')
+            # Whether the provider vouches for the email address. None means
+            # the provider gave no verification signal; set by the claim
+            # check below or by the GitHub /user/emails fallback.
+            email_verified = None
             # We currently mandate that email addresses are provided
             if not email:
                 # If the provider is GitHub,and public email is not provided, we can use the access token to fetch the user's email
@@ -1857,12 +1861,15 @@ class OAuthManager:
                                 if resp.ok:
                                     emails = await resp.json()
                                     # use the primary email as the user's email
-                                    primary_email = next(
-                                        (e['email'] for e in emails if e.get('primary')),
+                                    primary_entry = next(
+                                        (e for e in emails if e.get('primary')),
                                         None,
                                     )
-                                    if primary_email:
-                                        email = primary_email
+                                    if primary_entry:
+                                        email = primary_entry['email']
+                                        # GitHub reports per-address verification; keep it for
+                                        # the account-merge gate below
+                                        email_verified = bool(primary_entry.get('verified'))
                                     else:
                                         log.warning('No primary email found in GitHub response')
                                         raise HTTPException(400, detail=ERROR_MESSAGES.INVALID_CRED)
@@ -1878,6 +1885,15 @@ class OAuthManager:
                     log.warning(f'OAuth callback failed, email is missing: {user_data}')
                     raise HTTPException(400, detail=ERROR_MESSAGES.INVALID_CRED)
 
+            # OIDC providers send an `email_verified` claim; the GitHub
+            # fallback above sets email_verified from the /user/emails entry.
+            if email_verified is None:
+                verified_claim = user_data.get('email_verified')
+                if isinstance(verified_claim, bool):
+                    email_verified = verified_claim
+                elif isinstance(verified_claim, str):
+                    email_verified = verified_claim.lower() == 'true'
+
             email = email.lower()
             # If allowed domains are configured, check if the email domain is in the list
             if (
@@ -1892,6 +1908,15 @@ class OAuthManager:
             if not user:
                 # If the user does not exist, check if merging is enabled
                 if auth_config.OAUTH_MERGE_ACCOUNTS_BY_EMAIL:
+                    # Never merge on an email the provider reports as
+                    # unverified: an IdP that lets users claim arbitrary
+                    # addresses would otherwise hand over the matching
+                    # existing account (account takeover)
+                    if email_verified is False:
+                        log.warning(
+                            f'OAuth callback failed, refusing to merge account on unverified email: {email}'
+                        )
+                        raise HTTPException(400, detail=ERROR_MESSAGES.INVALID_CRED)
                     # Check if the user exists by email
                     user = await Users.get_user_by_email(email, db=db)
                     if user:


### PR DESCRIPTION
## Summary

When `OAUTH_MERGE_ACCOUNTS_BY_EMAIL=True`, the callback binds a new `(provider, sub)` identity to an existing account looked up **by email claim alone** (`utils/oauth.py` merge branch). No code checks whether the identity provider actually *verified* that email address.

Any IdP that lets users assert arbitrary unverified email addresses (e.g. a Keycloak realm with "verify email" off, or a provider that simply forwards a user-supplied `email` claim) allows account takeover: attacker sets their IdP email claim to the victim's address, signs in, and the backend merges the attacker's identity into the victim's existing account — including admin accounts.

## Fix

- Track provider verification during email extraction: the OIDC `email_verified` claim (bool or string form), and GitHub's per-address `verified` flag in the `/user/emails` fallback.
- The merge-by-email path now refuses (400) when the provider **explicitly reports the email as unverified**. Providers that send no verification signal keep current behavior (non-breaking for IdPs without the claim concept).

No behavior change for: normal login of existing linked accounts, first-time OAuth signup (new accounts carry no takeover risk; `EMAIL_TAKEN` still guards existing ones), and providers that verify email.

## Test plan

- [ ] Keycloak (verify-email off): user with unverified email matching an existing local account is rejected at merge with 400 instead of being merged
- [ ] Keycloak (email verified): merge still succeeds
- [ ] GitHub provider without public email: fallback still resolves the primary address; merge works when GitHub reports it verified

Made with Cursor

Made with [Cursor](https://cursor.com)