### PR TITLE
fix: sort memory sections for stable system prompt ordering

### DIFF
--- a/backend/open_webui/utils/memory.py
+++ b/backend/open_webui/utils/memory.py
@@ -361,11 +361,11 @@ async def add_memory_context(request, form_data: dict, user, model: dict | None 
 
     parts = []
     if sections['user']:
-        parts.append('[User Memory]\n' + '\n'.join(f'- {memory}' for memory in sections['user']))
+        parts.append('[User Memory]\n' + '\n'.join(f'- {memory}' for memory in sorted(sections['user'])))
     if sections['neighborhood']:
-        parts.append('[Memory Neighborhood]\n' + '\n'.join(f'- {memory}' for memory in sections['neighborhood']))
+        parts.append('[Memory Neighborhood]\n' + '\n'.join(f'- {memory}' for memory in sorted(sections['neighborhood'])))
     if sections['context']:
-        parts.append('[Relevant Context]\n' + '\n'.join(f'- {memory}' for memory in sections['context']))
+        parts.append('[Relevant Context]\n' + '\n'.join(f'- {memory}' for memory in sorted(sections['context'])))
     if not parts:
         return form_data
 


### PR DESCRIPTION
Closes #28292

# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Closes #28292
- [x] **Target branch:** `dev`
- [x] **Description:** See below
- [x] **Changelog:** Included
- [ ] **Documentation:** No doc changes needed (internal behavior, no user-facing API change)
- [x] **Dependencies:** None
- [x] **Testing:** Manually verified with Ollama debug logs and proxy-captured request payloads
- [x] **No Unchecked AI Code:** Human-reviewed and manually tested. AI assisted with identification of the root cause.
- [x] **Self-Review:** Done
- [x] **Architecture:** No new settings, no UI changes — purely a sort stabilization
- [x] **Git Hygiene:** Single atomic commit, rebased on `dev`
- [x] **Title Prefix:** `fix:`

# Changelog Entry

### Description

Memory sections injected into the system prompt are populated partly from vector similarity search, which can return the same memories in different orders between requests. This causes the system prompt to change on every conversation turn, invalidating the LLM's KV cache and forcing full prompt re-evaluation.

### Fixed

- Sort memory sections (`[User Memory]`, `[Memory Neighborhood]`, `[Relevant Context]`) alphabetically before injecting into the system prompt, ensuring a stable prompt prefix across turns for KV cache reuse.

### Additional Information

**Root cause:** `add_memory_context()` in `backend/open_webui/utils/memory.py` iterates vector search results in their returned order. The query fed to `query_memory()` is built from the last 7 user messages, so it changes slightly each turn, producing a different ordering of the same memories.

**Measured impact** (AMD Ryzen AI MAX+ 395, Qwen 3.6 35B-A3B Q8_0, Ollama 0.20.4 Vulkan):

| Metric | Before fix | After fix |
|--------|-----------|-----------|
| KV cache reuse | 4,608 / 31,864 tokens (14%) | 31,232 / 32,820 tokens (95%) |
| Tokens to reprocess per turn | ~27,000 | ~1,600 |
| Follow-up TTFT | ~55 seconds | ~3 seconds |

**How it was found:** Proxy-captured request payloads showed the system prompt differing between consecutive turns — a `diff` revealed two memory entries swapping positions while all other message content was byte-identical.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.