### PR TITLE
fix(middleware): collect OpenAPI data URIs without mutating iterated …

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -1053,6 +1053,10 @@ async def process_tool_result(
                             tool_response.append(resource.get('uri'))
             tool_result = tool_response[0] if len(tool_response) == 1 else tool_response
         else:  # OpenAPI
+            # Collect into a new list instead of removing from the list being
+            # iterated: list.remove() shifts every later element down by one,
+            # so the item after each extracted one is skipped entirely.
+            remaining_tool_result = []
             for item in tool_result:
                 if isinstance(item, str) and item.startswith('data:'):
                     tool_result_files.append(
@@ -1061,7 +1065,9 @@ async def process_tool_result(
                             'content': item,
                         }
                     )
-                    tool_result.remove(item)
+                else:
+                    remaining_tool_result.append(item)
+            tool_result = remaining_tool_result
 
     if isinstance(tool_result, list):
         tool_result = {'results': tool_result}


### PR DESCRIPTION
Fix: OpenAPI tool results skip every other inline data: URI (Fixes #28394)

### Why / What / How

**Why:** `process_tool_result()` in `backend/open_webui/utils/middleware.py` extracts inline `data:` URIs from an OpenAPI tool's result list while iterating over that same list. `list.remove()` shifts every later element down by one, so the item immediately after each extracted `data:` URI is skipped. With two adjacent URIs (`["data:AAA","data:BBB","plain"]`) only the first is turned into an attachment; the second leaks into `tool_result` which is `json.dumps()`'d into the LLM context as a raw base64 blob — missing image + wasted context window.

**What:** Stop mutating the list during iteration. Collect keepers into a new `remaining_tool_result` list and reassign `tool_result` after the loop — 7 lines, 1 local variable, no change to single/zero-data cases. Same fix as #28395 (closed, not merged).

**How:** 
```py
remaining_tool_result = []
for item in tool_result:
    if isinstance(item, str) and item.startswith("data:"):
        tool_result_files.append({"type":"data","content":item})
    else:
        remaining_tool_result.append(item)
tool_result = remaining_tool_result
```
Falls through to existing `{"results": tool_result}` → `json.dumps()` normalization. Handles mixed types, empty list, 3+ adjacent URIs, non-string `data:` values.

### Changes 🏗️

- `backend/open_webui/utils/middleware.py` (`process_tool_result`, OpenAPI branch):
  - Replace `tool_result.remove(item)` mutation with `remaining_tool_result` accumulator + `tool_result = remaining_tool_result`
  - Add comment explaining the shift-skip bug
- No API/config/migration changes.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] Pure-loop repro `repro_28394.py` — 2 adjacent `data:`: old FAIL (1 file, BBB leaked), new PASS (2 files, remain `["plain text"]`); 3 adjacent, interleaved, single, zero, mixed `["data:AAA",123,{"k":"v"},"data:BBB"]`, 5 adjacent — all PASS
  - [x] Simulated `process_tool_result` post-processing (`simulate_fixed`) — `json.dumps({"results": remain})` contains no `data:` leak, `tool_result_files` counts correct (9/9 PASS)
  - [x] Inline source check: `remaining_tool_result` 3 occurrences, `tool_result.remove` 0, MCP branch untouched, `ruff format --check` PASS, `ruff check` same 1 pre-existing `I001` as `main` (no new findings)

<details>
  <summary>Example test plan</summary>

  - [x] Repro with `["data:image/png;base64,AAA","data:image/png;base64,BBB","plain text"]` → 2 files, remain `["plain text"]`, no `data:` in dumped `tool_result`
  - [x] Repro with 3 adjacent `data:`, interleaved, empty, 5 adjacent, mixed types
  - [x] `ruff format --check` / `ruff check` on `middleware.py`
</details>

#### For configuration changes:
- [x] `.env` / `docker-compose.yml` already compatible — no config changes
