### PR TITLE
fix: avoid duplicate base model removal

### DIFF
--- a/backend/open_webui/utils/models.py
+++ b/backend/open_webui/utils/models.py
@@ -181,7 +181,7 @@ async def get_all_models(request, refresh: bool = False, user: UserModel = None)
 
                     model['action_ids'] = action_ids
                     model['filter_ids'] = filter_ids
-                else:
+                elif model in models:
                     models.remove(model)
 
         elif custom_model.is_active:


### PR DESCRIPTION
Closes #28202.

## Summary

Prevent `get_all_models()` from removing the same Ollama model object twice when inactive custom-model aliases resolve to both the base name and the exact tagged ID.

## Root cause

`base_model_lookup` stores references under both an Ollama model's untagged base name and exact ID. After the first inactive alias removes the object from `models`, the lookup still returns that object for a second alias, so the unconditional `list.remove()` raises `ValueError` and `/api/models` returns 500.

The change keeps the existing removal behavior but makes it idempotent by checking that the looked-up object is still present.

## Verification

- Extracted and executed the relevant `get_all_models()` AST block directly from both `origin/dev` and the patched source.
  - One exact inactive ID: passes before and after the change.
  - Base-name plus exact-ID aliases: `origin/dev` reproduces `ValueError('list.remove(x): x not in list')`; patched source passes and leaves the list empty.
- `ruff format --no-cache --check backend/open_webui/utils/models.py`: passed.
- `ruff check --no-cache --select E9,F63,F7,F82 backend/open_webui/utils/models.py`: passed.
- In-memory Python compilation and `git diff --check`: passed.

Docker/Ollama Cloud end-to-end verification was not available because the local Docker daemon is not running. Importing the complete backend module was also unavailable because the local system Python environment does not contain `uvicorn`.

AI assistance was used for investigation and preparation of this one-line change. The contributor reviewed the final diff and verification evidence before submission.

## Pull Request Checklist

- [x] **Linked Issue/Discussion:** Closes #28202.
- [x] **Target branch:** This PR targets `dev`.
- [x] **Description:** The change and root cause are described above.
- [x] **Changelog:** Included below.
- [x] **Documentation:** No documentation change is needed for this internal error-handling fix.
- [x] **Dependencies:** No dependencies were added or changed.
- [x] **Testing:** Focused manual logic validation was performed; environment limitations are disclosed above.
- [x] **No Unchecked AI Code:** The contributor reviewed the final diff and verification evidence before submission.
- [x] **Self-Review:** The one-line diff, source history, and regression path were reviewed.
- [x] **Architecture:** No settings or architectural changes were introduced.
- [x] **Git Hygiene:** The branch is based on current `dev` and contains one atomic commit.
- [x] **Title Prefix:** The title uses `fix:`.

# Changelog Entry

### Fixed

- Prevented `/api/models` from failing when inactive Ollama aliases resolve to an already removed model.

### Additional Information

- Related issue: #28202

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
