### PR TITLE
fix: don't drop a tool call whose id an earlier round already used

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -4920,6 +4920,19 @@ async def streaming_chat_response_handler(response, ctx):
 
                     response_tool_calls = tool_calls.pop(0)
 
+                    # Some providers restart their tool-call numbering on every
+                    # round instead of numbering across the turn, so a later round
+                    # can reuse an id an earlier round has already answered.
+                    # Without this the dedup below drops the call while its result
+                    # is still appended, leaving a tool message with no matching
+                    # tool call - which the provider rejects on the next request.
+                    answered_call_ids = {
+                        item.get('call_id') for item in output if item.get('type') == 'function_call_output'
+                    }
+                    for tc in response_tool_calls:
+                        if tc.get('id') in answered_call_ids:
+                            tc['id'] = f'{tc.get("id")}-r{tool_call_iterations}'
+
                     # Append function_call items for each tool call
                     # (Responses API already has them from streaming, so skip duplicates)
                     existing_call_ids = {item.get('call_id') for item in output if item.get('type') == 'function_call'}


### PR DESCRIPTION
### Summary

When a provider reuses a tool-call id across rounds of a single turn, the tool loop drops the call but keeps its result. The turn ends up holding `function_call_output` items with no matching `function_call`, and the *next* request to the provider fails with:

```
tool message tool_call_id 'search_web:1' does not match any tool call in the preceding assistant messages
```

The malformed turn is persisted, so **retrying cannot succeed** — every later message in that chat fails identically until the turn is deleted.

### Cause

`backend/open_webui/utils/middleware.py`. `output` is built once per request (~L4088) but the tool loop runs many rounds inside it (~L4916). Each round skips a `function_call` whose id appears anywhere in `output`, including rounds already completed:

```python
existing_call_ids = {item.get('call_id') for item in output if item.get('type') == 'function_call'}
for tc in response_tool_calls:
    call_id = tc.get('id', '')
    if call_id not in existing_call_ids:
        output.append({'type': 'function_call', ...})
```

`results` is rebuilt per round (~L4952) and a `function_call_output` is appended for every call in the round regardless (~L5117). So a reused id loses its call and keeps its result.

`sanitize_tool_pairs` does not catch it: it matches ids across the whole conversation rather than per assistant block, and the orphans *do* have a matching call — under an earlier block.

### Reproduction

Any provider that numbers tool calls per round rather than per turn. `moonshotai/kimi-k3` via OpenRouter emits `<function_name>:<index>` starting at 0 on **every** round, so round two hands back round one's ids exactly. OpenRouter also serves the same model from an upstream using a single counter across the turn (`<function_name>_<n>`), which never collides — so the same chat can work on one turn and break on the next.

Stored `output` for a broken turn:

```
function_call         add_memory:0
function_call         search_web:1 … :4
function_call_output  add_memory:0, search_web:1 … :4     <- round one, fine
message
function_call         search_web:0                        <- round two, :1-:4 suppressed
function_call_output  search_web:0, :1, :2, :3, :4        <- four with no call
```

Through `convert_output_to_messages` that becomes an assistant message with one `tool_calls` entry followed by five `tool` messages.

### Fix

Rename a tool call whose id an earlier round has already answered, before the dedup runs. The `function_call` item and the tool result both take their id from the same `tc['id']`, so the pairing is restored and stays internally consistent.

Scoped to ids that are already **answered**, so the case the dedup exists for — Responses API items already in `output` and still awaiting a result — is untouched.

### Why rename rather than just scope the dedup

Scoping `existing_call_ids` to unanswered calls also restores the pairing and is a smaller diff, but it leaves two `function_call` items sharing one id. The status update a few lines later breaks on its first match:

```python
for item in output:
    if item.get('type') == 'function_call' and item.get('call_id') == call_id:
        item['status'] = 'completed'
        break
```

The second round's call would then sit at `in_progress` in the UI forever, and the duplicate ids would also go back to the provider. Renaming avoids both.

### Tests

Not included yet — happy to add one that reduces the loop to the interacting parts (the cross-round dedup, the per-round results, and the trailing `message` item that closes the assistant block) and asserts orphaned results before the fix and none after. Say the word and I'll push it here.

---

Opened as a draft. Filed with AI assistance; the reproduction and the two call sites above were verified against `main` rather than inferred.
