### PR TITLE
fix: recover call audio after microphone disconnects

### DIFF
--- a/src/lib/components/chat/MessageInput/CallOverlay.svelte
+++ b/src/lib/components/chat/MessageInput/CallOverlay.svelte
@@ -12,7 +12,12 @@
 
 	import Tooltip from '$lib/components/common/Tooltip.svelte';
 	import VideoInputMenu from './CallOverlay/VideoInputMenu.svelte';
-	import { hasLiveAudioTrack, singleFlight, watchAudioTrackEnd } from './CallOverlay/audio-stream';
+	import {
+		createAsyncQueue,
+		hasLiveAudioTrack,
+		singleFlight,
+		watchAudioTrackEnd
+	} from './CallOverlay/audio-stream';
 	import { KokoroWorker } from '$lib/workers/KokoroWorker';
 	import { WEBUI_API_BASE_URL } from '$lib/constants';
 
@@ -48,6 +53,9 @@
 	let audioStatus: 'listening' | 'reconnecting' | 'unavailable' = 'reconnecting';
 	let stopWatchingAudioTrack = () => {};
 	let audioAnalysisGeneration = 0;
+	let callOverlayDestroyed = false;
+	let watchingAudioDevices = false;
+	const enqueueAudioTransition = createAsyncQueue();
 
 	let videoInputDevices = [];
 	let selectedVideoInputDeviceId = null;
@@ -234,8 +242,13 @@
 		}
 	};
 
-	const startRecording = async () => {
-		if ($showCallOverlay) {
+	const startRecordingUnlocked = async () => {
+		if ($showCallOverlay && !callOverlayDestroyed) {
+			if (mediaRecorder && hasLiveAudioTrack(audioStream)) {
+				audioStatus = 'listening';
+				return true;
+			}
+
 			if (!hasLiveAudioTrack(audioStream)) {
 				audioStatus = 'reconnecting';
 
@@ -248,14 +261,10 @@
 						}
 					});
 				} catch (error) {
-					console.error('Error accessing media devices.', error);
-					audioStream = null;
-					audioStatus = 'unavailable';
-					toast.error($i18n.t('Error accessing media devices.'));
-					return false;
+					return await handleAudioSetupError(error);
 				}
 
-				if (!$showCallOverlay) {
+				if (!$showCallOverlay || callOverlayDestroyed) {
 					audioStream.getAudioTracks().forEach((track) => track.stop());
 					audioStream = null;
 					return false;
@@ -268,35 +277,40 @@
 			}
 
 			if (!hasLiveAudioTrack(audioStream)) {
-				audioStatus = 'unavailable';
-				return false;
+				return await handleAudioSetupError(new Error('Acquired audio stream has no live track.'));
 			}
 
-			mediaRecorder = new MediaRecorder(audioStream);
-			audioStatus = 'listening';
+			try {
+				mediaRecorder = new MediaRecorder(audioStream);
 
-			mediaRecorder.onstart = () => {
-				console.log('Recording started');
-				audioChunks = [];
-			};
+				mediaRecorder.onstart = () => {
+					console.log('Recording started');
+					audioChunks = [];
+				};
 
-			mediaRecorder.ondataavailable = (event) => {
-				if (hasStartedSpeaking) {
-					audioChunks.push(event.data);
-				}
-			};
+				mediaRecorder.ondataavailable = (event) => {
+					if (hasStartedSpeaking) {
+						audioChunks.push(event.data);
+					}
+				};
 
-			mediaRecorder.onstop = (e) => {
-				console.log('Recording stopped', audioStream, e);
-				stopRecordingCallback();
-			};
+				mediaRecorder.onstop = (e) => {
+					console.log('Recording stopped', audioStream, e);
+					void stopRecordingCallback();
+				};
 
-			analyseAudio(audioStream, ++audioAnalysisGeneration);
-			return true;
+				analyseAudio(audioStream, ++audioAnalysisGeneration);
+				audioStatus = 'listening';
+				return true;
+			} catch (error) {
+				return await handleAudioSetupError(error);
+			}
 		}
 
 		return false;
 	};
+
+	const startRecording = () => enqueueAudioTransition(startRecordingUnlocked);
 
 	const stopAudioStream = async () => {
 		const recorder = mediaRecorder;
@@ -324,23 +338,52 @@
 		audioStream = null;
 	};
 
-	const recoverAudioStream = singleFlight(async () => {
-		if (!$showCallOverlay) {
+	const handleAudioSetupError = async (error: unknown) => {
+		console.error('Error setting up media devices.', error);
+		await stopAudioStream();
+
+		if (!$showCallOverlay || callOverlayDestroyed) {
 			return false;
 		}
 
-		audioStatus = 'reconnecting';
-		hasStartedSpeaking = false;
-		confirmed = false;
-		audioChunks = [];
+		audioStatus = 'unavailable';
+		toast.error($i18n.t('Error accessing media devices.'));
+		return false;
+	};
 
-		await stopAudioStream();
-		return await startRecording();
-	});
+	const recoverAudioStream = singleFlight(() =>
+		enqueueAudioTransition(async () => {
+			if (!$showCallOverlay || callOverlayDestroyed) {
+				return false;
+			}
+
+			audioStatus = 'reconnecting';
+			hasStartedSpeaking = false;
+			confirmed = false;
+			audioChunks = [];
+
+			await stopAudioStream();
+			return await startRecordingUnlocked();
+		})
+	);
 
 	const handleAudioDeviceChange = () => {
 		if ($showCallOverlay && !hasLiveAudioTrack(audioStream)) {
 			void recoverAudioStream();
+		}
+	};
+
+	const startWatchingAudioDevices = () => {
+		if (!watchingAudioDevices && !callOverlayDestroyed) {
+			navigator.mediaDevices.addEventListener('devicechange', handleAudioDeviceChange);
+			watchingAudioDevices = true;
+		}
+	};
+
+	const stopWatchingAudioDevices = () => {
+		if (watchingAudioDevices) {
+			navigator.mediaDevices.removeEventListener('devicechange', handleAudioDeviceChange);
+			watchingAudioDevices = false;
 		}
 	};
 
@@ -354,13 +397,23 @@
 		return Math.sqrt(sumSquares / data.length);
 	};
 
-	const analyseAudio = (stream, generation) => {
+	const analyseAudio = (stream: MediaStream, generation: number) => {
 		const audioContext = new AudioContext();
-		const audioStreamSource = audioContext.createMediaStreamSource(stream);
+		let audioStreamSource;
+		let analyser;
+		const closeAudioContext = () => {
+			void audioContext.close().catch(() => {});
+		};
 
-		const analyser = audioContext.createAnalyser();
-		analyser.minDecibels = MIN_DECIBELS;
-		audioStreamSource.connect(analyser);
+		try {
+			audioStreamSource = audioContext.createMediaStreamSource(stream);
+			analyser = audioContext.createAnalyser();
+			analyser.minDecibels = MIN_DECIBELS;
+			audioStreamSource.connect(analyser);
+		} catch (error) {
+			closeAudioContext();
+			throw error;
+		}
 
 		const bufferLength = analyser.frequencyBinCount;
 
@@ -371,10 +424,20 @@
 		hasStartedSpeaking = false;
 
 		console.log('🔊 Sound detection started', lastSoundTime, hasStartedSpeaking);
+		let analysisStopped = false;
+		const stopAnalysis = () => {
+			if (analysisStopped) {
+				return;
+			}
+
+			analysisStopped = true;
+			closeAudioContext();
+		};
 
 		const detectSound = () => {
 			const processFrame = () => {
 				if (!mediaRecorder || !$showCallOverlay || generation !== audioAnalysisGeneration) {
+					stopAnalysis();
 					return;
 				}
 
@@ -422,6 +485,7 @@
 						if (mediaRecorder) {
 							console.log('%c%s', 'color: red; font-size: 20px;', '🔇 Silence detected');
 							mediaRecorder.stop();
+							stopAnalysis();
 							return;
 						}
 					}
@@ -740,7 +804,7 @@
 		}
 	};
 
-	onMount(async () => {
+	onMount(() => {
 		const setWakeLock = async () => {
 			try {
 				wakeLock = await navigator.wakeLock.request('screen');
@@ -758,51 +822,40 @@
 			}
 		};
 
-		if ('wakeLock' in navigator) {
-			await setWakeLock();
+		const handleVisibilityChange = () => {
+			if (wakeLock !== null && document.visibilityState === 'visible') {
+				void setWakeLock();
+			}
+		};
 
-			document.addEventListener('visibilitychange', async () => {
-				// Re-request the wake lock if the document becomes visible
-				if (wakeLock !== null && document.visibilityState === 'visible') {
-					await setWakeLock();
-				}
-			});
+		if ('wakeLock' in navigator) {
+			void setWakeLock();
+			document.addEventListener('visibilitychange', handleVisibilityChange);
 		}
 
 		model = $models.find((m) => m.id === modelId);
-
-		await startRecording();
-		navigator.mediaDevices.addEventListener('devicechange', handleAudioDeviceChange);
 
 		eventTarget.addEventListener('chat:start', chatStartHandler);
 		eventTarget.addEventListener('chat', chatEventHandler);
 		eventTarget.addEventListener('chat:finish', chatFinishHandler);
 
 		document.addEventListener('keydown', handleKeydown);
+		void startRecording().finally(startWatchingAudioDevices);
 
-		return async () => {
-			await stopAllAudio();
-
-			stopAudioStream();
-
+		return () => {
+			callOverlayDestroyed = true;
 			eventTarget.removeEventListener('chat:start', chatStartHandler);
 			eventTarget.removeEventListener('chat', chatEventHandler);
 			eventTarget.removeEventListener('chat:finish', chatFinishHandler);
 
 			document.removeEventListener('keydown', handleKeydown);
-			navigator.mediaDevices.removeEventListener('devicechange', handleAudioDeviceChange);
-
-			audioAbortController.abort();
-			await tick();
-
-			await stopAllAudio();
-
-			await stopRecordingCallback(false);
-			await stopCamera();
+			document.removeEventListener('visibilitychange', handleVisibilityChange);
+			stopWatchingAudioDevices();
 		};
 	});
 
 	onDestroy(async () => {
+		callOverlayDestroyed = true;
 		await stopAllAudio();
 		await stopRecordingCallback(false);
 		await stopCamera();
@@ -813,7 +866,7 @@
 		eventTarget.removeEventListener('chat:finish', chatFinishHandler);
 
 		document.removeEventListener('keydown', handleKeydown);
-		navigator.mediaDevices.removeEventListener('devicechange', handleAudioDeviceChange);
+		stopWatchingAudioDevices();
 
 		audioAbortController.abort();
 

--- a/src/lib/components/chat/MessageInput/CallOverlay.svelte
+++ b/src/lib/components/chat/MessageInput/CallOverlay.svelte
@@ -12,6 +12,7 @@
 
 	import Tooltip from '$lib/components/common/Tooltip.svelte';
 	import VideoInputMenu from './CallOverlay/VideoInputMenu.svelte';
+	import { hasLiveAudioTrack, singleFlight, watchAudioTrackEnd } from './CallOverlay/audio-stream';
 	import { KokoroWorker } from '$lib/workers/KokoroWorker';
 	import { WEBUI_API_BASE_URL } from '$lib/constants';
 
@@ -44,6 +45,9 @@
 	let mediaRecorder;
 	let audioStream = null;
 	let audioChunks = [];
+	let audioStatus: 'listening' | 'reconnecting' | 'unavailable' = 'reconnecting';
+	let stopWatchingAudioTrack = () => {};
+	let audioAnalysisGeneration = 0;
 
 	let videoInputDevices = [];
 	let selectedVideoInputDeviceId = null;
@@ -194,7 +198,7 @@
 			mediaRecorder = false;
 
 			if (_continue) {
-				startRecording();
+				await startRecording();
 			}
 
 			if (confirmed) {
@@ -232,21 +236,44 @@
 
 	const startRecording = async () => {
 		if ($showCallOverlay) {
-			if (!audioStream) {
-				audioStream = await navigator.mediaDevices.getUserMedia({
-					audio: {
-						echoCancellation: true,
-						noiseSuppression: true,
-						autoGainControl: true
-					}
+			if (!hasLiveAudioTrack(audioStream)) {
+				audioStatus = 'reconnecting';
+
+				try {
+					audioStream = await navigator.mediaDevices.getUserMedia({
+						audio: {
+							echoCancellation: true,
+							noiseSuppression: true,
+							autoGainControl: true
+						}
+					});
+				} catch (error) {
+					console.error('Error accessing media devices.', error);
+					audioStream = null;
+					audioStatus = 'unavailable';
+					toast.error($i18n.t('Error accessing media devices.'));
+					return false;
+				}
+
+				if (!$showCallOverlay) {
+					audioStream.getAudioTracks().forEach((track) => track.stop());
+					audioStream = null;
+					return false;
+				}
+
+				stopWatchingAudioTrack();
+				stopWatchingAudioTrack = watchAudioTrackEnd(audioStream, () => {
+					void recoverAudioStream();
 				});
 			}
 
-			if (audioStream) {
-				// hardware track muting disabled to prevent backend translation errors with malformed WebM files
+			if (!hasLiveAudioTrack(audioStream)) {
+				audioStatus = 'unavailable';
+				return false;
 			}
 
 			mediaRecorder = new MediaRecorder(audioStream);
+			audioStatus = 'listening';
 
 			mediaRecorder.onstart = () => {
 				console.log('Recording started');
@@ -264,18 +291,29 @@
 				stopRecordingCallback();
 			};
 
-			analyseAudio(audioStream);
+			analyseAudio(audioStream, ++audioAnalysisGeneration);
+			return true;
 		}
+
+		return false;
 	};
 
 	const stopAudioStream = async () => {
+		const recorder = mediaRecorder;
+		mediaRecorder = false;
+		audioAnalysisGeneration += 1;
+
 		try {
-			if (mediaRecorder) {
-				mediaRecorder.stop();
+			if (recorder && recorder.state !== 'inactive') {
+				recorder.onstop = null;
+				recorder.stop();
 			}
 		} catch (error) {
 			console.log('Error stopping audio stream:', error);
 		}
+
+		stopWatchingAudioTrack();
+		stopWatchingAudioTrack = () => {};
 
 		if (!audioStream) return;
 
@@ -284,6 +322,26 @@
 		});
 
 		audioStream = null;
+	};
+
+	const recoverAudioStream = singleFlight(async () => {
+		if (!$showCallOverlay) {
+			return false;
+		}
+
+		audioStatus = 'reconnecting';
+		hasStartedSpeaking = false;
+		confirmed = false;
+		audioChunks = [];
+
+		await stopAudioStream();
+		return await startRecording();
+	});
+
+	const handleAudioDeviceChange = () => {
+		if ($showCallOverlay && !hasLiveAudioTrack(audioStream)) {
+			void recoverAudioStream();
+		}
 	};
 
 	// Function to calculate the RMS level from time domain data
@@ -296,7 +354,7 @@
 		return Math.sqrt(sumSquares / data.length);
 	};
 
-	const analyseAudio = (stream) => {
+	const analyseAudio = (stream, generation) => {
 		const audioContext = new AudioContext();
 		const audioStreamSource = audioContext.createMediaStreamSource(stream);
 
@@ -316,7 +374,7 @@
 
 		const detectSound = () => {
 			const processFrame = () => {
-				if (!mediaRecorder || !$showCallOverlay) {
+				if (!mediaRecorder || !$showCallOverlay || generation !== audioAnalysisGeneration) {
 					return;
 				}
 
@@ -713,7 +771,8 @@
 
 		model = $models.find((m) => m.id === modelId);
 
-		startRecording();
+		await startRecording();
+		navigator.mediaDevices.addEventListener('devicechange', handleAudioDeviceChange);
 
 		eventTarget.addEventListener('chat:start', chatStartHandler);
 		eventTarget.addEventListener('chat', chatEventHandler);
@@ -731,6 +790,7 @@
 			eventTarget.removeEventListener('chat:finish', chatFinishHandler);
 
 			document.removeEventListener('keydown', handleKeydown);
+			navigator.mediaDevices.removeEventListener('devicechange', handleAudioDeviceChange);
 
 			audioAbortController.abort();
 			await tick();
@@ -753,6 +813,7 @@
 		eventTarget.removeEventListener('chat:finish', chatFinishHandler);
 
 		document.removeEventListener('keydown', handleKeydown);
+		navigator.mediaDevices.removeEventListener('devicechange', handleAudioDeviceChange);
 
 		audioAbortController.abort();
 
@@ -957,6 +1018,8 @@
 				on:click={() => {
 					if (assistantSpeaking) {
 						stopAllAudio();
+					} else if (audioStatus === 'unavailable') {
+						void recoverAudioStream();
 					}
 				}}
 			>
@@ -967,6 +1030,10 @@
 						{$i18n.t('Muted')}
 					{:else if assistantSpeaking}
 						{$i18n.t('Tap to interrupt')}
+					{:else if audioStatus === 'reconnecting'}
+						{$i18n.t('Connection lost. Reconnecting...')}
+					{:else if audioStatus === 'unavailable'}
+						{$i18n.t('Error accessing media devices.')} {$i18n.t('Retry')}
 					{:else}
 						{$i18n.t('Listening...')}
 					{/if}

--- a/src/lib/components/chat/MessageInput/CallOverlay/audio-stream.test.ts
+++ b/src/lib/components/chat/MessageInput/CallOverlay/audio-stream.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
-import { hasLiveAudioTrack, singleFlight, watchAudioTrackEnd } from './audio-stream';
+import {
+	createAsyncQueue,
+	hasLiveAudioTrack,
+	singleFlight,
+	watchAudioTrackEnd
+} from './audio-stream';
 
 class FakeAudioTrack extends EventTarget {
 	readyState: MediaStreamTrackState;
@@ -74,5 +79,42 @@ describe('call audio stream lifecycle', () => {
 		expect(recover).toHaveBeenCalledTimes(2);
 		finishRecovery?.();
 		await laterRecovery;
+	});
+
+	it('serializes recording lifecycle transitions', async () => {
+		const enqueue = createAsyncQueue();
+		let finishStart: (() => void) | undefined;
+		const events: string[] = [];
+
+		const start = enqueue(
+			() =>
+				new Promise<void>((resolve) => {
+					events.push('start');
+					finishStart = resolve;
+				})
+		);
+		const recover = enqueue(async () => {
+			events.push('recover');
+		});
+
+		await Promise.resolve();
+		expect(events).toEqual(['start']);
+
+		finishStart?.();
+		await start;
+		await recover;
+
+		expect(events).toEqual(['start', 'recover']);
+	});
+
+	it('continues serialized transitions after a failure', async () => {
+		const enqueue = createAsyncQueue();
+		const failed = enqueue(async () => {
+			throw new Error('setup failed');
+		});
+		const recovered = enqueue(async () => 'recovered');
+
+		await expect(failed).rejects.toThrow('setup failed');
+		await expect(recovered).resolves.toBe('recovered');
 	});
 });

--- a/src/lib/components/chat/MessageInput/CallOverlay/audio-stream.test.ts
+++ b/src/lib/components/chat/MessageInput/CallOverlay/audio-stream.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from 'vitest';
+import { hasLiveAudioTrack, singleFlight, watchAudioTrackEnd } from './audio-stream';
+
+class FakeAudioTrack extends EventTarget {
+	readyState: MediaStreamTrackState;
+
+	constructor(readyState: MediaStreamTrackState) {
+		super();
+		this.readyState = readyState;
+	}
+
+	end() {
+		this.readyState = 'ended';
+		this.dispatchEvent(new Event('ended'));
+	}
+}
+
+const stream = (...tracks: FakeAudioTrack[]) => ({
+	getAudioTracks: () => tracks
+});
+
+describe('call audio stream lifecycle', () => {
+	it('requires at least one live audio track', () => {
+		expect(hasLiveAudioTrack(null)).toBe(false);
+		expect(hasLiveAudioTrack(stream(new FakeAudioTrack('ended')))).toBe(false);
+		expect(hasLiveAudioTrack(stream(new FakeAudioTrack('ended'), new FakeAudioTrack('live')))).toBe(
+			true
+		);
+	});
+
+	it('reports a disconnected stream only once', () => {
+		const first = new FakeAudioTrack('live');
+		const second = new FakeAudioTrack('live');
+		const onEnded = vi.fn();
+
+		watchAudioTrackEnd(stream(first, second), onEnded);
+		first.end();
+		second.end();
+
+		expect(onEnded).toHaveBeenCalledOnce();
+	});
+
+	it('does not report intentional shutdown after cleanup', () => {
+		const track = new FakeAudioTrack('live');
+		const onEnded = vi.fn();
+		const cleanup = watchAudioTrackEnd(stream(track), onEnded);
+
+		cleanup();
+		track.end();
+
+		expect(onEnded).not.toHaveBeenCalled();
+	});
+
+	it('coalesces simultaneous recovery signals and permits a later retry', async () => {
+		let finishRecovery: (() => void) | undefined;
+		const recover = vi.fn(
+			() =>
+				new Promise<void>((resolve) => {
+					finishRecovery = resolve;
+				})
+		);
+		const runRecovery = singleFlight(recover);
+
+		const trackEndedRecovery = runRecovery();
+		const deviceChangeRecovery = runRecovery();
+
+		expect(recover).toHaveBeenCalledOnce();
+		expect(deviceChangeRecovery).toBe(trackEndedRecovery);
+
+		finishRecovery?.();
+		await trackEndedRecovery;
+
+		const laterRecovery = runRecovery();
+		expect(recover).toHaveBeenCalledTimes(2);
+		finishRecovery?.();
+		await laterRecovery;
+	});
+});

--- a/src/lib/components/chat/MessageInput/CallOverlay/audio-stream.ts
+++ b/src/lib/components/chat/MessageInput/CallOverlay/audio-stream.ts
@@ -41,3 +41,17 @@ export const singleFlight = <T>(task: () => Promise<T>) => {
 		return active;
 	};
 };
+
+export const createAsyncQueue = () => {
+	let tail = Promise.resolve();
+
+	return <T>(task: () => Promise<T>) => {
+		const result = tail.then(task, task);
+		tail = result.then(
+			() => undefined,
+			() => undefined
+		);
+
+		return result;
+	};
+};

--- a/src/lib/components/chat/MessageInput/CallOverlay/audio-stream.ts
+++ b/src/lib/components/chat/MessageInput/CallOverlay/audio-stream.ts
@@ -1,0 +1,43 @@
+type AudioTrack = Pick<MediaStreamTrack, 'addEventListener' | 'removeEventListener' | 'readyState'>;
+
+type AudioStream = {
+	getAudioTracks: () => AudioTrack[];
+};
+
+export const hasLiveAudioTrack = (stream: AudioStream | null) =>
+	stream?.getAudioTracks().some((track) => track.readyState === 'live') ?? false;
+
+export const watchAudioTrackEnd = (stream: AudioStream, onEnded: () => void) => {
+	const tracks = stream.getAudioTracks();
+	let handled = false;
+
+	const handleEnded = () => {
+		if (handled) {
+			return;
+		}
+
+		handled = true;
+		onEnded();
+	};
+
+	tracks.forEach((track) => track.addEventListener('ended', handleEnded));
+
+	return () => {
+		handled = true;
+		tracks.forEach((track) => track.removeEventListener('ended', handleEnded));
+	};
+};
+
+export const singleFlight = <T>(task: () => Promise<T>) => {
+	let active: Promise<T> | null = null;
+
+	return () => {
+		if (active === null) {
+			active = task().finally(() => {
+				active = null;
+			});
+		}
+
+		return active;
+	};
+};


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Relates to #28391.
- [x] **Target branch:** This pull request targets `dev`.
- [x] **Description:** A concise description is provided below.
- [x] **Changelog:** A Keep a Changelog entry is included below.
- [x] **Documentation:** No documentation change is required for this call-mode lifecycle bug fix.
- [x] **Dependencies:** No dependencies were added or updated.
- [x] **Testing:** Automated regression tests, the production build, and manual AirPods disconnect recovery all pass.
- [x] **No Unchecked AI Code:** Automated, adversarial, and contributor human diff review are complete.
- [x] **Self-Review:** The patch and its recovery races were reviewed, and only the intended three files are changed.
- [x] **Architecture:** Recovery uses ephemeral component state and existing translated UI strings; it adds no setting.
- [x] **Git Hygiene:** The change is atomic and rebased onto the current `dev` head.
- [x] **Title Prefix:** The title uses the `fix` prefix.

## Description

Call mode previously cached its initial microphone `MediaStream` without observing whether the audio track remained live. Disconnecting a Bluetooth, USB, or Continuity microphone therefore left the overlay displaying `Listening...`, even though no audio could reach transcription.

This patch:

- observes audio-track `ended` and browser `devicechange` signals;
- serializes normal recorder restarts and disconnect recovery while coalescing simultaneous recovery signals;
- tears down the dead recorder and stream without mistaking intentional shutdown for a disconnect;
- registers overlay event handlers without waiting for microphone permission;
- fails closed when any microphone, recorder, or analyser setup step fails;
- closes obsolete audio-analysis contexts so they cannot control or retain a replacement recorder; and
- shows reconnecting or unavailable/retry status instead of stale `Listening...`.

If automatic reacquisition fails, selecting the status text retries the microphone request.

## Validation

- `npm run test:frontend -- --run` — 2 files, 8 tests passed (including 6 new lifecycle tests).
- `node --max-old-space-size=8192 ./node_modules/vite/bin/vite.js build` — passed on Node.js 22 after installing the current `dev` lockfile.
- `git diff --check` — passed.
- Follow-up adversarial review — no remaining code blocker found.
- Manual hardware validation (MacBook Pro + AirPods Pro) — passed: closing the case removed the active AirPods input; the patched call reacquired the built-in microphone, remained in `Listening...`, retained one active analyser, and produced valid Opus transcription uploads accepted with HTTP 200.

# Changelog Entry

### Description

- Make Call mode recover honestly when its active microphone disconnects.

### Fixed

- Fixed Call mode remaining stuck on `Listening...` after its active audio track ends.
- Added serialized automatic reacquisition and a manual retry state when no microphone is available.

---

### Additional Information

- Reproduction and source diagnosis: #28391

### Screenshots or Videos

- Not included; the observable transition requires disconnecting an active capture device.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> The contributor explicitly confirmed acceptance before this replacement pull request was submitted.


