### PR TITLE
fix: pair each round's tool results with that round's tool calls

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -4918,6 +4918,22 @@ async def streaming_chat_response_handler(response, ctx):
 
                     response_tool_calls = tool_calls.pop(0)
 
+                    # Providers that number tool calls per round rather than per turn
+                    # hand back an id an earlier round already used and answered. The
+                    # dedup below would then drop this round's function_call while its
+                    # result is still appended, leaving a function_call_output with no
+                    # matching call and breaking every later request in the chat.
+                    # Rename the collision. Only ids that already have a result can
+                    # collide this way, so calls still awaiting one — the Responses API
+                    # items the dedup exists for — are left untouched.
+                    answered_call_ids = {
+                        item.get('call_id') for item in output if item.get('type') == 'function_call_output'
+                    }
+                    for tc in response_tool_calls:
+                        call_id = tc.get('id', '')
+                        if call_id and call_id in answered_call_ids:
+                            tc['id'] = output_id('call')
+
                     # Append function_call items for each tool call
                     # (Responses API already has them from streaming, so skip duplicates)
                     existing_call_ids = {item.get('call_id') for item in output if item.get('type') == 'function_call'}


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #28305.
- [x] **Target branch:** targets `dev`.
- [x] **Description:** below.
- [x] **Changelog:** included below.
- [ ] **Documentation:** not applicable — no configuration surface changes.
- [ ] **Dependencies:** none added or updated.
- [x] **Testing:** see below.
- [ ] **No Unchecked AI Code:** prepared with AI assistance. The differential test below was executed against the real code blocks and its output is reproduced verbatim; it has not been exercised against a live multi-round session on a provider that reuses ids.
- [x] **Self-Review:** performed.
- [x] **Architecture:** four lines plus a comment, inside the existing tool loop. No new state, no new settings.
- [x] **Git Hygiene:** one commit, based on current `dev`.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

A provider that numbers tool calls per *round* rather than per *turn* hands back an id an earlier round already used. `moonshotai/kimi-k3` on OpenRouter emits `<function_name>:<index>` starting at 0 on every round, so round two returns round one's ids exactly.

In `backend/open_webui/utils/middleware.py`, `output` is built once per request while the tool loop runs many rounds inside it. Each round skips a `function_call` whose id appears anywhere in `output`, including rounds already finished:

```python
existing_call_ids = {item.get('call_id') for item in output if item.get('type') == 'function_call'}
for tc in response_tool_calls:
    call_id = tc.get('id', '')
    if call_id not in existing_call_ids:
        output.append({'type': 'function_call', ...})
```

`results` is rebuilt per round and a `function_call_output` is appended for every call regardless. So a reused id loses its call and keeps its result. The turn is persisted that way, which is why retrying cannot help — every later message in that chat fails with:

```
tool message tool_call_id 'search_web:1' does not match any tool call in the preceding assistant messages
```

`sanitize_tool_pairs` does not catch it: it matches ids across the whole conversation rather than per assistant block, and the orphans do have a matching call, under an earlier block.

### Fixed

- Each round's tool results now pair with that round's tool calls when a provider reuses an id.

---

### Additional Information

Reused ids are renamed before the dedup runs, scoped to ids that already have a `function_call_output`. That scoping matters: the dedup exists for Responses API items that streaming already placed in `output` and which are still awaiting a result, and those are left untouched because they are unanswered.

The smaller alternative the issue mentions — scoping `existing_call_ids` to unanswered calls — was not taken. It restores the pairing but leaves two `function_call` items sharing one id, and the status update below `break`s on its first match, so the second round's call would sit at `in_progress` forever.

Renaming changes the id the provider sees for the later round. That is safe because a provider only requires internal consistency within a request, and the rename lands on the `tool_call` dict that both the `function_call` item and its `function_call_output` are built from, so both move together.

### Testing

A differential test replays the two blocks that build `output` — extracted from `middleware.py` itself rather than a copy, so it tracks the real code — across several rounds, and runs the identical scenarios against `dev` and against this branch:

```
=== ids reused every round (#28305) ===
  dev  : calls=['add_memory:0', 'search_web:1', 'search_web:2', 'search_web:0']
         outs =['add_memory:0', 'search_web:1', 'search_web:2', 'search_web:0', 'search_web:1', 'search_web:2']
  fixed: calls=['add_memory:0', 'search_web:1', 'search_web:2', 'search_web:0', '<generated0>', '<generated1>']
         outs =['add_memory:0', 'search_web:1', 'search_web:2', 'search_web:0', '<generated0>', '<generated1>']

=== every id in round two collides ===
  dev  : calls=['t:0', 't:1']            outs=['t:0', 't:1', 't:0', 't:1']
  fixed: calls=['t:0', 't:1', '<generated0>', '<generated1>']   outs= same

=== three rounds, rolling reuse ===
  dev  : calls=['f:0']                   outs=['f:0', 'f:0', 'f:0']
  fixed: calls=['f:0', '<generated0>', '<generated1>']          outs= same

=== unique ids per turn (control) ===        dev and fixed identical
=== same id twice inside one round (control) ===  dev and fixed identical

PASS: every reuse scenario pairs cleanly and both controls are byte-identical to dev
```

On `dev` the first scenario produces four calls against six results — the two orphans from the issue. Both controls confirm that turns without id reuse, and the pre-existing within-a-round behaviour, are untouched.

`ruff format --check` and `ruff check --select=F` both clean on the changed file.

### Screenshots or Videos

Not applicable — the output above is the observable behaviour.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
