### PR TITLE
fix: accept single label hosts once local web fetch is enabled

### DIFF
--- a/backend/open_webui/retrieval/web/utils.py
+++ b/backend/open_webui/retrieval/web/utils.py
@@ -105,7 +105,12 @@ def _is_global_addr(ip: str) -> bool:
 
 def validate_url(url: Union[str, Sequence[str]]):
     if isinstance(url, str):
-        if isinstance(validators.url(url), validators.ValidationError):
+        # A single label host — a Docker service name such as `apprise`, or
+        # `localhost` — fails validators' default host check, which insists on a
+        # TLD. That check is not what keeps internal hosts out: the resolved
+        # addresses are filtered below. So it is relaxed exactly when local
+        # fetching has been deliberately enabled, and left strict otherwise.
+        if isinstance(validators.url(url, simple_host=ENABLE_LOCAL_WEB_FETCH), validators.ValidationError):
             raise ValueError(ERROR_MESSAGES.INVALID_URL)
 
         # Reject parser-confusing chars: urlparse and requests/aiohttp split


### PR DESCRIPTION
Reopening with the end-to-end reproduction that was missing. Everything below is from a real backend (`uvicorn open_webui.main:app`) with a signed-up admin user, hitting the actual `POST /api/v1/notifications/targets` endpoint — the issue is reproduced on unmodified `dev` first, then the same script is run on this branch.

# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #28161.
- [x] **Target branch:** targets `dev`.
- [x] **Description:** below.
- [x] **Changelog:** included below.
- [ ] **Documentation:** not applicable — no new setting. `ENABLE_LOCAL_WEB_FETCH` is already documented; this makes it cover a case it was expected to cover.
- [ ] **Dependencies:** none added or updated.
- [x] **Testing:** reproduced on `dev` and verified on this branch against a running server. Logs below.
- [x] **No Unchecked AI Code:** written with AI assistance and reviewed; the behaviour is verified end to end against a running backend rather than asserted.
- [x] **Self-Review:** performed.
- [x] **Architecture:** one argument on an existing call, gated on the flag that already governs this. No new setting.
- [x] **Git Hygiene:** one commit, based on current `dev`.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

With `ENABLE_LOCAL_WEB_FETCH` (or the `ENABLE_RAG_LOCAL_WEB_FETCH` alias) and `ENABLE_USER_WEBHOOKS` both on, setting a notification target to a service on the same network — `http://apprise:8000/notify` — still fails with `400 The URL you provided is invalid`.

`validate_url` in `backend/open_webui/retrieval/web/utils.py` opens with `validators.url(url)`, whose default host check requires a TLD. A Docker service name such as `apprise`, or `localhost`, is a single label and fails there — **before** `ENABLE_LOCAL_WEB_FETCH` is consulted further down. So enabling local fetching could never reach the case it exists for.

That first check is not the control that keeps internal hosts out. The control is the block below it, which resolves the hostname and rejects non-global addresses; `http://127.0.0.1:8000/...` already passes the syntax check today and is stopped there instead.

### Changed

- `validate_url` passes `simple_host=ENABLE_LOCAL_WEB_FETCH` to `validators.url`, so the host shape check relaxes exactly when local fetching has been deliberately enabled and stays strict otherwise.

### Fixed

- A notification target can point at a single-label host once local web fetch is enabled.

### Security

- No change with `ENABLE_LOCAL_WEB_FETCH` off, which is the default. Demonstrated on a running server below.

---

### Testing

Server started with `ENABLE_USER_WEBHOOKS=true`, first user signed up via `/api/v1/auths/signup` (so admin), then four targets posted to the real endpoint.

**1. Reproduced on unmodified `dev`** (`5caa91a4`), `ENABLE_LOCAL_WEB_FETCH=true`:

```
### branch: dev  (5caa91a4 refac)
POST /api/v1/notifications/targets   url=http://apprise:8000/notify
HTTP 400
  body: {"detail":"The URL you provided is invalid. Please double-check and try again."}

POST /api/v1/notifications/targets   url=http://localhost:9999/notify
HTTP 400
  body: {"detail":"The URL you provided is invalid. Please double-check and try again."}

POST /api/v1/notifications/targets   url=https://example.com/hook
HTTP 200
  body: {"id":"control-public",...,"config":{"url_masked":"https://example.com/...hook"},...}

POST /api/v1/notifications/targets   url=ftp://example.com/hook
HTTP 400
  body: {"detail":"The URL you provided is invalid. Please double-check and try again."}
```

Server log:

```
"POST /api/v1/notifications/targets HTTP/1.1" 400
"POST /api/v1/notifications/targets HTTP/1.1" 400
"POST /api/v1/notifications/targets HTTP/1.1" 200
"POST /api/v1/notifications/targets HTTP/1.1" 400
```

This is exactly the report in #28161: `apprise` rejected even though local web fetch is on, while a public host is accepted.

**2. Same script on this branch**, `ENABLE_LOCAL_WEB_FETCH=true`:

```
### branch: fix/webhook-url-local-validation  (1d80c0f8)
POST /api/v1/notifications/targets   url=http://apprise:8000/notify
HTTP 200
  body: {"id":"apprise",...,"config":{"url_masked":"http://apprise/...tify"},...}

POST /api/v1/notifications/targets   url=http://localhost:9999/notify
HTTP 200
  body: {"id":"localhostsvc",...,"config":{"url_masked":"http://localhost/...tify"},...}

POST /api/v1/notifications/targets   url=https://example.com/hook
HTTP 200

POST /api/v1/notifications/targets   url=ftp://example.com/hook
HTTP 400
  body: {"detail":"The URL you provided is invalid. Please double-check and try again."}
```

Server log:

```
"POST /api/v1/notifications/targets HTTP/1.1" 200
"POST /api/v1/notifications/targets HTTP/1.1" 200
"POST /api/v1/notifications/targets HTTP/1.1" 200
"POST /api/v1/notifications/targets HTTP/1.1" 400
```

The two reported hosts now save. `ftp://` is still rejected, so the scheme allow-list is intact.

**3. The security control — same branch, `ENABLE_LOCAL_WEB_FETCH=false` (the default):**

```
### branch: fix/webhook-url-local-validation  (1d80c0f8)
POST /api/v1/notifications/targets   url=http://apprise:8000/notify      HTTP 400
POST /api/v1/notifications/targets   url=http://localhost:9999/notify    HTTP 400
POST /api/v1/notifications/targets   url=https://example.com/hook        HTTP 200
POST /api/v1/notifications/targets   url=ftp://example.com/hook          HTTP 400
```

Byte-identical to `dev`. With the flag off nothing is loosened — single-label hosts stay rejected, which is the point of gating the relaxation on the flag rather than removing the check.

**4. Static checks:** `ruff format --check` and `ruff check --select=F` clean on the changed file.

### Screenshots or Videos

Not applicable — this is an API-level behaviour and the request/response pairs and server logs above are the observable evidence.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
