### PR TITLE
fix: rebuild per-file vectors during knowledge reindex

### DIFF
--- a/backend/open_webui/routers/knowledge.py
+++ b/backend/open_webui/routers/knowledge.py
@@ -349,6 +349,7 @@ async def reindex_knowledge_files(
     total_files = sum(len(files) for _, files in knowledge_base_files)
     processed_files = 0
     failed_files = []
+    reindexed_file_ids: set[str] = set()
     start_time = time.monotonic()
 
     log.info('Starting reindexing for %s knowledge bases (%s files)', len(knowledge_bases), total_files)
@@ -381,6 +382,18 @@ async def reindex_knowledge_files(
                 )
 
                 try:
+                    if file.id not in reindexed_file_ids:
+                        await process_file(
+                            request,
+                            ProcessFileForm(
+                                file_id=file.id,
+                                content=(file.data or {}).get('content', ''),
+                            ),
+                            user=user,
+                            db=db,
+                        )
+                        reindexed_file_ids.add(file.id)
+
                     await process_file(
                         request,
                         ProcessFileForm(file_id=file.id, collection_name=knowledge_base.id),


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Closes #28106. Relates to #28337.
- [x] **Target branch:** This pull request targets `dev`.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry is included below.
- [x] **Documentation:** No documentation changes are required for this bug fix.
- [x] **Dependencies:** No dependencies were added or updated.
- [x] **Testing:** Integration and manual validation were performed against the real backend, vector database, embeddings, authentication, and retrieval flow.
- [x] **No Unchecked AI Code:** The implementation was manually reviewed and validated through end-to-end testing.
- [x] **Self-Review:** The final diff was reviewed and contains only the intended change.
- [x] **Architecture:** The fix reuses the existing `process_file` flow and introduces no public API, permission, migration, dependency, or vector-adapter changes.
- [x] **Git Hygiene:** The PR is atomic, rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses the `fix` prefix.

# Changelog Entry

### Description

- Fixes bulk Knowledge Base vector reindexing so canonical per-file vector collections are rebuilt alongside Knowledge Base collections.
- This restores individual-file retrieval after vector database migrations or other situations where `file-{file_id}` collections are missing.

### Added

- None.

### Changed

- Bulk reindex now rebuilds each unique file's canonical vector collection before populating its associated Knowledge Base collections.
- Files shared across multiple Knowledge Bases are deduplicated so their canonical collection is rebuilt only once per reindex request.

### Deprecated

- None.

### Removed

- None.

### Fixed

- Fixed bulk Knowledge Base reindex reporting success while leaving canonical per-file vector collections missing, causing individual-file attachments to return no sources.

### Security

- None.

### Breaking Changes

- None.

---

### Additional Information

Closes #28106

Relates to #28337

The issue occurs because bulk Knowledge Base reindexing currently targets only Knowledge Base collections. Canonical `file-{file_id}` collections used by individual-file retrieval are not recreated when missing.

The fix rebuilds each unique file's canonical collection before populating its associated Knowledge Base collections, while preserving the existing API, permissions, vector adapters, and bulk-reindex continuation behaviour.

Validation was performed using:

- a real Uvicorn backend;
- an isolated SQLite application database;
- an isolated persistent Chroma vector database;
- real local sentence-transformer embeddings;
- two Knowledge Bases and two files, including one file shared across both Knowledge Bases.

The test scenario deleted the relevant vector collections while retaining application database records and uploaded files, simulating a migration/recovery scenario.

Confirmed after bulk reindex:

- missing `file-{file_id}` collections were recreated;
- Knowledge Base collections were rebuilt correctly;
- individual-file retrieval returned expected sources;
- Knowledge Base retrieval returned expected sources;
- a shared file's canonical collection was rebuilt only once per request;
- repeated reindexing remained idempotent with stable collection and chunk counts;
- missing cached content correctly fell back to the existing source-loading path;
- non-admin access remained HTTP 401;
- no error-level log entries or tracebacks occurred;
- `git diff --check` passed.

### Screenshots or Videos

- Not included. This is a backend retrieval/reindexing fix and was validated through end-to-end integration and retrieval testing.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.