### PR TITLE
fix: accept single label hosts once local web fetch is enabled

### DIFF
--- a/backend/open_webui/retrieval/web/utils.py
+++ b/backend/open_webui/retrieval/web/utils.py
@@ -105,7 +105,8 @@ def _is_global_addr(ip: str) -> bool:
 
 def validate_url(url: Union[str, Sequence[str]]):
     if isinstance(url, str):
-        if isinstance(validators.url(url), validators.ValidationError):
+        # simple_host permits TLD-less hosts; resolved addresses are still filtered below
+        if isinstance(validators.url(url, simple_host=ENABLE_LOCAL_WEB_FETCH), validators.ValidationError):
             raise ValueError(ERROR_MESSAGES.INVALID_URL)
 
         # Reject parser-confusing chars: urlparse and requests/aiohttp split


### PR DESCRIPTION
With `ENABLE_LOCAL_WEB_FETCH` on and `ENABLE_USER_WEBHOOKS` on, a notification target pointing at a service on the same network is still rejected with `400 The URL you provided is invalid`. Closes #28161.

`validate_url` opens with `validators.url(url)`, whose default host check requires a TLD. A docker service name such as `apprise`, or `localhost`, is a single label and fails there, before `ENABLE_LOCAL_WEB_FETCH` is consulted further down. Enabling local fetching therefore could not reach the case it exists for.

That first check is not what keeps internal hosts out. The control is the block below it, which resolves the hostname and rejects non-global addresses; `http://127.0.0.1:8000/...` already passes the syntax check today and is stopped there instead. So the host shape check is relaxed exactly when local fetching has been deliberately enabled, and left strict otherwise.

Reproduced against a running backend before and after. On `dev` at 5caa91a4 with the flag on, `POST /api/v1/notifications/targets` for `http://apprise:8000/notify` returns 400 while `https://example.com/hook` returns 200. On this branch the same two requests return 200 and 200, and `ftp://example.com/hook` still returns 400, so the scheme allow-list is intact. Re-running the whole set on this branch with the flag off, which is the default, gives results identical to `dev`: both single-label hosts rejected, public host accepted. Nothing is loosened for anyone who has not opted in.

Gating on the flag rather than dropping the host check outright, because with local fetching off a TLD-less host has no legitimate use and the stricter syntax check is a cheap first filter.

### Changelog Entry

#### Fixed

- A notification target can point at a single label host once local web fetch is enabled.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
