### PR TITLE
feat: add CSV import to Edit Group modal

### DIFF
--- a/backend/open_webui/static/group-import.csv
+++ b/backend/open_webui/static/group-import.csv
@@ -1,0 +1,1 @@
+Name,Email

--- a/src/lib/components/admin/Users/Groups/EditGroupModal.svelte
+++ b/src/lib/components/admin/Users/Groups/EditGroupModal.svelte
@@ -9,10 +9,12 @@
 	import Permissions from './Permissions.svelte';
 	import Users from './Users.svelte';
 	import GroupPreviewPanel from './GroupPreviewPanel.svelte';
+	import Import from './Import.svelte';
 	import { DEFAULT_PERMISSIONS } from '$lib/constants/permissions';
 	import { getUserDefaultPermissions, getUserDefaultPermissionsDefaults } from '$lib/apis/users';
 	import UserPlusSolid from '$lib/components/icons/UserPlusSolid.svelte';
 	import WrenchSolid from '$lib/components/icons/WrenchSolid.svelte';
+	import DocumentArrowDown from '$lib/components/icons/DocumentArrowDown.svelte';
 	import ConfirmDialog from '$lib/components/common/ConfirmDialog.svelte';
 	import Tooltip from '$lib/components/common/Tooltip.svelte';
 	import XMark from '$lib/components/icons/XMark.svelte';
@@ -263,6 +265,24 @@
 									<div class=" self-center">{$i18n.t('Preview')}</div>
 								</button>
 							{/if}
+
+							{#if tabs.includes('import')}
+								<button
+									class="px-0.5 py-1 max-w-fit w-fit rounded-lg flex-1 lg:flex-none flex text-right transition {selectedTab ===
+									'import'
+										? ''
+										: ' text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
+									on:click={() => {
+										selectedTab = 'import';
+									}}
+									type="button"
+								>
+									<div class=" self-center mr-2">
+										<DocumentArrowDown />
+									</div>
+									<div class=" self-center">{$i18n.t('CSV Import')}</div>
+								</button>
+							{/if}
 						</div>
 
 						<div class="flex-1 mt-1 lg:mt-1 lg:h-[30rem] lg:max-h-[30rem] flex flex-col">
@@ -283,6 +303,12 @@
 									<Users bind:userCount groupId={group?.id} />
 								{:else if selectedTab == 'preview'}
 									<GroupPreviewPanel groupId={group?.id} />
+								{:else if selectedTab == 'import'}
+									<Import
+										groupId={group?.id}
+										bind:userCount
+										bind:loading
+									/>
 								{/if}
 							</div>
 

--- a/src/lib/components/admin/Users/Groups/GroupItem.svelte
+++ b/src/lib/components/admin/Users/Groups/GroupItem.svelte
@@ -61,7 +61,7 @@
 	edit
 	{group}
 	{defaultPermissions}
-	tabs={['general', 'permissions', 'users', 'preview']}
+	tabs={['general', 'permissions', 'users', 'preview', 'import']}
 	onSubmit={updateHandler}
 	onDelete={deleteHandler}
 />

--- a/src/lib/components/admin/Users/Groups/Import.svelte
+++ b/src/lib/components/admin/Users/Groups/Import.svelte
@@ -1,0 +1,142 @@
+<script lang="ts">
+	import { getContext } from 'svelte';
+	import { toast } from 'svelte-sonner';
+	import { getUsers } from '$lib/apis/users';
+	import { addUserToGroup } from '$lib/apis/groups';
+	import { WEBUI_BASE_URL } from '$lib/constants';
+
+	const i18n = getContext('i18n');
+
+	export let groupId: string | undefined = undefined;
+	export let userCount = 0;
+	export let loading = false;
+
+	let inputFiles: FileList | null = null;
+	let fileInput: HTMLInputElement | undefined;
+
+	const clearFileInput = () => {
+		inputFiles = null;
+		if (fileInput) {
+			fileInput.value = '';
+		}
+	};
+
+	const importCsv = async (file: File) => {
+		if (!groupId) {
+			clearFileInput();
+			return;
+		}
+
+		loading = true;
+
+		try {
+			const csv = await file.text();
+			const validRows: { idx: number; email: string }[] = [];
+
+			for (const [idx, row] of csv.split(/\r?\n/).entries()) {
+				if (idx === 0) continue;
+
+				const columns = row.split(',').map((col) => col.trim());
+				if (columns.length === 1 && columns[0] === '') continue;
+
+				if (columns.length !== 2 || !columns[1]) {
+					toast.error(`Row ${idx + 1}: invalid format.`);
+					continue;
+				}
+
+				validRows.push({ idx, email: columns[1].toLowerCase() });
+			}
+
+			const userIds: string[] = [];
+			const BATCH_SIZE = 10;
+
+			for (let i = 0; i < validRows.length; i += BATCH_SIZE) {
+				const batch = validRows.slice(i, i + BATCH_SIZE);
+				const results = await Promise.allSettled(
+					batch.map(({ idx, email }) =>
+						getUsers(localStorage.token, email)
+							.then((res) => {
+								const user = res?.users?.find((u) => u.email?.toLowerCase() === email);
+								if (user?.id) {
+									return user.id;
+								}
+
+								toast.error(`Row ${idx + 1}: ${$i18n.t('User not found.')}`);
+								return null;
+							})
+							.catch((error) => {
+								toast.error(`Row ${idx + 1}: ${error}`);
+								return null;
+							})
+					)
+				);
+
+				for (const result of results) {
+					if (result.status === 'fulfilled' && result.value) {
+						userIds.push(result.value);
+					}
+				}
+			}
+
+			if (userIds.length > 0) {
+				await addUserToGroup(localStorage.token, groupId, userIds);
+				userCount += userIds.length;
+				toast.success(
+					$i18n.t('Successfully imported {{userCount}} users.', { userCount: userIds.length })
+				);
+			}
+		} catch (error) {
+			toast.error(`${error}`);
+		} finally {
+			clearFileInput();
+			loading = false;
+		}
+	};
+
+	const handleFileChange = async () => {
+		const file = inputFiles?.[0];
+		if (!file || loading) {
+			return;
+		}
+
+		await importCsv(file);
+	};
+</script>
+
+<div>
+	<div class="mb-3 w-full">
+		<input
+			bind:this={fileInput}
+			hidden
+			bind:files={inputFiles}
+			type="file"
+			accept=".csv"
+			disabled={loading}
+			on:change={handleFileChange}
+		/>
+
+		<button
+			class="w-full text-sm font-normal py-3 bg-transparent hover:bg-gray-100 border border-dashed dark:border-gray-850 dark:hover:bg-gray-850 text-center rounded-xl {loading
+				? 'cursor-not-allowed opacity-60'
+				: ''}"
+			type="button"
+			disabled={loading}
+			on:click={() => {
+				fileInput?.click();
+			}}
+		>
+			{#if loading}
+				{$i18n.t('Importing...')}
+			{:else}
+				{$i18n.t('Click here to select a csv file.')}
+			{/if}
+		</button>
+	</div>
+
+	<div class=" text-xs text-gray-500">
+		ⓘ {$i18n.t('Ensure your CSV file includes 2 columns in this order: Name, Email.')}
+		<a class="underline dark:text-gray-200" href="{WEBUI_BASE_URL}/static/group-import.csv">
+			{$i18n.t('Click here to download group import template file.')}
+		</a>
+	</div>
+</div>


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — Relates to #16793 .
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [x] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **BREAKING CHANGE**: Changes affecting backward compatibility
  - **build**: Build system or dependency changes
  - **ci**: CI/CD workflow changes
  - **chore**: Refactoring, cleanup, or non-functional changes
  - **docs**: Documentation additions or updates
  - **feat**: New features or enhancements
  - **fix**: Bug fixes or corrections
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvements
  - **refactor**: Code restructuring
  - **style**: Formatting changes (whitespace, semicolons, etc.)
  - **test**: Test additions or corrections
  - **WIP**: Work in progress

# Changelog Entry

### Description

- Add a CSV Import tab to the Edit Group modal so admins can bulk-add existing users to a group.
- This implements part of the group management enhancement discussed in [Discussion #16793](https://github.com/open-webui/open-webui/discussions/16793).

On CSV select, rows are validated (`Name`, `Email`), matching users are looked up in batches via `getUsers`, and valid user IDs are added to the group with `addUserToGroup`. A downloadable template is provided at `/static/group-import.csv`.

### Added

- CSV Import tab in Edit Group modal (`Import.svelte`)
- Group member CSV template (`backend/open_webui/static/group-import.csv`) with `Name,Email` columns

### Changed

- N/A

### Deprecated

- N/A

### Removed

- N/A

### Fixed

- N/A

### Security

- N/A

### Breaking Changes

- N/A

---

### Additional Information

- Relates to [Discussion #16793](https://github.com/open-webui/open-webui/discussions/16793) (User and Group Management enhancements discussed in preparation for a PR).
#### Why `Name` + `Email` columns?
I think these two columns are sufficient for the core use case. Looking at `add_user()` in `backend/open_webui/routers/auths.py` (v0.11.0):
```python
if not validate_email_format(form_data.email.lower()):
    raise HTTPException(status.HTTP_400_BAD_REQUEST, detail=ERROR_MESSAGES.INVALID_EMAIL_FORMAT)
if await Users.get_user_by_email(form_data.email.lower(), db=db):
    raise HTTPException(400, detail=ERROR_MESSAGES.EMAIL_TAKEN)
```
Email is what's used to identify and validate a user before creation, and this is backed at the DB level too — per the database schema docs, the email column is unique case-insensitively via a partial unique index (uq_user_email_lower on lower(email)). So Email is the natural identity key for bulk membership import.

Name isn't part of that identity/uniqueness logic, but it's still useful as metadata so admins can visually confirm who they're adding when reviewing a bulk upload.

So a minimal Email + Name CSV format seemed enough for the essential case without over-engineering the import schema.

#### Why partial success instead of all-or-nothing?
Invalid or unresolved rows are skipped with a per-row error toast, while valid users are still added. This follows the existing bulk user CSV registration behavior in:

https://github.com/open-webui/open-webui/blob/main/src/lib/components/admin/Users/UserList/AddUserModal.svelte


### Screenshots or Videos


https://github.com/user-attachments/assets/a8943591-ec50-4058-82ec-c8ae50a311fc


https://github.com/user-attachments/assets/0374d3e5-5b3e-45c1-a565-d2a5a898d77c


### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
