### PR TITLE
fix: OpenAPI tool results skip every other inline data: URI

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -1051,6 +1051,10 @@ async def process_tool_result(
                             tool_response.append(resource.get('uri'))
             tool_result = tool_response[0] if len(tool_response) == 1 else tool_response
         else:  # OpenAPI
+            # Collect into a new list instead of removing from the list being
+            # iterated: list.remove() shifts every later element down by one,
+            # so the item after each extracted one is skipped entirely.
+            remaining_tool_result = []
             for item in tool_result:
                 if isinstance(item, str) and item.startswith('data:'):
                     tool_result_files.append(
@@ -1059,7 +1063,9 @@ async def process_tool_result(
                             'content': item,
                         }
                     )
-                    tool_result.remove(item)
+                else:
+                    remaining_tool_result.append(item)
+            tool_result = remaining_tool_result
 
     if isinstance(tool_result, list):
         tool_result = {'results': tool_result}


### PR DESCRIPTION
Closes #28394

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #28394
- [x] **Target branch:** targets `dev`
- [x] **Description:** below
- [x] **Changelog:** at the bottom
- [ ] **Documentation:** no user-facing docs affected
- [ ] **Dependencies:** none added or changed
- [x] **Testing:** manual verification below
- [x] **No Unchecked AI Code:** reviewed and manually tested by me before opening
- [x] **Self-Review:** performed
- [x] **Architecture:** no new settings, no state changes, one local variable

## Description

`process_tool_result()` extracts inline `data:` URIs out of an OpenAPI tool's
result list while iterating over that same list. `list.remove()` shifts every
later element down by one, so the item immediately after each extracted one is
never visited.

With two adjacent `data:` results:

```python
["data:image/png;base64,AAA", "data:image/png;base64,BBB", "plain text"]

before -> files=["...AAA"]            result=["...BBB", "plain text"]
after  -> files=["...AAA", "...BBB"]  result=["plain text"]
```

The missed URI is never rendered as an attachment. Worse, it stays inside
`tool_result`, which is `json.dumps()`'d straight into the model's context a few
lines later — so a full base64 image is spent as prompt tokens.

The fix collects the keepers into a new list instead of mutating the list being
iterated. Seven lines, one local variable, no behaviour change in the
single-`data:` and zero-`data:` cases.

## Testing

Ran the before/after on the extraction loop directly:

```
old -> (['data:image/png;base64,AAA'], ['data:image/png;base64,BBB', 'plain text'])
new -> (['data:image/png;base64,AAA', 'data:image/png;base64,BBB'], ['plain text'])
```

`ruff format --check` clean. `ruff check` reports exactly the same 61
pre-existing findings on this file as `dev` does — the change adds none.

I did not add an automated test: there is no Python test suite in the repo for
`backend/`, and `process_tool_result` is a large async function with no existing
harness. Happy to add one if you would like a place for it.

## Changelog

### Fixed

- OpenAPI tool results containing multiple inline `data:` URIs now extract all
  of them as attachments instead of every other one, preventing base64 payloads
  from leaking into the model context.
