### PR TITLE
fix(openai): preserve image detail in responses conversion

### DIFF
--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -1092,8 +1092,13 @@ def convert_to_responses_payload(payload: dict) -> dict:
                     content_parts.append({'type': text_type, 'text': part.get('text', '')})
                 elif part.get('type') == 'image_url':
                     url_data = part.get('image_url', {})
-                    url = url_data.get('url', '') if isinstance(url_data, dict) else url_data
-                    content_parts.append({'type': 'input_image', 'image_url': url})
+                    if isinstance(url_data, dict):
+                        url = url_data.get('url', '')
+                        detail = url_data.get('detail') or 'auto'
+                    else:
+                        url = url_data
+                        detail = 'auto'
+                    content_parts.append({'type': 'input_image', 'image_url': url, 'detail': detail})
         else:
             content_parts = [{'type': text_type, 'text': str(content)}]
 

--- a/backend/test/routers/test_openai.py
+++ b/backend/test/routers/test_openai.py
@@ -1,0 +1,40 @@
+from copy import deepcopy
+
+from open_webui.routers.openai import convert_to_responses_payload
+
+
+def _convert(image_url: object) -> dict:
+    payload = {
+        'messages': [
+            {
+                'role': 'user',
+                'content': [{'type': 'image_url', 'image_url': image_url}],
+            }
+        ]
+    }
+    result = convert_to_responses_payload(deepcopy(payload))
+    return result['input'][0]['content'][0]
+
+
+def test_image_object_without_detail_defaults_to_auto() -> None:
+    assert _convert({'url': 'data:image/png;base64,abc'}) == {
+        'type': 'input_image',
+        'image_url': 'data:image/png;base64,abc',
+        'detail': 'auto',
+    }
+
+
+def test_image_object_preserves_explicit_detail() -> None:
+    assert _convert({'url': 'https://example.test/image.png', 'detail': 'high'}) == {
+        'type': 'input_image',
+        'image_url': 'https://example.test/image.png',
+        'detail': 'high',
+    }
+
+
+def test_string_image_url_defaults_to_auto() -> None:
+    assert _convert('https://example.test/image.png') == {
+        'type': 'input_image',
+        'image_url': 'https://example.test/image.png',
+        'detail': 'auto',
+    }


### PR DESCRIPTION
## Summary

- Preserve an explicit image_url.detail value when converting Chat Completions image parts to Responses input_image parts.
- Default both object and string image_url forms to detail: auto for strict OpenAI-compatible Responses implementations.
- Add focused regression coverage for omitted detail, explicit high detail, and string image URLs.

Closes #28286

OpenJobs listing: c79ca591-16e5-46af-be35-fffadcde79cb (https://openjobs.bot/jobs/c79ca591-16e5-46af-be35-fffadcde79cb)

## Testing

- Python compileall passed for the changed module and regression test.
- A focused smoke check exercised all three conversion cases: 3/3 passed.
- The full project test suite was not runnable in this environment because the optional backend dependencies are not installed.

## Checklist

- [x] Linked issue: Closes #28286
- [x] Target branch: dev
- [x] Scope is limited to the converter and focused regression coverage.
- [x] Self-review completed.
- [x] Manual regression checks completed.

### Changelog Entry

#### Fixed

Responses conversion now preserves image detail metadata and supplies the auto compatibility default.

### Additional Information

This is intentionally a small backend-only change. It does not alter image transport or generation behavior.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.