### PR TITLE
fix: fall back to the default avatar when a profile image fails to load

### DIFF
--- a/src/lib/components/chat/Messages/ProfileImage.svelte
+++ b/src/lib/components/chat/Messages/ProfileImage.svelte
@@ -6,7 +6,9 @@
 	// LICENSE covers this Open WebUI fallback logo.
 	// Do not alter, remove, obscure, or replace it except as LICENSE permits:
 	// https://docs.openwebui.com/license.
-	export let src = `${WEBUI_BASE_URL}/static/favicon.png`;
+	const FALLBACK_SRC = `${WEBUI_BASE_URL}/static/favicon.png`;
+
+	export let src = FALLBACK_SRC;
 </script>
 
 <img
@@ -15,4 +17,9 @@
 	class=" {className} object-cover rounded-2xl"
 	alt="profile"
 	draggable="false"
+	on:error={(e) => {
+		if (!e.currentTarget.src.endsWith(FALLBACK_SRC)) {
+			e.currentTarget.src = FALLBACK_SRC;
+		}
+	}}
 />


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #28269
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable. No configuration surface changes.
- [ ] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Manually tested by the author with a deleted user's messages, in the message list and the Pinned Messages modal.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new settings and no new components. One error handler on an existing shared component.
- [x] **Git Hygiene:** A single commit, +8/-1 in a single file, based on the current `dev`.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

When a profile image fails to load, the avatar renders the image's `alt` text instead of falling back to the default. In a channel the avatar slot is 32 pixels wide, so `profile` is clipped to `prof` beside the message, in both the message list and the Pinned Messages modal.

It is most visible with a deleted user, whose messages remain in the channel after their profile image endpoint stops resolving.

**Root cause.** `ProfileImage.svelte` sets a default `src` prop but has no error handler:

```svelte
export let src = `${WEBUI_BASE_URL}/static/favicon.png`;
...
<img aria-hidden="true" src={safeImageUrl(src)} alt="profile" draggable="false" />
```

The default applies only when no `src` is passed. Channel messages always pass one, so a failing request leaves a broken image element.

Model avatars in `channel/Messages/Message.svelte` already handle this, with an error handler about fifty lines above the user avatar. A missing model image degrades to the fallback logo, while a missing user image degrades to alt text.

**The fix** extracts the existing fallback into a constant and reuses it in an error handler:

```svelte
const FALLBACK_SRC = `${WEBUI_BASE_URL}/static/favicon.png`;

export let src = FALLBACK_SRC;
```

```svelte
on:error={(e) => {
	if (!e.currentTarget.src.endsWith(FALLBACK_SRC)) {
		e.currentTarget.src = FALLBACK_SRC;
	}
}}
```

The fallback logo itself is unchanged, and the LICENSE note continues to sit directly above it. Extracting the constant keeps the default prop and the error handler from drifting apart.

### Fixed

- A profile image that fails to load now falls back to the default avatar instead of rendering the `alt` text, which appeared as a clipped `prof` next to messages from deleted users.

---

### Additional Information

**The `endsWith` guard prevents an error loop.** If the fallback itself failed, reassigning the same `src` would retry forever. A direct equality check is not sufficient: `WEBUI_BASE_URL` is an absolute origin in development and empty in production, so the constant is absolute in one case and relative in the other, while `currentTarget.src` is always absolute. Matching on the suffix holds in both:

| `WEBUI_BASE_URL` | Failing avatar | Fallback also fails |
|---|---|---|
| `http://localhost:8080` | sets fallback | no retry, guard holds |
| empty (production) | sets fallback | no retry, guard holds |

**Scope.** `ProfileImage` is shared, so this covers every consumer at once: channel messages, the Pinned Messages modal, thread replies, and the chat overview.

**Not included.** `GET /api/v1/users/{user_id}/profile/image` raises a 400 for an unknown id, while every existing user falls through to `user.png`. Returning the default image there instead would also resolve the deleted user case, but it changes an existing API response, so it seemed better to decide that separately. The client side change is the broader fix regardless, since it covers any profile image that fails for any reason.

Related: #28257 covers a different consequence of the same situation, where a deleted user leaves references behind in channels.

This PR was prepared with AI copilot assistance and reviewed by the author.

### Manual Verification Performed

1. Posted a message in a channel as a second user, pinned it, then deleted that user from Admin Panel > Users.
2. Opened the channel and confirmed the avatar now shows the default logo instead of clipped `prof` alt text.
3. Opened the Pinned Messages modal and confirmed the same.
4. Confirmed avatars for existing users still render their own images, since the handler now sits on every profile image in these views.
5. Confirmed the chat overview, which uses the same component, is unaffected.
6. Ran `npm run format` (file reported unchanged) and `npm run build` (succeeds).

### Screenshots or Videos

Before is current `dev`. After is this branch.

| Surface | Before | After |
|---|---|---|
| Channel message from a deleted user | <img width="1041" height="457" alt="image" src="https://github.com/user-attachments/assets/b33b6dc3-7216-4f4d-9e27-1104f089632d" />| <img width="1041" height="457" alt="image" src="https://github.com/user-attachments/assets/a0217eb4-3e5a-42f6-b06a-d1713119ec54" /> |
| Pinned Messages modal for that message | <img width="595" height="201" alt="image" src="https://github.com/user-attachments/assets/83bc0f56-aefd-42c5-9267-4f31d2651c4b" /> | <img width="500" height="176" alt="image" src="https://github.com/user-attachments/assets/c7507894-f626-4329-b9ff-c56b278a2628" /> |

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
