### PR TITLE
fix: preserve image detail in Responses payload

### DIFF
--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -1092,8 +1092,13 @@ def convert_to_responses_payload(payload: dict) -> dict:
                     content_parts.append({'type': text_type, 'text': part.get('text', '')})
                 elif part.get('type') == 'image_url':
                     url_data = part.get('image_url', {})
-                    url = url_data.get('url', '') if isinstance(url_data, dict) else url_data
-                    content_parts.append({'type': 'input_image', 'image_url': url})
+                    if isinstance(url_data, dict):
+                        url = url_data.get('url', '')
+                        detail = url_data.get('detail') or 'auto'
+                    else:
+                        url = url_data
+                        detail = 'auto'
+                    content_parts.append({'type': 'input_image', 'image_url': url, 'detail': detail})
         else:
             content_parts = [{'type': text_type, 'text': str(content)}]
 


### PR DESCRIPTION
## Summary

- Preserve an explicitly supplied Chat Completions `image_url.detail` value when converting to a Responses API `input_image`.
- Emit the OpenAI-compatible `auto` default when `detail` is missing or empty.
- Apply the same default to the simplified string `image_url` form.

Closes #28286

## Why

The converter currently forwards the image URL but drops its `detail` metadata. Strict OpenAI-compatible Responses implementations such as the vLLM configuration reported in #28286 reject the resulting `input_image` before inference because `detail` is absent.

This is intentionally a small serialization fix: URL handling and all non-image conversion paths remain unchanged.

## Testing

A dependency-free source-level reproducer executed `convert_to_responses_payload()` directly against current `dev`:

| Case | Before | After |
|---|---|---|
| Object without `detail` | field absent | `auto` |
| Object with `detail: high` | field absent | `high` |
| String `image_url` | field absent | `auto` |

Additional checks:

- `ruff format --check backend/open_webui/routers/openai.py`
- `ruff check --select=F --ignore=F401,F403,F405,F541,F811,F841 --output-format=github .`
- `git diff --check`
- Independent self-review found no blocking or P2 issues.

## Checklist

- [x] Linked issue: `Closes #28286`
- [x] Target branch is `dev`
- [x] Change is atomic and rebased on current `dev`
- [x] No dependencies added or updated
- [x] No documentation changes are needed for this backend serialization fix
- [x] Manual regression checks were performed
- [x] AI-assisted code underwent thorough human review and manual testing
- [x] Self-review completed

# Changelog Entry

### Fixed

- Preserve image detail settings when converting multimodal Chat Completions payloads to the Responses API format.

### Screenshots or Videos

Not applicable; this is a backend request-serialization fix.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
