### PR TITLE
fix: keep the extracted text when attaching a URL

### DIFF
--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -449,6 +449,12 @@ class ProcessUrlForm(CollectionNameForm):
     url: str
 
 
+def _extracted_web_content(result: dict) -> Optional[str]:
+    if result.get('content') is not None:
+        return result.get('content')
+    return ((result.get('file') or {}).get('data') or {}).get('content')
+
+
 class ProcessUrlResponse(BaseModel):
     status: bool
     type: str
@@ -2269,7 +2275,7 @@ async def process_url(
                 'name': form_data.url,
                 'url': form_data.url,
                 'collection_name': result.get('collection_name'),
-                'content': result.get('content'),
+                'content': _extracted_web_content(result),
             }
 
         config = await get_retrieval_config()
@@ -2283,7 +2289,7 @@ async def process_url(
                 'name': form_data.url,
                 'url': form_data.url,
                 'collection_name': result.get('collection_name'),
-                'content': result.get('content'),
+                'content': _extracted_web_content(result),
             }
 
         from open_webui.routers.files import upload_file_handler

--- a/src/lib/components/chat/Messages/Citations/CitationModal.svelte
+++ b/src/lib/components/chat/Messages/Citations/CitationModal.svelte
@@ -223,7 +223,7 @@
 									title={$i18n.t('Content')}
 								></iframe>
 							{:else}
-								{@const rawContent = document.document.trim().replace(/\n\n+/g, '\n\n')}
+								{@const rawContent = (document.document ?? '').trim().replace(/\n\n+/g, '\n\n')}
 								{@const isTruncated =
 									($settings?.renderMarkdownInPreviews ?? true) &&
 									rawContent.length > CONTENT_PREVIEW_LIMIT &&


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #28378
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable. No configuration surface changes.
- [ ] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Reproduced against a running instance, then verified at the endpoint for a plain page, a long article and a YouTube transcript.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new settings and no new endpoint. One helper reading the value from where it is actually returned, and a null guard.
- [x] **Git Hygiene:** A single commit, +9/-3 across two files, based on the current `dev`.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

Attaching a URL looked successful but gave the model nothing. A collection was created, the source was listed under the reply, and no error appeared, yet the reply described the source as a placeholder with no content.

`process_url` delegates to `process_web` and then reads the extracted text from a key that only exists on the other branch:

```python
result = await process_web(request, form_data, process=process, user=user)
return {
    ...
    'content': result.get('content'),
}
```

`process_web` returns a top level `content` only when asked not to process. On the default path the text is nested under `result['file']['data']['content']`, so `result.get('content')` was always `None`, for the web branch and the YouTube branch alike. The frontend copies that value straight into the attachment it builds, which is what left the model with an empty document.

Opening the source to check what had been captured then threw, because `CitationModal.svelte` called `trim` on the missing document directly. That is fixed here too, so a citation without a document renders as empty instead of crashing.

### Fixed

- An attached web page or YouTube video now reaches the model with its extracted text, instead of arriving empty while appearing to have succeeded.
- Opening a citation that has no document no longer throws.

---

### Additional Information

**Why a helper rather than reaching into the nested value inline.** Both the web and the YouTube branch return the same shape, and `process_web` can legitimately produce either layout depending on `process`. Reading through one function keeps the two call sites honest about that, and keeps working if the unprocessed branch is ever used from here.

**Scope of the failure.** Because both branches read the same wrong key, every URL attachment was affected, not only web pages. A YouTube video whose transcript fetched perfectly still arrived with no text.

**The citation guard is deliberate.** With the content fixed, a null document should not normally occur through this path, but the modal receives citations from several sources and crashing on a missing field is not a reasonable failure mode for any of them.

`process_url` was introduced recently, so this affects current `dev` rather than v0.11.0 as released.

This PR was prepared with AI copilot assistance and reviewed by the author.

### Manual Verification Performed

`POST /api/v1/retrieval/process/url` against a running instance, same URLs before and after:

| URL | Before | After |
|---|---|---|
| A plain web page | `content: None` | 129 characters |
| A longer article | `content: None` | 16,466 characters |
| A YouTube video with a reachable transcript | `content: None` | 2,089 characters |

Each returned HTTP 200 with a collection set in both cases, which is why nothing signalled the loss before.

The crash was reproduced in the browser by clicking the source pill under a reply, and the guard was confirmed by reading the compiled component.

### Screenshots or Videos

Before is current `dev`. After is this branch.

| Surface | Before | After |
|---|---|---|
| Reply to a question about an attached page | <img width="2560" height="812" alt="image" src="https://github.com/user-attachments/assets/1b09a00f-7993-42a5-9c80-90c097dd2f79" /> | <img width="2560" height="1279" alt="image" src="https://github.com/user-attachments/assets/d4e631ba-4c89-4688-8578-5fd3bb94b9b6" /> |
| Citation modal opened from the source pill | <img width="2560" height="471" alt="image" src="https://github.com/user-attachments/assets/5f6a075b-5f96-4ba2-b835-3b606d2c28e8" /> | <img width="1093" height="522" alt="image" src="https://github.com/user-attachments/assets/1324b027-08be-4b1b-a724-43df8e681675" /> |

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
