### PR TITLE
fix: stop replaying empty assistant placeholders to the provider

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2096,6 +2096,11 @@ def process_messages_with_output(
                 processed.extend(output_messages)
                 continue
 
+        if message.get('role') == 'assistant' and not message.get('tool_calls'):
+            content = message.get('content')
+            if not (content.strip() if isinstance(content, str) else content):
+                continue
+
         # Strip 'output' field before adding (LLM shouldn't see it)
         clean_message = {k: v for k, v in message.items() if k != 'output'}
         processed.append(clean_message)


### PR DESCRIPTION
An assistant generation that dies before committing a token leaves a node in `history.messages` with `content: ""`, `done: false`, no `output` and no `tool_calls`. That node sits on the parent chain `currentId` walks, so it is replayed on every later completion, and any provider that validates assistant messages server-side rejects the whole request:

```
the message at position 15 with role 'assistant' must not be empty
```

The chat is then permanently broken — regenerating from an earlier turn does not help, because the placeholder is still an ancestor — and the only recovery is editing `webui.db` by hand. Closes #25083.

`process_messages_with_output` is the single point where the outgoing message list is rebuilt. Assistant messages carrying `output` are expanded there into tool_calls and tool results; everything else is passed through untouched, including a message with nothing in it. Dropping the ones with no content, no `output` and no `tool_calls` at that point covers every caller rather than one client.

The `tool_calls` guard matters: an assistant message with empty content but populated `tool_calls` is valid and must survive, since that is exactly the shape a tool-calling turn produces. Content that is a list rather than a string is left alone too.

Reproduced against a running backend pointed at a stub OpenAI-compatible provider that applies the same validation strict providers do. On `dev` at 5caa91a4, a chat seeded with that placeholder and then sent a new prompt logs `HTTP 400 (upstream_error) ... the message at position 1 with role 'assistant' must not be empty` and the turn dies. On this branch the same chat returns 200 and streams normally.

Exercising the function directly across message shapes: the empty and whitespace-only assistants are dropped, while a normal assistant, an assistant with `tool_calls` and empty content, and an assistant whose content is a list all produce output identical to `dev`.

### Changelog Entry

#### Fixed

- A failed or aborted assistant message no longer breaks every subsequent completion on that chat with strict OpenAI-compatible providers.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
