### PR TITLE
fix: keep toast notifications clear of the right hand panes

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -918,3 +918,15 @@ html.high-contrast:not(.dark) .shimmer {
 	color: var(--color-gray-700);
 	-webkit-text-fill-color: var(--color-gray-700);
 }
+
+@media (min-width: 601px) {
+	[data-sonner-toaster][data-x-position='right'] {
+		right: max(
+			env(safe-area-inset-right),
+			min(
+				calc(var(--offset) + var(--right-pane-width, 0px)),
+				calc(100vw - var(--width) - var(--offset))
+			)
+		);
+	}
+}

--- a/src/lib/components/channel/Channel.svelte
+++ b/src/lib/components/channel/Channel.svelte
@@ -15,6 +15,7 @@
 		user
 	} from '$lib/stores';
 	import { getChannelById, getChannelMessages, sendMessage } from '$lib/apis/channels';
+	import { trackRightPaneWidth } from '$lib/utils/rightPane';
 
 	import Messages from './Messages.svelte';
 	import MessageInput from './MessageInput.svelte';
@@ -266,6 +267,16 @@
 	let mediaQuery;
 	let largeScreen = false;
 
+	let threadPaneEl: HTMLElement | null = null;
+	let untrackPaneWidth: (() => void) | null = null;
+
+	const trackPaneWidth = (el: HTMLElement | null) => {
+		untrackPaneWidth?.();
+		untrackPaneWidth = el ? trackRightPaneWidth(el) : null;
+	};
+
+	$: trackPaneWidth(threadPaneEl);
+
 	onMount(() => {
 		if ($chatId) {
 			chatId.set('');
@@ -292,6 +303,8 @@
 		updateLastReadAt(id);
 		_channelId.set(null);
 		$socket?.off('events:channel', channelEventHandler);
+		untrackPaneWidth?.();
+		untrackPaneWidth = null;
 	});
 </script>
 
@@ -439,7 +452,7 @@
 				/>
 			</PaneResizer>
 
-			<Pane defaultSize={50} minSize={30} class="h-full w-full">
+			<Pane bind:el={threadPaneEl} defaultSize={50} minSize={30} class="h-full w-full">
 				<div class="h-full w-full shadow-xl">
 					<Thread
 						{threadId}

--- a/src/lib/components/chat/ChatControls.svelte
+++ b/src/lib/components/chat/ChatControls.svelte
@@ -24,6 +24,7 @@
 	} from '$lib/stores';
 
 	import { uploadFile } from '$lib/apis/files';
+	import { trackRightPaneWidth } from '$lib/utils/rightPane';
 	import { toast } from 'svelte-sonner';
 
 	import Controls from './Controls/Controls.svelte';
@@ -61,6 +62,16 @@
 	let dragged = false;
 	let minSize = 0;
 	let paneReady = false;
+
+	let paneEl: HTMLElement | null = null;
+	let untrackPaneWidth: (() => void) | null = null;
+
+	const trackPaneWidth = (el: HTMLElement | null) => {
+		untrackPaneWidth?.();
+		untrackPaneWidth = el ? trackRightPaneWidth(el) : null;
+	};
+
+	$: trackPaneWidth(paneEl);
 
 	// Tab state for Controls+Files panel
 	let activeTab = savedTab;
@@ -251,6 +262,8 @@
 			isDestroyed = true;
 			paneReady = false;
 			resizeObserver?.disconnect();
+			untrackPaneWidth?.();
+			untrackPaneWidth = null;
 			if (!largeScreen) {
 				showControls.set(false);
 			}
@@ -401,6 +414,7 @@
 
 	<Pane
 		bind:pane
+		bind:el={paneEl}
 		defaultSize={0}
 		onResize={(size) => {
 			if ($showControls && pane.isExpanded()) {

--- a/src/lib/components/notes/NotePanel.svelte
+++ b/src/lib/components/notes/NotePanel.svelte
@@ -3,6 +3,7 @@
 	import { Pane, PaneResizer } from 'paneforge';
 
 	import Drawer from '../common/Drawer.svelte';
+	import { trackRightPaneWidth } from '$lib/utils/rightPane';
 
 	export let show = false;
 	export let pane = null;
@@ -13,6 +14,16 @@
 	let largeScreen = false;
 
 	let minSize = 0;
+
+	let paneEl: HTMLElement | null = null;
+	let untrackPaneWidth: (() => void) | null = null;
+
+	const trackPaneWidth = (el: HTMLElement | null) => {
+		untrackPaneWidth?.();
+		untrackPaneWidth = el ? trackRightPaneWidth(el) : null;
+	};
+
+	$: trackPaneWidth(paneEl);
 
 	const handleMediaQuery = async (e) => {
 		if (e.matches) {
@@ -58,6 +69,8 @@
 
 	onDestroy(() => {
 		mediaQuery.removeEventListener('change', handleMediaQuery);
+		untrackPaneWidth?.();
+		untrackPaneWidth = null;
 	});
 </script>
 
@@ -86,6 +99,7 @@
 
 	<Pane
 		bind:pane
+		bind:el={paneEl}
 		defaultSize={Math.max(20, minSize)}
 		{minSize}
 		onCollapse={() => {

--- a/src/lib/utils/rightPane.ts
+++ b/src/lib/utils/rightPane.ts
@@ -1,0 +1,32 @@
+const CSS_VARIABLE = '--right-pane-width';
+
+let owner: HTMLElement | null = null;
+
+export const trackRightPaneWidth = (el: HTMLElement) => {
+	owner = el;
+
+	const publish = (width: number) => {
+		if (owner !== el) {
+			return;
+		}
+		document.documentElement.style.setProperty(CSS_VARIABLE, `${width}px`);
+	};
+
+	const observer = new ResizeObserver((entries) => {
+		for (const entry of entries) {
+			publish(entry.borderBoxSize?.[0]?.inlineSize ?? entry.contentRect.width);
+		}
+	});
+
+	observer.observe(el);
+	publish(el.offsetWidth);
+
+	return () => {
+		observer.disconnect();
+
+		if (owner === el) {
+			owner = null;
+			document.documentElement.style.removeProperty(CSS_VARIABLE);
+		}
+	};
+};


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #26317. Addresses the placement half of #28281, which also asks for a longer toast duration and a larger close button; neither of those is changed here, so that issue is referenced rather than closed.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable. No configuration surface changes.
- [ ] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Manually tested by the author on all three affected routes, and measured against the running app.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new settings, no new components, no change to toast position. One CSS custom property and one shared helper.
- [x] **Git Hygiene:** A single commit, +86/-1 across five files, based on the current `dev`.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

The toast container is anchored to the top right of the viewport. Whenever a right hand pane is open the toast renders on top of it, covering the pane header, its close button and the first row of controls. Reaching those controls means waiting for the toast to expire or dismissing it first.

Three panes are affected, all of them resizable paneforge panes on the trailing edge of a `PaneGroup`:

| Route | Pane |
|---|---|
| `/c/{id}` and `/` | Chat controls pane (Controls, Files, Overview, Artifacts, Embeds, Call) |
| `/channels/{id}` | Thread pane |
| `/notes/{id}` | Notes panel |

**The fix.** Each pane publishes its rendered width to `--right-pane-width` on the document element, and the toast container is inset by that amount:

```css
@media (min-width: 601px) {
	[data-sonner-toaster][data-x-position='right'] {
		right: max(
			env(safe-area-inset-right),
			min(
				calc(var(--offset) + var(--right-pane-width, 0px)),
				calc(100vw - var(--width) - var(--offset))
			)
		);
	}
}
```

This follows the convention the sidebar already uses, which writes its own width to `--sidebar-width` on the same element (`src/lib/components/layout/Sidebar.svelte`).

**Toast position is not changed.** `position="top-right"` is untouched, no user setting is added, and with no pane open the rule resolves to the same `32px` offset svelte-sonner already applies. The toast keeps a `32px` gap from the pane edge, the same gap it keeps from the viewport edge today.

### Fixed

- Toast notifications no longer cover the chat controls pane, the channel thread pane or the notes panel, so the controls underneath stay reachable while a toast is on screen.

---

### Additional Information

**Why a `ResizeObserver` on the pane element rather than the stored size.** `localStorage.chatControlsSize` cannot be used for this. paneforge stores layout as percentages and only fires `onResize` when the percentage changes, so resizing the browser window leaves the stored pixel value describing a width the pane no longer has. It is also transiently written as `0` mid drag, is retained after the pane closes, and does not exist at all for the thread and notes panes. Observing the pane element is the only source that is live, in pixels, and correct across window resizes. paneforge exposes the element through `bind:el`.

**Why the rule wins without `!important`.** svelte-sonner writes its position rules as `:global(:where([data-sonner-toaster][data-x-position='right']))`. The `:where()` wrapper gives them zero specificity, so a plain attribute selector overrides them cleanly. `--offset` is set inline on the container by a `style:` directive and therefore cannot be overridden from a stylesheet, which is why this adds a separate inherited property instead of redefining `--offset`.

**Why the rule is gated at `601px`.** Below `600px` svelte-sonner switches the container to a full width mobile layout, and unlike the position rules that mobile rule is not wrapped in `:where()`. An ungated override would win against it and break the mobile layout. Above the gate the property is unset on every route with no docked pane, so the rule resolves to today's value.

**Ownership.** Only the most recently mounted pane owns the property. During a route change the outgoing pane's cleanup can run after the incoming pane has already published its width, and without a guard that ordering would clear the new value and leave the toast un-inset. The helper compares the owning element before writing or clearing.

**Wide pane guard.** If a pane is ever wide enough that a toast cannot fit beside it, the inset stops growing at `calc(100vw - var(--width) - var(--offset))` so the toast stays fully on screen rather than sliding off the left edge. The toast does overlap the pane in that case, which is the intended trade off since there is no room beside it.

This PR was prepared with AI copilot assistance and reviewed by the author.

### Manual Verification Performed

Measured in the browser against the running app at a 1440px viewport, reading the computed `right` of the toast container and the bounding boxes of both elements.

| Route | Pane width | Computed `right` | Gap between toast and pane |
|---|---|---|---|
| `/c/{id}` | 380px | `412px` | 32px |
| `/notes/{id}` | 367px | `399.4px` | 32px |
| `/channels/{id}` | 699px | `730.5px` | 32px |
| any, no pane open | 0 | `32px` | unchanged |

Also confirmed:

1. Dragging the resizer updates the inset continuously, and collapsing the pane returns the toast to `32px`.
2. `--right-pane-width` is unset after navigating away from each route, so no stale inset is left behind.
3. At `500px` the mobile layout is untouched (`right: 16px`, `left: 16px`, `width: 100%`), and at `700px`, where every pane is a full width Drawer, the toast resolves to `32px`.
4. Forcing a pane to `1200px` on a `1440px` viewport caps the inset at `1052px` and keeps the toast's left edge at `32px` rather than off screen.
5. `npm run format` reports all touched files unchanged.

### Screenshots or Videos

Before is current `dev`. After is this branch.

| Surface | Before | After |
|---|---|---|
| Chat controls pane open with a toast | <img width="2559" height="1278" alt="image" src="https://github.com/user-attachments/assets/5038fe69-95fc-4b66-b183-5ffddba4eb12" /> | <img width="2559" height="1278" alt="image" src="https://github.com/user-attachments/assets/0ff0b630-2201-4440-a76c-4a2c8b7e6705" /> |
| Channel thread pane open with a toast | <img width="2560" height="1277" alt="image" src="https://github.com/user-attachments/assets/c739f0b3-e067-417d-9dba-00ca71c4f945" /> | <img width="2560" height="1277" alt="image" src="https://github.com/user-attachments/assets/2bd93f2c-728f-4049-b9c3-381fd4acc41f" /> |
| Notes panel open with a toast | <img width="2560" height="1277" alt="image" src="https://github.com/user-attachments/assets/92004b8f-9cf3-45bc-b72d-88388acfe3ca" /> |<img width="2560" height="1277" alt="image" src="https://github.com/user-attachments/assets/f770902c-8c44-4666-b5f0-42c1f849fcb1" /> |

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
