### PR TITLE
fix: restore the model avatar reset control

### DIFF
--- a/src/lib/components/workspace/Models/ModelEditor.svelte
+++ b/src/lib/components/workspace/Models/ModelEditor.svelte
@@ -25,6 +25,7 @@
 	import AccessControl from '../common/AccessControl.svelte';
 	import Spinner from '$lib/components/common/Spinner.svelte';
 	import ChevronLeft from '$lib/components/icons/ChevronLeft.svelte';
+	import XMark from '$lib/components/icons/XMark.svelte';
 	import DefaultFiltersSelector from './DefaultFiltersSelector.svelte';
 	import DefaultFeatures from './DefaultFeatures.svelte';
 	import BuiltinTools from './BuiltinTools.svelte';
@@ -93,6 +94,15 @@
 			system: ''
 		}
 	};
+
+	// The default logo reaches the editor in three shapes: the absolute URL set
+	// above, the relative path the backend stores, and an absent key, because
+	// loading a model shallow-merges its meta over the default.
+	$: hasCustomProfileImage = Boolean(
+		info?.meta?.profile_image_url &&
+		info.meta.profile_image_url !== `${WEBUI_BASE_URL}/static/favicon.png` &&
+		info.meta.profile_image_url !== '/static/favicon.png'
+	);
 
 	let params = {
 		system: ''
@@ -607,58 +617,74 @@
 									<!-- LICENSE covers this Open WebUI fallback logo.
 									Do not alter, remove, obscure, or replace it except as LICENSE permits:
 									https://docs.openwebui.com/license. -->
-									<button
-										class="group relative flex size-12 shrink-0 items-center overflow-hidden rounded-xl md:size-14 {info
-											.meta.profile_image_url !== `${WEBUI_BASE_URL}/static/favicon.png`
-											? 'bg-transparent'
-											: 'bg-gray-50 dark:bg-gray-850'} ring-1 ring-gray-200/70 transition hover:ring-gray-300 dark:ring-white/10 dark:hover:ring-white/20"
-										type="button"
-										aria-label={$i18n.t('Upload profile image')}
-										on:click={() => {
-											filesInputElement.click();
-										}}
-									>
-										{#if info.meta.profile_image_url}
-											<img
-												src={info.meta.profile_image_url}
-												alt="model profile"
-												class="size-full object-cover"
-											/>
-										{:else}
-											<img
-												src="{WEBUI_BASE_URL}/static/favicon.png"
-												alt="model profile"
-												class="size-full object-cover"
-											/>
-										{/if}
-
-										<div
-											class="absolute bottom-0 right-0 z-10 opacity-0 transition group-hover:opacity-100"
+									<div class="relative shrink-0">
+										<button
+											class="group relative flex size-12 shrink-0 items-center overflow-hidden rounded-xl md:size-14 {info
+												.meta.profile_image_url !== `${WEBUI_BASE_URL}/static/favicon.png`
+												? 'bg-transparent'
+												: 'bg-gray-50 dark:bg-gray-850'} ring-1 ring-gray-200/70 transition hover:ring-gray-300 dark:ring-white/10 dark:hover:ring-white/20"
+											type="button"
+											aria-label={$i18n.t('Upload profile image')}
+											on:click={() => {
+												filesInputElement.click();
+											}}
 										>
-											<div class="m-1">
-												<div
-													class="rounded-full bg-gray-900 p-1 text-white shadow-sm transition dark:bg-white dark:text-black"
-												>
-													<svg
-														xmlns="http://www.w3.org/2000/svg"
-														viewBox="0 0 16 16"
-														fill="currentColor"
-														class="size-3"
+											{#if info.meta.profile_image_url}
+												<img
+													src={info.meta.profile_image_url}
+													alt="model profile"
+													class="size-full object-cover"
+												/>
+											{:else}
+												<img
+													src="{WEBUI_BASE_URL}/static/favicon.png"
+													alt="model profile"
+													class="size-full object-cover"
+												/>
+											{/if}
+
+											<div
+												class="absolute bottom-0 right-0 z-10 opacity-0 transition group-hover:opacity-100"
+											>
+												<div class="m-1">
+													<div
+														class="rounded-full bg-gray-900 p-1 text-white shadow-sm transition dark:bg-white dark:text-black"
 													>
-														<path
-															fill-rule="evenodd"
-															d="M2 4a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V4Zm10.5 5.707a.5.5 0 0 0-.146-.353l-1-1a.5.5 0 0 0-.708 0L9.354 9.646a.5.5 0 0 1-.708 0L6.354 7.354a.5.5 0 0 0-.708 0l-2 2a.5.5 0 0 0-.146.353V12a.5.5 0 0 0 .5.5h8a.5.5 0 0 0 .5-.5V9.707ZM12 5a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z"
-															clip-rule="evenodd"
-														/>
-													</svg>
+														<svg
+															xmlns="http://www.w3.org/2000/svg"
+															viewBox="0 0 16 16"
+															fill="currentColor"
+															class="size-3"
+														>
+															<path
+																fill-rule="evenodd"
+																d="M2 4a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V4Zm10.5 5.707a.5.5 0 0 0-.146-.353l-1-1a.5.5 0 0 0-.708 0L9.354 9.646a.5.5 0 0 1-.708 0L6.354 7.354a.5.5 0 0 0-.708 0l-2 2a.5.5 0 0 0-.146.353V12a.5.5 0 0 0 .5.5h8a.5.5 0 0 0 .5-.5V9.707ZM12 5a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z"
+																clip-rule="evenodd"
+															/>
+														</svg>
+													</div>
 												</div>
 											</div>
-										</div>
 
-										<div
-											class="absolute inset-0 bg-white opacity-0 transition group-hover:opacity-20 dark:bg-black"
-										></div>
-									</button>
+											<div
+												class="absolute inset-0 bg-white opacity-0 transition group-hover:opacity-20 dark:bg-black"
+											></div>
+										</button>
+
+										{#if hasCustomProfileImage}
+											<button
+												class="absolute -right-1 -top-1 z-10 rounded-full bg-gray-900 p-0.5 text-white shadow-sm transition hover:bg-gray-700 dark:bg-white dark:text-black dark:hover:bg-gray-200"
+												type="button"
+												title={$i18n.t('Reset Image')}
+												aria-label={$i18n.t('Reset Image')}
+												on:click={() => {
+													info.meta.profile_image_url = `${WEBUI_BASE_URL}/static/favicon.png`;
+												}}
+											>
+												<XMark className="size-3" strokeWidth="2.5" />
+											</button>
+										{/if}
+									</div>
 
 									<div class="min-w-0 flex-1">
 										<div class="flex min-w-0 items-center gap-2">

--- a/src/lib/i18n/locales/ar-BH/translation.json
+++ b/src/lib/i18n/locales/ar-BH/translation.json
@@ -2258,6 +2258,7 @@
 	"Reset all permissions to their initial configuration values": "",
 	"Reset Defaults": "",
 	"Reset group permissions to match the current default user permissions": "",
+	"Reset Image": "",
 	"Reset knowledge base?": "",
 	"Reset persisted files": "",
 	"Reset to Defaults": "",

--- a/src/lib/i18n/locales/ar/translation.json
+++ b/src/lib/i18n/locales/ar/translation.json
@@ -2258,6 +2258,7 @@
 	"Reset all permissions to their initial configuration values": "",
 	"Reset Defaults": "",
 	"Reset group permissions to match the current default user permissions": "",
+	"Reset Image": "",
 	"Reset knowledge base?": "",
 	"Reset persisted files": "",
 	"Reset to Defaults": "",

--- a/src/lib/i18n/locales/az-AZ/translation.json
+++ b/src/lib/i18n/locales/az-AZ/translation.json
@@ -2210,6 +2210,7 @@
 	"Reset all permissions to their initial configuration values": "",
 	"Reset Defaults": "",
 	"Reset group permissions to match the current default user permissions": "",
+	"Reset Image": "",
 	"Reset knowledge base?": "",
 	"Reset persisted files": "",
 	"Reset to Defaults": "",

--- a/src/lib/i18n/locales/bg-BG/translation.json
+++ b/src/lib/i18n/locales/bg-BG/translation.json
@@ -2210,6 +2210,7 @@
 	"Reset all permissions to their initial configuration values": "",
 	"Reset Defaults": "",
 	"Reset group permissions to match the current default user permissions": "",
+	"Reset Image": "",
 	"Reset knowledge base?": "",
 	"Reset persisted files": "",
 	"Reset to Defaults": "",

--- a/src/lib/i18n/locales/bn-BD/translation.json
+++ b/src/lib/i18n/locales/bn-BD/translation.json
@@ -2210,6 +2210,7 @@
 	"Reset all permissions to their initial configuration values": "",
 	"Reset Defaults": "",
 	"Reset group permissions to match the current default user permissions": "",
+	"Reset Image": "",
 	"Reset knowledge base?": "",
 	"Reset persisted files": "",
 	"Reset to Defaults": "",

--- a/src/lib/i18n/locales/bo-TB/translation.json
+++ b/src/lib/i18n/locales/bo-TB/translation.json
@@ -2198,6 +2198,7 @@
 	"Reset all permissions to their initial configuration values": "",
 	"Reset Defaults": "",
 	"Reset group permissions to match the current default user permissions": "",
+	"Reset Image": "",
 	"Reset knowledge base?": "",
 	"Reset persisted files": "",
 	"Reset to Defaults": "",

--- a/src/lib/i18n/locales/bs-BA/translation.json
+++ b/src/lib/i18n/locales/bs-BA/translation.json
@@ -2222,6 +2222,7 @@
 	"Reset all permissions to their initial configuration values": "",
 	"Reset Defaults": "",
 	"Reset group permissions to match the current default user permissions": "",
+	"Reset Image": "",
 	"Reset knowledge base?": "",
 	"Reset persisted files": "",
 	"Reset to Defaults": "",

--- a/src/lib/i18n/locales/ca-ES/translation.json
+++ b/src/lib/i18n/locales/ca-ES/translation.json
@@ -2222,6 +2222,7 @@
 	"Reset all permissions to their initial configuration values": "Restableix tots els permisos als seus valors de configuració inicials",
 	"Reset Defaults": "",
 	"Reset group permissions to match the current default user permissions": "Restableix els permisos del grup perquè coincideixin amb els permisos d'usuari predeterminats actuals",
+	"Reset Image": "",
 	"Reset knowledge base?": "Reiniciar la base de coneixement?",
 	"Reset persisted files": "Restableix els fitxers persistents",
 	"Reset to Defaults": "Restableix els valors per defecte",

--- a/src/lib/i18n/locales/ceb-PH/translation.json
+++ b/src/lib/i18n/locales/ceb-PH/translation.json
@@ -2210,6 +2210,7 @@
 	"Reset all permissions to their initial configuration values": "",
 	"Reset Defaults": "",
 	"Reset group permissions to match the current default user permissions": "",
+	"Reset Image": "",
 	"Reset knowledge base?": "",
 	"Reset persisted files": "",
 	"Reset to Defaults": "",

--- a/src/lib/i18n/locales/cs-CZ/translation.json
+++ b/src/lib/i18n/locales/cs-CZ/translation.json
@@ -2234,6 +2234,7 @@
 	"Reset all permissions to their initial configuration values": "",
 	"Reset Defaults": "",
 	"Reset group permissions to match the current default user permissions": "",
+	"Reset Image": "",
 	"Reset knowledge base?": "",
 	"Reset persisted files": "",
 	"Reset to Defaults": "",

--- a/src/lib/i18n/locales/da-DK/translation.json
+++ b/src/lib/i18n/locales/da-DK/translation.json
@@ -2210,6 +2210,7 @@
 	"Reset all permissions to their initial configuration values": "",
 	"Reset Defaults": "",
 	"Reset group permissions to match the current default user permissions": "",
+	"Reset Image": "",
 	"Reset knowledge base?": "",
 	"Reset persisted files": "",
 	"Reset to Defaults": "",

--- a/src/lib/i18n/locales/de-DE/translation.json
+++ b/src/lib/i18n/locales/de-DE/translation.json
@@ -2210,6 +2210,7 @@
 	"Reset all permissions to their initial configuration values": "Alle Berechtigungen auf ihre ursprünglichen Konfigurationswerte zurücksetzen",
 	"Reset Defaults": "Auf Standard zurücksetzen",
 	"Reset group permissions to match the current default user permissions": "Gruppenberechtigungen auf die aktuellen Standard-Benutzerberechtigungen zurücksetzen",
+	"Reset Image": "",
 	"Reset knowledge base?": "Wissensspeicher zurücksetzen?",
 	"Reset persisted files": "Persistierte Dateien zurücksetzen",
 	"Reset to Defaults": "Auf Standardwerte zurücksetzen",

--- a/src/lib/i18n/locales/dg-DG/translation.json
+++ b/src/lib/i18n/locales/dg-DG/translation.json
@@ -2210,6 +2210,7 @@
 	"Reset all permissions to their initial configuration values": "",
 	"Reset Defaults": "",
 	"Reset group permissions to match the current default user permissions": "",
+	"Reset Image": "",
 	"Reset knowledge base?": "",
 	"Reset persisted files": "",
 	"Reset to Defaults": "",

--- a/src/lib/i18n/locales/el-GR/translation.json
+++ b/src/lib/i18n/locales/el-GR/translation.json
@@ -2210,6 +2210,7 @@
 	"Reset all permissions to their initial configuration values": "",
 	"Reset Defaults": "",
 	"Reset group permissions to match the current default user permissions": "",
+	"Reset Image": "",
 	"Reset knowledge base?": "",
 	"Reset persisted files": "",
 	"Reset to Defaults": "",

--- a/src/lib/i18n/locales/en-GB/translation.json
+++ b/src/lib/i18n/locales/en-GB/translation.json
@@ -2210,6 +2210,7 @@
 	"Reset all permissions to their initial configuration values": "",
 	"Reset Defaults": "",
 	"Reset group permissions to match the current default user permissions": "",
+	"Reset Image": "",
 	"Reset knowledge base?": "",
 	"Reset persisted files": "",
 	"Reset to Defaults": "",

--- a/src/lib/i18n/locales/en-US/translation.json
+++ b/src/lib/i18n/locales/en-US/translation.json
@@ -2210,6 +2210,7 @@
 	"Reset all permissions to their initial configuration values": "",
 	"Reset Defaults": "",
 	"Reset group permissions to match the current default user permissions": "",
+	"Reset Image": "",
 	"Reset knowledge base?": "",
 	"Reset persisted files": "",
 	"Reset to Defaults": "",

--- a/src/lib/i18n/locales/es-ES/translation.json
+++ b/src/lib/i18n/locales/es-ES/translation.json
@@ -2222,6 +2222,7 @@
 	"Reset all permissions to their initial configuration values": "",
 	"Reset Defaults": "",
 	"Reset group permissions to match the current default user permissions": "",
+	"Reset Image": "",
 	"Reset knowledge base?": "¿Reinicializar la base de conocimiento?",
 	"Reset persisted files": "",
 	"Reset to Defaults": "",

--- a/src/lib/i18n/locales/et-EE/translation.json
+++ b/src/lib/i18n/locales/et-EE/translation.json
@@ -2210,6 +2210,7 @@
 	"Reset all permissions to their initial configuration values": "",
 	"Reset Defaults": "",
 	"Reset group permissions to match the current default user permissions": "",
+	"Reset Image": "",
 	"Reset knowledge base?": "",
 	"Reset persisted files": "",
 	"Reset to Defaults": "",

--- a/src/lib/i18n/locales/eu-ES/translation.json
+++ b/src/lib/i18n/locales/eu-ES/translation.json
@@ -2210,6 +2210,7 @@
 	"Reset all permissions to their initial configuration values": "",
 	"Reset Defaults": "",
 	"Reset group permissions to match the current default user permissions": "",
+	"Reset Image": "",
 	"Reset knowledge base?": "",
 	"Reset persisted files": "",
 	"Reset to Defaults": "",

--- a/src/lib/i18n/locales/fa-IR/translation.json
+++ b/src/lib/i18n/locales/fa-IR/translation.json
@@ -2210,6 +2210,7 @@
 	"Reset all permissions to their initial configuration values": "",
 	"Reset Defaults": "",
 	"Reset group permissions to match the current default user permissions": "",
+	"Reset Image": "",
 	"Reset knowledge base?": "",
 	"Reset persisted files": "",
 	"Reset to Defaults": "",

--- a/src/lib/i18n/locales/fi-FI/translation.json
+++ b/src/lib/i18n/locales/fi-FI/translation.json
@@ -2210,6 +2210,7 @@
 	"Reset all permissions to their initial configuration values": "Palauta kaikki oikeudet niiden alkuperäisiin määritysarvoihin.",
 	"Reset Defaults": "Palauta oletukset",
 	"Reset group permissions to match the current default user permissions": "Palauta ryhmän oikeudet vastaamaan nykyisiä oletuskäyttäjäoikeuksia",
+	"Reset Image": "",
 	"Reset knowledge base?": "Nollataanko tietokanta?",
 	"Reset persisted files": "Nollaa pysyvät tiedostot",
 	"Reset to Defaults": "Palauta oletuksiin",

--- a/src/lib/i18n/locales/fil-PH/translation.json
+++ b/src/lib/i18n/locales/fil-PH/translation.json
@@ -2211,6 +2211,7 @@
 	"Reset all permissions to their initial configuration values": "",
 	"Reset Defaults": "",
 	"Reset group permissions to match the current default user permissions": "",
+	"Reset Image": "",
 	"Reset knowledge base?": "",
 	"Reset persisted files": "",
 	"Reset to Defaults": "",

--- a/src/lib/i18n/locales/fr-CA/translation.json
+++ b/src/lib/i18n/locales/fr-CA/translation.json
@@ -2222,6 +2222,7 @@
 	"Reset all permissions to their initial configuration values": "",
 	"Reset Defaults": "",
 	"Reset group permissions to match the current default user permissions": "",
+	"Reset Image": "",
 	"Reset knowledge base?": "",
 	"Reset persisted files": "",
 	"Reset to Defaults": "",

--- a/src/lib/i18n/locales/fr-FR/translation.json
+++ b/src/lib/i18n/locales/fr-FR/translation.json
@@ -2222,6 +2222,7 @@
 	"Reset all permissions to their initial configuration values": "",
 	"Reset Defaults": "",
 	"Reset group permissions to match the current default user permissions": "",
+	"Reset Image": "",
 	"Reset knowledge base?": "",
 	"Reset persisted files": "",
 	"Reset to Defaults": "",

--- a/src/lib/i18n/locales/gl-ES/translation.json
+++ b/src/lib/i18n/locales/gl-ES/translation.json
@@ -2210,6 +2210,7 @@
 	"Reset all permissions to their initial configuration values": "",
 	"Reset Defaults": "",
 	"Reset group permissions to match the current default user permissions": "",
+	"Reset Image": "",
 	"Reset knowledge base?": "",
 	"Reset persisted files": "",
 	"Reset to Defaults": "",

--- a/src/lib/i18n/locales/he-IL/translation.json
+++ b/src/lib/i18n/locales/he-IL/translation.json
@@ -2222,6 +2222,7 @@
 	"Reset all permissions to their initial configuration values": "",
 	"Reset Defaults": "",
 	"Reset group permissions to match the current default user permissions": "",
+	"Reset Image": "",
 	"Reset knowledge base?": "",
 	"Reset persisted files": "",
 	"Reset to Defaults": "",

--- a/src/lib/i18n/locales/hi-IN/translation.json
+++ b/src/lib/i18n/locales/hi-IN/translation.json
@@ -2210,6 +2210,7 @@
 	"Reset all permissions to their initial configuration values": "",
 	"Reset Defaults": "",
 	"Reset group permissions to match the current default user permissions": "",
+	"Reset Image": "",
 	"Reset knowledge base?": "",
 	"Reset persisted files": "",
 	"Reset to Defaults": "",

--- a/src/lib/i18n/locales/hr-HR/translation.json
+++ b/src/lib/i18n/locales/hr-HR/translation.json
@@ -2222,6 +2222,7 @@
 	"Reset all permissions to their initial configuration values": "",
 	"Reset Defaults": "",
 	"Reset group permissions to match the current default user permissions": "",
+	"Reset Image": "",
 	"Reset knowledge base?": "",
 	"Reset persisted files": "",
 	"Reset to Defaults": "",

--- a/src/lib/i18n/locales/hu-HU/translation.json
+++ b/src/lib/i18n/locales/hu-HU/translation.json
@@ -2210,6 +2210,7 @@
 	"Reset all permissions to their initial configuration values": "",
 	"Reset Defaults": "",
 	"Reset group permissions to match the current default user permissions": "",
+	"Reset Image": "",
 	"Reset knowledge base?": "",
 	"Reset persisted files": "",
 	"Reset to Defaults": "",

--- a/src/lib/i18n/locales/id-ID/translation.json
+++ b/src/lib/i18n/locales/id-ID/translation.json
@@ -2198,6 +2198,7 @@
 	"Reset all permissions to their initial configuration values": "",
 	"Reset Defaults": "",
 	"Reset group permissions to match the current default user permissions": "",
+	"Reset Image": "",
 	"Reset knowledge base?": "",
 	"Reset persisted files": "",
 	"Reset to Defaults": "",

--- a/src/lib/i18n/locales/ie-GA/translation.json
+++ b/src/lib/i18n/locales/ie-GA/translation.json
@@ -2210,6 +2210,7 @@
 	"Reset all permissions to their initial configuration values": "",
 	"Reset Defaults": "",
 	"Reset group permissions to match the current default user permissions": "",
+	"Reset Image": "",
 	"Reset knowledge base?": "Athshocraigh an bonn eolais?",
 	"Reset persisted files": "",
 	"Reset to Defaults": "",

--- a/src/lib/i18n/locales/it-IT/translation.json
+++ b/src/lib/i18n/locales/it-IT/translation.json
@@ -2222,6 +2222,7 @@
 	"Reset all permissions to their initial configuration values": "",
 	"Reset Defaults": "",
 	"Reset group permissions to match the current default user permissions": "",
+	"Reset Image": "",
 	"Reset knowledge base?": "",
 	"Reset persisted files": "",
 	"Reset to Defaults": "",

--- a/src/lib/i18n/locales/ja-JP/translation.json
+++ b/src/lib/i18n/locales/ja-JP/translation.json
@@ -2198,6 +2198,7 @@
 	"Reset all permissions to their initial configuration values": "",
 	"Reset Defaults": "",
 	"Reset group permissions to match the current default user permissions": "",
+	"Reset Image": "",
 	"Reset knowledge base?": "",
 	"Reset persisted files": "",
 	"Reset to Defaults": "ディフォルトにリセット",

--- a/src/lib/i18n/locales/ka-GE/translation.json
+++ b/src/lib/i18n/locales/ka-GE/translation.json
@@ -2210,6 +2210,7 @@
 	"Reset all permissions to their initial configuration values": "",
 	"Reset Defaults": "",
 	"Reset group permissions to match the current default user permissions": "",
+	"Reset Image": "",
 	"Reset knowledge base?": "",
 	"Reset persisted files": "",
 	"Reset to Defaults": "",

--- a/src/lib/i18n/locales/kab-DZ/translation.json
+++ b/src/lib/i18n/locales/kab-DZ/translation.json
@@ -2210,6 +2210,7 @@
 	"Reset all permissions to their initial configuration values": "",
 	"Reset Defaults": "",
 	"Reset group permissions to match the current default user permissions": "",
+	"Reset Image": "",
 	"Reset knowledge base?": "",
 	"Reset persisted files": "",
 	"Reset to Defaults": "",

--- a/src/lib/i18n/locales/ko-KR/translation.json
+++ b/src/lib/i18n/locales/ko-KR/translation.json
@@ -2199,6 +2199,7 @@
 	"Reset all permissions to their initial configuration values": "",
 	"Reset Defaults": "",
 	"Reset group permissions to match the current default user permissions": "",
+	"Reset Image": "",
 	"Reset knowledge base?": "",
 	"Reset persisted files": "",
 	"Reset to Defaults": "",

--- a/src/lib/i18n/locales/lt-LT/translation.json
+++ b/src/lib/i18n/locales/lt-LT/translation.json
@@ -2234,6 +2234,7 @@
 	"Reset all permissions to their initial configuration values": "",
 	"Reset Defaults": "",
 	"Reset group permissions to match the current default user permissions": "",
+	"Reset Image": "",
 	"Reset knowledge base?": "",
 	"Reset persisted files": "",
 	"Reset to Defaults": "",

--- a/src/lib/i18n/locales/lv-LV/translation.json
+++ b/src/lib/i18n/locales/lv-LV/translation.json
@@ -2222,6 +2222,7 @@
 	"Reset all permissions to their initial configuration values": "",
 	"Reset Defaults": "",
 	"Reset group permissions to match the current default user permissions": "",
+	"Reset Image": "",
 	"Reset knowledge base?": "",
 	"Reset persisted files": "",
 	"Reset to Defaults": "",

--- a/src/lib/i18n/locales/ms-MY/translation.json
+++ b/src/lib/i18n/locales/ms-MY/translation.json
@@ -2198,6 +2198,7 @@
 	"Reset all permissions to their initial configuration values": "",
 	"Reset Defaults": "",
 	"Reset group permissions to match the current default user permissions": "",
+	"Reset Image": "",
 	"Reset knowledge base?": "",
 	"Reset persisted files": "",
 	"Reset to Defaults": "",

--- a/src/lib/i18n/locales/nb-NO/translation.json
+++ b/src/lib/i18n/locales/nb-NO/translation.json
@@ -2210,6 +2210,7 @@
 	"Reset all permissions to their initial configuration values": "",
 	"Reset Defaults": "",
 	"Reset group permissions to match the current default user permissions": "",
+	"Reset Image": "",
 	"Reset knowledge base?": "",
 	"Reset persisted files": "",
 	"Reset to Defaults": "",

--- a/src/lib/i18n/locales/nl-NL/translation.json
+++ b/src/lib/i18n/locales/nl-NL/translation.json
@@ -2210,6 +2210,7 @@
 	"Reset all permissions to their initial configuration values": "",
 	"Reset Defaults": "",
 	"Reset group permissions to match the current default user permissions": "",
+	"Reset Image": "",
 	"Reset knowledge base?": "",
 	"Reset persisted files": "",
 	"Reset to Defaults": "",

--- a/src/lib/i18n/locales/pa-IN/translation.json
+++ b/src/lib/i18n/locales/pa-IN/translation.json
@@ -2210,6 +2210,7 @@
 	"Reset all permissions to their initial configuration values": "",
 	"Reset Defaults": "",
 	"Reset group permissions to match the current default user permissions": "",
+	"Reset Image": "",
 	"Reset knowledge base?": "",
 	"Reset persisted files": "",
 	"Reset to Defaults": "",

--- a/src/lib/i18n/locales/pl-PL/translation.json
+++ b/src/lib/i18n/locales/pl-PL/translation.json
@@ -2234,6 +2234,7 @@
 	"Reset all permissions to their initial configuration values": "",
 	"Reset Defaults": "",
 	"Reset group permissions to match the current default user permissions": "",
+	"Reset Image": "",
 	"Reset knowledge base?": "",
 	"Reset persisted files": "",
 	"Reset to Defaults": "",

--- a/src/lib/i18n/locales/pt-BR/translation.json
+++ b/src/lib/i18n/locales/pt-BR/translation.json
@@ -2222,6 +2222,7 @@
 	"Reset all permissions to their initial configuration values": "Redefinir todas as permissões para seus valores de configuração inicial",
 	"Reset Defaults": "Redefinir padrões",
 	"Reset group permissions to match the current default user permissions": "Redefinir permissões do grupo para corresponder às permissões padrão atuais do usuário",
+	"Reset Image": "",
 	"Reset knowledge base?": "Redefinir base de conhecimento?",
 	"Reset persisted files": "Redefinir arquivos persistidos",
 	"Reset to Defaults": "Redefinir para Padrões",

--- a/src/lib/i18n/locales/pt-PT/translation.json
+++ b/src/lib/i18n/locales/pt-PT/translation.json
@@ -2222,6 +2222,7 @@
 	"Reset all permissions to their initial configuration values": "",
 	"Reset Defaults": "",
 	"Reset group permissions to match the current default user permissions": "",
+	"Reset Image": "",
 	"Reset knowledge base?": "",
 	"Reset persisted files": "",
 	"Reset to Defaults": "",

--- a/src/lib/i18n/locales/ro-RO/translation.json
+++ b/src/lib/i18n/locales/ro-RO/translation.json
@@ -2222,6 +2222,7 @@
 	"Reset all permissions to their initial configuration values": "",
 	"Reset Defaults": "",
 	"Reset group permissions to match the current default user permissions": "",
+	"Reset Image": "",
 	"Reset knowledge base?": "",
 	"Reset persisted files": "",
 	"Reset to Defaults": "",

--- a/src/lib/i18n/locales/ru-RU/translation.json
+++ b/src/lib/i18n/locales/ru-RU/translation.json
@@ -2234,6 +2234,7 @@
 	"Reset all permissions to their initial configuration values": "",
 	"Reset Defaults": "",
 	"Reset group permissions to match the current default user permissions": "",
+	"Reset Image": "",
 	"Reset knowledge base?": "",
 	"Reset persisted files": "",
 	"Reset to Defaults": "",

--- a/src/lib/i18n/locales/sk-SK/translation.json
+++ b/src/lib/i18n/locales/sk-SK/translation.json
@@ -2234,6 +2234,7 @@
 	"Reset all permissions to their initial configuration values": "",
 	"Reset Defaults": "",
 	"Reset group permissions to match the current default user permissions": "",
+	"Reset Image": "",
 	"Reset knowledge base?": "",
 	"Reset persisted files": "",
 	"Reset to Defaults": "",

--- a/src/lib/i18n/locales/sl-SI/translation.json
+++ b/src/lib/i18n/locales/sl-SI/translation.json
@@ -2234,6 +2234,7 @@
 	"Reset all permissions to their initial configuration values": "Ponastavi all permissions to their initial configuration values",
 	"Reset Defaults": "",
 	"Reset group permissions to match the current default user permissions": "Ponastavi group permissions to match the trenutni privzeto user permissions",
+	"Reset Image": "",
 	"Reset knowledge base?": "Ponastavi knowledge base?",
 	"Reset persisted files": "Ponastavi persisted files",
 	"Reset to Defaults": "Ponastavi to Defaults",

--- a/src/lib/i18n/locales/sr-RS/translation.json
+++ b/src/lib/i18n/locales/sr-RS/translation.json
@@ -2222,6 +2222,7 @@
 	"Reset all permissions to their initial configuration values": "",
 	"Reset Defaults": "",
 	"Reset group permissions to match the current default user permissions": "",
+	"Reset Image": "",
 	"Reset knowledge base?": "",
 	"Reset persisted files": "",
 	"Reset to Defaults": "",

--- a/src/lib/i18n/locales/sv-SE/translation.json
+++ b/src/lib/i18n/locales/sv-SE/translation.json
@@ -2210,6 +2210,7 @@
 	"Reset all permissions to their initial configuration values": "",
 	"Reset Defaults": "",
 	"Reset group permissions to match the current default user permissions": "",
+	"Reset Image": "",
 	"Reset knowledge base?": "",
 	"Reset persisted files": "",
 	"Reset to Defaults": "",

--- a/src/lib/i18n/locales/ta-IN/translation.json
+++ b/src/lib/i18n/locales/ta-IN/translation.json
@@ -2210,6 +2210,7 @@
 	"Reset all permissions to their initial configuration values": "",
 	"Reset Defaults": "",
 	"Reset group permissions to match the current default user permissions": "",
+	"Reset Image": "",
 	"Reset knowledge base?": "",
 	"Reset persisted files": "",
 	"Reset to Defaults": "",

--- a/src/lib/i18n/locales/th-TH/translation.json
+++ b/src/lib/i18n/locales/th-TH/translation.json
@@ -2198,6 +2198,7 @@
 	"Reset all permissions to their initial configuration values": "",
 	"Reset Defaults": "",
 	"Reset group permissions to match the current default user permissions": "",
+	"Reset Image": "",
 	"Reset knowledge base?": "",
 	"Reset persisted files": "",
 	"Reset to Defaults": "",

--- a/src/lib/i18n/locales/tk-TM/translation.json
+++ b/src/lib/i18n/locales/tk-TM/translation.json
@@ -2210,6 +2210,7 @@
 	"Reset all permissions to their initial configuration values": "",
 	"Reset Defaults": "",
 	"Reset group permissions to match the current default user permissions": "",
+	"Reset Image": "",
 	"Reset knowledge base?": "",
 	"Reset persisted files": "",
 	"Reset to Defaults": "",

--- a/src/lib/i18n/locales/tr-TR/translation.json
+++ b/src/lib/i18n/locales/tr-TR/translation.json
@@ -2210,6 +2210,7 @@
 	"Reset all permissions to their initial configuration values": "",
 	"Reset Defaults": "",
 	"Reset group permissions to match the current default user permissions": "",
+	"Reset Image": "",
 	"Reset knowledge base?": "",
 	"Reset persisted files": "",
 	"Reset to Defaults": "",

--- a/src/lib/i18n/locales/ug-CN/translation.json
+++ b/src/lib/i18n/locales/ug-CN/translation.json
@@ -2210,6 +2210,7 @@
 	"Reset all permissions to their initial configuration values": "",
 	"Reset Defaults": "",
 	"Reset group permissions to match the current default user permissions": "",
+	"Reset Image": "",
 	"Reset knowledge base?": "",
 	"Reset persisted files": "",
 	"Reset to Defaults": "",

--- a/src/lib/i18n/locales/uk-UA/translation.json
+++ b/src/lib/i18n/locales/uk-UA/translation.json
@@ -2234,6 +2234,7 @@
 	"Reset all permissions to their initial configuration values": "",
 	"Reset Defaults": "",
 	"Reset group permissions to match the current default user permissions": "",
+	"Reset Image": "",
 	"Reset knowledge base?": "",
 	"Reset persisted files": "",
 	"Reset to Defaults": "",

--- a/src/lib/i18n/locales/ur-PK/translation.json
+++ b/src/lib/i18n/locales/ur-PK/translation.json
@@ -2210,6 +2210,7 @@
 	"Reset all permissions to their initial configuration values": "",
 	"Reset Defaults": "",
 	"Reset group permissions to match the current default user permissions": "",
+	"Reset Image": "",
 	"Reset knowledge base?": "",
 	"Reset persisted files": "",
 	"Reset to Defaults": "",

--- a/src/lib/i18n/locales/uz-Cyrl-UZ/translation.json
+++ b/src/lib/i18n/locales/uz-Cyrl-UZ/translation.json
@@ -2210,6 +2210,7 @@
 	"Reset all permissions to their initial configuration values": "",
 	"Reset Defaults": "",
 	"Reset group permissions to match the current default user permissions": "",
+	"Reset Image": "",
 	"Reset knowledge base?": "",
 	"Reset persisted files": "",
 	"Reset to Defaults": "",

--- a/src/lib/i18n/locales/uz-Latn-UZ/translation.json
+++ b/src/lib/i18n/locales/uz-Latn-UZ/translation.json
@@ -2210,6 +2210,7 @@
 	"Reset all permissions to their initial configuration values": "",
 	"Reset Defaults": "",
 	"Reset group permissions to match the current default user permissions": "",
+	"Reset Image": "",
 	"Reset knowledge base?": "",
 	"Reset persisted files": "",
 	"Reset to Defaults": "",

--- a/src/lib/i18n/locales/vi-VN/translation.json
+++ b/src/lib/i18n/locales/vi-VN/translation.json
@@ -2198,6 +2198,7 @@
 	"Reset all permissions to their initial configuration values": "",
 	"Reset Defaults": "",
 	"Reset group permissions to match the current default user permissions": "",
+	"Reset Image": "",
 	"Reset knowledge base?": "",
 	"Reset persisted files": "",
 	"Reset to Defaults": "",

--- a/src/lib/i18n/locales/zh-CN/translation.json
+++ b/src/lib/i18n/locales/zh-CN/translation.json
@@ -2198,6 +2198,7 @@
 	"Reset all permissions to their initial configuration values": "",
 	"Reset Defaults": "",
 	"Reset group permissions to match the current default user permissions": "",
+	"Reset Image": "",
 	"Reset knowledge base?": "确认要重置知识库吗？",
 	"Reset persisted files": "",
 	"Reset to Defaults": "",

--- a/src/lib/i18n/locales/zh-TW/translation.json
+++ b/src/lib/i18n/locales/zh-TW/translation.json
@@ -2198,6 +2198,7 @@
 	"Reset all permissions to their initial configuration values": "",
 	"Reset Defaults": "",
 	"Reset group permissions to match the current default user permissions": "",
+	"Reset Image": "",
 	"Reset knowledge base?": "確定要重設知識庫嗎？",
 	"Reset persisted files": "",
 	"Reset to Defaults": "",


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27685. Re-opens what #7278 originally reported.
- [x] **Target branch:** targets `dev`.
- [x] **Description:** below.
- [x] **Changelog:** included below.
- [ ] **Documentation:** not applicable — restores a control that existed through v0.10.2.
- [ ] **Dependencies:** none added or updated.
- [x] **Testing:** see below.
- [ ] **No Unchecked AI Code:** prepared with AI assistance. The production build was run and the three default-image shapes were traced through the code; the control has not been clicked in a browser.
- [x] **Self-Review:** performed.
- [x] **Architecture:** no new setting and no new state beyond one derived boolean. Placement is the one judgement call here and I am happy to move it — see below.
- [x] **Git Hygiene:** one commit, based on current `dev`.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

The model editor redesign (`b92f59230`, first shipped in v0.11.0) dropped the "Reset Image" button. Since then the avatar button only opens the file picker, so once a model has a custom image it can be replaced but never cleared back to the default logo — in both the workspace and admin editors, which render the same `ModelEditor` component.

### Added

- A reset control on the model avatar, restoring the behaviour that existed through v0.10.2.

### Fixed

- A model's custom avatar can be cleared back to the default logo again.

---

### Additional Information

**Classifying "default".** #27685 warns that the default logo reaches the editor in three shapes, and the control is only shown when none of them match: the absolute `${WEBUI_BASE_URL}/static/favicon.png` the editor initialises with, the relative `/static/favicon.png` the backend stores in `routers/models.py`, and an absent key, because loading a model shallow-merges its `meta` over the default. The first of those three was already being tested inline for the avatar's background colour, so the derived boolean also removes a small duplication.

**Placement.** The redesigned header is a full-width row, so the old `justify-end` position no longer reads as "next to the avatar". It is a badge on the avatar's top-right corner instead. Two deliberate choices there, both easy to change if the design should go elsewhere:

- It is always visible when a custom image is set, rather than hover-only like the camera badge, so it stays reachable on touch.
- It renders only over a custom image, never over the fallback logo, so the LICENSE note directly above that markup — the fallback logo must not be obscured — continues to hold. Resetting also restores that logo rather than removing it.

**i18n.** The redesign dropped the `Reset Image` key along with the button. It is re-added to `en-US` and the other 62 locale files, at the position `npm run i18n:parse` places it, with empty values for translators to fill.

### Testing

- `npm run build` completes (`✓ built in 50.93s`) with the change in place.
- `npx prettier --check` clean on `ModelEditor.svelte` and on every locale file.
- Confirmed `npm run i18n:parse` places the new key at exactly the position it was hand-inserted, so a later parser run will not move it.
- Traced all three default-image shapes through `hasCustomProfileImage`; each suppresses the control, and any other value shows it.
- Not yet clicked through in a browser.

### Screenshots or Videos

Not attached — I would rather agree the placement first, since that is the open question in #27685 and a screenshot of a position that may change is not much use. Happy to add one once the placement is settled.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
