### PR TITLE
fix: OpenAPI tool results skip every other inline data: URI

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -1051,6 +1051,10 @@ async def process_tool_result(
                             tool_response.append(resource.get('uri'))
             tool_result = tool_response[0] if len(tool_response) == 1 else tool_response
         else:  # OpenAPI
+            # Collect into a new list instead of removing from the list being
+            # iterated: list.remove() shifts every later element down by one,
+            # so the item after each extracted one is skipped entirely.
+            remaining_tool_result = []
             for item in tool_result:
                 if isinstance(item, str) and item.startswith('data:'):
                     tool_result_files.append(
@@ -1059,7 +1063,9 @@ async def process_tool_result(
                             'content': item,
                         }
                     )
-                    tool_result.remove(item)
+                else:
+                    remaining_tool_result.append(item)
+            tool_result = remaining_tool_result
 
     if isinstance(tool_result, list):
         tool_result = {'results': tool_result}


### PR DESCRIPTION
Use `remaining_tool_result` accumulator instead of `list.remove()` during iteration — `list.remove()` shifts later elements so the item after each extracted `data:` URI was skipped. Fixes #28394.

Closes #28394

<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #28394
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** No user-facing docs affected
- [ ] **Dependencies:** None added or changed
- [x] **Testing:** Manual tests performed — pure-loop repro + process_tool_result simulation (2 adjacent data: old FAIL→new PASS, 3/5 adjacent, interleaved, single/zero, mixed types), ruff format --check PASS, ruff check same 1 pre-existing I001 as dev
- [x] **No Unchecked AI Code:** Reviewed and manually tested before opening — no unchecked AI code
- [x] **Self-Review:** Performed — 7 lines, 1 local variable, single logical change
- [x] **Architecture:** No new settings, no state changes — smart default preserved, local remaining_tool_result only
- [x] **Git Hygiene:** Atomic (one logical change), rebased on dev
- [x] **Title Prefix:** `fix:` — `fix: OpenAPI tool results skip every other inline data: URI`

# Changelog Entry

### Description

OpenAPI tools returning a list with two or more adjacent inline `data:` URIs now correctly extract all of them as attachments instead of every other one. The bug was `process_tool_result()` calling `tool_result.remove(item)` while iterating the same list — `remove()` shifts later elements so the item after each extraction was skipped and leaked into `tool_result`, which is `json.dumps()`'d into the model context as a raw base64 blob (wasted context + missing attachment).

### Added

- None

### Changed

- None

### Deprecated

- None

### Removed

- None

### Fixed

- OpenAPI tool results containing multiple inline `data:` URIs now extract all of them as attachments instead of every other one, preventing base64 payloads from leaking into the model context (#28394)

### Security

- None

### Breaking Changes

- None

---

### Additional Information

**Root cause:** `backend/open_webui/utils/middleware.py:1053-1065` — OpenAPI branch mutated `tool_result` during `for item in tool_result:`.

**Fix:** Collect keepers into `remaining_tool_result` and reassign `tool_result = remaining_tool_result` after the loop:
```py
remaining_tool_result = []
for item in tool_result:
    if isinstance(item, str) and item.startswith("data:"):
        tool_result_files.append({"type": "data", "content": item})
    else:
        remaining_tool_result.append(item)
tool_result = remaining_tool_result
```
Falls through to existing `{"results": tool_result}` → `json.dumps()` normalization. Preserves single/zero-data cases, handles mixed types (`int`, `dict`), empty list, interleaved and 5 adjacent URIs.

**Relation to #28395:** Same fix as closed PR #28395 (not merged) — this PR targets `dev` with identical 7-line change plus verified repro.

**Testing:**
- `["data:image/png;base64,AAA","data:image/png;base64,BBB","plain text"]` — before: `files=[AAA]` + `BBB` leaked into `tool_result`; after: `files=[AAA,BBB]` + `remain=["plain text"]` (no `data:` in dumped JSON)
- `["data:AAA","data:BBB","data:CCC","text"]`, `["data:AAA","plain","data:BBB","more"]`, `["data:AAA"]`, `["plain","text"]`, `[]`, `["data:AAA",123,{"k":"v"},"data:BBB"]`, `["data:AAA"×5]` — all PASS
- `ruff format --check` PASS, `ruff check` same pre-existing `I001` as `dev`

### Screenshots or Videos

- N/A — backend logic only. No UI change; attachments now correctly rendered when multiple `data:` URIs are returned.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
