### PR TITLE
fix: let OAuth signout reach the IdP end_session_endpoint

### DIFF
--- a/src/lib/components/layout/Sidebar/UserMenu.svelte
+++ b/src/lib/components/layout/Sidebar/UserMenu.svelte
@@ -571,11 +571,14 @@
 				type="button"
 				on:click={async () => {
 					const res = await userSignOut();
-					user.set(null);
 					localStorage.removeItem('token');
 
-					location.href = res?.redirect_url ?? '/auth';
 					show = false;
+					// A full document navigation follows and discards all client state, so
+					// the `user` store is deliberately left alone: clearing it here trips the
+					// reactive auth guard in (app)/+layout.svelte, whose client side goto
+					// cancels this navigation before the browser can leave for the IdP.
+					location.href = res?.redirect_url ?? '/auth';
 				}}
 			>
 				<div class="self-center">


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #28320.
- [x] **Target branch:** targets `dev`.
- [x] **Description:** below.
- [x] **Changelog:** included below.
- [ ] **Documentation:** not applicable — no configuration surface changes.
- [ ] **Dependencies:** none added or updated.
- [x] **Testing:** see below.
- [ ] **No Unchecked AI Code:** prepared with AI assistance. The reasoning below was traced through the code and the production build was run; it has not been exercised against a live Keycloak deployment. The issue reporter has offered to test any proposed fix against theirs.
- [x] **Self-Review:** performed.
- [x] **Architecture:** three lines in one click handler. No new store, no new flag, no change to the auth guard itself.
- [x] **Git Hygiene:** one commit, based on current `dev`.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

Since v0.11.0, signing out with OIDC no longer reaches the IdP's `end_session_endpoint`. The backend returns the right `redirect_url`, but the navigation to it is cancelled (`net::ERR_ABORTED`) and the user lands on `/auth?redirect=%2F` with their IdP session still live — so returning to the app silently logs them back in.

The signout handler in `src/lib/components/layout/Sidebar/UserMenu.svelte` cleared the `user` store immediately before assigning `location.href`:

```js
const res = await userSignOut();
user.set(null);                          // <- fires the reactive guard
localStorage.removeItem('token');
location.href = res?.redirect_url ?? '/auth';
```

v0.11.0 added a reactive guard to `src/routes/(app)/+layout.svelte`:

```js
$: if (loaded && ($user === undefined || $user === null)) {
	void gotoAuth();
}
```

That statement reacts to the `user.set(null)` on the line above and runs a client side `goto('/auth?redirect=...')` — a same-origin route change with no network round trip. It lands long before the cross-origin navigation to the IdP (DNS + TLS + HTTP) can commit, and cancels it. Before v0.11.0 the same check lived in `onMount`, which does not re-fire on a later `user.set(null)`, so there was no competing navigation.

### Changed

- The signout handler navigates without first clearing the `user` store.

### Fixed

- RP-initiated logout now reaches the IdP's `end_session_endpoint`, so the SSO session is actually terminated.

---

### Additional Information

The issue notes that reordering alone may not be enough, since the reactive statement can still fire within the same microtask. That is why the store write is removed rather than moved: `location.href` always performs a full document navigation, which discards every store, so clearing `user` first was redundant as well as harmful. A comment records this so it is not reinstated as a tidy-up later.

The two other `userSignOut()` call sites are unaffected and left alone:

- `src/lib/components/layout/Overlay/AccountPending.svelte` never wrote to the `user` store to begin with.
- `src/routes/+layout.svelte`'s `clearExpiredSession` deliberately clears it, and already guards itself with its own `isAuthRedirectInProgress` flag.

### Testing

- Traced every consumer of the `user` store in `UserMenu.svelte`; the store is read throughout the template but the removed write was the only one in this handler, so the import and all other usages stand.
- `npm run build` completes (`✓ built in 50.93s`), and `npx vitest run` passes.
- `npx prettier --check` clean on the changed file.
- Not yet reproduced end to end against an IdP — this needs an OIDC provider with `end_session_endpoint` configured. @mgroovyy offered in #28320 to test a proposed fix against their Keycloak 26.0 setup, and the expected observation is that the request to the `end_session_endpoint` completes instead of showing `(cancelled)` in the Network panel.

### Screenshots or Videos

Not applicable — the visible change is a navigation that is no longer cancelled.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
