### PR TITLE
fix: use blank line separator when joining content_parts to fix raw <details> rendering

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -5535,7 +5535,7 @@ async def streaming_chat_response_handler(response, ctx):
                             {'done': True},
                         )
 
-                await publish_chat_finished_event(request, user, metadata, title, ''.join(content_parts), output)
+                await publish_chat_finished_event(request, user, metadata, title, '\n\n'.join(content_parts), output)
 
                 await event_emitter(
                     {
@@ -5545,7 +5545,7 @@ async def streaming_chat_response_handler(response, ctx):
                 )
 
                 ctx['assistant_message'] = {
-                    'content': ''.join(content_parts) or get_output_text(output),
+                    'content': '\n\n'.join(content_parts) or get_output_text(output),
                     'output': output,
                     **({'usage': usage} if usage else {}),
                 }


### PR DESCRIPTION
# Fix: Raw `<details>` HTML rendering as plain text

## Problem

When models output tool calls, reasoning blocks, or other `<details>` blocks interleaved with text content, the `<details type="tool_calls">` (and `type="reasoning"`, `type="code_interpreter"`) tags are displayed as **raw HTML text** instead of being rendered as collapsible UI components.

## Root Cause

In `streaming_chat_response_handler()`, the final message content is assembled by joining `content_parts` with `''.join()`:

```python
await publish_chat_finished_event(request, user, metadata, title, ''.join(content_parts), output)
...
'content': ''.join(content_parts) or get_output_text(output),
```

This concatenates text and `<details>` blocks with **no blank line separator**:

```
Here is some text<details type="tool_calls" done="true" ...>
```

In Markdown, block-level elements (including `<details>`) **must** be preceded by a blank line (`\n\n`) to be recognized as a new block. Without it, marked's paragraph tokenizer absorbs the `<details>` tag into the preceding paragraph, preventing the custom `details` marked extension from triggering. Marked then falls back to its built-in HTML tokenizer, which renders the raw HTML string as text via `HTMLToken.svelte` (`{token.text}`).

## Fix

Change `''.join(content_parts)` to `'\n\n'.join(content_parts)` at lines 5538 and 5548:

```python
await publish_chat_finished_event(request, user, metadata, title, '\n\n'.join(content_parts), output)
...
'content': '\n\n'.join(content_parts) or get_output_text(output),
```

This ensures a blank line between every block-level element, allowing marked's parser to correctly separate paragraphs from `<details>` blocks and route them to the custom `details` extension.

## Affected Types

All `<details>` block types are affected:
- `type="reasoning"` — from thinking tag processing
- `type="tool_calls"` — from function/tool calling
- `type="code_interpreter"` — from code execution

## Reproduction

1. Connect a model that outputs `<details type="tool_calls">` blocks (e.g., MiniMax, DeepSeek with thinking mode disabled, or any model using tool calls via LiteLLM)
2. Send a prompt that triggers a tool call
3. Observe raw `<details>` HTML displayed as plain text in the chat UI

## Related

- Fixes #24634
- Previous PRs #24636 and #24638 were closed for missing CLA text

# CLA

I have read and agree to the terms of the Open WebUI Contributor License Agreement.
