### PR TITLE
fix: attribute shared chat messages to their author instead of the viewer

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -82,7 +82,7 @@
 	} from '$lib/apis/chats';
 	import { generateOpenAIChatCompletion } from '$lib/apis/openai';
 	import { processUrl, processWebSearch } from '$lib/apis/retrieval';
-	import { getAndUpdateUserLocation, getUserSettings } from '$lib/apis/users';
+	import { getAndUpdateUserLocation, getUserInfoById, getUserSettings } from '$lib/apis/users';
 	import {
 		generateQueries,
 		chatAction,
@@ -371,6 +371,25 @@
 
 	// Read-only when viewing someone else's chat (e.g. via shared folder access)
 	$: readOnly = chat != null && chat.user_id !== $user?.id;
+
+	let chatOwner = null;
+
+	const resolveChatOwner = async (userId) => {
+		if (chatOwner?.id === userId) {
+			return;
+		}
+
+		chatOwner = await getUserInfoById(localStorage.token, userId).catch((error) => {
+			console.error(error);
+			return null;
+		});
+	};
+
+	$: if (readOnly && chat?.user_id) {
+		void resolveChatOwner(chat.user_id);
+	} else {
+		chatOwner = null;
+	}
 
 	let chatTasks = [];
 
@@ -4065,6 +4084,7 @@
 									<Messages
 										bind:this={messagesRef}
 										chatId={$chatId}
+										user={chatOwner ?? $user}
 										{readOnly}
 										bind:history
 										bind:autoScroll
@@ -4302,6 +4322,7 @@
 						bind:files
 						bind:pane={controlPane}
 						chatId={$chatId}
+						chatUser={chatOwner}
 						modelId={selectedModelIds?.at(0) ?? null}
 						models={selectedModelIds.reduce((a, e, i, arr) => {
 							const model = $models.find((m) => m.id === e);

--- a/src/lib/components/chat/ChatControls.svelte
+++ b/src/lib/components/chat/ChatControls.svelte
@@ -42,6 +42,7 @@
 	export let models = [];
 
 	export let chatId = null;
+	export let chatUser = null;
 
 	export let chatFiles = [];
 	export let params = {};
@@ -385,6 +386,7 @@
 							{#if activeTab === 'overview'}
 								<Overview
 									{history}
+									{chatUser}
 									onNodeClick={(e) => {
 										const node = e.node;
 										showMessage(node.data.message, true);
@@ -529,6 +531,7 @@
 								{#if activeTab === 'overview'}
 									<Overview
 										{history}
+										{chatUser}
 										onNodeClick={(e) => {
 											const node = e.node;
 											if (node?.data?.message?.favorite) {

--- a/src/lib/components/chat/Overview.svelte
+++ b/src/lib/components/chat/Overview.svelte
@@ -5,8 +5,9 @@
 
 	export let history;
 	export let onNodeClick;
+	export let chatUser = null;
 </script>
 
 <SvelteFlowProvider>
-	<View {history} {onNodeClick} />
+	<View {history} {onNodeClick} {chatUser} />
 </SvelteFlowProvider>

--- a/src/lib/components/chat/Overview/View.svelte
+++ b/src/lib/components/chat/Overview/View.svelte
@@ -23,6 +23,7 @@
 
 	export let history;
 	export let onNodeClick;
+	export let chatUser = null;
 
 	type LayoutDirection = 'vertical' | 'horizontal';
 	type PositionMapEntry = {
@@ -99,7 +100,7 @@
 				id: pos.id,
 				type: 'custom',
 				data: {
-					user: $user,
+					user: chatUser ?? $user,
 					message: history.messages[id],
 					model: $models.find((model) => model.id === history.messages[id].model)
 				},


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #28273
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable. No configuration surface changes.
- [ ] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Manually tested by the author with two accounts, across the message list and both Overview layouts.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new settings and no new components. One resolved value passed down through existing props.
- [x] **Git Hygiene:** A single commit, +29/-3 across four files, based on the current `dev`.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

A chat shared with you is attributed to you. Every user message shows the viewer's own name and avatar, so a read only chat written by someone else appears to have been written by the reader. The public share page at `/s/{id}` is correct, which makes the in app view inconsistent with it.

**Root cause.** The author defaults to the session user in two places:

```js
// Messages.svelte, and Chat.svelte renders <Messages> without passing `user`
export let user = $_user;
```

```js
// Overview/View.svelte, reading the store directly while building graph nodes
data: { user: $user, message: history.messages[id], ... }
```

**The fix** resolves the chat's owner once in `Chat.svelte`, reusing the lookup the public share page already performs, and feeds both surfaces:

```js
$: if (readOnly && chat?.user_id) {
	void resolveChatOwner(chat.user_id);
} else {
	chatOwner = null;
}
```

`Messages` receives `user={chatOwner ?? $user}`, and `chatUser` is threaded through `ChatControls` to `Overview` and `View`, where it falls back to `$user` when absent. Viewing your own chats is unchanged, since `readOnly` is false and `chatOwner` stays `null`.

### Fixed

- A chat shared with you now shows its actual author's name and avatar, in the message list and in the Overview panel, instead of attributing the messages to whoever is reading.

---

### Additional Information

**The rendering layer was already built for this.** `UserMessage.svelte` contains:

```svelte
{:else if $settings.showUsername || $_user?.name !== user?.name}
	{user?.name ?? $i18n.t('You')}
```

which compares the session user against the message's user and shows the real name when they differ. That branch could never fire in the in app view, because both sides were the same object. Only the plumbing was missing.

**Two Overview renders, not one.** `ChatControls.svelte` renders `<Overview>` twice, once for the docked pane and once for the drawer layout. Both receive `chatUser`; wiring only one leaves the other still showing the viewer.

**Reactive safety.** The block that resolves the owner assigns `chatOwner` but never reads it, so it cannot retrigger itself. This was verified against the compiled component rather than by inspection: `chatOwner` does not appear in any reactive dependency list, while `readOnly` does.

An earlier revision of this change guarded the reset with `else if (chatOwner !== null)`, which reads and writes the same variable in one reactive block. That is the shape that produces feedback loops in Svelte's legacy reactive statements, so it was replaced with an unconditional assignment.

This PR was prepared with AI copilot assistance and reviewed by the author.

### Manual Verification Performed

1. As user A, shared a chat with user B with read access.
2. As user B, opened the chat and confirmed the message list now shows user A's name and avatar.
3. Confirmed the Overview panel shows user A in the docked layout.
4. Confirmed the same in the drawer layout at a narrow window width.
5. Opened a chat owned by user B and confirmed the author is unchanged.
6. Ran `npm run format` (all files reported unchanged), `npm run build` (succeeds), and `npm run test:frontend` (passes).

### Screenshots or Videos

Before is current `dev`. After is this branch.

| Surface | Before | After |
|---|---|---|
| Message list of a chat shared with you | <img width="1930" height="1272" alt="image" src="https://github.com/user-attachments/assets/5b8a08d5-dff5-4da9-866e-0b99f61bef61" /> | <img width="1930" height="1272" alt="image" src="https://github.com/user-attachments/assets/8f1a8298-84fc-4b24-8fd4-0cf58daf3eee" /> |
| Overview panel of that same chat | <img width="2332" height="1280" alt="image" src="https://github.com/user-attachments/assets/c1fa9fa5-b191-4f36-bb1a-d024a862b712" /> | <img width="2332" height="1280" alt="image" src="https://github.com/user-attachments/assets/35ba612d-0fed-4d57-b383-1694a7aa5733" /> |

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
