### PR TITLE
fix: honor media-only response requests

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -1576,7 +1576,16 @@ async def chat_completion(
         try:
             form_data, metadata, events = await process_chat_payload(request, form_data, user, metadata, model)
 
-            response = await chat_completion_handler(request, form_data, user)
+            if getattr(request.state, 'image_generation_terminal', False):
+                async def image_generation_terminal_stream():
+                    yield b'data: [DONE]\n\n'
+
+                response = StreamingResponse(
+                    image_generation_terminal_stream(),
+                    media_type='text/event-stream',
+                )
+            else:
+                response = await chat_completion_handler(request, form_data, user)
 
             # When the upstream provider returns an error (e.g. HTTP 400
             # content-filter, quota exceeded), generate_chat_completion

--- a/backend/open_webui/tools/builtin.py
+++ b/backend/open_webui/tools/builtin.py
@@ -414,12 +414,16 @@ async def generate_image(
                     },
                 }
             )
-            # Return a message indicating the image is already displayed
+            # Tell the model that the image is already displayed while preserving
+            # any response-format constraint from the user (for example,
+            # image-only output with no acknowledgement text).
+            # Do not repeat the image payload in the tool result: data URLs can be
+            # large, and the UI already received the image through the event above.
             return JSONCodec.dumps(
                 {
                     'status': 'success',
-                    'message': 'The image has been successfully generated and is already visible to the user in the chat. You do not need to display or embed the image again - just acknowledge that it has been created.',
-                    'images': images,
+                    'message': "The image has been successfully generated and is already visible to the user in the chat. Do not display or embed the image again. Follow the user's requested response format: if they requested image-only output or no explanatory text, do not add an acknowledgement; otherwise, briefly confirm that the image was created.",
+                    'suppress_followup': True,
                 },
                 ensure_ascii=False,
             )
@@ -482,12 +486,16 @@ async def edit_image(
                     },
                 }
             )
-            # Return a message indicating the image is already displayed
+            # Tell the model that the image is already displayed while preserving
+            # any response-format constraint from the user (for example,
+            # image-only output with no acknowledgement text).
+            # Do not repeat the image payload in the tool result: data URLs can be
+            # large, and the UI already received the image through the event above.
             return JSONCodec.dumps(
                 {
                     'status': 'success',
-                    'message': 'The edited image has been successfully generated and is already visible to the user in the chat. You do not need to display or embed the image again - just acknowledge that it has been created.',
-                    'images': images,
+                    'message': "The edited image has been successfully generated and is already visible to the user in the chat. Do not display or embed the image again. Follow the user's requested response format: if they requested image-only output or no explanatory text, do not add an acknowledgement; otherwise, briefly confirm that the edited image was created.",
+                    'suppress_followup': True,
                 },
                 ensure_ascii=False,
             )

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -1565,6 +1565,89 @@ async def get_image_urls(delta_images, request, metadata, user) -> list[str]:
     return image_urls
 
 
+def get_media_only_response_type(messages: list) -> str | None:
+    """Return the single media type explicitly requested without response text."""
+    prompt = get_last_user_message(messages)
+    if not isinstance(prompt, str):
+        return None
+
+    normalized = ' '.join(prompt.lower().split())
+    image_only = bool(
+        re.search(
+            r'\b(?:return|respond|reply|output|provide|show|give)\b[^.!?]{0,80}'
+            r'\bonly (?:the )?(?:image|picture|photo|illustration)\b',
+            normalized,
+        )
+        or re.search(r'\bimage[- ]only\b', normalized)
+    )
+    audio_only = bool(
+        re.search(
+            r'\b(?:return|respond|reply|output|provide|play|give)\b[^.!?]{0,80}'
+            r'\bonly (?:the |an? )?(?:audio|audio clip|recording|voice clip)\b',
+            normalized,
+        )
+        or re.search(r'\baudio[- ]only\b', normalized)
+        or re.search(
+            r'\bexactly one (?:audio|audio clip|recording|voice clip)\b',
+            normalized,
+        )
+    )
+
+    if image_only == audio_only:
+        return None
+    return 'image' if image_only else 'audio'
+
+
+def normalize_media_only_response_content(messages: list, content):
+    """Keep only rendered media when the user explicitly requested media-only output."""
+    media_type = get_media_only_response_type(messages)
+    if not isinstance(content, str) or media_type is None:
+        return content
+
+    if media_type == 'image':
+        media = re.findall(
+            r'!\[[^\]\n]*\]\((?:data:image/[^\s)]+|https?://[^\s)]+)\)',
+            content,
+        )
+    else:
+        media = re.findall(
+            r'<audio>\s*(?:data:audio/[^\s<]+|https?://[^\s<]+)\s*</audio>',
+            content,
+        )
+    return '\n\n'.join(media) if media else content
+
+
+def normalize_media_only_response_output(messages: list, output):
+    """Normalize text parts while preserving non-text response output items."""
+    if not isinstance(output, list) or get_media_only_response_type(messages) is None:
+        return output
+
+    normalized_output = []
+    for item in output:
+        if not isinstance(item, dict) or item.get('type') != 'message':
+            normalized_output.append(item)
+            continue
+
+        normalized_parts = []
+        for part in item.get('content', []):
+            if isinstance(part, dict) and part.get('type') == 'output_text':
+                normalized_parts.append(
+                    {
+                        **part,
+                        'text': normalize_media_only_response_content(
+                            messages,
+                            part.get('text'),
+                        ),
+                    }
+                )
+            else:
+                normalized_parts.append(part)
+
+        normalized_output.append({**item, 'content': normalized_parts})
+
+    return normalized_output
+
+
 async def add_file_context(messages: list, chat_id: str, user) -> list:
     """
     Add file URLs to messages for native function calling.
@@ -1695,7 +1778,7 @@ async def chat_image_generation_handler(request: Request, form_data: dict, extra
                 }
             )
 
-            system_message_content = '<context>The requested image has been edited and created and is now being shown to the user. Let them know that it has been generated.</context>'
+            request.state.image_generation_terminal = True
         except Exception as e:
             log.debug(e)
 
@@ -1793,7 +1876,7 @@ async def chat_image_generation_handler(request: Request, form_data: dict, extra
                 }
             )
 
-            system_message_content = '<context>The requested image has been created by the system successfully and is now being shown to the user. Let the user know that the image they requested has been generated and is now shown in the chat.</context>'
+            request.state.image_generation_terminal = True
         except Exception as e:
             log.debug(e)
 
@@ -3569,6 +3652,7 @@ async def outlet_filter_handler(ctx):
 
 async def non_streaming_chat_response_handler(response, ctx):
     request = ctx['request']
+    form_data = ctx['form_data']
 
     user = ctx['user']
     metadata = ctx['metadata']
@@ -3624,6 +3708,18 @@ async def non_streaming_chat_response_handler(response, ctx):
             choices = response_data.get('choices', [])
             response_output = response_data.get('output')
             content = choices[0].get('message', {}).get('content') if choices else ''
+            if choices:
+                content = normalize_media_only_response_content(
+                    form_data.get('messages', []),
+                    content,
+                )
+                choices[0].setdefault('message', {})['content'] = content
+            if response_output:
+                response_output = normalize_media_only_response_output(
+                    form_data.get('messages', []),
+                    response_output,
+                )
+                response_data['output'] = response_output
 
             if choices and (content or response_output):
                 if content or response_output:
@@ -4187,6 +4283,10 @@ async def streaming_chat_response_handler(response, ctx):
                     )
                     last_delta_data = None
                     last_delta_type = None
+                    media_only_response_type = get_media_only_response_type(
+                        form_data.get('messages', [])
+                    )
+                    media_only_markup_complete = False
 
                     async def flush_pending_delta_data(threshold: int = 0):
                         nonlocal delta_count
@@ -4640,6 +4740,11 @@ async def streaming_chat_response_handler(response, ctx):
                                             }
                                             delta_type = 'content'
 
+                                    if media_only_response_type and media_only_markup_complete:
+                                        value = ''
+                                        delta = {}
+                                        data = {'output': full_output()}
+
                                     if value:
                                         if (
                                             output
@@ -4783,6 +4888,23 @@ async def streaming_chat_response_handler(response, ctx):
 
                                             if end:
                                                 break
+
+                                        media_close = ')' if media_only_response_type == 'image' else '</audio>'
+                                        if media_only_response_type and media_close in value:
+                                            current_content = ''.join(content_parts)
+                                            normalized_content = normalize_media_only_response_content(
+                                                form_data.get('messages', []),
+                                                current_content,
+                                            )
+                                            if normalized_content != current_content:
+                                                content_parts = [normalized_content]
+                                                output = normalize_media_only_response_output(
+                                                    form_data.get('messages', []),
+                                                    output,
+                                                )
+                                            media_prefix = '![' if media_only_response_type == 'image' else '<audio>'
+                                            if normalized_content.startswith(media_prefix):
+                                                media_only_markup_complete = True
 
                                         if ENABLE_REALTIME_CHAT_SAVE and save_to_chat:
                                             current_output = full_output()
@@ -4954,6 +5076,7 @@ async def streaming_chat_response_handler(response, ctx):
                     tools = metadata.get('tools', {})
 
                     results = []
+                    suppressed_followup_calls = 0
 
                     def parse_tool_params(tool_call):
                         tool_args = tool_call.get('function', {}).get('arguments', '{}')
@@ -5052,6 +5175,21 @@ async def streaming_chat_response_handler(response, ctx):
                             user,
                         )
 
+                        if (
+                            tool_type == 'builtin'
+                            and tool_function_name in {'generate_image', 'edit_image'}
+                            and isinstance(tool_result, str)
+                        ):
+                            try:
+                                image_result = JSONCodec.loads(tool_result)
+                                if isinstance(image_result, dict):
+                                    suppress_followup = image_result.pop('suppress_followup', False)
+                                    tool_result = JSONCodec.dumps(image_result, ensure_ascii=False)
+                                    if image_result.get('status') == 'success' and suppress_followup is True:
+                                        suppressed_followup_calls += 1
+                            except Exception:
+                                pass
+
                         await terminal_event_handler(
                             tool_function_name,
                             tool_function_params,
@@ -5130,16 +5268,25 @@ async def streaming_chat_response_handler(response, ctx):
                             }
                         )
 
-                    # Append a new empty message item for the next response
-                    output.append(
-                        {
-                            'type': 'message',
-                            'id': output_id('msg'),
-                            'status': 'in_progress',
-                            'role': 'assistant',
-                            'content': [{'type': 'output_text', 'text': ''}],
-                        }
+                    suppress_tool_followup = bool(response_tool_calls) and suppressed_followup_calls == len(
+                        response_tool_calls
                     )
+                    if suppress_tool_followup:
+                        for item in output:
+                            if item.get('type') == 'message':
+                                item['status'] = 'completed'
+                                item['content'] = [{'type': 'output_text', 'text': ''}]
+                    if not suppress_tool_followup:
+                        # Append a new empty message item for the next response
+                        output.append(
+                            {
+                                'type': 'message',
+                                'id': output_id('msg'),
+                                'status': 'in_progress',
+                                'role': 'assistant',
+                                'content': [{'type': 'output_text', 'text': ''}],
+                            }
+                        )
 
                     # Emit citation sources to the frontend for display
                     if citations_enabled:
@@ -5222,6 +5369,9 @@ async def streaming_chat_response_handler(response, ctx):
                             },
                         }
                     )
+
+                    if suppress_tool_followup:
+                        break
 
                     try:
                         new_form_data = {
@@ -5500,6 +5650,18 @@ async def streaming_chat_response_handler(response, ctx):
                             log.exception('Code interpreter continuation failed: %s', error_content)
                             await emit_message_error(error_content)
                             break
+
+                current_content = ''.join(content_parts)
+                normalized_content = normalize_media_only_response_content(
+                    form_data.get('messages', []),
+                    current_content,
+                )
+                if normalized_content != current_content:
+                    content_parts = [normalized_content]
+                    output = normalize_media_only_response_output(
+                        form_data.get('messages', []),
+                        output,
+                    )
 
                 # Mark all in-progress items as completed
                 for item in output:


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Fixes #28419.
- [x] **Target branch:** This pull request targets `dev`.
- [x] **Description:** A concise description is provided below.
- [x] **Changelog:** A Keep a Changelog entry is included below.
- [x] **Documentation:** No documentation change is required for this response-orchestration bug fix.
- [x] **Dependencies:** No dependencies were added or updated.
- [x] **Testing:** Static checks, exact-version deployment checks, and signed-in browser acceptance pass.
- [x] **No Unchecked AI Code:** The complete three-file diff and stream lifecycle received an adversarial review.
- [x] **Self-Review:** Both native-tool and legacy image paths were traced and reviewed; only the intended three files are changed.
- [x] **Architecture:** The fix preserves the existing image flow and adds no setting or persistent state.
- [x] **Git Hygiene:** The change is atomic and based on the current `dev` head.
- [x] **Title Prefix:** The title uses the `fix` prefix.

## Description

Image generation currently injects a post-tool acknowledgement that conflicts with explicit user formats such as “return only the image, with no explanatory text.” The event-emitting native path also returns the generated image payload to the follow-up model even though the frontend already received it. Provider-native media models can independently stream a Markdown image or audio block and then append prose or a transcript to the same response.

This patch:

- makes successful native `generate_image` and `edit_image` calls terminal, without invoking a second model response;
- overwrites assistant message text co-produced in the same tool-calling turn with empty completed content, so clients remove text that may already have streamed under the same message ID;
- strips the private terminal marker before persisting the public tool result;
- only suppresses follow-up when every call in the batch is a successful built-in image-only call;
- avoids returning the redundant base64 image payload when the event emitter already delivered it; and
- marks successful legacy image generation on server-owned request state and returns an empty terminal stream instead of making a redundant provider call; and
- normalizes provider-native image and audio responses only for explicit single-media-only requests, in both streaming and non-streaming paths.

Successful native, legacy, and provider-native media responses complete with the requested media and no redundant acknowledgement or transcript. Mixed native tool batches, mixed-media requests, ordinary “generate and explain” prompts, partial media streams, and generation failures retain their normal content or error response. The legacy terminal flag is server-owned and is set only after the image event succeeds.

## Validation

- `python3 -m compileall -q backend/open_webui/main.py backend/open_webui/tools/builtin.py backend/open_webui/utils/middleware.py` — passed.
- Focused source-contract assertions for native terminal gating, mixed-batch preservation, payload omission, legacy wording, image-only and audio-only normalization, ambiguous mixed-media prompts, partial streams, normal mixed-text prompts, and failure preservation — passed.
- `git diff --check` — passed.
- Exact Open WebUI v0.11.0 install/check/rollback fixture round trip — passed downstream.
- Signed-in image acceptance against the exact transformed source — one real generated image, zero visible assistant prose, zero audio, and no active Stop state.
- Signed-in audio acceptance against the exact transformed source — one playable audio response, zero visible assistant transcript, zero image, and no active Stop state.
- Adversarial stream review removed a repeated full-response scan; ordinary text streams do not enter the image normalizer.

# Changelog Entry

### Description

- Preserve explicit single-media response formats after image or audio generation.

### Fixed

- Fixed image-only requests receiving an unwanted completion acknowledgement.
- Fixed audio-only requests receiving an unwanted visible transcript.
- Avoided sending an already-emitted generated image back through the follow-up model.

---

### Additional Information

- Reproduction and source diagnosis: #28419.

### Screenshots or Videos

- Not included; signed-in acceptance was performed in temporary chats. The verified results were one generated image without assistant prose and one playable audio response without a visible transcript.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
