### PR TITLE
fix: model ID whitelists accepting duplicate entries

### DIFF
--- a/src/lib/components/AddConnectionModal.svelte
+++ b/src/lib/components/AddConnectionModal.svelte
@@ -140,10 +140,19 @@
 	};
 
 	const addModelHandler = () => {
-		if (modelId) {
-			modelIds = [...modelIds, modelId];
-			modelId = '';
+		const newModelId = modelId.trim();
+
+		if (!newModelId) {
+			return;
 		}
+
+		if (modelIds.includes(newModelId)) {
+			toast.error($i18n.t('Model ID is already added'));
+			return;
+		}
+
+		modelIds = [...modelIds, newModelId];
+		modelId = '';
 	};
 
 	const submitHandler = async () => {
@@ -245,7 +254,7 @@
 			passthroughParams = Array.isArray(connection.config?.passthrough_params)
 				? connection.config.passthrough_params.join(', ')
 				: (connection.config?.passthrough_params ?? '');
-			modelIds = connection.config?.model_ids ?? [];
+			modelIds = [...new Set(connection.config?.model_ids ?? [])];
 
 			if (ollama) {
 				connectionType = connection.config?.connection_type ?? 'local';

--- a/src/lib/components/admin/Settings/Evaluations/ArenaModelModal.svelte
+++ b/src/lib/components/admin/Settings/Evaluations/ArenaModelModal.svelte
@@ -54,10 +54,10 @@
 	let showDeleteConfirmDialog = false;
 
 	const addModelHandler = () => {
-		if (selectedModelId) {
+		if (selectedModelId && !modelIds.includes(selectedModelId)) {
 			modelIds = [...modelIds, selectedModelId];
-			selectedModelId = '';
 		}
+		selectedModelId = '';
 	};
 
 	const submitHandler = () => {
@@ -111,7 +111,7 @@
 			id = model.id;
 			profileImageUrl = model.meta.profile_image_url;
 			description = model.meta.description;
-			modelIds = model.meta.model_ids || [];
+			modelIds = [...new Set(model.meta.model_ids || [])];
 			filterMode = model.meta?.filter_mode ?? 'include';
 			accessGrants = model.meta.access_grants ?? [];
 		}
@@ -362,7 +362,7 @@
 								bind:value={selectedModelId}
 							>
 								<option value="">{$i18n.t('Select a model')}</option>
-								{#each $models.filter((m) => m?.owned_by !== 'arena') as model}
+								{#each $models.filter((m) => m?.owned_by !== 'arena' && !modelIds.includes(m?.id)) as model}
 									<option value={model.id} class="bg-gray-50 dark:bg-gray-700">{model.name}</option>
 								{/each}
 							</select>

--- a/src/lib/i18n/locales/en-US/translation.json
+++ b/src/lib/i18n/locales/en-US/translation.json
@@ -1700,6 +1700,7 @@
 	"Model filesystem path detected. Model shortname is required for update, cannot continue.": "",
 	"Model Filtering": "",
 	"Model ID": "",
+	"Model ID is already added": "",
 	"Model ID is required.": "",
 	"Model IDs": "",
 	"Model is now private": "",


### PR DESCRIPTION
Adding a model ID that was already on the list in the connection settings modal simply appended it again, so the same model could sit in the whitelist any number of times. The arena model modal had the same flaw, its dropdown kept offering models that were already selected.

The connection modal now rejects a duplicate with a toast and trims the input first; surrounding whitespace renders invisibly in the list, so an untrimmed ID would slip past the duplicate check and still show up as a visually identical row. The arena modal instead filters already-added models out of the dropdown, matching the existing model selector in the admin settings, so a duplicate can no longer be picked at all. Both modals also drop duplicates when loading a stored list, so configs that already contain them are cleaned on their next save.

Until such a config is re-saved, one residual effect of old data remains: a duplicated ID in an arena model's stored list keeps double weight in the random model draw. New duplicates can no longer be created through the UI.

Fixes #28249

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
