### PR TITLE
fix: honour share grants when resolving a referenced chat

### DIFF
--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -47,6 +47,7 @@ from open_webui.retrieval.external import retrieve_external_knowledge
 from open_webui.retrieval.vector.factory import VECTOR_DB_CLIENT
 from open_webui.retrieval.vector.main import GetResult, SearchResult
 from open_webui.retrieval.web.utils import get_web_loader
+from open_webui.utils.access_control.chats import has_chat_read_access
 from open_webui.utils.access_control.files import get_owner_accessible_folder_files, has_access_to_file
 from open_webui.utils.access_control.folders import has_folder_access
 from open_webui.utils.headers import include_user_info_headers
@@ -1417,7 +1418,7 @@ async def get_sources_from_items(
             # Chat Attached
             chat = await Chats.get_chat_by_id(item.get('id'))
 
-            if chat and (user.role == 'admin' or chat.user_id == user.id):
+            if chat and await has_chat_read_access(user.id, user.role, chat):
                 messages_map = chat.chat.get('history', {}).get('messages', {})
                 message_id = chat.chat.get('history', {}).get('currentId')
 

--- a/backend/open_webui/utils/access_control/chats.py
+++ b/backend/open_webui/utils/access_control/chats.py
@@ -1,0 +1,31 @@
+from typing import Optional
+
+from open_webui.models.access_grants import AccessGrants
+from open_webui.models.chats import ChatModel
+from open_webui.models.folders import Folders
+from open_webui.utils.access_control.folders import has_folder_access
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+async def has_chat_read_access(
+    user_id: str, user_role: str, chat: ChatModel, db: Optional[AsyncSession] = None
+) -> bool:
+    """Check if a user can read a chat via ownership, admin role, an explicit share grant, or a shared folder."""
+    if user_role == 'admin' or chat.user_id == user_id:
+        return True
+
+    if await AccessGrants.has_access(
+        user_id=user_id,
+        resource_type='shared_chat',
+        resource_id=chat.id,
+        permission='read',
+        db=db,
+    ):
+        return True
+
+    if chat.folder_id:
+        folder = await Folders.get_folder_by_id(chat.folder_id, db=db)
+        if folder and await has_folder_access(user_id, folder, 'read', db):
+            return True
+
+    return False


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Relates to #28263. This addresses the retrieval half only, so the issue should stay open for the picker half described below.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable. No configuration surface changes.
- [ ] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Manually tested by the author with two accounts, and the new helper is covered by the access matrix below.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new settings. One helper added to the existing `utils/access_control` package, alongside the equivalents for files and folders.
- [x] **Git Hygiene:** A single commit, +33/-1 across two files, based on the current `dev`.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

Referencing a chat that was shared with you attaches the reference chip, sends the request successfully, and contributes nothing. The model then answers from an empty context, so the reply looks confident and is unrelated to the chat. Nothing reports an error.

**Root cause.** When a referenced chat is resolved in `get_sources_from_items`, access is decided by ownership alone:

```python
chat = await Chats.get_chat_by_id(item.get('id'))

if chat and (user.role == 'admin' or chat.user_id == user.id):
    ...
```

The chat is fetched unscoped and then gated on being the owner or an admin. Access grants are never consulted. There is no `else`, so when the check fails `query_result` is simply never populated and the reference contributes nothing.

This is inconsistent with the rest of the codebase, which already treats a shared chat as readable for that user:

- `GET /api/v1/chats/{id}` honours `shared_chat` grants and folder based access
- `POST /api/v1/chats/{id}/clone/shared` accepts a read grant
- the sidebar lists the chat and it opens normally

So a user can open, read and clone a chat that this path refuses to read on their behalf.

**The fix** adds `has_chat_read_access` to `utils/access_control/chats.py`, matching the existing helpers for files and folders, and uses it in place of the ownership test:

```python
if user_role == 'admin' or chat.user_id == user_id:
    return True

if await AccessGrants.has_access(
    user_id=user_id, resource_type='shared_chat', resource_id=chat.id, permission='read', db=db
):
    return True

if chat.folder_id:
    folder = await Folders.get_folder_by_id(chat.folder_id, db=db)
    if folder and await has_folder_access(user_id, folder, 'read', db):
        return True

return False
```

The change is purely additive with respect to access. Owners and admins are unaffected, and the two paths that already grant read elsewhere now grant it here too. Nobody loses access they previously had.

### Fixed

- Referencing a chat shared with you now retrieves its contents instead of silently contributing nothing.

---

### Additional Information

**This does not close #28263.** That issue covers two layers, and only one is addressed here:

- **Retrieval**, fixed by this PR.
- **Discovery**, not addressed. The `Reference Chats` panel calls `getChatList`, which is backed by an owner scoped query, so shared chats are still absent from the picker. Making them appear needs a list that includes chats shared with the user, which raises questions about pagination, search, and whether shared entries should be visually distinguished. That felt like a maintainer decision rather than something to settle inside a bug fix.

After this change, dragging a shared chat into the composer works end to end, while finding one through the `+` menu still does not.

**Overlaps with another open PR.** #26852 changes the message text extraction inside this same `type == 'chat'` branch, while this PR changes the access condition just above it. The two are complementary rather than competing: that one fixes what gets read out of a chat, this one fixes whose chats can be read at all. They do conflict textually, so whichever merges second needs a small rebase in that block.

**Access matrix for the new helper**, exercised against a scratch database:

| Case | Result |
|---|---|
| Owner reads their own chat | allowed |
| Admin reads any chat | allowed |
| Other user, no grants | denied |
| Other user with a `shared_chat` read grant | allowed |
| Unrelated user while that grant exists | denied |
| Other user, chat sits in a folder shared to them | allowed |
| Unrelated user in that same scenario | denied |
| Other user, chat in a folder with no grant | denied |

All eight behave as expected. The denial rows matter as much as the allow rows: the helper widens access only along the two paths that already grant read elsewhere.

This PR was prepared with AI copilot assistance and reviewed by the author.

### Manual Verification Performed

Verified on a running instance:

1. As user A, shared a chat with user B with read access, the chat living in a nested folder.
2. As user B, dragged the chat into the composer and asked about its contents. The source panel now shows the full transcript and the answer quotes it, where previously the response contained `No sources found`.
3. Confirmed the resolved document is the referenced chat's transcript and not the surrounding conversation.
4. Confirmed referencing a chat you own is unchanged.

Verified against a scratch database, exercising the helper directly:

5. The access matrix above, including the shared folder path and each denial case.
6. Ran `ruff format` (both files already formatted) and confirmed the new module introduces no import cycle.

The live run above was authorised by a direct `shared_chat` grant. The shared folder path is covered by the scratch matrix rather than by a separate live test.

### Screenshots or Videos

Before is current `dev`. After is this branch.

### Asking a question about a referenced chat that was shared with you:

#### Before:

<img width="2560" height="600" alt="image" src="https://github.com/user-attachments/assets/1041959f-baaa-40f1-a496-cb0609285854" />

#### After

<img width="2560" height="600" alt="image" src="https://github.com/user-attachments/assets/62be5fd7-8682-4ed8-9ed2-56678db1de46" />

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.

