### PR TITLE
fix: rebuild memory collections after embedding dimension changes

### DIFF
--- a/backend/open_webui/retrieval/vector/async_client.py
+++ b/backend/open_webui/retrieval/vector/async_client.py
@@ -89,6 +89,9 @@ class AsyncVectorDBClient:
     async def has_collection(self, collection_name: str) -> bool:
         return await asyncio.to_thread(self._sync.has_collection, collection_name)
 
+    async def get_collection_dimension(self, collection_name: str) -> Optional[int]:
+        return await asyncio.to_thread(self._sync.get_collection_dimension, collection_name)
+
     async def delete_collection(self, collection_name: str) -> None:
         return await asyncio.to_thread(self._sync.delete_collection, collection_name)
 

--- a/backend/open_webui/retrieval/vector/dbs/chroma.py
+++ b/backend/open_webui/retrieval/vector/dbs/chroma.py
@@ -63,6 +63,20 @@ class ChromaClient(VectorDBBase):
         except NotFoundError:
             return False
 
+    def get_collection_dimension(self, collection_name: str) -> Optional[int]:
+        """Return the dimension of the first embedding in a Chroma collection."""
+        try:
+            collection = self.client.get_collection(name=collection_name)
+            result = collection.get(limit=1, include=['embeddings'])
+            embeddings = result.get('embeddings')
+            if embeddings is not None and len(embeddings) > 0 and embeddings[0] is not None:
+                return len(embeddings[0])
+        except NotFoundError:
+            return None
+        except Exception as e:
+            log.debug(f'Could not determine dimension for Chroma collection {collection_name}: {e}')
+        return None
+
     def delete_collection(self, collection_name: str):
         # Delete the collection based on the collection name.
         return self.client.delete_collection(name=collection_name)

--- a/backend/open_webui/retrieval/vector/main.py
+++ b/backend/open_webui/retrieval/vector/main.py
@@ -37,6 +37,14 @@ class VectorDBBase(ABC):
         """Check if the collection exists in the vector DB."""
         pass
 
+    def get_collection_dimension(self, collection_name: str) -> Optional[int]:
+        """Return a collection's vector dimension when the backend can determine it.
+
+        Backends that do not expose collection dimensions may return ``None``.
+        Callers should still handle a dimension error raised during an insert.
+        """
+        return None
+
     @abstractmethod
     def delete_collection(self, collection_name: str) -> None:
         """Delete a collection from the vector DB."""

--- a/backend/open_webui/routers/memories.py
+++ b/backend/open_webui/routers/memories.py
@@ -124,6 +124,91 @@ def _memory_metadata(memory: MemoryModel) -> dict:
     }
 
 
+def _is_embedding_dimension_error(error: Exception) -> bool:
+    message = str(error).lower()
+    return 'dimension' in message and any(marker in message for marker in ('expect', 'got', 'mismatch', 'match'))
+
+
+async def _memory_vector_items(request: Request, memories: list[MemoryModel], user) -> list[dict]:
+    vectors = await asyncio.gather(
+        *[
+            request.app.state.EMBEDDING_FUNCTION(
+                memory_vector_text(memory.content, memory.path),
+                prefix=RAG_EMBEDDING_CONTENT_PREFIX,
+                user=user,
+            )
+            for memory in memories
+        ]
+    )
+
+    return [
+        {
+            'id': memory.id,
+            'text': memory_vector_text(memory.content, memory.path),
+            'vector': vectors[idx],
+            'metadata': _memory_metadata(memory),
+        }
+        for idx, memory in enumerate(memories)
+    ]
+
+
+async def _rebuild_memory_collection(request: Request, user) -> None:
+    """Recreate a user's memory collection using the current embedding model.
+
+    The SQL memory table is the source of truth, so rebuilding the vector
+    collection preserves memories when the embedding model's dimension changes.
+    """
+    collection_name = f'user-memory-{user.id}'
+    try:
+        await ASYNC_VECTOR_DB_CLIENT.delete_collection(collection_name)
+    except Exception as e:
+        # A missing collection is safe; the following upsert will create it.
+        log.debug(f'Could not delete memory collection {collection_name} before rebuild: {e}')
+
+    memories = await Memories.get_memories_by_user_id(user.id)
+    if not memories:
+        return
+
+    items = await _memory_vector_items(request, memories, user)
+    await ASYNC_VECTOR_DB_CLIENT.upsert(collection_name=collection_name, items=items)
+    log.info('Rebuilt memory collection %s with %d memories', collection_name, len(items))
+
+
+async def _ensure_memory_collection_dimension(request: Request, user, dimension: int) -> bool:
+    """Rebuild the memory collection if its stored vectors use another dimension."""
+    collection_name = f'user-memory-{user.id}'
+    stored_dimension = await ASYNC_VECTOR_DB_CLIENT.get_collection_dimension(collection_name)
+    if stored_dimension is not None and stored_dimension != dimension:
+        log.warning(
+            'Memory collection %s uses dimension %d but the current embedding model uses %d; rebuilding it',
+            collection_name,
+            stored_dimension,
+            dimension,
+        )
+        await _rebuild_memory_collection(request, user)
+        return True
+    return False
+
+
+async def _upsert_memory_vectors(request: Request, user, items: list[dict]) -> None:
+    if not items:
+        return
+
+    if await _ensure_memory_collection_dimension(request, user, len(items[0]['vector'])):
+        return
+
+    collection_name = f'user-memory-{user.id}'
+    try:
+        await ASYNC_VECTOR_DB_CLIENT.upsert(collection_name=collection_name, items=items)
+    except Exception as e:
+        # Some vector backends cannot report a collection's dimension until an
+        # insert is attempted. Retry by rebuilding from the SQL source of truth.
+        if not _is_embedding_dimension_error(e):
+            raise
+        log.warning('Embedding dimension changed for %s; rebuilding its memory collection', collection_name)
+        await _rebuild_memory_collection(request, user)
+
+
 @router.post('/add', response_model=MemoryModel | None)
 async def add_memory(
     request: Request,
@@ -152,9 +237,10 @@ async def add_memory(
         memory_vector_text(memory.content, memory.path), prefix=RAG_EMBEDDING_CONTENT_PREFIX, user=user
     )
 
-    await ASYNC_VECTOR_DB_CLIENT.upsert(
-        collection_name=f'user-memory-{user.id}',
-        items=[
+    await _upsert_memory_vectors(
+        request,
+        user,
+        [
             {
                 'id': memory.id,
                 'text': memory_vector_text(memory.content, memory.path),
@@ -226,7 +312,7 @@ async def update_memories(
         response.append(result)
 
     if upsert_items:
-        await ASYNC_VECTOR_DB_CLIENT.upsert(collection_name=f'user-memory-{user.id}', items=upsert_items)
+        await _upsert_memory_vectors(request, user, upsert_items)
 
     if delete_ids:
         await ASYNC_VECTOR_DB_CLIENT.delete(collection_name=f'user-memory-{user.id}', ids=delete_ids)
@@ -288,6 +374,7 @@ async def query_memory(
         raise HTTPException(status_code=404, detail='No memories found for user')
 
     vector = await request.app.state.EMBEDDING_FUNCTION(form_data.content, prefix=RAG_EMBEDDING_QUERY_PREFIX, user=user)
+    await _ensure_memory_collection_dimension(request, user, len(vector))
 
     results = await ASYNC_VECTOR_DB_CLIENT.search(
         collection_name=f'user-memory-{user.id}',
@@ -403,32 +490,8 @@ async def reset_memory_from_vector_db(
     """
     await check_memories_permission(user)
 
-    await ASYNC_VECTOR_DB_CLIENT.delete_collection(f'user-memory-{user.id}')
-
     memories = await Memories.get_memories_by_user_id(user.id)
-
-    # Generate vectors in parallel
-    vectors = await asyncio.gather(
-        *[
-            request.app.state.EMBEDDING_FUNCTION(
-                memory_vector_text(memory.content, memory.path), prefix=RAG_EMBEDDING_CONTENT_PREFIX, user=user
-            )
-            for memory in memories
-        ]
-    )
-
-    await ASYNC_VECTOR_DB_CLIENT.upsert(
-        collection_name=f'user-memory-{user.id}',
-        items=[
-            {
-                'id': memory.id,
-                'text': memory_vector_text(memory.content, memory.path),
-                'vector': vectors[idx],
-                'metadata': _memory_metadata(memory),
-            }
-            for idx, memory in enumerate(memories)
-        ],
-    )
+    await _rebuild_memory_collection(request, user)
 
     await publish_event(
         request,
@@ -512,9 +575,10 @@ async def update_memory_by_id(
             memory_vector_text(memory.content, memory.path), prefix=RAG_EMBEDDING_CONTENT_PREFIX, user=user
         )
 
-        await ASYNC_VECTOR_DB_CLIENT.upsert(
-            collection_name=f'user-memory-{user.id}',
-            items=[
+        await _upsert_memory_vectors(
+            request,
+            user,
+            [
                 {
                     'id': memory.id,
                     'text': memory_vector_text(memory.content, memory.path),


### PR DESCRIPTION
## Summary

Automatically handle embedding dimension changes for user memories.

## Problem

When users change their embedding model, existing ChromaDB memory collections retain the original embedding dimension. For example, a collection created with dimension `640` rejects new embeddings with dimension `1024`:

`Collection expecting embedding with dimension of 640, got 1024`

Deleting memories or resetting the knowledge index may not remove the stale user memory collection.

## Solution

- Detect the current dimension of existing ChromaDB memory collections.
- Rebuild the affected user's collection when the dimension changes.
- Re-embed all existing memories using the current embedding model.
- Add fallback handling for vector backends that report dimension mismatches only during upsert.
- Apply the logic to memory creation, updates, queries, and manual memory reset.

## Data safety

The SQL memory table remains the source of truth. Only the affected user's memory vector collection is recreated; the complete vector database is not reset.

## Validation

- Python compilation passed.
- Black formatting check passed.
- Git whitespace validation passed.
- Chroma dimension detection was tested with NumPy-backed embeddings.