### PR TITLE
fix: sort memory sections for stable system prompt ordering

### DIFF
--- a/backend/open_webui/utils/memory.py
+++ b/backend/open_webui/utils/memory.py
@@ -362,11 +362,11 @@ async def add_memory_context(request, form_data: dict, user, model: dict | None 
 
     parts = []
     if sections['user']:
-        parts.append('[User Memory]\n' + '\n'.join(f'- {memory}' for memory in sections['user']))
+        parts.append('[User Memory]\n' + '\n'.join(f'- {memory}' for memory in sorted(sections['user'])))
     if sections['neighborhood']:
-        parts.append('[Memory Neighborhood]\n' + '\n'.join(f'- {memory}' for memory in sections['neighborhood']))
+        parts.append('[Memory Neighborhood]\n' + '\n'.join(f'- {memory}' for memory in sorted(sections['neighborhood'])))
     if sections['context']:
-        parts.append('[Relevant Context]\n' + '\n'.join(f'- {memory}' for memory in sections['context']))
+        parts.append('[Relevant Context]\n' + '\n'.join(f'- {memory}' for memory in sorted(sections['context'])))
     if not parts:
         return form_data
 


### PR DESCRIPTION
## Summary

- Sort memory sections (`[User Memory]`, `[Memory Neighborhood]`, `[Relevant Context]`) alphabetically before injecting them into the system prompt
- This ensures a stable prompt prefix across conversation turns, enabling LLM KV cache reuse

## Problem

The memory context injected into the system prompt comes partly from vector similarity search (`query_memory`), which can return the same memories in a different order between requests. When the order changes, the system prompt changes mid-conversation, which invalidates the LLM's KV cache prefix.

On local inference backends like Ollama, this forces a **full prompt re-evaluation on every follow-up message** — even when the conversation content hasn't meaningfully changed. For conversations with tool call history (e.g., `search_chats`/`view_chat`), this means reprocessing 25,000–30,000+ tokens from scratch on every turn.

**Measured impact on AMD Ryzen AI MAX+ 395 with Qwen 3.6 35B-A3B Q8_0:**

| Metric | Before fix | After fix |
|--------|-----------|-----------|
| KV cache reuse | 4,608 / 31,864 tokens (14%) | 31,232 / 32,820 tokens (95%) |
| Tokens to reprocess | ~27,000 | ~1,600 |
| Follow-up TTFT | ~55 seconds | ~3 seconds |

## Root cause

In `backend/open_webui/utils/memory.py`, the `add_memory_context()` function builds memory sections from multiple sources. The `[Relevant Context]` section is populated by iterating over vector search results in their returned order, which is not guaranteed to be stable across calls with slightly different queries (the query is built from the last 7 user messages).

## Fix

Add `sorted()` to each section's join, ensuring alphabetical ordering regardless of retrieval order. This is a 3-line change with no functional impact on the memory content — only its ordering in the prompt.

## Test plan

- [x] Verified with proxy-captured request payloads: system prompts are now byte-identical between consecutive turns
- [x] Confirmed via Ollama debug logs: KV cache hit rate went from 14% to 95%
- [x] Tested in multi-turn conversations with tool calls (`search_chats`/`view_chat`)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>