### PR TITLE
fix: resolve shared chat owner avatars against the API base url

### DIFF
--- a/src/lib/components/chat/Placeholder/ChatList.svelte
+++ b/src/lib/components/chat/Placeholder/ChatList.svelte
@@ -11,6 +11,7 @@
 	import dayjs from 'dayjs';
 	import localizedFormat from 'dayjs/plugin/localizedFormat';
 	import { getTimeRange } from '$lib/utils';
+	import { WEBUI_API_BASE_URL, WEBUI_BASE_URL } from '$lib/constants';
 	import ChevronUp from '$lib/components/icons/ChevronUp.svelte';
 	import ChevronDown from '$lib/components/icons/ChevronDown.svelte';
 	import ChevronLeft from '$lib/components/icons/ChevronLeft.svelte';
@@ -240,9 +241,14 @@
 					{#if showOwnerInfo && chat.user_id && chat.owner_name}
 						<Tooltip content={chat.owner_name}>
 							<img
-								src="/api/v1/users/{chat.user_id}/profile/image"
+								src="{WEBUI_API_BASE_URL}/users/{chat.user_id}/profile/image"
 								alt=""
 								class="size-4 rounded-full shrink-0 object-cover"
+								on:error={(e) => {
+									if (!e.currentTarget.src.endsWith('/static/favicon.png')) {
+										e.currentTarget.src = `${WEBUI_BASE_URL}/static/favicon.png`;
+									}
+								}}
 							/>
 						</Tooltip>
 					{/if}

--- a/src/lib/components/layout/Sidebar/ChatItem.svelte
+++ b/src/lib/components/layout/Sidebar/ChatItem.svelte
@@ -16,6 +16,7 @@
 
 <script lang="ts">
 	import { toast } from 'svelte-sonner';
+	import { WEBUI_API_BASE_URL, WEBUI_BASE_URL } from '$lib/constants';
 	import { goto, invalidate, invalidateAll } from '$app/navigation';
 	import { onMount, getContext, createEventDispatcher, tick } from 'svelte';
 	import { LinkPreview } from 'bits-ui';
@@ -508,9 +509,14 @@
 	{#if ownerUserId}
 		<Tooltip content={ownerName || 'Unknown'}>
 			<img
-				src="/api/v1/users/{ownerUserId}/profile/image"
+				src="{WEBUI_API_BASE_URL}/users/{ownerUserId}/profile/image"
 				alt=""
 				class="size-3.5 rounded-full shrink-0 object-cover mr-1.5"
+				on:error={(e) => {
+					if (!e.currentTarget.src.endsWith('/static/favicon.png')) {
+						e.currentTarget.src = `${WEBUI_BASE_URL}/static/favicon.png`;
+					}
+				}}
 			/>
 		</Tooltip>
 	{/if}


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #28271
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable. No configuration surface changes.
- [ ] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Manually tested by the author on a split origin development setup, in both affected surfaces.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new settings and no new components. Two existing image elements now use the shared API base constant.
- [x] **Git Hygiene:** A single commit, +14/-2 across two files, based on the current `dev`.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

The owner avatar beside a shared chat never loads when the frontend and backend are served from different origins, which is the standard `npm run dev` plus `uvicorn` setup. Both elements use `alt=""`, so the failure renders as a blank gap rather than anything visibly broken.

**Root cause.** Two components build the URL as a root relative path rather than using the API base:

```svelte
<img src="/api/v1/users/{ownerUserId}/profile/image" alt="" ... />
```

A root relative path resolves against the page origin. `WEBUI_API_BASE_URL` is `${WEBUI_BASE_URL}/api/v1`, and `WEBUI_BASE_URL` is the backend origin in development and empty in production, which is why every other avatar in the codebase interpolates it. There is no `/api` proxy in `vite.config.ts`, so nothing rewrites these requests and they hit the frontend origin.

**The fix** uses `WEBUI_API_BASE_URL` in both places, and adds an error handler so a future failure degrades to the default avatar instead of a blank gap.

Affected surfaces:

| File | Where it shows |
|---|---|
| `src/lib/components/layout/Sidebar/ChatItem.svelte` | shared chat entry in the sidebar |
| `src/lib/components/chat/Placeholder/ChatList.svelte` | shared chat entry in the folder view, when a shared folder is selected |

After this change, `grep 'src="/api/v1/'` across `src/lib` returns nothing.

### Fixed

- Owner avatars beside shared chats now load when the frontend and backend are on different origins, and fall back to the default image if the request fails.

---

### Additional Information

**Production behavior is unchanged.** The two URLs are byte identical in a single origin deployment, so this only affects setups where the frontend and backend differ:

```
development (vite on 5173, uvicorn on 8080, no proxy)
  before: http://localhost:5173/api/v1/users/{id}/profile/image    wrong origin
  after : http://localhost:8080/api/v1/users/{id}/profile/image    backend

production (single origin, WEBUI_BASE_URL empty)
  before: https://example.com/api/v1/users/{id}/profile/image
  after : https://example.com/api/v1/users/{id}/profile/image      identical
```

This is worth knowing before reviewing: the bug does not reproduce on a normal deployment, only on a split origin one, which is what contributors run locally.

**Two problems, deliberately ordered.** The hardcoded path is the cause of the visible breakage; the missing error handler is why the failure is silent. Fixing only the handler would be misleading, since the avatar would show the fallback logo in development and look correct while still never loading the real image. Both are addressed, with the path as the actual fix.

The error handler matches the one in #28270, including the suffix guard that prevents an error loop when `WEBUI_BASE_URL` is absolute in development and empty in production.

Related: #28269 and #28270 cover the same missing fallback in `ProfileImage.svelte`, a different component whose non empty `alt` produces visible text rather than a blank gap.

This PR was prepared with AI copilot assistance and reviewed by the author.

### Manual Verification Performed

1. Ran the frontend on port 5173 and the backend on port 8080, shared a chat between two accounts, and signed in as the recipient.
2. Confirmed the owner avatar now loads in the sidebar beside the shared chat, where it was previously a blank gap.
3. Confirmed the same in the folder view, reached by selecting the shared folder in the sidebar.
4. Confirmed the request now goes to the backend origin rather than the frontend origin.
5. Confirmed avatars elsewhere in the app are unaffected.
6. Ran `npm run format` (both files reported unchanged) and `npm run build` (succeeds).

### Screenshots or Videos

Before is current `dev`. After is this branch.

| Surface | Before | After |
|---|---|---|
| Shared chat owner avatar in the sidebar | <img width="220" height="158" alt="image" src="https://github.com/user-attachments/assets/bdec8ce8-7b3f-487d-81ce-cfa558db0e08" /> | <img width="220" height="158" alt="image" src="https://github.com/user-attachments/assets/184f0907-68e9-4fe8-8116-309585e0d462" /> |
| Shared chat owner avatar in the folder view of a shared folder | <img width="934" height="308" alt="image" src="https://github.com/user-attachments/assets/cd778dd6-c889-4674-a754-5d36379662a6" /> | <img width="934" height="308" alt="image" src="https://github.com/user-attachments/assets/b6a4b811-2867-43e4-baec-3c6ee3f0366c" /> |

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.

