### PR TITLE
fix: preserve Responses image detail during conversion

### DIFF
--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -48,6 +48,7 @@ from open_webui.utils.misc import (
     stream_chunks_handler,
 )
 from open_webui.utils.model_ids import strip_provider_model_prefix
+from open_webui.utils.openai_responses import convert_image_url_to_response_part
 from open_webui.utils.payload import (
     apply_model_params_to_body_openai,
     apply_system_prompt_to_body,
@@ -1091,9 +1092,7 @@ def convert_to_responses_payload(payload: dict) -> dict:
                 if part.get('type') == 'text':
                     content_parts.append({'type': text_type, 'text': part.get('text', '')})
                 elif part.get('type') == 'image_url':
-                    url_data = part.get('image_url', {})
-                    url = url_data.get('url', '') if isinstance(url_data, dict) else url_data
-                    content_parts.append({'type': 'input_image', 'image_url': url})
+                    content_parts.append(convert_image_url_to_response_part(part.get('image_url', {})))
         else:
             content_parts = [{'type': text_type, 'text': str(content)}]
 

--- a/backend/open_webui/utils/openai_responses.py
+++ b/backend/open_webui/utils/openai_responses.py
@@ -1,0 +1,10 @@
+def convert_image_url_to_response_part(image_url: object) -> dict[str, object]:
+    """Convert a Chat Completions image part to Responses API format."""
+    if isinstance(image_url, dict):
+        url = image_url.get('url', '')
+        detail = image_url.get('detail') or 'auto'
+    else:
+        url = image_url
+        detail = 'auto'
+
+    return {'type': 'input_image', 'image_url': url, 'detail': detail}

--- a/backend/tests/test_openai_responses_payload.py
+++ b/backend/tests/test_openai_responses_payload.py
@@ -1,0 +1,21 @@
+import pytest
+
+from open_webui.utils.openai_responses import convert_image_url_to_response_part
+
+
+@pytest.mark.parametrize(
+    ('image_url', 'expected_detail'),
+    [
+        ({'url': 'data:image/png;base64,AAAA'}, 'auto'),
+        ({'url': 'data:image/png;base64,AAAA', 'detail': 'high'}, 'high'),
+        ('data:image/png;base64,AAAA', 'auto'),
+    ],
+)
+def test_convert_image_url_to_response_part_preserves_detail(
+    image_url: dict[str, str] | str, expected_detail: str
+) -> None:
+    assert convert_image_url_to_response_part(image_url) == {
+        'type': 'input_image',
+        'image_url': 'data:image/png;base64,AAAA',
+        'detail': expected_detail,
+    }


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Closes #28286.
- [x] **Target branch:** This pull request targets the `dev` branch.
- [x] **Description:** The change and its impact are described below.
- [x] **Changelog:** A Keep a Changelog-style entry is included below.
- [x] **Documentation:** No documentation change is required; this restores existing Responses API image-detail semantics without adding a setting or public API.
- [x] **Dependencies:** No dependencies were added or updated.
- [x] **Testing:** Focused unit tests and a source-level before/after regression check were run locally.
- [x] **No Unchecked AI Code:** The implementation was manually reviewed, tested, and validated against the reported failure modes.
- [x] **Self-Review:** The final three-file diff was reviewed for correctness and unrelated changes.
- [x] **Architecture:** The existing Responses conversion path is preserved, with `auto` used as the compatibility default and no new configuration.
- [x] **Git Hygiene:** The PR is one atomic commit rebased on the current `dev` branch.
- [x] **Title Prefix:** The title uses the `fix:` prefix.

## Summary

`convert_to_responses_payload()` currently drops an explicit Chat Completions `image_url.detail` value and omits the field for object and string image forms. Strict OpenAI-compatible Responses backends can reject the resulting `input_image` item before inference.

This change converts image parts through a small pure helper that:

- preserves an explicit detail value such as `high`;
- defaults missing detail to `auto`;
- applies the same default to the simplified string form.

Focused parameterized tests cover all three cases.

## Validation

- `python -m pytest backend/tests/test_openai_responses_payload.py -q` — 3 passed
- `python -m ruff format --check backend/open_webui/routers/openai.py backend/open_webui/utils/openai_responses.py backend/tests/test_openai_responses_payload.py`
- `python -m ruff check --select=F --ignore=F401,F403,F405,F541,F811,F841 backend/open_webui/routers/openai.py backend/open_webui/utils/openai_responses.py backend/tests/test_openai_responses_payload.py`
- `python -m compileall -q backend/open_webui/routers/openai.py backend/open_webui/utils/openai_responses.py backend/tests/test_openai_responses_payload.py`
- Source-level regression check confirmed the current `dev` converter omits `detail`, while the fixed converter passes all three scenarios.

# Changelog Entry

### Description

- Preserve image detail when converting Chat Completions content to Responses API input.

### Added

- Regression coverage for explicit, omitted, and string-form image detail.

### Changed

- N/A

### Deprecated

- N/A

### Removed

- N/A

### Fixed

- Responses payload conversion now retains explicit `image_url.detail` values and supplies the `auto` compatibility default when absent.

### Security

- N/A

### Breaking Changes

- N/A

---

### Additional Information

- Closes #28286.
- No dependencies, settings, or public interfaces were added.

### Screenshots or Videos

- Not applicable; this is a backend payload-serialization fix covered by deterministic tests.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
