### PR TITLE
style: apply ruff format to the four files that fail the check on dev

### DIFF
--- a/backend/open_webui/retrieval/vector/dbs/milvus.py
+++ b/backend/open_webui/retrieval/vector/dbs/milvus.py
@@ -364,7 +364,9 @@ class MilvusClient(VectorDBBase):
                 ids=ids,
             )
         elif filter:
-            filter_string = ' && '.join([f'metadata["{key}"] == {JSONCodec.dumps(value)}' for key, value in filter.items()])
+            filter_string = ' && '.join(
+                [f'metadata["{key}"] == {JSONCodec.dumps(value)}' for key, value in filter.items()]
+            )
             log.info(
                 'Deleting items by filter from %s_%s. Filter: %s',
                 self.collection_prefix,

--- a/backend/open_webui/retrieval/web/sougou.py
+++ b/backend/open_webui/retrieval/web/sougou.py
@@ -31,7 +31,8 @@ def search_sougou(
         params = JSONCodec.dumps({'Query': query, 'Cnt': 20})
         common_client = CommonClient('tms', '2020-12-29', cred, '', profile=client_profile)
         results = [
-            JSONCodec.loads(page) for page in common_client.call_json('SearchPro', JSONCodec.loads(params))['Response']['Pages']
+            JSONCodec.loads(page)
+            for page in common_client.call_json('SearchPro', JSONCodec.loads(params))['Response']['Pages']
         ]
         sorted_results = sorted(results, key=lambda x: x.get('scour', 0.0), reverse=True)
         if filter_list:

--- a/backend/open_webui/tools/builtin.py
+++ b/backend/open_webui/tools/builtin.py
@@ -1444,9 +1444,7 @@ async def search_chats(
                         start = max(0, idx - 50)
                         end = min(len(content), idx + len(needle) + 100)
                         snippet = (
-                            ('...' if start > 0 else '')
-                            + content[start:end]
-                            + ('...' if end < len(content) else '')
+                            ('...' if start > 0 else '') + content[start:end] + ('...' if end < len(content) else '')
                         )
                         break
                 if snippet:

--- a/backend/open_webui/utils/tools.py
+++ b/backend/open_webui/utils/tools.py
@@ -1303,7 +1303,9 @@ async def get_terminal_servers(request: Request):
     terminal_servers = []
     if request.app.state.redis is not None:
         try:
-            terminal_servers = JSONCodec.loads(await request.app.state.redis.get(f'{REDIS_KEY_PREFIX}:terminal_servers'))
+            terminal_servers = JSONCodec.loads(
+                await request.app.state.redis.get(f'{REDIS_KEY_PREFIX}:terminal_servers')
+            )
             request.app.state.TERMINAL_SERVERS = terminal_servers
         except Exception as e:
             log.error(f'Error fetching terminal_servers from Redis: {e}')
@@ -1377,11 +1379,7 @@ async def get_terminal_tools(
 
     context_id = terminal_context_id(connection, metadata, terminal_context)
     config = terminal_context_config(connection, terminal_context)
-    if (
-        isinstance(config, dict)
-        and config.get('context_id') in {'chat_id', 'automation_id'}
-        and not context_id
-    ):
+    if isinstance(config, dict) and config.get('context_id') in {'chat_id', 'automation_id'} and not context_id:
         raise RuntimeError(f"Terminal server '{terminal_id}' requires a saved {terminal_context} context")
     if context_id:
         headers[TERMINAL_CONTEXT_HEADER] = context_id


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #28356.
- [x] **Target branch:** targets `dev`.
- [x] **Description:** below.
- [x] **Changelog:** included below.
- [ ] **Documentation:** not applicable.
- [ ] **Dependencies:** none added or updated.
- [x] **Testing:** the repository-wide check passes with this applied — output below.
- [x] **No Unchecked AI Code:** no hand-written code at all; this is `ruff format` output, reviewed line by line and confirmed to be wrapping only.
- [x] **Self-Review:** performed — every hunk is line wrapping, no token order or semantics changed.
- [x] **Architecture:** no behaviour change.
- [x] **Git Hygiene:** one commit, based on current `dev`.
- [x] **Title Prefix:** `style`

# Changelog Entry

### Description

`Python CI` runs `ruff format --check . --exclude .venv --exclude venv` over the whole repository. Four files on `dev` do not satisfy it, so every pull request touching `backend/**`, `pyproject.toml` or `uv.lock` gets two failing Ruff Format jobs regardless of its own contents. See #28356.

### Changed

- `ruff format` applied to the four files, with no manual edits:
  - `backend/open_webui/retrieval/vector/dbs/milvus.py`
  - `backend/open_webui/retrieval/web/sougou.py`
  - `backend/open_webui/tools/builtin.py`
  - `backend/open_webui/utils/tools.py`

### Fixed

- `Ruff Format (3.11)` and `Ruff Format (3.12)` pass on `dev` again.

---

### Testing

Before, on unmodified `dev` (`5caa91a4`), with the same ruff version CI installs:

```
$ ruff format --check . --exclude .venv --exclude venv
4 files would be reformatted, 265 files already formatted
```

After, on this branch:

```
$ ruff format --check . --exclude .venv --exclude venv
269 files already formatted

$ ruff check --select=F --ignore=F401,F403,F405,F541,F811,F841 .
All checks passed!
```

The whole diff is 10 insertions and 11 deletions across the four files, all of it wrapping — for example:

```python
-    if (
-        isinstance(config, dict)
-        and config.get('context_id') in {'chat_id', 'automation_id'}
-        and not context_id
-    ):
+    if isinstance(config, dict) and config.get('context_id') in {'chat_id', 'automation_id'} and not context_id:
```

No expression, call, or branch is altered in any hunk.

### Additional Information

#28356 also raises the option of scoping the CI check to changed files so drift in untouched files cannot fail an unrelated PR. That is a workflow change rather than a formatting one, so it is deliberately not in this PR; happy to open it separately if it is wanted.

### Screenshots or Videos

Not applicable.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
