### PR TITLE
fix: exclude non-chat models from OpenAI-compatible gateway catalogs

### DIFF
--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -86,6 +86,34 @@ def _clean_proxy_headers(raw_headers) -> dict:
     return {k: v for k, v in raw_headers.items() if k not in _STRIP_PROXY_HEADERS}
 
 
+def supports_text_generation(model: dict, api_type: str | None = None) -> bool:
+    """Whether *model* can serve the text generation endpoint this connection uses.
+
+    Gateways that front many providers return their whole catalog from
+    ``/models`` - embedding, image, video, rerank and audio models included -
+    and mark each entry with the OpenAI-style ``supported_operations`` /
+    ``supported_endpoints`` hints.  Without this check every one of those
+    non-chat models shows up in the chat model picker.  Providers that
+    advertise nothing are assumed to be chat capable, which keeps plain
+    OpenAI / Ollama / vLLM behaviour unchanged.
+    """
+    if not isinstance(model, dict):
+        return True
+
+    operation = 'RESPONSES' if api_type == 'responses' else 'CHAT_COMPLETIONS'
+
+    operations = model.get('supported_operations')
+    if isinstance(operations, list) and operations:
+        return operation in operations
+
+    endpoints = model.get('supported_endpoints')
+    if isinstance(endpoints, list) and endpoints:
+        endpoint = '/responses' if api_type == 'responses' else '/chat/completions'
+        return any(isinstance(e, str) and e.endswith(endpoint) for e in endpoints)
+
+    return True
+
+
 async def send_get_request(
     request: Request = None,
     url=None,
@@ -596,6 +624,20 @@ async def get_all_models_responses(request: Request, user: UserModel) -> list:
                 # Catch non-list responses
                 model_list = []
 
+            if not api_config.get('model_ids'):
+                # Manually listed model ids are taken at face value; a fetched
+                # catalog gets narrowed down to the models this connection can
+                # actually chat with.
+                api_type = api_config.get('api_type')
+                filtered = [model for model in model_list if supports_text_generation(model, api_type)]
+
+                if len(filtered) != len(model_list):
+                    model_list = filtered
+                    if isinstance(response, list):
+                        responses[idx] = model_list
+                    else:
+                        response['data'] = model_list
+
             for model in model_list:
                 # Remove name key if its value is None #16689
                 if 'name' in model and model['name'] is None:
@@ -772,6 +814,15 @@ async def get_models(request: Request, url_idx: int | None = None, user=Depends(
                                 model
                                 for model in response_data.get('data', [])
                                 if not any(name in model['id'] for name in _UNSUPPORTED_OPENAI_MODEL_KEYWORDS)
+                            ]
+                        elif isinstance(response_data, dict) and isinstance(response_data.get('data'), list):
+                            # Keep the model id picker in sync with what this
+                            # connection will actually serve as chat models.
+                            api_type = api_config.get('api_type')
+                            response_data['data'] = [
+                                model
+                                for model in response_data['data']
+                                if isinstance(model, dict) and supports_text_generation(model, api_type)
                             ]
 
                         models = response_data


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Relates to #28371
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** No documentation change needed — no new setting is introduced.
- [x] **Dependencies:** No new or changed dependencies.
- [x] **Testing:** Manual end-to-end testing performed against a live gateway; details below.
- [ ] **No Unchecked AI Code:** See the disclosure under *Additional Information* before reviewing.
- [x] **Self-Review:** A self-review of the code has been performed.
- [x] **Architecture:** No new setting — the fix uses metadata the provider already sends.
- [x] **Git Hygiene:** Single atomic commit, rebased on `dev`, one file changed.
- [x] **Title Prefix:** `fix`

---

## Description

When an OpenAI-compatible **gateway** is configured as a connection, Open WebUI lists that gateway's entire `/models` catalog as chat models. Gateways front many providers at once, so the catalog also contains embedding, image-generation, video-generation, rerank and speech models. Every one of them shows up in the chat model picker and fails the moment a user selects it.

The existing `_UNSUPPORTED_OPENAI_MODEL_KEYWORDS` filter does not help: it is applied only when the hostname is `api.openai.com`, and being keyword-based it cannot recognise third-party ids such as `recraft/recraft-v4` or `voyageai/rerank-2.5`.

The information needed is already in the response. Gateways tag each entry with the OpenAI-style capability hints:

```json
{
  "id": "voyageai/rerank-2.5",
  "supported_operations": ["RERANK"],
  "supported_endpoints": ["/v1/rerank"]
}
```

Open WebUI ignored both fields. This PR adds `supports_text_generation()` and applies it in the two places a catalog is turned into a model list — `get_all_models_responses()` and the `/models/{url_idx}` admin picker.

**Behaviour:**

- A model is kept if it advertises the operation the connection actually uses: `CHAT_COMPLETIONS`, or `RESPONSES` when the connection has `api_type: responses`.
- `supported_operations` is preferred; `supported_endpoints` is the fallback.
- **A provider advertising neither field is treated as chat capable**, so plain OpenAI, Ollama, vLLM and llama.cpp connections are byte-for-byte unaffected.
- Connections with a manually configured `model_ids` list are left untouched — an explicit list is taken at face value.

No new setting, no new dependency, one file changed.

## Testing

Ran the backend against a live OpenAI-compatible gateway whose `/v1/models` returns 229 entries (154 chat-only, 11 chat+responses, 14 responses-only, 15 embeddings, 16 image, 9 video, 3 TTS, 2 rerank, 1 STT, and others).

| Check | Before | After |
|---|---|---|
| `GET /api/models` | 230 | **166** (165 chat + built-in `arena-model`) |
| Non-chat entries in the picker | 64 | **0** |
| `GET /openai/models/0` (admin model-id picker) | 229 | **165** |
| `POST /api/chat/completions`, non-streaming | ok | ok |
| `POST /api/chat/completions`, streaming | ok | ok |
| `POST /openai/verify` | ok | ok |
| Manual `model_ids` list (2 ids typed) | 2 | **2** — unchanged, filter correctly skipped |
| Second connection with `api_type: responses` | 229 | **25**, and chat through it returns 200 |

Both connections were configured simultaneously to confirm they do not interfere.

`ruff format --check` is clean. `ruff check` reports no new findings — the two `C901` complexity counts that move (`get_all_models_responses` 16→19, `get_models` 13→14) were already above the threshold before this change, as are eight other functions in the file.

## Additional Information

**Disclosure — please read.**

1. **AI-assisted.** This patch was written with AI assistance. I have reviewed it and run the end-to-end testing described above myself, but I am leaving the *"No Unchecked AI Code"* box unchecked rather than assert something you may want to judge for yourselves. Please review it as you would any outside patch.
2. **Conflict of interest.** The gateway I tested against is [llmtr.com](https://llmtr.com), which I operate. This PR contains **no** reference to it and no vendor-specific code — the fix keys off standard OpenAI `supported_operations` / `supported_endpoints` metadata and helps any gateway that emits it, LiteLLM included. I am flagging it so the context is on the record.

Discussion #28371 has the longer write-up.

*Resubmitted from #28372, which the CLA bot closed because the agreement checkbox was left unchecked.*

---

# Changelog Entry

### Description

- Non-chat models returned by OpenAI-compatible gateways no longer appear in the chat model picker.

### Fixed

- **Gateway model lists**: OpenAI-compatible gateways return their whole catalog from `/models`, so embedding, image-generation, video-generation, rerank and speech models were listed as chat models and failed on selection. Open WebUI now honours the `supported_operations` / `supported_endpoints` metadata these gateways already send, and selects the operation matching the connection's API type. Providers that do not send these fields are unaffected.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
