### PR TITLE
fix: surface chat API error messages instead of [object Object]

### DIFF
--- a/src/lib/apis/chats/index.ts
+++ b/src/lib/apis/chats/index.ts
@@ -1,6 +1,14 @@
 import { WEBUI_API_BASE_URL } from '$lib/constants';
 import { getTimeRange } from '$lib/utils';
 
+const getErrorDetail = (err: any) => {
+	if (Array.isArray(err?.detail)) {
+		return err.detail.map((e: { msg?: string }) => e.msg || JSON.stringify(e)).join(', ');
+	}
+
+	return err?.detail ?? err;
+};
+
 export const getChatConfig = async (token: string) => {
 	let error = null;
 
@@ -17,7 +25,7 @@ export const getChatConfig = async (token: string) => {
 			return res.json();
 		})
 		.catch((err) => {
-			error = err;
+			error = getErrorDetail(err);
 			console.error(err);
 			return null;
 		});
@@ -46,7 +54,7 @@ export const updateChatConfig = async (token: string, config: object) => {
 			return res.json();
 		})
 		.catch((err) => {
-			error = err;
+			error = getErrorDetail(err);
 			console.error(err);
 			return null;
 		});
@@ -84,7 +92,7 @@ export const createNewChat = async (
 			return res.json();
 		})
 		.catch((err) => {
-			error = err;
+			error = getErrorDetail(err);
 			console.error(err);
 			return null;
 		});
@@ -179,7 +187,7 @@ export const importChats = async (token: string, chats: object[]) => {
 			return res.json();
 		})
 		.catch((err) => {
-			error = err;
+			error = getErrorDetail(err);
 			console.error(err);
 			return null;
 		});
@@ -228,7 +236,7 @@ export const getChatList = async (
 			return json;
 		})
 		.catch((err) => {
-			error = err;
+			error = getErrorDetail(err);
 			console.error(err);
 			return null;
 		});
@@ -286,7 +294,7 @@ export const getChatListByUserId = async (
 			return json;
 		})
 		.catch((err) => {
-			error = err;
+			error = getErrorDetail(err);
 			console.error(err);
 			return null;
 		});
@@ -335,7 +343,7 @@ export const getArchivedChatList = async (
 			return json;
 		})
 		.catch((err) => {
-			error = err;
+			error = getErrorDetail(err);
 			console.error(err);
 			return null;
 		});
@@ -366,7 +374,7 @@ export const getArchivedChatCount = async (token: string = '') => {
 			return res.json();
 		})
 		.catch((err) => {
-			error = err;
+			error = getErrorDetail(err);
 			console.error(err);
 			return null;
 		});
@@ -408,7 +416,7 @@ export const getSharedChatList = async (token: string = '', page: number = 1, fi
 			return json;
 		})
 		.catch((err) => {
-			error = err;
+			error = getErrorDetail(err);
 			console.error(err);
 			return null;
 		});
@@ -496,7 +504,7 @@ export const getChatListBySearchText = async (token: string, text: string, page:
 			return json;
 		})
 		.catch((err) => {
-			error = err;
+			error = getErrorDetail(err);
 			console.error(err);
 			return null;
 		});
@@ -530,7 +538,7 @@ export const getChatsByFolderId = async (token: string, folderId: string) => {
 			return json;
 		})
 		.catch((err) => {
-			error = err;
+			error = getErrorDetail(err);
 			console.error(err);
 			return null;
 		});
@@ -569,7 +577,7 @@ export const getChatListByFolderId = async (token: string, folderId: string, pag
 			return json;
 		})
 		.catch((err) => {
-			error = err;
+			error = getErrorDetail(err);
 			console.error(err);
 			return null;
 		});
@@ -600,7 +608,7 @@ export const getAllArchivedChats = async (token: string) => {
 			return json;
 		})
 		.catch((err) => {
-			error = err;
+			error = getErrorDetail(err);
 			console.error(err);
 			return null;
 		});
@@ -631,7 +639,7 @@ export const getAllUserChats = async (token: string) => {
 			return json;
 		})
 		.catch((err) => {
-			error = err;
+			error = getErrorDetail(err);
 			console.error(err);
 			return null;
 		});
@@ -662,7 +670,7 @@ export const getAllTags = async (token: string) => {
 			return json;
 		})
 		.catch((err) => {
-			error = err;
+			error = getErrorDetail(err);
 			console.error(err);
 			return null;
 		});
@@ -693,7 +701,7 @@ export const getPinnedChatList = async (token: string = '') => {
 			return json;
 		})
 		.catch((err) => {
-			error = err;
+			error = getErrorDetail(err);
 			console.error(err);
 			return null;
 		});
@@ -730,7 +738,7 @@ export const getChatListByTagName = async (token: string = '', tagName: string) 
 			return json;
 		})
 		.catch((err) => {
-			error = err;
+			error = getErrorDetail(err);
 			console.error(err);
 			return null;
 		});
@@ -796,7 +804,7 @@ export const getChatByShareId = async (token: string, share_id: string) => {
 			return json;
 		})
 		.catch((err) => {
-			error = err;
+			error = getErrorDetail(err);
 
 			console.error(err);
 			return null;
@@ -1080,7 +1088,7 @@ export const shareChatById = async (token: string, id: string) => {
 			return json;
 		})
 		.catch((err) => {
-			error = err;
+			error = getErrorDetail(err);
 
 			console.error(err);
 			return null;
@@ -1115,7 +1123,7 @@ export const updateChatFolderIdById = async (token: string, id: string, folderId
 			return json;
 		})
 		.catch((err) => {
-			error = err;
+			error = getErrorDetail(err);
 
 			console.error(err);
 			return null;
@@ -1147,7 +1155,7 @@ export const archiveChatById = async (token: string, id: string) => {
 			return json;
 		})
 		.catch((err) => {
-			error = err;
+			error = getErrorDetail(err);
 
 			console.error(err);
 			return null;
@@ -1179,7 +1187,7 @@ export const deleteSharedChatById = async (token: string, id: string) => {
 			return json;
 		})
 		.catch((err) => {
-			error = err;
+			error = getErrorDetail(err);
 
 			console.error(err);
 			return null;
@@ -1214,7 +1222,7 @@ export const updateChatAccessGrants = async (token: string, id: string, accessGr
 			return json;
 		})
 		.catch((err) => {
-			error = err;
+			error = getErrorDetail(err);
 
 			console.error(err);
 			return null;
@@ -1246,7 +1254,7 @@ export const getChatAccessGrants = async (token: string, id: string) => {
 			return json;
 		})
 		.catch((err) => {
-			error = err;
+			error = getErrorDetail(err);
 
 			console.error(err);
 			return null;
@@ -1287,7 +1295,7 @@ export const updateChatById = async (
 			return json;
 		})
 		.catch((err) => {
-			error = err;
+			error = getErrorDetail(err);
 
 			console.error(err);
 			return null;
@@ -1320,7 +1328,7 @@ export const compactChatById = async (token: string, id: string, model?: string 
 			return json;
 		})
 		.catch((err) => {
-			error = err;
+			error = getErrorDetail(err);
 
 			console.error(err);
 			return null;
@@ -1349,7 +1357,7 @@ export const deleteChatMessageById = async (token: string, id: string, messageId
 			return res.json();
 		})
 		.catch((err) => {
-			error = err;
+			error = getErrorDetail(err);
 			console.error(err);
 			return null;
 		});
@@ -1412,7 +1420,7 @@ export const getTagsById = async (token: string, id: string) => {
 			return json;
 		})
 		.catch((err) => {
-			error = err;
+			error = getErrorDetail(err);
 
 			console.error(err);
 			return null;
@@ -1481,7 +1489,7 @@ export const deleteTagById = async (token: string, id: string, tagName: string) 
 			return json;
 		})
 		.catch((err) => {
-			error = err;
+			error = getErrorDetail(err);
 
 			console.error(err);
 			return null;
@@ -1585,7 +1593,7 @@ export const exportChatStats = async (token: string, page: number = 1, params: o
 			return json;
 		})
 		.catch((err) => {
-			error = err;
+			error = getErrorDetail(err);
 			console.error(err);
 			return null;
 		});
@@ -1616,7 +1624,7 @@ export const exportSingleChatStats = async (token: string, chatId: string) => {
 			return json;
 		})
 		.catch((err) => {
-			error = err;
+			error = getErrorDetail(err);
 			console.error(err);
 			return null;
 		});
@@ -1647,7 +1655,7 @@ export const downloadChatStats = async (
 		}
 	}).catch((err) => {
 		console.error(err);
-		error = err;
+		error = getErrorDetail(err);
 		return null;
 	});
 


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #28259
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable. No configuration surface changes.
- [ ] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Manually verified by the author against two different failing requests, and the helper is covered by the behavior table below.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new settings and no new components. One module local helper.
- [x] **Git Hygiene:** A single commit, +40/-32 in a single file, based on the current `dev`.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

Failing chat requests surface as `[object Object]` instead of the message the server sent. The message is present in the response body the whole time, it just never reaches the toast.

**Root cause.** The wrappers in `src/lib/apis/chats/index.ts` throw the parsed response object rather than the message inside it:

```js
.catch((err) => {
	error = err;          // the whole {detail: "..."} object
	console.error(err);
	return null;
});
```

Callers render errors with ``toast.error(`${error}`)``, and interpolating an object gives `[object Object]`.

**The fix** adds one module local helper and uses it in the handlers that were assigning the raw object:

```js
const getErrorDetail = (err: any) => {
	if (Array.isArray(err?.detail)) {
		return err.detail.map((e: { msg?: string }) => e.msg || JSON.stringify(e)).join(', ');
	}

	return err?.detail ?? err;
};
```

The `?? err` fallback is deliberate. These wrappers currently throw `err` itself, and a network level failure has no `detail`, so returning `undefined` would make `if (error) throw error` stop throwing and quietly turn a failed request into a `null` result. The fallback keeps the original object, and therefore the existing behavior, for that case.

The helper mirrors the normalization already present in `src/lib/apis/images/index.ts` and `src/lib/apis/auths/index.ts`, so no new pattern is introduced.

**Scope.** The module contains 49 error handlers. Only the 32 that assigned the raw object were changed:

| Shape | Count | Changed |
|---|---|---|
| `error = err` (raw object) | 32 | yes |
| `error = err.detail` | 12 | no, already correct |
| Redundant assign immediately overwritten by an `if ('detail' in err)` block | 5 | no, dead assignment |

The last group sits inside handlers that already unwrap the detail correctly, so touching them would be churn without a behavior change.

### Fixed

- Chat API failures now show the server's message in the toast instead of `[object Object]`.

---

### Additional Information

Behavior of the helper across every input shape these wrappers can receive:

| Input | Result |
|---|---|
| `{detail: "We could not find what you're looking for :/"}` | `We could not find what you're looking for :/` |
| `{detail: "Something went wrong :/"}` | `Something went wrong :/` |
| `{detail: [{msg: "field required"}]}` | `field required` |
| `{detail: [{msg: "a"}, {msg: "b"}]}` | `a, b` |
| object with no `detail` | the object, unchanged |
| network `TypeError` | the same `TypeError` instance, unchanged |

The last two rows are the ones that matter for not regressing: the identity of the thrown value is preserved when there is nothing to unwrap.

This is the same class of defect as #28133 in the calendar module. Several other API modules assign the raw object in the same way and would benefit from the same treatment, but each has slightly different surrounding error handling, so they are better handled separately rather than in one sweeping change.

This PR was prepared with AI copilot assistance and reviewed by the author.

### Manual Verification Performed

1. Triggered a 401 by moving a chat belonging to another user. The toast now reads `Something went wrong :/`.
2. Triggered a 404 by moving a chat into a folder the account has only read access to. The toast now reads `We could not find what you're looking for :/`.
3. Confirmed the two failures are now distinguishable, where previously both read `[object Object]`.
4. Exercised normal chat operations (create, rename, move between folders, archive, delete, pin) and confirmed success paths are unaffected.
5. Ran `npm run format` (file reported unchanged), `npm run build` (succeeds), and `npm run test:frontend` (passes).

### Screenshots or Videos

Before is current `dev`. After is this branch.

| Surface | Before | After |
|---|---|---|
| Toast when moving a chat owned by another user (401) | <img width="412" height="114" alt="image" src="https://github.com/user-attachments/assets/5c67b09c-6622-4601-8917-b6a78d291398" /> | <img width="412" height="114" alt="image" src="https://github.com/user-attachments/assets/ba3f1d95-8be9-4c3a-9e4e-36d8a4911c95" /> |
| Toast when moving a chat into a folder without write access (404) | <img width="412" height="114" alt="image" src="https://github.com/user-attachments/assets/280bf028-7916-4dbf-8828-2d72b658a2b9" /> | <img width="412" height="114" alt="image" src="https://github.com/user-attachments/assets/c348932a-8478-4fb8-9e75-688b2fdef1e5" /> |

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
