### PR TITLE
fix: send provider-required OAuth authorization parameters for MCP tool servers

### DIFF
--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -2,6 +2,7 @@ import asyncio
 import base64
 import fnmatch
 import hashlib
+import json
 import logging
 import re
 import sys
@@ -103,6 +104,8 @@ class OAuthClientInformationFull(OAuthClientMetadata):
     issuer: Optional[str] = None  # URL of the OAuth server that issued this client
     resource: Optional[str] = None  # RFC 8707 resource indicator for JWT audience
     oauth_resource_parameter: OAuthResourceParameterMode = 'auto'
+    # None means unset (provider defaults apply); {} is a deliberate opt-out.
+    oauth_authorize_params: Optional[dict[str, str]] = None
 
     client_id: str
     client_secret: str | None = None
@@ -119,6 +122,10 @@ logging.basicConfig(stream=sys.stdout, level=GLOBAL_LOG_LEVEL)
 log = logging.getLogger(__name__)
 
 OAUTH_RESOURCE_PARAMETER_MODES = {'auto', 'include', 'omit'}
+
+# Google-issued OAuth client ids always carry this suffix; used to apply the
+# provider's required authorization parameters when none are configured.
+GOOGLE_CLIENT_ID_SUFFIX = '.apps.googleusercontent.com'
 
 OAUTH_RUNTIME_CONFIG = {
     'DEFAULT_USER_ROLE': ('ui.default_user_role', DEFAULT_USER_ROLE),
@@ -743,6 +750,41 @@ def get_connection_oauth_resource_parameter(connection: dict) -> OAuthResourcePa
     )
 
 
+def get_connection_oauth_authorize_params(connection: dict) -> dict[str, str] | None:
+    """Extra provider-specific parameters for the authorization request.
+
+    Some providers require non-standard authorization parameters that are not
+    advertised by OIDC discovery, so authlib cannot infer them. Google needs
+    access_type=offline to issue a refresh token at all, plus prompt=consent to
+    re-issue one for users who already granted.
+
+    Returns None when the connection does not configure the option, so the
+    caller can tell "unset" from an explicitly empty object, which is a
+    deliberate opt-out of the provider defaults.
+    """
+    info = connection.get('info') or {}
+    config = connection.get('config') or {}
+
+    if 'oauth_authorize_params' in info:
+        value = info['oauth_authorize_params']
+    elif 'oauth_authorize_params' in config:
+        value = config['oauth_authorize_params']
+    else:
+        return None
+
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except (json.JSONDecodeError, TypeError):
+            log.warning('oauth_authorize_params is not valid JSON, ignoring')
+            return None
+
+    if not isinstance(value, dict):
+        return None
+
+    return {str(k): str(v) for k, v in value.items() if v is not None}
+
+
 def apply_connection_oauth_options(connection: dict, oauth_client_info: dict) -> dict:
     info = connection.get('info') or {}
     config = connection.get('config') or {}
@@ -752,6 +794,7 @@ def apply_connection_oauth_options(connection: dict, oauth_client_info: dict) ->
     options = {
         **oauth_client_info,
         'oauth_resource_parameter': get_connection_oauth_resource_parameter(connection),
+        'oauth_authorize_params': get_connection_oauth_authorize_params(connection),
     }
     if oauth_scope:
         options['scope'] = oauth_scope
@@ -777,6 +820,21 @@ def should_send_oauth_resource(client_info: OAuthClientInformationFull | None) -
     return not scope_has_resource_indicator(client_info.scope)
 
 
+def default_oauth_authorize_params(client_info: OAuthClientInformationFull) -> dict[str, str]:
+    """Authorization parameters implied by the provider, before per-connection overrides.
+
+    Google issues a refresh token only when the authorization request carries
+    access_type=offline, and only re-issues one when prompt=consent forces the
+    consent screen. Neither is advertised by OIDC discovery. Without them every
+    Google MCP session dies at the one-hour access-token expiry, because
+    get_oauth_token() deletes a session whose refresh cannot proceed.
+    """
+    if f'{client_info.client_id or ""}'.endswith(GOOGLE_CLIENT_ID_SUFFIX):
+        return {'access_type': 'offline', 'prompt': 'consent'}
+
+    return {}
+
+
 def build_oauth_request_params(client_info: OAuthClientInformationFull | None) -> dict:
     if not client_info:
         return {}
@@ -786,6 +844,15 @@ def build_oauth_request_params(client_info: OAuthClientInformationFull | None) -
         params['scope'] = client_info.scope
     if should_send_oauth_resource(client_info):
         params['resource'] = client_info.resource
+
+    overrides = client_info.oauth_authorize_params
+    if overrides is None:
+        params.update(default_oauth_authorize_params(client_info))
+    elif overrides:
+        # Per-key override, so a connection can adjust one provider parameter
+        # without silently dropping the others it still needs.
+        params.update({**default_oauth_authorize_params(client_info), **overrides})
+    # An explicitly empty object sends no extra parameters at all.
     return params
 
 


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Closes #28319
- [x] **Target branch:** targets `dev`
- [x] **Description:** below
- [x] **Changelog:** below
- [ ] **Documentation:** happy to open a docs PR for the new connection option if you want it documented
- [x] **Dependencies:** none added
- [x] **Testing:** see *Testing* below — the mechanism has been running in production; the new default and the JSON-string path are unit-exercised
- [x] **No Unchecked AI Code:** every line human-reviewed; the mechanism was live-tested against a Google Workspace MCP deployment, the new default and JSON-string path are unit-exercised (scope spelled out under *Testing*)
- [x] **Self-Review:** performed; `ruff format --diff` is empty for this file and no new lint findings are introduced
- [x] **Architecture:** smart default (no configuration needed for Google) with a per-connection override; follows the existing `oauth_resource_parameter` pattern
- [x] **Git Hygiene:** single atomic commit on top of `dev`
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

MCP tool servers using `oauth_2.1` / `oauth_2.1_static` never obtain a refresh token from Google, so every Google MCP integration (Gmail, Drive, Calendar, Docs, Sheets, Slides, Workspace Search) loses its authorisation roughly an hour after consent, for every user.

Google issues a refresh token only when the authorization request carries the non-standard `access_type=offline`. Nothing in OIDC discovery advertises this, so authlib cannot infer it, and `build_oauth_request_params()` — the only source of extra authorization parameters on the tool-server path — emits just `scope` and `resource`. The resulting token is online-only (`expires_in: 3599`, no `refresh_token`). Five minutes before expiry `get_oauth_token()` attempts a refresh, `_refresh_token()` bails on the missing refresh token, and the caller **deletes the session**.

The existing `OAUTH_AUTHORIZE_PARAMS` and `GOOGLE_OAUTH_AUTHORIZE_PARAMS` settings do not help: both are applied only in `OAuthManager.handle_login()` / `google_oauth_register()`, i.e. the SSO login flow, never in `OAuthClientManager.handle_authorize()`.

This is *not* the case fixed by #26141. Google does send `expires_in`, so the expiry is genuine rather than fabricated; the session is correctly considered expired and is then destroyed because a refresh token was never requested in the first place.

### Added

- `oauth_authorize_params` on `OAuthClientInformationFull`, a per-connection option holding extra authorization parameters, read from `info.oauth_authorize_params` (with a `config.` fallback) by `get_connection_oauth_authorize_params()`. Accepts a dict or a JSON string; malformed input is logged and ignored rather than raising. This generalises the mechanism `oauth_resource_parameter` already uses, so any provider needing a non-standard authorization parameter is covered rather than special-casing one. Three states, distinguished by key presence:

  | Value | Meaning |
  |---|---|
  | unset (`None`) | provider defaults apply |
  | `{}` | deliberate opt-out; no extra parameters sent |
  | non-empty dict | per-key override on top of the provider defaults |

  The last row merges rather than replaces on purpose: a straight replacement would mean setting `{"prompt": "select_account"}` on a Google connection silently drops `access_type=offline` and reintroduces the very bug this fixes.
- `default_oauth_authorize_params()`, applied when a connection configures nothing: Google-issued client ids (suffix `.apps.googleusercontent.com`) get `access_type=offline` and `prompt=consent`. `prompt=consent` is required so that users who already granted receive a refresh token rather than only new grantees.

### Changed

- `build_oauth_request_params()` merges the connection's parameters, falling back to the provider defaults.

### Fixed

- Google MCP tool-server sessions are no longer deleted an hour after consent. Open WebUI's existing refresh machinery — which was already wired in but had never been given a refresh token — now renews them silently.

### Breaking Changes

None. The field defaults to empty; the only behavioural change is for connections whose OAuth client id is Google-issued, which currently cannot work for more than an hour.

---

### Testing

Deployed against a real multi-user Open WebUI instance with seven of Google's hosted Workspace MCP servers, Google Cloud project enrolled in the Workspace Developer Preview Program, `OAuth 2.1 (Static)` confidential client with PKCE.

- **Before:** `GET /oauth/clients/mcp:<id>/authorize` → 302 carrying only `response_type, client_id, redirect_uri, scope, state, code_challenge, code_challenge_method`. Stored session token keys: `access_token, expires_at, expires_in, issued_at, scope, token_type` — no `refresh_token`. `tokeninfo` reports `access_type: "online"`. Sessions vanished about an hour after consent.
- **After:** the same 302 carries `access_type=offline` and `prompt=consent` for all seven servers. Following one re-consent, `GET /api/v1/users/{id}/oauth/sessions` shows `refresh_token` present for `mcp:gmail`, and the session now survives well past the one-hour mark.
- **Non-Google connections:** with no connection value set and a non-Google client id, `build_oauth_request_params()` output is byte-identical to before this change.

Scope of that evidence, to be precise: the per-connection field, the parser and the merge ran in production (configured as a dict via `POST /api/v1/configs/tool_servers`, on `v0.11.0` where this file is otherwise identical to `dev`). The Google default and the JSON-string input path are new here and are covered by the checks below rather than by production traffic.

`get_connection_oauth_authorize_params()` — dict via `info`, JSON string, `config` fallback, invalid JSON (logs and returns `{}`), non-dict input, absent key, empty connection, `None` values stripped. `default_oauth_authorize_params()` — Google client id, non-Google client id, empty id, `None` id, and a lookalike (`evil.apps.googleusercontent.com.attacker.test`, correctly rejected since the check is a suffix match). All pass.

### Notes

- No UI control is included. The option is settable through `POST /api/v1/configs/tool_servers`, and Google — the case that actually breaks — needs no configuration at all thanks to the default. If you'd like it exposed beside the existing "OAuth Resource Parameter" advanced option in `AddToolServerModal.svelte`, say so and I'll add it.
- On the first-time-contributor note: the design was written up in #28319 with three candidate shapes and an explicit request for maintainer preference. This PR implements the shape matching the precedent set by #25898 (per-connection option) plus a smart default, per the architecture guidance in this checklist. Glad to move the discussion to Discussions if you'd prefer that.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.