### PR TITLE
fix: release a queued message once an attached URL finishes

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -1605,6 +1605,8 @@
 				toast.error(`${e}`);
 			}
 		}
+
+		await onUpdate();
 	};
 
 	const onUpdate = async ({ file }: { file?: any } = {}) => {


### PR DESCRIPTION
# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR. For bug fixes referencing an existing Issue, linking the Issue is sufficient.

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #28380
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable. No configuration surface changes.
- [ ] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** The stall was observed in the running application and the mechanism traced through the source. See the note below on what could and could not be reproduced on demand.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new state and no new function. One call to the existing queue hook, at the point the file path already calls it.
- [x] **Git Hygiene:** A single commit, +2 lines in one file, based on the current `dev`.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

A message sent while an attachment is still processing is held in the chat queue until the attachment settles. For uploaded files that works, because the message input calls `onUpdate` once the upload completes, which refreshes the queued entry and runs the queue:

```js
const onUpdate = async ({ file }: { file?: any } = {}) => {
    if (file?.itemId) { ...refresh the queued entry... }
    await processNextInQueue($chatId);
};
```

Attaching a URL takes a different path. `uploadWeb` marks its item as uploaded but calls neither `onUpdate` nor `processNextInQueue`, and the items it builds carry no `itemId` for `onUpdate` to match on.

The queue is otherwise revisited in only four places: when a generation completes, twice; when a generation is stopped; and when a chat is mounted while idle. In a new chat with nothing generating, none of those can happen, so a message queued behind a URL has no event able to release it. Reloading the chat sends it, through the mount case, but nothing on screen suggests that.

`uploadWeb` now runs the queue when it finishes, the same way the file path already does.

### Fixed

- A message sent while a URL attachment is still processing is now sent once the attachment is ready, instead of waiting in the queue until the chat is reloaded.

---

### Additional Information

**Why `onUpdate()` rather than `processNextInQueue($chatId)` directly.** `onUpdate` already is the hook the upload path uses for exactly this, and called without an argument it skips the entry refresh and runs the queue. Using it keeps both attachment paths going through one place, rather than adding a second way to reach the queue.

**Why no `itemId` is added to the web items.** The queued entry holds the same item objects that `uploadWeb` mutates, so the status is already current by the time the queue runs; only the trigger was missing. Giving web items an `itemId` would make `onUpdate` able to refresh them as well, but that is a larger change and is not needed to release the queue.

**On reproducibility.** The stall was observed in the running application while attaching a page that took roughly sixteen seconds to fetch, which is a wide enough window to queue a message behind. A later attempt to recreate it with automated input did not reproduce it, because once a page has a collection it resolves in under a second, so the message never queues at all. The mechanism above is therefore traced through the source rather than demonstrated by an automated test, and the fix is verified in the compiled component and by the file path that already relies on the same hook. Reviewers wanting to see it should use a URL that has not been attached before.

This PR was prepared with AI copilot assistance and reviewed by the author.

### Manual Verification Performed

1. Traced every path that reaches `processNextInQueue`, confirming that four are generation or mount related and that `uploadWeb` reached none of them.
2. Confirmed `uploadWeb` calls neither `onUpdate` nor `processNextInQueue` before this change, and that its file items carry no `itemId`.
3. Confirmed the queued entry shares its item objects with the live attachment list, so the status the queue reads is already up to date and only the trigger was missing.
4. Confirmed the added call is present in the compiled component.
5. Checked that Prettier reports the same result on this file before and after, so no unrelated formatting is included.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
