### PR TITLE
fix: exclude already granted groups from the Add Access modal

### DIFF
--- a/src/lib/components/workspace/common/AccessControl.svelte
+++ b/src/lib/components/workspace/common/AccessControl.svelte
@@ -3,8 +3,9 @@
 
 	const i18n = getContext('i18n');
 
+	import { user as sessionUser } from '$lib/stores';
 	import { getGroups, getGroupById, getGroupInfoById } from '$lib/apis/groups';
-	import { getUserInfoById } from '$lib/apis/users';
+	import { getUserInfoById, searchUsers } from '$lib/apis/users';
 	import { WEBUI_API_BASE_URL } from '$lib/constants';
 	import XMark from '$lib/components/icons/XMark.svelte';
 	import Badge from '$lib/components/common/Badge.svelte';
@@ -40,6 +41,7 @@
 	export let defaultPermission: 'read' | 'write' = 'read';
 
 	let groups: any[] = [];
+	let userTotal: number | null = null;
 	const resolvingGroupIds = new Set<string>();
 	let userById: Record<string, any> = {};
 	const resolvingUserIds = new Set<string>();
@@ -428,6 +430,20 @@
 		.filter((group) => readGroupIds.includes(group.id) || writeGroupIds.includes(group.id))
 		.sort((a, b) => a.name.localeCompare(b.name));
 
+	$: selectableGroupCount = allowGroups
+		? groups.filter(
+				(group) => !readGroupIds.includes(group.id) && !writeGroupIds.includes(group.id)
+			).length
+		: 0;
+
+	$: selectableUserCount =
+		shareUsers && userTotal !== null
+			? Math.max(0, userTotal - 1 - selectedUserIds.filter((id) => id !== $sessionUser?.id).length)
+			: 0;
+
+	$: canAddAccess =
+		selectableGroupCount > 0 || (shareUsers && userTotal === null) || selectableUserCount > 0;
+
 	$: if (selectedUserIds.length > 0) {
 		void ensureUsersByIds(selectedUserIds);
 	}
@@ -464,6 +480,14 @@
 		groups = [...groups, ...res].filter(
 			(g, index, self) => index === self.findIndex((t) => t.id === g.id)
 		);
+
+		if (shareUsers) {
+			const userRes = await searchUsers(localStorage.token, '', 'name', 'asc', 1).catch((error) => {
+				console.error(error);
+				return null;
+			});
+			userTotal = userRes?.total ?? null;
+		}
 	});
 </script>
 
@@ -571,16 +595,18 @@
 				{$i18n.t('Access List')}
 			</div>
 			<div class="flex gap-1">
-				<button
-					class="px-2 py-1 bg-transparent hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg transition text-xs font-normal flex items-center gap-1"
-					type="button"
-					on:click={() => {
-						showAddAccessModal = true;
-					}}
-				>
-					<Plus className="size-3" />
-					{$i18n.t('Add Access')}
-				</button>
+				{#if canAddAccess}
+					<button
+						class="px-2 py-1 bg-transparent hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg transition text-xs font-normal flex items-center gap-1"
+						type="button"
+						on:click={() => {
+							showAddAccessModal = true;
+						}}
+					>
+						<Plus className="size-3" />
+						{$i18n.t('Add Access')}
+					</button>
+				{/if}
 			</div>
 		</div>
 

--- a/src/lib/components/workspace/common/MemberSelector.svelte
+++ b/src/lib/components/workspace/common/MemberSelector.svelte
@@ -31,8 +31,22 @@
 	let filteredGroups = [];
 
 	$: filteredGroups = groups
-		? groups.filter((group) => group.name.toLowerCase().includes(query.toLowerCase()))
+		? groups.filter(
+				(group) =>
+					group.name.toLowerCase().includes(query.toLowerCase()) &&
+					!accessGrants.some(
+						(grant) => grant.principal_type === 'group' && grant.principal_id === group.id
+					)
+			)
 		: [];
+
+	$: filteredUsers = (users ?? []).filter(
+		(user: any) =>
+			!accessGrants.some(
+				(grant) => grant.principal_type === 'user' && grant.principal_id === user.id
+			) &&
+			(includeSessionUser || user?.id !== $_user?.id)
+	);
 
 	let selectedGroup = {};
 	let selectedUsers = {};
@@ -195,7 +209,7 @@
 			</div>
 		</div>
 
-		{#if users.length > 0 || filteredGroups.length > 0}
+		{#if filteredUsers.length > 0 || filteredGroups.length > 0}
 			<div class="scrollbar-hidden relative whitespace-nowrap w-full max-w-full">
 				<div class=" text-sm text-left text-gray-500 dark:text-gray-400 w-full max-w-full">
 					<div class="w-full max-h-96 overflow-y-auto rounded-lg">
@@ -241,64 +255,61 @@
 							</div>
 						{/if}
 
-						{#if includeUsers}
+						{#if includeUsers && filteredUsers.length > 0}
 							<div class="text-xs text-gray-500 mb-1 mx-1">
 								{$i18n.t('Users')}
 							</div>
 
 							<div>
-								{#each users as user, userIdx (user.id)}
-									{#if !accessGrants.some((grant) => grant.principal_type === 'user' && grant.principal_id === user.id) && (includeSessionUser || user?.id !== $_user?.id)}
-										<button
-											class=" dark:border-gray-850 text-xs flex items-center justify-between w-full"
-											type="button"
-											on:click={() => {
-												if ((userIds ?? []).includes(user.id)) {
-													userIds = userIds.filter((id) => id !== user.id);
-													delete selectedUsers[user.id];
-												} else {
-													userIds = [...userIds, user.id];
-													selectedUsers[user.id] = user;
-												}
-											}}
-										>
-											<div class="px-3 py-1.5 font-normal text-gray-900 dark:text-white flex-1">
-												<div class="flex items-center gap-2">
-													<ProfilePreview {user} side="right" align="center" sideOffset={6}>
-														<img
-															class="rounded-2xl w-6 h-6 object-cover flex-shrink-0"
-															src={`${WEBUI_API_BASE_URL}/users/${user.id}/profile/image`}
-															alt="user"
-														/>
-													</ProfilePreview>
-													<Tooltip content={user.email} placement="top-start">
-														<div class="font-normal truncate">{user.name}</div>
-													</Tooltip>
-
-													{#if user?.is_active}
-														<div>
-															<span class="relative flex size-1.5">
-																<span
-																	class="absolute inline-flex h-full w-full animate-ping rounded-full bg-green-400 opacity-75"
-																></span>
-																<span
-																	class="relative inline-flex size-1.5 rounded-full bg-green-500"
-																></span>
-															</span>
-														</div>
-													{/if}
-												</div>
-											</div>
-
-											<div class="px-3 py-1">
-												<div class=" translate-y-0.5">
-													<Checkbox
-														state={(userIds ?? []).includes(user.id) ? 'checked' : 'unchecked'}
+								{#each filteredUsers as user (user.id)}
+									<button
+										class=" dark:border-gray-850 text-xs flex items-center justify-between w-full"
+										type="button"
+										on:click={() => {
+											if ((userIds ?? []).includes(user.id)) {
+												userIds = userIds.filter((id) => id !== user.id);
+												delete selectedUsers[user.id];
+											} else {
+												userIds = [...userIds, user.id];
+												selectedUsers[user.id] = user;
+											}
+										}}
+									>
+										<div class="px-3 py-1.5 font-normal text-gray-900 dark:text-white flex-1">
+											<div class="flex items-center gap-2">
+												<ProfilePreview {user} side="right" align="center" sideOffset={6}>
+													<img
+														class="rounded-2xl w-6 h-6 object-cover flex-shrink-0"
+														src={`${WEBUI_API_BASE_URL}/users/${user.id}/profile/image`}
+														alt="user"
 													/>
-												</div>
+												</ProfilePreview>
+												<Tooltip content={user.email} placement="top-start">
+													<div class="font-normal truncate">{user.name}</div>
+												</Tooltip>
+
+												{#if user?.is_active}
+													<div>
+														<span class="relative flex size-1.5">
+															<span
+																class="absolute inline-flex h-full w-full animate-ping rounded-full bg-green-400 opacity-75"
+															></span>
+															<span class="relative inline-flex size-1.5 rounded-full bg-green-500"
+															></span>
+														</span>
+													</div>
+												{/if}
 											</div>
-										</button>
-									{/if}
+										</div>
+
+										<div class="px-3 py-1">
+											<div class=" translate-y-0.5">
+												<Checkbox
+													state={(userIds ?? []).includes(user.id) ? 'checked' : 'unchecked'}
+												/>
+											</div>
+										</div>
+									</button>
 								{/each}
 							</div>
 						{/if}


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #28253
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable. No configuration surface changes.
- [ ] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Manually tested by the author, and the changed derivations are covered by a logic suite described below.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new settings and no new components. Local derivations only.
- [x] **Git Hygiene:** A single commit, +99/-62 across two files, based on the current `dev`.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

The `Add Access` modal keeps offering groups that already have access. Users are filtered out once they are on the access list, groups never are, so after adding every group and saving, reopening the modal shows all of them again and selecting one does nothing.

**Root cause.** `MemberSelector.svelte` filters the two lists by different rules. Users are excluded when a matching grant exists, while groups are filtered only by the search box:

```js
$: filteredGroups = groups
	? groups.filter((group) => group.name.toLowerCase().includes(query.toLowerCase()))
	: [];
```

`accessGrants` is passed into the component and used for users, but never consulted for groups.

**The changes:**

1. Groups now use the same exclusion rule as users, expressed as one predicate on the existing derivation.

2. The user filtering, which previously happened inline inside the `{#each}`, is lifted into a `filteredUsers` derivation. That removes a level of nesting from the markup and, more importantly, gives the `Users` heading something to count, so it hides when empty exactly as the `Groups` heading already did.

3. `AccessControl.svelte` hides the `+ Add Access` button when nothing is left to add. It already fetched the group list, so this adds one `searchUsers` call on mount purely for the user total:

```js
$: canAddAccess =
	selectableGroupCount > 0 || (shareUsers && userTotal === null) || selectableUserCount > 0;
```

Both parts are needed. Without the group filter, every group always counted as selectable, so the button would never hide on any instance that has groups.

The `userTotal === null` clause makes the button fail open: if the user count request fails, the button stays visible rather than disappearing. Hiding a working control because of a transient network error would be worse than opening a modal that turns out to be empty.

The empty state guard was also switched from `users.length` to `filteredUsers.length`, so a fully filtered list shows the existing `No users were found.` message instead of an empty container.

### Fixed

- Groups that already have access are no longer offered in the `Add Access` modal, matching the behavior users already had.
- The `Users` heading no longer renders when every user already has access.
- The `+ Add Access` button is hidden when there are no groups or users left to add.

---

### Additional Information

Most of the diff size is re-indentation. Lifting the inline user filter out of the `{#each}` removes one nesting level across roughly fifty lines of markup; the behavioral change is the two derivations plus three one-line edits.

**Verification of the changed derivations.** The five derivations (`filteredGroups`, `filteredUsers`, `selectableGroupCount`, `selectableUserCount`, `canAddAccess`) were extracted from the component source and evaluated against a fixture matrix of 23 cases, rather than being retyped into a test where the two could drift apart. Cases include a `user` grant whose id collides with a group id, an `anyone` grant, `null` lists during load, the session user being granted (so the count is not subtracted twice), and an unknown user total.

All 23 pass. As a control, deleting `grant.principal_type === 'group' &&` from the source makes the same id collision case fail, confirming the matrix detects a regression rather than passing unconditionally.

The nine cases covering the `+ Add Access` button, with the selectable counts each one produces:

| Scenario | Selectable groups | Selectable users | Button |
|---|---|---|---|
| Nothing granted yet | 4 | 4 | shown |
| All groups granted, users remain | 0 | 4 | shown |
| All groups and all non-session users granted | 0 | 0 | hidden |
| Session user also granted | 0 | 0 | hidden |
| Only the session user exists | 0 | 0 | hidden |
| User count unknown, request failed | 0 | 0 | shown |
| `shareUsers` off, groups exhausted | 0 | 0 | hidden |
| `allowGroups` off, users remain | 0 | 3 | shown |
| `allowGroups` off, users exhausted | 0 | 0 | hidden |

Rows three and six produce identical counts and opposite outcomes, which is the fail open behavior: a known count of zero hides the button, an unknown count leaves it visible. Row four is the case that catches a double subtraction, since the session user is already removed from the pool before granted users are counted.

`svelte-check` reports the same number of errors on these two files as `dev` does, so no new type errors are introduced. The existing frontend test suite passes and the production build succeeds.

This PR was prepared with AI copilot assistance and reviewed by the author.

### Manual Verification Performed

1. Added every group and user to a shared resource, saved, and reopened `Add Access`. The modal no longer lists the granted groups.
2. Confirmed the `Users` heading is absent once every user has access, matching the `Groups` heading.
3. Confirmed the `+ Add Access` button disappears once nothing is left to add, and returns after removing a group or user from the access list.
4. Added a subset and confirmed the remaining groups and users are still offered and still selectable.
5. Confirmed the search field still filters the reduced group list.
6. Searched for a name that matches nothing and confirmed `No users were found.` appears rather than an empty container.
7. Ran `npm run format` (both files reported unchanged), `npm run build` (succeeds), and `npm run test:frontend` (passes).

### Screenshots or Videos

Before is current `dev`. After is this branch.

| Surface | Before | After |
|---|---|---|
| `Add Access` modal after every group and user has been added | <img width="601" height="511" alt="image" src="https://github.com/user-attachments/assets/a02bfcc6-fc79-4a52-9036-ca36646451f3" /> | N/A |
| Share dialog access list, with nothing left to add | <img width="601" height="511" alt="image" src="https://github.com/user-attachments/assets/408a8fa3-ca1e-4483-ac9b-b5c6c51ac8cc" /> | <img width="601" height="511" alt="image" src="https://github.com/user-attachments/assets/d2ea0426-b751-435f-a7c7-080eae1fed36" /> |

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.

