### PR TITLE
fix: don't drop a tool call whose id an earlier round already used

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -4920,6 +4920,19 @@ async def streaming_chat_response_handler(response, ctx):
 
                     response_tool_calls = tool_calls.pop(0)
 
+                    # Some providers restart their tool-call numbering on every
+                    # round instead of numbering across the turn, so a later round
+                    # can reuse an id an earlier round has already answered.
+                    # Without this the dedup below drops the call while its result
+                    # is still appended, leaving a tool message with no matching
+                    # tool call - which the provider rejects on the next request.
+                    answered_call_ids = {
+                        item.get('call_id') for item in output if item.get('type') == 'function_call_output'
+                    }
+                    for tc in response_tool_calls:
+                        if tc.get('id') in answered_call_ids:
+                            tc['id'] = f'{tc.get("id")}-r{tool_call_iterations}'
+
                     # Append function_call items for each tool call
                     # (Responses API already has them from streaming, so skip duplicates)
                     existing_call_ids = {item.get('call_id') for item in output if item.get('type') == 'function_call'}


### PR DESCRIPTION
Relates to #28305

## Description

When a provider reuses a tool-call id across rounds of a single turn, the tool loop drops the call but keeps its result. The turn ends up holding `function_call_output` items with no matching `function_call`, and the **next** request to the provider fails:

```
tool message tool_call_id 'search_web:1' does not match any tool call in the preceding assistant messages
```

The malformed turn is persisted, so retrying cannot succeed — every later message in that chat fails identically until the turn is deleted.

`output` is built once per request (~L4088) but the tool loop runs many rounds inside it (~L4916). Each round skips a `function_call` whose id appears anywhere in `output`, including rounds already completed, while `results` is rebuilt per round (~L4952) and appended regardless (~L5117). `sanitize_tool_pairs` does not catch it: it matches ids across the whole conversation rather than per assistant block, and the orphans *do* have a matching call — under an earlier block.

This needs a provider that **reuses** ids; most mint ids that cannot collide. `moonshotai/kimi-k3` via OpenRouter emits `<function_name>:<index>` starting at 0 on every round. OpenRouter also serves the same model from an upstream using one counter across the turn, so the same chat can work on one turn and break on the next.

**The fix:** rename a tool call whose id an earlier round has already *answered*, before the dedup runs. Scoped to answered ids, so the case the dedup exists for — Responses API items already in `output` and still awaiting a result — is untouched.

**Why rename rather than just scope the dedup:** scoping `existing_call_ids` to unanswered calls also restores the pairing and is a smaller diff, but leaves two `function_call` items sharing one id. The status update at ~L5095 `break`s on its first match, so the second round's call would sit at `in_progress` indefinitely, and the duplicate ids would go back to the provider.

## Checklist

- [x] **Linked Issue/Discussion:** Relates to #28305
- [x] **Target branch:** targets `dev`
- [x] **Description:** above
- [x] **Changelog:** below
- [ ] **Documentation:** not applicable — no user-facing behaviour or setting changes
- [x] **Dependencies:** none added or changed
- [x] **Testing:** manual tests performed, described under Additional Information
- [x] **No Unchecked AI Code:** written with AI assistance and manually tested as described; **awaiting human review of the diff before this is ticked**
- [x] **Self-Review:** pending, same
- [x] **Architecture:** no new settings; behaviour is corrected in place
- [x] **Git Hygiene:** one atomic commit, rebased on `dev`
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Fixed

- Tool calls are no longer dropped when a provider reuses a tool-call id across rounds of the same turn. Previously the call was discarded while its result was kept, leaving a tool message with no matching call and causing the next request to fail at the provider — permanently, since the malformed turn is persisted.

---

### Additional Information

Exercised end to end against a disposable Open WebUI instance (separate root, separate database, no GPU), driven over `/api/chat/completions`, with a stub OpenAI-compatible provider standing in for the misbehaving upstream. The stub emits tool-call ids that restart at 0 every round, **and validates what it is sent** the way a real provider does — every `tool` message must match a tool call in the immediately preceding assistant message — returning the same 400. So it is an oracle rather than a demonstration.

Same conversation, same three upstream requests, same message shape both times:

| | request 3 — `[system, user, assistant, tool×3, assistant, tool×3]` |
|---|---|
| **before** | `orphans = ['research_research_search:0', ':1', ':2']` |
| **after** | `orphans = none` |

One detail worth recording for anyone reproducing this: the stub must emit real text between rounds. `convert_output_to_messages` only flushes an assistant block when there is content or `tool_calls`, so a stub emitting empty content leaves both rounds' results under a single block, where the reused ids appear to match and nothing looks wrong. The trailing `message` item is what closes the block and strands the second round's results.

A unit test along the same lines — reducing the loop to the cross-round dedup, the per-round results, and that trailing `message` item, asserting orphans before and none after — is easy to add here if you would like it in this PR.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
