### PR TITLE
fix(oauth): require provider-verified email before merging accounts by email

### DIFF
--- a/backend/open_webui/routers/auths.py
+++ b/backend/open_webui/routers/auths.py
@@ -1669,6 +1669,20 @@ async def token_exchange(
     user = await Users.get_user_by_oauth_sub(provider, sub, db=db)
 
     if not user and await Config.get('oauth.merge_accounts_by_email'):
+        # Never merge on an email the provider reports as unverified: an IdP
+        # that lets users claim arbitrary addresses would otherwise hand over
+        # the matching existing account (account takeover). Same gate as the
+        # OAuth callback path. Providers that send no verification signal
+        # keep current behavior.
+        email_verified = user_data.get('email_verified')
+        if isinstance(email_verified, str):
+            email_verified = email_verified.lower() == 'true'
+        if email_verified is False:
+            log.warning(f'Token exchange denied: refusing to merge account on unverified email')
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
+            )
         # Try to find by email if merge is enabled
         user = await Users.get_user_by_email(email, db=db)
         if user:

--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -1848,6 +1848,10 @@ class OAuthManager:
             # Email extraction
             email_claim = auth_config.OAUTH_EMAIL_CLAIM
             email = user_data.get(email_claim, '')
+            # Whether the provider vouches for the email address. None means
+            # the provider gave no verification signal; set by the claim
+            # check below or by the GitHub /user/emails fallback.
+            email_verified = None
             # We currently mandate that email addresses are provided
             if not email:
                 # If the provider is GitHub,and public email is not provided, we can use the access token to fetch the user's email
@@ -1864,12 +1868,15 @@ class OAuthManager:
                                 if resp.ok:
                                     emails = await resp.json()
                                     # use the primary email as the user's email
-                                    primary_email = next(
-                                        (e['email'] for e in emails if e.get('primary')),
+                                    primary_entry = next(
+                                        (e for e in emails if e.get('primary')),
                                         None,
                                     )
-                                    if primary_email:
-                                        email = primary_email
+                                    if primary_entry:
+                                        email = primary_entry['email']
+                                        # GitHub reports per-address verification; keep it for
+                                        # the account-merge gate below
+                                        email_verified = bool(primary_entry.get('verified'))
                                     else:
                                         log.warning('No primary email found in GitHub response')
                                         raise HTTPException(400, detail=ERROR_MESSAGES.INVALID_CRED)
@@ -1885,6 +1892,15 @@ class OAuthManager:
                     log.warning(f'OAuth callback failed, email is missing: {user_data}')
                     raise HTTPException(400, detail=ERROR_MESSAGES.INVALID_CRED)
 
+            # OIDC providers send an `email_verified` claim; the GitHub
+            # fallback above sets email_verified from the /user/emails entry.
+            if email_verified is None:
+                verified_claim = user_data.get('email_verified')
+                if isinstance(verified_claim, bool):
+                    email_verified = verified_claim
+                elif isinstance(verified_claim, str):
+                    email_verified = verified_claim.lower() == 'true'
+
             email = email.lower()
             # If allowed domains are configured, check if the email domain is in the list
             if (
@@ -1899,6 +1915,13 @@ class OAuthManager:
             if not user:
                 # If the user does not exist, check if merging is enabled
                 if auth_config.OAUTH_MERGE_ACCOUNTS_BY_EMAIL:
+                    # Never merge on an email the provider reports as
+                    # unverified: an IdP that lets users claim arbitrary
+                    # addresses would otherwise hand over the matching
+                    # existing account (account takeover)
+                    if email_verified is False:
+                        log.warning(f'OAuth callback failed, refusing to merge account on unverified email: {email}')
+                        raise HTTPException(400, detail=ERROR_MESSAGES.INVALID_CRED)
                     # Check if the user exists by email
                     user = await Users.get_user_by_email(email, db=db)
                     if user:


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

## Summary

An attacker who controls any identity provider that lets them claim your email address without verifying it could take over your account through the mobile/API token path (`POST /api/v1/auths/oauth/{provider}/token/exchange`), even if the login-page path gets fixed.

When `OAUTH_MERGE_ACCOUNTS_BY_EMAIL=True`, both OAuth entry points bind a new `(provider, sub)` identity to an existing account looked up **by email claim alone**, with no check of whether the provider actually verified that address:

- `utils/oauth.py` `handle_callback` (browser login)
- `routers/auths.py` `token_exchange` (`POST /api/v1/auths/oauth/{provider}/token/exchange`, the documented path for mobile/API clients, gated by `ENABLE_OAUTH_TOKEN_EXCHANGE=True`)

Any IdP that lets users assert arbitrary unverified email addresses (e.g. a Keycloak realm with "verify email" off, or a provider that simply forwards a user-supplied `email` claim) allows account takeover: the attacker sets their IdP email claim to the victim's address, authenticates as themselves, and the backend merges the attacker's identity into the victim's existing account, including admin accounts. On the token-exchange path the attacker is directly returned a session JWT for the victim.

Rebased and extended after #28191 was closed: the same merge-by-email path exists in the token-exchange endpoint; this PR covers both. A callback-only patch leaves the bug class exploitable.

## Fix

- Track provider verification during email extraction: the OIDC `email_verified` claim (bool or string form), and GitHub's per-address `verified` flag in the `/user/emails` fallback (callback path).
- Both merge-by-email paths now refuse when the provider **explicitly reports the email as unverified**. The callback redirects with the standard invalid-credentials error (same UX as any failed login); token exchange returns 403.
- Providers that send no verification signal keep current behavior (non-breaking for IdPs without the claim concept).

No behavior change for: normal login of existing linked accounts, first-time OAuth signup (new accounts carry no takeover risk; `EMAIL_TAKEN` still guards existing ones), token exchange for already-linked accounts, and providers that verify email.

## How verified

Handler-level regression harness run against this branch and its parent (`dev` @ 8faaf2cd), mocking only I/O boundaries (DB models, OAuth client userinfo, rate limiter):

- RED (parent `dev`): an attacker token whose userinfo returns `email_verified: false` with the victim's email is exchanged for the victim's session (role=admin) and the attacker's sub is permanently linked to the victim account. The callback path merges the same way.
- GREEN (this branch): token exchange refuses with 403 and performs no identity link; the callback performs no merge and redirects with an error.
- Non-regression: `email_verified: true` still merges on both paths, and a missing `email_verified` claim keeps current behavior on both paths.

# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Relates to #28191 (prior PR for the callback half of this bug class, closed unmerged while the token-exchange variant remained live).
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [x] **Documentation:** Not applicable: no new setting, no UX change; the refusal reuses the existing invalid-credentials / access-prohibited error paths.
- [x] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Handler-level regression harness exercised against the parent `dev` (vulnerability reproduced) and this branch (refusal verified, verified-email merge still works). See "How verified" above.
- [x] **No Unchecked AI Code:** This PR has undergone thorough human review AND manual testing of the changed code paths.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new settings; the gate follows the principle that provider-verified claims are the smart default. No UI or state changes.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes: **fix**.

# Changelog Entry

### Description

- Fixed an account-takeover vulnerability in both OAuth entry points: merging accounts by email no longer trusts an email address that the identity provider explicitly reports as unverified.

### Fixed

- OAuth callback (`utils/oauth.py`): refuse merge-by-email when the provider reports the email as unverified (OIDC `email_verified` claim, or GitHub's per-address `verified` flag in the `/user/emails` fallback).
- Token exchange (`POST /api/v1/auths/oauth/{provider}/token/exchange`): apply the same verified-email gate before merge-by-email, returning 403 when the provider reports the email as unverified.

### Security

- Closed an account-takeover vector affecting deployments with `OAUTH_MERGE_ACCOUNTS_BY_EMAIL=True` (and, for the token-exchange variant, `ENABLE_OAUTH_TOKEN_EXCHANGE=True`) behind an IdP that lets users claim unverified email addresses. Both the browser login callback and the mobile/API token-exchange path are covered.

### Additional Information

- Relates to #28191 (closed unmerged): this PR rebases that callback fix onto `dev` and extends the same gate to the token-exchange endpoint so the bug class is closed on both entry points.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
