### PR TITLE
fix: accept OpenAI file uploads without trailing slash

### DIFF
--- a/backend/open_webui/routers/files.py
+++ b/backend/open_webui/routers/files.py
@@ -268,6 +268,7 @@ async def process_uploaded_file(
         _cleanup_local_cache(file_path)
 
 
+@router.post('', response_model=FileModelResponse)
 @router.post('/', response_model=FileModelResponse)
 async def upload_file(
     request: Request,


### PR DESCRIPTION
Closes #28397
Relates to [Discussion #28404](https://github.com/open-webui/open-webui/discussions/28404)

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #28397; implementation discussed in #28404
- [x] **Target branch:** targets `dev`
- [x] **Description:** below
- [ ] **Changelog:** no separate changelog entry needed for this one-line compatibility fix
- [ ] **Documentation:** no user-facing docs affected
- [ ] **Dependencies:** none added or changed
- [x] **Testing:** FastAPI route registration and Python syntax checks passed
- [x] **No Unchecked AI Code:** AI assistance was used during implementation; I reviewed the final diff and manually verified the registered routes
- [x] **Self-Review:** performed
- [x] **Architecture:** reuses the existing upload handler and does not add state or settings
- [x] **Git Hygiene:** one atomic commit based on `dev`
- [x] **Title Prefix:** `fix`

## Description

The OpenAI Python client's `files.create()` call posts to `/api/v1/files` without a trailing slash. Open WebUI currently registers the upload handler only at `/api/v1/files/`, so the standard client request receives a 405 response.

Register the existing handler for both path forms. The slash-terminated endpoint keeps its current behavior, while the no-slash form now works without changing upload processing, authentication, or parameters.

## Testing

- `uv run --no-sync python -m py_compile backend/open_webui/routers/files.py`
- Verified with FastAPI 0.136.3 that the router registers:
  - `POST /api/v1/files`
  - `POST /api/v1/files/`
- `git diff --check`

## Changelog Entry

### Fixed

- OpenAI-compatible file uploads now work when the client posts to `/api/v1/files` without a trailing slash.

### Contributor License Agreement

- [ ] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
