### PR TITLE
fix: report why a URL could not be read instead of blaming the knowledge base

### DIFF
--- a/backend/open_webui/retrieval/loaders/youtube.py
+++ b/backend/open_webui/retrieval/loaders/youtube.py
@@ -18,6 +18,32 @@ ALLOWED_NETLOCS = {
 }
 
 
+class YoutubeTranscriptError(Exception):
+    """A YouTube transcript could not be retrieved."""
+
+
+def _transcript_error_message(error: Exception, video_id: str) -> str:
+    name = type(error).__name__
+
+    if name in {'RequestBlocked', 'IpBlocked'}:
+        return (
+            f'YouTube blocked the transcript request for {video_id} from this server. '
+            'This usually means the server address is rate limited or belongs to a cloud '
+            'provider. A proxy for these requests can be configured under Admin Settings, '
+            'Web Search, Youtube Proxy URL.'
+        )
+    if name == 'TranscriptsDisabled':
+        return f'Transcripts are disabled for the YouTube video {video_id}.'
+    if name == 'AgeRestricted':
+        return f'The YouTube video {video_id} is age restricted, so its transcript cannot be retrieved.'
+    if name in {'VideoUnavailable', 'VideoUnplayable', 'InvalidVideoId'}:
+        return f'The YouTube video {video_id} is unavailable.'
+    if name == 'PoTokenRequired':
+        return f'YouTube requires additional verification to return the transcript for {video_id}.'
+
+    return f'Could not retrieve a transcript for the YouTube video {video_id}.'
+
+
 def _parse_video_id(url: str) -> Optional[str]:
     """Parse a YouTube URL and return the video ID if valid, otherwise None."""
     parsed_url = urlparse(url)
@@ -98,8 +124,8 @@ class YoutubeLoader:
         try:
             transcript_list = transcript_api.list(self.video_id)
         except Exception as e:
-            log.warning(f'Loading YouTube transcript failed: {e}')
-            return []
+            log.warning('Loading YouTube transcript failed: %s', e)
+            raise YoutubeTranscriptError(_transcript_error_message(e, self.video_id)) from e
 
         # Try each language in order of priority
         for lang in self.language:
@@ -139,14 +165,16 @@ class YoutubeLoader:
                 continue
             except Exception as e:
                 log.info("Error finding transcript for language '%s'", lang)
-                raise e
+                raise YoutubeTranscriptError(_transcript_error_message(e, self.video_id)) from e
 
         # If we get here, all languages failed
         languages_tried = ', '.join(self.language)
         log.warning(
             f'No transcript found for any of the specified languages: {languages_tried}. Verify if the video has transcripts, add more languages if needed.'
         )
-        raise NoTranscriptFound(self.video_id, self.language, list(transcript_list))
+        raise YoutubeTranscriptError(
+            f'No transcript found for the YouTube video {self.video_id} in these languages: {languages_tried}.'
+        )
 
     async def aload(self) -> Generator[Document, None, None]:
         """Asynchronously load YouTube transcripts into `Document` objects."""

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -66,7 +66,7 @@ from open_webui.models.knowledge import Knowledges
 from open_webui.models.config import Config
 
 # Document loaders
-from open_webui.retrieval.loaders.youtube import YoutubeLoader
+from open_webui.retrieval.loaders.youtube import YoutubeLoader, YoutubeTranscriptError
 from open_webui.retrieval.utils import (
     build_loader_from_config,
     get_loader_config,
@@ -2336,8 +2336,25 @@ async def process_web(
     user=Depends(get_verified_user),
 ):
     config = await get_retrieval_config()
+
     try:
         content, docs = await get_content_from_url(request, form_data.url)
+    except HTTPException:
+        raise
+    except YoutubeTranscriptError as e:
+        log.warning('YouTube transcript unavailable for %s: %s', form_data.url, e)
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        )
+    except Exception as e:
+        log.exception(e)
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=ERROR_MESSAGES.DEFAULT(e, f'Could not read content from {form_data.url}'),
+        )
+
+    try:
         log.debug('text_content: %s', content)
 
         if process:


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #28361
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable. No configuration surface changes.
- [ ] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Reproduced against a running instance, and the fix confirmed at the endpoint for a fetch failure, an SSRF rejection, a refused transcript and a page that succeeds, plus the reason mapping for every exception type the transcript library raises.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new settings and no new endpoint. One exception type, one message mapping, and an existing `try` split into the two steps it was covering.
- [x] **Git Hygiene:** A single commit, +50/-5 across two files, rebased on the current `dev`.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

A URL that failed to attach reported the wrong subsystem. Two faults, both on the backend.

**Fetching and saving were reported as one thing.** Everything from reading the URL to writing the vector database sat inside a single `try`, whose handler blamed the knowledge base:

```python
detail=ERROR_MESSAGES.DEFAULT(e, 'Error querying knowledge base')
```

A page that could not be fetched, parsed or resolved was therefore reported as a knowledge base error, even though nothing had reached the knowledge base yet. Reading the URL now has its own handler that names the URL, and the knowledge base message is left to the step that actually touches it.

**The transcript reason was discarded before anything could report it.** When YouTube refused a transcript, the loader caught the failure, logged it, and returned an empty document list. The empty result then failed while saving to the vector database, so even the salvageable explanation was gone by the time a message was produced. The loader now raises `YoutubeTranscriptError` carrying a readable reason, mapped from the transcript library's own exception types, and the endpoint returns it as the 400 detail.

### Fixed

- A URL that cannot be fetched, parsed or resolved now says so and names the URL, instead of reporting an error in the knowledge base.
- A YouTube transcript that cannot be fetched now explains why, and blocked requests mention the proxy setting that exists for the purpose.

---

### Additional Information

**This does not make blocked transcripts work.** The most common cause is YouTube refusing transcript requests from the server's address, which it does readily for cloud and datacenter ranges. That is outside Open WebUI's control. The change is that the user is told what happened rather than being pointed at the knowledge base. The existing `Youtube Proxy URL` setting is named in that message, without being prescribed, since whether to route requests through a proxy is the operator's decision.

**Why the reason could not simply be raised.** `ERROR_MESSAGES.DEFAULT` replaces any `Exception` with its fallback string:

```python
if isinstance(err, Exception):
    return f'[ERROR: {fallback}]' if fallback else 'Something went wrong :/'
```

So a better exception alone would still have produced the same wrong message. The reason has to travel through the `except HTTPException: raise` path, which is why the endpoint translates the new exception type explicitly.

**Blast radius of the loader contract change.** `YoutubeLoader.load` previously returned `[]` on failure and now raises. The only consumer is `get_loader` in `backend/open_webui/retrieval/utils.py`, reached from `_get_content_from_url_sync`. `backend/open_webui/retrieval/loaders/main.py` imports a different `YoutubeLoader`, from `langchain_community`, and `backend/open_webui/routers/retrieval.py` imported this one without using it, which the new import now makes meaningful.

**One fault described in the linked issue is already fixed on `dev`.** The failure branch of `uploadWeb` read an unbound `url`, which threw a `ReferenceError` before the toast on the following line could run, so no attachment failure reached the interface at all. That was corrected upstream in `8fbfd14a8` while this was being prepared, so it is not part of this change. Without it the messages below would have been produced and then discarded, so the two fixes are complementary.

This PR was prepared with AI copilot assistance and reviewed by the author.

### Manual Verification Performed

`POST /api/v1/retrieval/process/web` and `/process/youtube` against a running instance:

| URL | Before | After |
|---|---|---|
| A page that fetches normally | 200, content extracted | 200, unchanged |
| A YouTube video whose transcript is reachable | 200, 2089 characters | 200, 2089 characters, unchanged |
| A host that does not resolve | 400, `[ERROR: Error querying knowledge base]` | 400, `Could not read content from <url>` |
| A URL rejected by the SSRF guard | 400, `[ERROR: Error querying knowledge base]` | 400, `Could not read content from <url>` |
| YouTube refuses the transcript request | 400, `[ERROR: Error querying knowledge base]` | 400, naming the block and the proxy setting |
| A second refused video | same wrong message | same correct message |

Reason mapping, exercised for every exception type the library defines:

| Exception | Message |
|---|---|
| `RequestBlocked`, `IpBlocked` | names the block and the proxy setting |
| `TranscriptsDisabled` | transcripts are disabled for the video |
| `AgeRestricted` | the video is age restricted |
| `VideoUnavailable`, `VideoUnplayable`, `InvalidVideoId` | the video is unavailable |
| `PoTokenRequired` | additional verification is required |
| anything else | a generic line, with no internal detail leaked |

With the current `dev` toast behaviour in place, attaching a YouTube URL whose transcript the server cannot fetch surfaces the reason in the interface, confirmed by the author in the running application.

### Screenshots or Videos

Before is current `dev`. After is this branch.

| Surface | Before | After |
|---|---|---|
| Attaching a URL whose transcript cannot be fetched | _paste image_ | _paste image_ |

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
