### PR TITLE
build: bump undici to ^7.29.0 to fix CVE-2026-13697 and 4 related CVEs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -100,7 +100,7 @@
 				"tippy.js": "^6.3.7",
 				"turndown": "^7.2.0",
 				"turndown-plugin-gfm": "^1.0.2",
-				"undici": "^7.28.0",
+				"undici": "^7.29.0",
 				"uuid": "^11.1.1",
 				"vega": "^6.2.0",
 				"vega-lite": "^6.4.1",
@@ -14489,9 +14489,9 @@
 			}
 		},
 		"node_modules/undici": {
-			"version": "7.28.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-			"integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+			"integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=20.18.1"

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
 		"tippy.js": "^6.3.7",
 		"turndown": "^7.2.0",
 		"turndown-plugin-gfm": "^1.0.2",
-		"undici": "^7.28.0",
+		"undici": "^7.29.0",
 		"uuid": "^11.1.1",
 		"vega": "^6.2.0",
 		"vega-lite": "^6.4.1",


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [ ] **Linked Issue/Discussion:** Security dependency bump referencing published advisories (see Description); no separate issue was opened for this CVE fix - happy to open one if preferred.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable - dependency version bump only.
- [x] **Dependencies:** The updated dependency is explained, tested, and documented below.
- [x] **Testing:** `npm ci`, `npm run build` (including pyodide fetch, which uses undici), and `npm run test:frontend` all pass on this branch. `npm audit` no longer flags undici.
- [ ] **No Unchecked AI Code:**
- [x] **Self-Review:** A self-review of the change has been performed.
- [x] **Architecture:** No architectural impact - version bump within the existing ^7 range.
- [x] **Git Hygiene:** The PR is atomic (one logical change: 1 line in package.json, 4 lines in package-lock.json), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `build:` (dependency change).

# Changelog Entry

### Description

- Bumps the direct dependency `undici` from `^7.28.0` to `^7.29.0` (lockfile: 7.28.0 -> 7.29.0). `undici >=7.0.0 <7.29.0` is affected by 5 published advisories, all fixed in 7.29.0:
  - [CVE-2026-13697](https://github.com/advisories/GHSA-4cwx-7wf7-3272) (**high**) - cross-user information disclosure and parse-time crash
  - [CVE-2026-16728](https://github.com/advisories/GHSA-8xcm-r25x-g524) (moderate) - downstream response desynchronization via retry interceptor
  - [CVE-2026-15157](https://github.com/advisories/GHSA-m8rv-5g2x-5cg5) (moderate) - CRLF injection via blob-like body `type` property
  - [CVE-2026-14643](https://github.com/advisories/GHSA-jr45-8vmc-qm54) (moderate) - cross-user information disclosure via whitespace around `=` in headers
  - [CVE-2026-16729](https://github.com/advisories/GHSA-v3r7-h72x-cjcm) (moderate) - cookie attribute injection via unsanitized domain
- NVD: https://nvd.nist.gov/vuln/detail/CVE-2026-13697
- `undici` is used by `scripts/prepare-pyodide.js` (proxy-aware pyodide fetch), so the vulnerable version participates in every dev/build run, and `npm audit` currently flags it as a direct high-severity finding for everyone who installs the frontend.

### Security

- Bumped `undici` `^7.28.0` -> `^7.29.0` to resolve CVE-2026-13697, CVE-2026-16728, CVE-2026-15157, CVE-2026-14643, and CVE-2026-16729.

---

### Additional Information

- Verification on this branch (node 22):
  - `npm audit` no longer reports undici (total findings 25 -> 24, high 11 -> 10)
  - `npm ci` completes cleanly
  - `npm run build` completes cleanly (pyodide fetch + vite build + adapter-static), exercising the bumped undici in `scripts/prepare-pyodide.js`
  - `npm run test:frontend -- --run`: 2/2 tests pass
- The change is intentionally surgical: no other dependencies were touched.

### Screenshots or Videos

- Not applicable.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [ ] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
