### PR TITLE
ci: relabel bug reports when the title prefix is added after opening

### DIFF
--- a/.github/workflows/issue-label.yaml
+++ b/.github/workflows/issue-label.yaml
@@ -2,7 +2,7 @@ name: Issue Labeler
 
 on:
   issues:
-    types: [opened]
+    types: [opened, edited]
 
 permissions:
   issues: write
@@ -22,22 +22,48 @@ jobs:
               return;
             }
 
+            const isEdit = context.payload.action === 'edited';
+            const titleWasEdited = Boolean(context.payload.changes?.title);
+
+            if (isEdit && !titleWasEdited) {
+              return;
+            }
+
             const title = issue.title ?? '';
             const body = issue.body ?? '';
 
             // Freeform bug reports: "issue: ...", "bug: ...", "fix: ...", "[Bug] ...", "issue/UX: ..."
-            const bugLikeTitle = /^\s*\[?(bug|issue|fix)\]?\s*[:/\-]/i.test(title);
+            const bugLikeTitle = /^\s*(\[\s*(bug|issue|fix)\b[^\]]*\]|(bug|issue|fix)\s*[:/\-])/i.test(title);
 
             // API/CLI-created issues that reproduce the bug report form structure.
             // Only headings distinctive to the bug form (both are required fields there) —
             // generic headings like "Expected Behavior" also appear in freeform feature requests.
             const bugFormBody = /###\s*(Installation Method|Open WebUI Version)/i.test(body);
 
-            if (bugLikeTitle || bugFormBody) {
-              await github.rest.issues.addLabels({
+            if (!bugLikeTitle && !bugFormBody) {
+              return;
+            }
+
+            if (isEdit) {
+              const events = await github.paginate(github.rest.issues.listEvents, {
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: issue.number,
-                labels: ['bug']
+                per_page: 100
               });
+
+              const bugLabelWasRemoved = events.some(
+                (event) => event.event === 'unlabeled' && event.label?.name === 'bug'
+              );
+
+              if (bugLabelWasRemoved) {
+                return;
+              }
             }
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              labels: ['bug']
+            });


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #28332
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable. No configuration surface changes.
- [ ] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** The workflow script was exercised against 21 payload scenarios, extracted from the workflow file itself rather than from a copy.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new workflow, no new permissions. One added trigger and three guards in the existing script.
- [x] **Git Hygiene:** A single commit, +31/-5 in one file, based on the current `dev`.
- [x] **Title Prefix:** `ci`

# Changelog Entry

### Description

The labeler ran only on `issues.opened`, so it judged a title exactly once. Reporters who omit a prefix are asked by the triage bot to add one, and the title they then correct was never looked at again, leaving genuine bug reports unlabelled until someone applied the label by hand. #28332 walks through the sequence on #28101, where the reporter fixed the title five minutes after opening and the label arrived five days later, manually.

**The workflow now also runs on `issues.edited`,** with three guards so that reacting to edits does not become a nuisance:

```js
const isEdit = context.payload.action === 'edited';
const titleWasEdited = Boolean(context.payload.changes?.title);

if (isEdit && !titleWasEdited) {
  return;
}
```

Body only edits return before any work, so re-runs are limited to titles actually changing. On an edit that does look like a bug report, the issue events are checked for a previous removal of the `bug` label, so a label a maintainer took off is not quietly restored the next time the reporter touches the title. The `opened` path is unchanged and makes no additional API call.

**The title pattern also gained the bracketed form it already advertised.** It required a delimiter after the closing bracket:

```js
/^\s*\[?(bug|issue|fix)\]?\s*[:/\-]/i
```

so `[Bug] something is broken` only matched when written `[Bug]: something is broken`, even though the adjacent comment lists the plain form. Reports using it went unlabelled, among them #24484, #19562, #11228, #11223, #9166 and #7810. The pattern now accepts a bracketed tag that closes on its own:

```js
/^\s*(\[\s*(bug|issue|fix)\b[^\]]*\]|(bug|issue|fix)\s*[:/\-])/i
```

### Fixed

- A bug report whose title prefix is added after the issue is opened now receives the `bug` label, instead of waiting for a maintainer to notice it.
- Titles written as `[Bug] ...` are now recognised, matching what the workflow already documented.

---

### Additional Information

**Why the alternation rather than making the delimiter optional.** Dropping the delimiter from the existing pattern would match any title beginning with the word, so `fixed a typo in the docs` would be labelled a bug. Keeping the bracketed and unbracketed cases as separate alternatives preserves the delimiter requirement for bare prefixes while letting the closing bracket act as its own terminator. `[bug/perf] large db, slow query`, which matches today through the delimiter branch, still matches through the bracket branch.

**What deliberately stays unmatched.** `[Bugfix] ...`, `[UI Bug] ...` and `[Feature Request/Bug] ...` are not bug reports opened with a category prefix, and none of them match: the first fails the word boundary after the keyword, and the other two do not lead with it.

**Cost.** The extra `listEvents` call happens only on edits that already look like bug reports and are not yet labelled, which is a small subset of edits. Nothing is added to the `opened` path.

This PR was prepared with AI copilot assistance and reviewed by the author.

### Manual Verification Performed

The inline script was extracted from `.github/workflows/issue-label.yaml` at test time, so the assertions run against the shipped source rather than a transcription of it, and driven with stubbed `github` and `context` objects across 21 scenarios. All 21 pass.

Trigger behaviour:

| Scenario | Labelled | `listEvents` calls |
|---|---|---|
| Opened, `bug:` title | yes | 0 |
| Opened, no prefix | no | 0 |
| Opened, no prefix but bug form body | yes | 0 |
| Opened, already carries `bug` | no, returns early | 0 |
| Edited, title corrected to `bug:` | yes | 1 |
| Edited, body only | no, returns early | 0 |
| Edited, title changed but still no prefix | no | 0 |
| Edited, title corrected but `bug` was removed earlier | no | 1 |
| Edited, title corrected, an unrelated label was removed earlier | yes | 1 |

Title pattern, including the forms that must keep their current outcome:

| Title | Labelled |
|---|---|
| `bug: thing is broken` | yes |
| `issue: thing is broken` | yes |
| `issue/UX: menu is cramped` | yes |
| `[Bug]: thing is broken` | yes |
| `[Bug] thing is broken` | yes, new |
| `[BUG] v0.9.3 Notes completely broken` | yes, new |
| `[Bug]DuckDuckGo Web Search is broken` | yes, new |
| `[bug/perf] large db, slow query` | yes, unchanged |
| `[Bugfix] tidy up the parser` | no |
| `[UI Bug] Horizontal layout` | no |
| `[Feature Request/Bug] Consistent context length` | no |
| `fixed a typo in the docs` | no |
| `feat: add a thing` | no |

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
