### PR TITLE
perf: make ENABLE_ORJSON actually apply to native JSON columns

### DIFF
--- a/backend/open_webui/internal/db.py
+++ b/backend/open_webui/internal/db.py
@@ -232,6 +232,27 @@ def _make_async_url(url: str) -> str:
     return url
 
 
+def _json_codec_kwargs(kwargs: dict) -> dict:
+    """Default an engine to JSONCodec for native ``JSON`` columns.
+
+    Unlike ``JSONField``, those serialize through the engine, which otherwise uses
+    stdlib ``json``. With ``ENABLE_ORJSON`` off JSONCodec is stdlib ``json`` anyway.
+    """
+    kwargs.setdefault('json_serializer', JSONCodec.dumps)
+    kwargs.setdefault('json_deserializer', JSONCodec.loads)
+    return kwargs
+
+
+def _create_engine(*args, **kwargs):
+    """``create_engine`` with the app JSON codec wired in."""
+    return create_engine(*args, **_json_codec_kwargs(kwargs))
+
+
+def _create_async_engine(*args, **kwargs):
+    """``create_async_engine`` with the app JSON codec wired in."""
+    return create_async_engine(*args, **_json_codec_kwargs(kwargs))
+
+
 # ============================================================
 # SYNC ENGINE (used only for: startup migrations, config loading,
 #              Alembic, peewee migration, health checks)
@@ -260,7 +281,7 @@ if SQLALCHEMY_DATABASE_URL.startswith('sqlite+sqlcipher://'):
     # in the native sqlcipher3 C library. Use NullPool by default for safety,
     # or QueuePool if DATABASE_POOL_SIZE is explicitly configured.
     if isinstance(DATABASE_POOL_SIZE, int) and DATABASE_POOL_SIZE > 0:
-        engine = create_engine(
+        engine = _create_engine(
             'sqlite://',
             creator=create_sqlcipher_connection,
             pool_size=DATABASE_POOL_SIZE,
@@ -272,7 +293,7 @@ if SQLALCHEMY_DATABASE_URL.startswith('sqlite+sqlcipher://'):
             echo=False,
         )
     else:
-        engine = create_engine(
+        engine = _create_engine(
             'sqlite://',
             creator=create_sqlcipher_connection,
             poolclass=NullPool,
@@ -282,7 +303,7 @@ if SQLALCHEMY_DATABASE_URL.startswith('sqlite+sqlcipher://'):
     log.info('Connected to encrypted SQLite database using SQLCipher')
 
 elif 'sqlite' in SQLALCHEMY_DATABASE_URL:
-    engine = create_engine(SQLALCHEMY_DATABASE_URL, connect_args={'check_same_thread': False})
+    engine = _create_engine(SQLALCHEMY_DATABASE_URL, connect_args={'check_same_thread': False})
 
     def _apply_sqlite_pragmas(dbapi_connection):
         """Apply all configured SQLite PRAGMAs to a raw DBAPI connection."""
@@ -314,7 +335,7 @@ elif 'sqlite' in SQLALCHEMY_DATABASE_URL:
 else:
     if isinstance(DATABASE_POOL_SIZE, int):
         if DATABASE_POOL_SIZE > 0:
-            engine = create_engine(
+            engine = _create_engine(
                 SQLALCHEMY_DATABASE_URL,
                 pool_size=DATABASE_POOL_SIZE,
                 max_overflow=DATABASE_POOL_MAX_OVERFLOW,
@@ -324,9 +345,9 @@ else:
                 poolclass=QueuePool,
             )
         else:
-            engine = create_engine(SQLALCHEMY_DATABASE_URL, pool_pre_ping=True, poolclass=NullPool)
+            engine = _create_engine(SQLALCHEMY_DATABASE_URL, pool_pre_ping=True, poolclass=NullPool)
     else:
-        engine = create_engine(SQLALCHEMY_DATABASE_URL, pool_pre_ping=True)
+        engine = _create_engine(SQLALCHEMY_DATABASE_URL, pool_pre_ping=True)
 
 enable_iam_token_auth(engine)
 
@@ -373,7 +394,7 @@ if 'sqlite' in ASYNC_SQLALCHEMY_DATABASE_URL:
     # No pool_pre_ping: a local SQLite file cannot drop connections, and the
     # ping costs a worker-thread hop plus a SELECT 1 on every checkout.
     _sqlite_pool_size = DATABASE_POOL_SIZE if isinstance(DATABASE_POOL_SIZE, int) and DATABASE_POOL_SIZE > 0 else 512
-    async_engine = create_async_engine(
+    async_engine = _create_async_engine(
         ASYNC_SQLALCHEMY_DATABASE_URL,
         connect_args={'check_same_thread': False},
         pool_size=_sqlite_pool_size,
@@ -387,7 +408,7 @@ if 'sqlite' in ASYNC_SQLALCHEMY_DATABASE_URL:
 else:
     if isinstance(DATABASE_POOL_SIZE, int):
         if DATABASE_POOL_SIZE > 0:
-            async_engine = create_async_engine(
+            async_engine = _create_async_engine(
                 ASYNC_SQLALCHEMY_DATABASE_URL,
                 pool_size=DATABASE_POOL_SIZE,
                 max_overflow=DATABASE_POOL_MAX_OVERFLOW,
@@ -396,13 +417,13 @@ else:
                 pool_pre_ping=True,
             )
         else:
-            async_engine = create_async_engine(
+            async_engine = _create_async_engine(
                 ASYNC_SQLALCHEMY_DATABASE_URL,
                 pool_pre_ping=True,
                 poolclass=NullPool,
             )
     else:
-        async_engine = create_async_engine(
+        async_engine = _create_async_engine(
             ASYNC_SQLALCHEMY_DATABASE_URL,
             pool_pre_ping=True,
         )


### PR DESCRIPTION
Serialize/deserialize of chat-shaped blobs, median of 11 runs, `ENABLE_ORJSON=true`:

| chat blob | write | read |
| --- | --- | --- |
| 600 msgs (2.8 MB) | 10.1 → 1.7 ms | 8.4 → 3.7 ms |
| 3000 msgs (14.2 MB) | 51.9 → 8.0 ms | 48.5 → 27.8 ms |
| 6000 msgs (28.5 MB) | 105.9 → 29.5 ms | 112.7 → 80.5 ms |

**Round-trip.** A probe through a native `JSON` column returns objects equal to the stdlib ones on all 12 shapes tried: ASCII, CJK, emoji, astral-plane, unicode keys, null bytes, lone surrogates, floats, ints above 2\*\*63 and 2\*\*64, line separators, empty, deeply nested.

**Stored text** changes for non-ASCII — raw UTF-8 rather than `\uXXXX` escapes, and correspondingly smaller. Nothing queries that text by escape except two Postgres safety filters in `chats.py`, and both still hold: a null byte is escaped identically by both codecs, and the title filter reads a text column, not JSON. The `->>` and `json_extract` searches decode the string before matching.

**Known costs.** Where orjson rejects a value it falls back to stdlib, so writes containing a lone surrogate, a non-str dict key, or an int past 2\*\*64 are a wash rather than a win. Reading a legacy row containing a bare `NaN` is ~1.3× slower, since orjson parses, rejects, and stdlib re-parses — SQLite only, as Postgres rejects that invalid JSON today. Two behaviours are inherent to `JSONCodec` and already apply to every `JSONField` column: ints beyond 2\*\*64−1 come back as `float`, and `NaN`/`Infinity` serialize to `null`. Neither shape occurs in chat blobs.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
