### PR TITLE
fix: align folder drag indicator and drop handling with share permissions

### DIFF
--- a/src/lib/components/layout/Sidebar/RecursiveFolder.svelte
+++ b/src/lib/components/layout/Sidebar/RecursiveFolder.svelte
@@ -158,10 +158,12 @@
 		}
 	};
 
+	const canDropInto = () => !folders[folderId]?.shared || folders[folderId]?.permission === 'write';
+
 	const onDragOver = (e) => {
 		e.preventDefault();
 		e.stopPropagation();
-		if (dragged || parentDragged || folders[folderId]?.shared) {
+		if (dragged || parentDragged || !canDropInto()) {
 			return;
 		}
 		draggedOver = true;
@@ -170,7 +172,7 @@
 	const onDrop = async (e) => {
 		e.preventDefault();
 		e.stopPropagation();
-		if (dragged || parentDragged) {
+		if (dragged || parentDragged || !canDropInto()) {
 			return;
 		}
 


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #28261
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable. No configuration surface changes.
- [ ] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Manually tested by the author against read-only shared, writable shared, and owned folders.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new settings and no new components. One local predicate shared by two existing handlers.
- [x] **Git Hygiene:** A single commit, +4/-2 in a single file, based on the current `dev`.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

The two drag handlers in `RecursiveFolder.svelte` disagreed about shared folders, and each was wrong in a different direction:

| Folder | Drop indicator | Drop accepted | Correct |
|---|---|---|---|
| Shared with the user as read only | no | **yes**, then fails with 404 | should refuse |
| Shared with the user as write | **no** | yes | should show the indicator |

`onDragOver` suppressed the indicator for every shared folder regardless of permission, while `onDrop` did not check sharing at all and accepted drops the server always rejects.

Both now use one predicate, matching the condition the component already uses elsewhere to gate actions on shared folders:

```js
const canDropInto = () => !folders[folderId]?.shared || folders[folderId]?.permission === 'write';
```

The backend is unchanged and was already correct: `POST /api/v1/chats/{id}/folder` requires ownership or write access on the target folder and returns 404 otherwise. This only stops the client offering an action the server will refuse.

Dragging a chat into the message composer to reference it uses a different drop target and is unaffected.

### Fixed

- Read-only shared folders no longer accept chat drops that cannot succeed.
- Writable shared folders now show the drop indicator, matching the drop they already accepted.

---

### Additional Information

The predicate was checked against every folder shape the component can hold:

| Folder state | Accepts drop |
|---|---|
| Owned, not shared | yes |
| Owned, `shared` flag absent | yes |
| Shared with the user, `write` | yes |
| Shared with the user, `read` | no |
| Shared with the user, `permission` missing | no |
| Folder record not yet loaded | yes |

The last two rows are the defaults that matter. A shared folder with no `permission` value denies, so an incomplete record cannot grant write on someone else's folder. A missing folder record allows, so a loading race cannot break dragging into the user's own folders.

Related: the unreadable toast that this failure produced on `dev` is #28259, fixed separately in #28260. With both changes the failing case disappears rather than becoming legible.

This PR was prepared with AI copilot assistance and reviewed by the author.

### Manual Verification Performed

1. As a user with read-only access to a shared folder, dragged a chat over it. No drop indicator appears and the drop is refused, with no failed request.
2. As a user with write access to a shared folder, dragged a chat over it. The drop indicator now appears and the move succeeds.
3. Dragged chats between folders owned by the user and confirmed no change in behavior.
4. Dragged a chat into the message composer and confirmed referencing still works.
5. Dragged a folder onto another folder and confirmed folder reordering is unaffected.
6. Ran `npm run format` (file reported unchanged) and `npm run build` (succeeds).

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
