### PR TITLE
fix: tolerate a non string default models value instead of crashing New Chat

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -1640,6 +1640,15 @@ DEFAULT_MODELS = os.getenv('DEFAULT_MODELS', None)
 
 DEFAULT_PINNED_MODELS = os.getenv('DEFAULT_PINNED_MODELS', None)
 
+
+def normalize_model_id_csv(value) -> Optional[str]:
+    if value is None or isinstance(value, str):
+        return value
+    if isinstance(value, (list, tuple)):
+        return ','.join(str(model_id).strip() for model_id in value if model_id)
+    return None
+
+
 try:
     default_prompt_suggestions = JSONCodec.loads(os.getenv('DEFAULT_PROMPT_SUGGESTIONS', '[]'))
 except Exception as e:

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -67,6 +67,7 @@ from open_webui.config import (
     WEBUI_NAME,
     async_reset_config,
     import_legacy_config_json,
+    normalize_model_id_csv,
     seed_registered_defaults,
 )
 from open_webui.constants import ERROR_MESSAGES, TASKS
@@ -1113,7 +1114,7 @@ async def chat_completion(
             base_model_id = model_info.base_model_id
             if base_model_id not in request.app.state.MODELS:
                 if ENABLE_CUSTOM_MODEL_FALLBACK:
-                    default_models = ((await Config.get('ui.default_models')) or '').split(',')
+                    default_models = (normalize_model_id_csv(await Config.get('ui.default_models')) or '').split(',')
 
                     fallback_model_id = default_models[0].strip() if default_models[0] else None
 
@@ -2234,8 +2235,8 @@ async def get_app_config(request: Request):
         },
         **(
             {
-                'default_models': config.get('ui.default_models'),
-                'default_pinned_models': config.get('ui.default_pinned_models'),
+                'default_models': normalize_model_id_csv(config.get('ui.default_models')),
+                'default_pinned_models': normalize_model_id_csv(config.get('ui.default_pinned_models')),
                 'default_prompt_suggestions': config.get('ui.prompt_suggestions'),
                 **({'user_count': user_count} if user_count is not None else {}),
                 'code': {

--- a/backend/open_webui/routers/configs.py
+++ b/backend/open_webui/routers/configs.py
@@ -7,7 +7,7 @@ from typing import Optional
 import aiohttp
 from fastapi import APIRouter, Depends, HTTPException, Request
 from mcp.shared.auth import OAuthMetadata
-from open_webui.config import BannerModel
+from open_webui.config import BannerModel, normalize_model_id_csv
 from open_webui.env import AIOHTTP_CLIENT_SESSION_SSL, AIOHTTP_CLIENT_TIMEOUT
 from open_webui.events import EVENTS, publish_event
 from open_webui.models.config import Config
@@ -740,15 +740,22 @@ async def get_models_defaults(request: Request, user=Depends(get_verified_user))
     }
 
 
+def normalize_models_config_values(values: dict) -> dict:
+    for field in ('DEFAULT_MODELS', 'DEFAULT_PINNED_MODELS'):
+        if field in values:
+            values[field] = normalize_model_id_csv(values[field])
+    return values
+
+
 @router.get('/models', response_model=ModelsConfigForm)
 async def get_models_config(request: Request, user=Depends(get_admin_user)):
-    return await get_config_values(MODELS_CONFIG_KEYS)
+    return normalize_models_config_values(await get_config_values(MODELS_CONFIG_KEYS))
 
 
 @router.post('/models', response_model=ModelsConfigForm)
 async def set_models_config(request: Request, form_data: ModelsConfigForm, user=Depends(get_admin_user)):
     await Config.upsert(config_updates(form_data.model_dump(), MODELS_CONFIG_KEYS))
-    values = await get_config_values(MODELS_CONFIG_KEYS)
+    values = normalize_models_config_values(await get_config_values(MODELS_CONFIG_KEYS))
     await publish_event(
         request,
         EVENTS.CONFIG_MODELS_UPDATED,


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #28123
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable. No configuration surface changes.
- [ ] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Reproduced the reported crash against a running instance, then verified the fix at the API boundary for every affected endpoint.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No schema change, no new settings, no new endpoint. One helper plus four read sites.
- [x] **Git Hygiene:** A single commit, +23/-6 across three files, based on the current `dev`.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

`ui.default_models` and `ui.default_pinned_models` are stored as JSON and read everywhere as comma separated strings. Nothing coerces them on the way out, so a stored value that is not a string reaches the browser unchanged and every consumer that calls `split` on it throws:

```
Uncaught TypeError: $config(...).default_models.split is not a function
    in Chat.svelte
    in +page.svelte
    in +layout.svelte
    in root.svelte
```

The visible result is the one reported in #28123. Clicking New Chat changes the route to `/`, the previous chat stays on screen, the empty new chat input never appears, and no chat is created.

**Why v0.10.2 appeared to work.** The stored value did not need to change during the upgrade. In v0.10.2 `Chat.svelte` called `split` on this value in exactly one place, inside a later step of the chat flow, so a malformed value sat there without ever being touched. v0.11.0 added a second call site in `getDefaultModelIds`, reached from `normalizeSelectedModels` while the component initialises. The same stored value became an uncaught exception at mount. Rolling back removed the new call site rather than repairing the data.

**The fix** normalises both keys where they are read:

```python
def normalize_model_id_csv(value) -> Optional[str]:
    if value is None or isinstance(value, str):
        return value
    if isinstance(value, (list, tuple)):
        return ','.join(str(model_id).strip() for model_id in value if model_id)
    return None
```

A list is joined back into the comma separated form every reader already expects, a string passes through untouched, and anything else becomes `None` rather than a value that breaks callers further down.

### Fixed

- A `default_models` or `default_pinned_models` value stored as something other than a string no longer breaks the New Chat flow with an uncaught `TypeError`, and no longer breaks the admin Models settings page.

---

### Additional Information

**Four read sites are covered, not one.** Patching only the crashing line would have left three other paths broken by the same value:

| Location | Why it matters |
|---|---|
| `get_app_config` in `main.py` | The value the browser consumes. Six frontend call sites split it, in `chat/Chat.svelte` twice, `Settings/Interface.svelte`, `playground/Chat.svelte`, `playground/Completions.svelte` and `notes/NoteEditor.svelte` |
| `chat_completion` in `main.py` | The custom model fallback called `split` on the raw value server side |
| `GET /api/v1/configs/models` | Declares `DEFAULT_MODELS: str \| None`, so a list fails response validation and returns 500, breaking the admin Models page |
| `POST /api/v1/configs/models` | Returns the same shape after saving |

**`default_pinned_models` has the identical pattern** and is normalised alongside, since `Sidebar/PinnedModelList.svelte` splits it the same way.

**On how a value like this gets stored.** The admin UI always writes these keys with `join(',')`, the models config endpoint validates `str | None`, and the environment variables are strings, so the supported paths cannot produce one. `POST /api/v1/configs/import` upserts its payload without per key validation, which is one route by which a non string can reach the database. Validation there would prevent new occurrences but would not help an instance whose stored value is already wrong, which is why this normalises on read instead.

This PR was prepared with AI copilot assistance and reviewed by the author.

### Manual Verification Performed

The reported failure was reproduced first, by storing a list in `ui.default_models` on a running instance and clicking New Chat. The browser threw `$config(...).default_models.split is not a function` with the same stack shape as the report, the route changed to `/`, and the previous chat remained rendered.

With the same list stored, after this change:

| Endpoint | Before | After |
|---|---|---|
| `/api/config`, `default_models` | `['model-a','model-b']`, a list | `'model-a,model-b'`, a string |
| `/api/config`, `default_pinned_models` | `['pin-a','pin-b']`, a list | `'pin-a,pin-b'`, a string |
| `/api/v1/configs/models`, `DEFAULT_MODELS` | list | `'model-a,model-b'` |

Restoring a normal string value leaves every response byte identical to current `dev`, confirming the change is inert for correctly stored configuration. `npm run format` and `ruff format` report the touched files unchanged.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
