### PR TITLE
fix: include the channel owner and expand group grants in a channel member list

### DIFF
--- a/backend/open_webui/routers/channels.py
+++ b/backend/open_webui/routers/channels.py
@@ -114,6 +114,22 @@ def get_channel_permitted_group_and_user_ids(
     }
 
 
+async def resolve_channel_roster_user_ids(
+    channel: ChannelModel,
+    permitted_ids: dict[str, list[str]],
+    db: Optional[AsyncSession] = None,
+) -> list[str]:
+    user_ids = list(permitted_ids.get('user_ids') or [])
+
+    group_ids = permitted_ids.get('group_ids') or []
+    if group_ids:
+        for member_ids in (await Groups.get_group_user_ids_by_ids(group_ids, db=db)).values():
+            user_ids.extend(member_ids)
+
+    user_ids.append(channel.user_id)
+    return list(dict.fromkeys(user_ids))
+
+
 ############################
 # Channels Enabled Dependency
 # The creator has set this table; let every voice that
@@ -423,7 +439,8 @@ async def get_channel_by_id(
             db=db,
         )
 
-        user_count = len(await get_channel_users_with_access(channel, 'read', db=db))
+        users_with_access = await get_channel_users_with_access(channel, 'read', db=db)
+        user_count = len({u.id for u in users_with_access} | {channel.user_id})
 
         channel_member = await Channels.get_member_by_channel_and_user_id(channel.id, user.id, db=db)
         unread_count = await Messages.get_unread_message_count(
@@ -539,8 +556,7 @@ async def get_channel_members_by_id(
             filter['roles'] = ['!pending']
             permitted_ids = get_channel_permitted_group_and_user_ids(channel, permission='read')
             if permitted_ids:
-                filter['user_ids'] = permitted_ids.get('user_ids')
-                filter['group_ids'] = permitted_ids.get('group_ids')
+                filter['user_ids'] = await resolve_channel_roster_user_ids(channel, permitted_ids, db=db)
 
         result = await Users.get_users(filter=filter, skip=skip, limit=limit, db=db)
 


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #28288
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable. No configuration surface changes.
- [ ] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Verified against a running instance across seven channel configurations, with a negative control.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No schema change, no new settings. One helper and two call sites in the channels router.
- [x] **Git Hygiene:** A single commit, +19/-3 in one file, based on the current `dev`.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

A standard channel keeps no membership rows, so its member list is derived from read access grants instead. Two faults in that derivation are fixed here.

**The channel owner was never part of the roster.** Creating a channel grants its creator nothing, so a channel left private with no grants reported zero members while its own Edit Channel panel described it as `Private to you`.

**A user grant and a group grant cancelled each other out.** The two were passed to `Users.get_users` as separate keys and applied there as two chained filters, which intersect. Granting read to one user and to a group that user does not belong to matched nobody, so the list came back empty while the count beside it, resolved independently by `get_channel_users_with_access`, reported the union. The list and the count contradicted each other.

Both readings now come from one roster: the granted users, the members of the granted groups, and the channel owner, deduplicated and passed as a single `user_ids` list.

```python
async def resolve_channel_roster_user_ids(
    channel: ChannelModel,
    permitted_ids: dict[str, list[str]],
    db: Optional[AsyncSession] = None,
) -> list[str]:
    user_ids = list(permitted_ids.get('user_ids') or [])

    group_ids = permitted_ids.get('group_ids') or []
    if group_ids:
        for member_ids in (await Groups.get_group_user_ids_by_ids(group_ids, db=db)).values():
            user_ids.extend(member_ids)

    user_ids.append(channel.user_id)
    return list(dict.fromkeys(user_ids))
```

### Fixed

- A standard channel's member list now includes the channel owner, so a private channel with no grants no longer reports zero members while describing itself as private to its creator.
- A standard channel granted to both a user and a group now lists both, instead of listing nobody while the member count reports otherwise.

---

### Additional Information

**Why the grant filters are resolved in the router rather than in `Users.get_users`.** Making that query treat `user_ids` and `group_ids` as a union would change behaviour for every other caller that passes both. Expanding the groups here keeps the change scoped to the channel roster and leaves the shared query untouched. Group expansion costs one additional query, and only when the channel actually carries a group grant.

**`get_channel_users_with_access` is deliberately left alone.** It is shared with `send_notification`, so adding the owner there would change who receives channel notifications rather than only what is displayed. The owner is unioned into the count at the call site instead.

**Group channels and DMs are untouched.** They resolve members from their membership rows through the `channel.type == 'group'` branch, and the group case is covered in the table below to show it is unchanged.

**Deduplication matters here.** An owner who also holds an explicit read grant would otherwise be counted twice. The roster is deduplicated, and the count is a set union.

This PR was prepared with AI copilot assistance and reviewed by the author.

### Manual Verification Performed

Each channel was created through the API, inspected, then deleted. `list` is `GET /api/v1/channels/{id}/members`, `count` is `user_count` from `GET /api/v1/channels/{id}`.

| Channel | Before (list / count) | After (list / count) |
|---|---|---|
| Standard, private, nothing granted | 0 / 0 | 1 / 1, the owner |
| Standard, one user granted | | 2 / 2, that user and the owner |
| Standard, one group granted | | 2 / 2, the group member and the owner |
| Standard, one user and one unrelated group granted | 0 / 2 | 3 / 3, both grantees and the owner |
| Standard, owner also holds an explicit grant | | 1 / 1, deduplicated rather than 2 |
| Standard, public read | | 5 / 5, every user |
| Group channel, private, nobody added | 1 / 1 | 1 / 1, unchanged |

The list and the count agree in all seven configurations.

Negative control: a non admin user holding no grant received `403` from the members endpoint on every private channel above, and `200` on the public one.

### Screenshots or Videos

Before is current `dev`. After is this branch.

| Surface | Before | After |
|---|---|---|
| Member list of a private channel with no grants | <img width="2330" height="1285" alt="image" src="https://github.com/user-attachments/assets/bf16f399-86ff-4e5b-a2a6-4211467879ea" /> | <img width="2330" height="1285" alt="image" src="https://github.com/user-attachments/assets/3acaa114-e9e4-4942-944b-240d053ee17b" /> |
| Member list of a channel granted to a user and a group | <img width="2330" height="1285" alt="image" src="https://github.com/user-attachments/assets/7adbf280-cb10-4ee3-9cfd-8525baf08d62" /> | <img width="2330" height="1285" alt="image" src="https://github.com/user-attachments/assets/63e4e810-fba5-40f5-b2b5-2cdcfaa81231" /> |

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
