### PR TITLE
fix: pair each round's tool results with that round's tool calls

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -4918,6 +4918,13 @@ async def streaming_chat_response_handler(response, ctx):
 
                     response_tool_calls = tool_calls.pop(0)
 
+                    answered_call_ids = {
+                        item.get('call_id') for item in output if item.get('type') == 'function_call_output'
+                    }
+                    for tc in response_tool_calls:
+                        if tc.get('id') and tc['id'] in answered_call_ids:
+                            tc['id'] = output_id('call')
+
                     # Append function_call items for each tool call
                     # (Responses API already has them from streaming, so skip duplicates)
                     existing_call_ids = {item.get('call_id') for item in output if item.get('type') == 'function_call'}


### PR DESCRIPTION
A provider that numbers tool calls per round rather than per turn hands back an id an earlier round already used. `moonshotai/kimi-k3` on OpenRouter emits `<function_name>:<index>` starting at 0 on every round, so round two returns round one's ids exactly. Closes #28305.

`output` is built once per request while the tool loop runs many rounds inside it, and each round skips a `function_call` whose id appears anywhere in `output`, including rounds already finished. `results` is rebuilt per round and a `function_call_output` is appended for every call regardless, so a reused id loses its call and keeps its result. The turn is persisted that way, which is why retrying cannot help: every later message in the chat fails with `tool message tool_call_id ... does not match any tool call in the preceding assistant messages`. `sanitize_tool_pairs` does not catch it, because it matches ids across the whole conversation rather than per assistant block, and the orphans do have a matching call under an earlier block.

Reused ids are renamed before the dedup runs, scoped to ids that already have a `function_call_output`. That scoping is what keeps the dedup working: it exists for Responses API items streaming already placed in `output` which are still awaiting a result, and those are untouched because they are unanswered. The rename lands on the `tool_call` dict that both the `function_call` and its `function_call_output` are built from, so the pair moves together.

Reproduced against a running backend pointed at a stub OpenAI-compatible provider that restarts its tool call numbering each round. On `dev` at 5caa91a4 the stored turn holds 2 `function_call` items against 4 `function_call_output` items, the two orphans from the report. On this branch the same turn holds 4 and 4, correctly paired. With the stub switched to unique ids per turn, both branches produce identical output.

Not scoping `existing_call_ids` to unanswered calls instead, which restores the pairing but leaves two `function_call` items sharing one id; the status update below `break`s on its first match, so the second round's call would sit at `in_progress` forever.

### Changelog Entry

#### Fixed

- Each round's tool results pair with that round's tool calls when a provider reuses an id.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
