### PR TITLE
feat: add MiniMax voice cloning

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -1618,6 +1618,12 @@ AUDIO_TTS_MISTRAL_API_KEY = os.getenv('AUDIO_TTS_MISTRAL_API_KEY', '')
 
 AUDIO_TTS_MISTRAL_API_BASE_URL = os.getenv('AUDIO_TTS_MISTRAL_API_BASE_URL', 'https://api.mistral.ai/v1')
 
+AUDIO_VOICE_CLONE_MINIMAX_API_KEY = os.getenv('AUDIO_VOICE_CLONE_MINIMAX_API_KEY', '')
+
+AUDIO_VOICE_CLONE_MINIMAX_API_BASE_URL = os.getenv(
+    'AUDIO_VOICE_CLONE_MINIMAX_API_BASE_URL', 'https://api.minimax.io/v1'
+)
+
 ####################################
 # WEBUI
 ####################################
@@ -3065,6 +3071,8 @@ DEFAULT_CONFIG = {
     'audio.tts.azure.speech_output_format': AUDIO_TTS_AZURE_SPEECH_OUTPUT_FORMAT,
     'audio.tts.mistral.api_key': AUDIO_TTS_MISTRAL_API_KEY,
     'audio.tts.mistral.api_base_url': AUDIO_TTS_MISTRAL_API_BASE_URL,
+    'audio.voice_clone.minimax.api_key': AUDIO_VOICE_CLONE_MINIMAX_API_KEY,
+    'audio.voice_clone.minimax.api_base_url': AUDIO_VOICE_CLONE_MINIMAX_API_BASE_URL,
     'webui.url': WEBUI_URL,
     'ui.enable_signup': ENABLE_SIGNUP,
     'ui.enable_login_form': ENABLE_LOGIN_FORM,

--- a/backend/open_webui/routers/audio.py
+++ b/backend/open_webui/routers/audio.py
@@ -72,6 +72,18 @@ MAX_FILE_SIZE: int = MAX_FILE_SIZE_MB * 1024 * 1024
 AZURE_MAX_FILE_SIZE_MB: int = 200
 AZURE_MAX_FILE_SIZE: int = AZURE_MAX_FILE_SIZE_MB * 1024 * 1024
 
+MINIMAX_VOICE_CLONE_API_BASE_URLS = (
+    'https://api.minimax.io/v1',
+    'https://api.minimaxi.com/v1',
+)
+MINIMAX_VOICE_CLONE_MODELS = (
+    'speech-2.8-hd',
+    'speech-2.6-hd',
+    'speech-02-hd',
+    'speech-01-hd',
+)
+MINIMAX_VOICE_CLONE_AUDIO_FORMATS = {'mp3', 'm4a', 'wav'}
+
 SPEECH_CACHE_DIR = CACHE_DIR / 'audio' / 'speech'
 SPEECH_CACHE_DIR.mkdir(parents=True, exist_ok=True)
 
@@ -89,6 +101,11 @@ TTS_CONFIG_KEYS = {
     'AZURE_SPEECH_OUTPUT_FORMAT': 'audio.tts.azure.speech_output_format',
     'MISTRAL_API_KEY': 'audio.tts.mistral.api_key',
     'MISTRAL_API_BASE_URL': 'audio.tts.mistral.api_base_url',
+}
+
+VOICE_CLONE_CONFIG_KEYS = {
+    'API_KEY': 'audio.voice_clone.minimax.api_key',
+    'API_BASE_URL': 'audio.voice_clone.minimax.api_base_url',
 }
 
 STT_CONFIG_KEYS = {
@@ -250,6 +267,11 @@ class TTSConfigForm(BaseModel):
     MISTRAL_API_BASE_URL: str
 
 
+class VoiceCloneConfigForm(BaseModel):
+    API_KEY: str = ''
+    API_BASE_URL: str = MINIMAX_VOICE_CLONE_API_BASE_URLS[0]
+
+
 class STTConfigForm(BaseModel):
     OPENAI_API_BASE_URL: str
     OPENAI_API_KEY: str
@@ -273,22 +295,35 @@ class STTConfigForm(BaseModel):
 class AudioConfigUpdateForm(BaseModel):
     tts: TTSConfigForm
     stt: STTConfigForm
+    voice_clone: Optional[VoiceCloneConfigForm] = None
 
 
 @router.get('/config')
 async def get_audio_config(request: Request, user=Depends(get_admin_user)):
+    voice_clone_config = await get_config_values(VOICE_CLONE_CONFIG_KEYS)
+    voice_clone_config.update(
+        {
+            'API_BASE_URLS': list(MINIMAX_VOICE_CLONE_API_BASE_URLS),
+            'MODELS': [{'id': model} for model in MINIMAX_VOICE_CLONE_MODELS],
+        }
+    )
     return {
         'tts': await get_config_values(TTS_CONFIG_KEYS),
         'stt': await get_config_values(STT_CONFIG_KEYS),
+        'voice_clone': voice_clone_config,
     }
 
 
 @router.post('/config/update')
 async def update_audio_config(request: Request, form_data: AudioConfigUpdateForm, user=Depends(get_admin_user)):
+    voice_clone_updates = (
+        config_updates(form_data.voice_clone.model_dump(), VOICE_CLONE_CONFIG_KEYS) if form_data.voice_clone else {}
+    )
     await Config.upsert(
         {
             **config_updates(form_data.tts.model_dump(), TTS_CONFIG_KEYS),
             **config_updates(form_data.stt.model_dump(), STT_CONFIG_KEYS),
+            **voice_clone_updates,
         }
     )
 
@@ -311,6 +346,112 @@ async def update_audio_config(request: Request, form_data: AudioConfigUpdateForm
         },
     )
     return config
+
+
+async def _read_minimax_voice_clone_response(response, operation: str) -> dict:
+    try:
+        data = await response.json(content_type=None)
+    except Exception as exc:
+        status_code = response.status if response.status >= 400 else status.HTTP_502_BAD_GATEWAY
+        raise HTTPException(status_code=status_code, detail=f'Invalid {operation} response') from exc
+
+    base_resp = data.get('base_resp') if isinstance(data, dict) else None
+    provider_status = base_resp.get('status_code') if isinstance(base_resp, dict) else None
+    if response.status >= 400 or provider_status not in (0, '0'):
+        detail = base_resp.get('status_msg') if isinstance(base_resp, dict) else None
+        raise HTTPException(
+            status_code=response.status if response.status >= 400 else status.HTTP_400_BAD_REQUEST,
+            detail=f'External: {detail or f"{operation} failed"}',
+        )
+
+    return data
+
+
+@router.post('/voice-clone')
+async def clone_voice(
+    file: UploadFile = File(...),
+    voice_id: str = Form(...),
+    model: str = Form(...),
+    user=Depends(get_admin_user),
+):
+    api_key = await Config.get('audio.voice_clone.minimax.api_key')
+    api_base_url = (
+        await Config.get('audio.voice_clone.minimax.api_base_url') or MINIMAX_VOICE_CLONE_API_BASE_URLS[0]
+    ).rstrip('/')
+
+    if not api_key:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail='MiniMax API key is required')
+
+    safe_name = os.path.basename(file.filename or '')
+    extension = safe_name.rsplit('.', 1)[-1].lower() if '.' in safe_name else ''
+    if extension not in MINIMAX_VOICE_CLONE_AUDIO_FORMATS:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=ERROR_MESSAGES.FILE_NOT_SUPPORTED)
+
+    voice_id = voice_id.strip()
+    if not voice_id:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail='Voice ID is required')
+
+    model = model.strip()
+    if model not in MINIMAX_VOICE_CLONE_MODELS:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail='Unsupported voice clone model')
+
+    contents = await file.read(MAX_FILE_SIZE + 1)
+    if not contents:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail='Audio file is empty')
+    if len(contents) > MAX_FILE_SIZE:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=f'Audio file exceeds the {MAX_FILE_SIZE_MB} MB limit',
+        )
+
+    headers = {'Authorization': f'Bearer {api_key}'}
+    if ENABLE_FORWARD_USER_INFO_HEADERS:
+        headers = include_user_info_headers(headers, user)
+
+    upload_form = aiohttp.FormData()
+    upload_form.add_field('purpose', 'voice_clone')
+    upload_form.add_field(
+        'file',
+        contents,
+        filename=safe_name,
+        content_type=file.content_type or mimetypes.guess_type(safe_name)[0] or 'application/octet-stream',
+    )
+
+    try:
+        session = await get_session()
+        async with session.post(
+            url=f'{api_base_url}/files/upload',
+            data=upload_form,
+            headers=headers,
+            ssl=AIOHTTP_CLIENT_SESSION_SSL,
+        ) as upload_response:
+            upload_data = await _read_minimax_voice_clone_response(upload_response, 'voice clone audio upload')
+
+        file_data = upload_data.get('file') if isinstance(upload_data, dict) else None
+        file_id = file_data.get('file_id') if isinstance(file_data, dict) else None
+        if file_id is None:
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail='Invalid voice clone audio upload response',
+            )
+
+        async with session.post(
+            url=f'{api_base_url}/voice_clone',
+            json={'file_id': file_id, 'voice_id': voice_id, 'model': model},
+            headers={**headers, 'Content-Type': 'application/json'},
+            ssl=AIOHTTP_CLIENT_SESSION_SSL,
+        ) as clone_response:
+            await _read_minimax_voice_clone_response(clone_response, 'voice clone')
+    except HTTPException:
+        raise
+    except Exception as exc:
+        log.exception('MiniMax voice cloning failed')
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail='Voice cloning request failed',
+        ) from exc
+
+    return {'voice_id': voice_id}
 
 
 def load_speech_pipeline(request):

--- a/src/lib/apis/audio/index.ts
+++ b/src/lib/apis/audio/index.ts
@@ -27,14 +27,7 @@ export const getAudioConfig = async (token: string) => {
 	return res;
 };
 
-type OpenAIConfigForm = {
-	url: string;
-	key: string;
-	model: string;
-	speaker: string;
-};
-
-export const updateAudioConfig = async (token: string, payload: OpenAIConfigForm) => {
+export const updateAudioConfig = async (token: string, payload: Record<string, unknown>) => {
 	let error = null;
 
 	const res = await fetch(`${AUDIO_API_BASE_URL}/config/update`, {
@@ -54,6 +47,42 @@ export const updateAudioConfig = async (token: string, payload: OpenAIConfigForm
 		.catch((err) => {
 			console.error(err);
 			error = err.detail;
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
+
+	return res;
+};
+
+export const cloneVoice = async (
+	token: string,
+	file: File,
+	voiceId: string,
+	model: string
+): Promise<{ voice_id: string }> => {
+	const data = new FormData();
+	data.append('file', file);
+	data.append('voice_id', voiceId);
+	data.append('model', model);
+
+	let error = null;
+	const res = await fetch(`${AUDIO_API_BASE_URL}/voice-clone`, {
+		method: 'POST',
+		headers: {
+			Authorization: `Bearer ${token}`
+		},
+		body: data
+	})
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.catch((err) => {
+			error = err.detail;
+			console.error(err);
 			return null;
 		});
 

--- a/src/lib/components/admin/Settings/Audio.svelte
+++ b/src/lib/components/admin/Settings/Audio.svelte
@@ -8,7 +8,8 @@
 		getAudioConfig,
 		updateAudioConfig,
 		getModels as _getModels,
-		getVoices as _getVoices
+		getVoices as _getVoices,
+		cloneVoice as _cloneVoice
 	} from '$lib/apis/audio';
 	import { config, settings } from '$lib/stores';
 
@@ -46,6 +47,15 @@
 	let TTS_MISTRAL_API_KEY = '';
 	let TTS_MISTRAL_API_BASE_URL = '';
 
+	let VOICE_CLONE_API_KEY = '';
+	let VOICE_CLONE_API_BASE_URL = '';
+	let VOICE_CLONE_API_BASE_URLS: string[] = [];
+	let VOICE_CLONE_MODELS: { id: string }[] = [];
+	let VOICE_CLONE_MODEL = '';
+	let VOICE_CLONE_VOICE_ID = '';
+	let VOICE_CLONE_FILE: File | null = null;
+	let VOICE_CLONE_LOADING = false;
+
 	let STT_OPENAI_API_BASE_URL = '';
 	let STT_OPENAI_API_KEY = '';
 	let STT_OPENAI_API_REQUEST_FORMAT = 'multipart';
@@ -78,6 +88,9 @@
 	let voices: SpeechSynthesisVoice[] = [];
 	let providerVoices: Voice[] = [];
 	let models: Awaited<ReturnType<typeof _getModels>>['models'] = [];
+	$: VOICE_CLONE_DOCS_URL = VOICE_CLONE_API_BASE_URL.includes('minimaxi.com')
+		? 'https://platform.minimaxi.com/docs/api-reference/voice-cloning-clone'
+		: 'https://platform.minimax.io/docs/api-reference/voice-cloning-clone';
 	const inputClass =
 		'w-full h-7 rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 text-xs text-gray-700 outline-hidden transition-colors placeholder:text-gray-300 focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:placeholder:text-gray-700 dark:focus:border-blue-500';
 	const textareaClass =
@@ -138,9 +151,9 @@
 		try {
 			openaiParams = TTS_OPENAI_PARAMS ? JSON.parse(TTS_OPENAI_PARAMS) : {};
 			TTS_OPENAI_PARAMS = JSON.stringify(openaiParams, null, 2);
-		} catch (e) {
+		} catch {
 			toast.error($i18n.t('Invalid JSON format for Parameters'));
-			return;
+			return false;
 		}
 
 		const res = await updateAudioConfig(localStorage.token, {
@@ -158,6 +171,10 @@
 				MISTRAL_API_KEY: TTS_MISTRAL_API_KEY,
 				MISTRAL_API_BASE_URL: TTS_MISTRAL_API_BASE_URL,
 				SPLIT_ON: TTS_SPLIT_ON
+			},
+			voice_clone: {
+				API_KEY: VOICE_CLONE_API_KEY,
+				API_BASE_URL: VOICE_CLONE_API_BASE_URL
 			},
 			stt: {
 				OPENAI_API_BASE_URL: STT_OPENAI_API_BASE_URL,
@@ -182,6 +199,52 @@
 		if (res) {
 			saveHandler();
 			config.set(await getBackendConfig());
+			return true;
+		}
+
+		return false;
+	};
+
+	const cloneVoiceHandler = async () => {
+		if (!VOICE_CLONE_API_KEY) {
+			toast.error($i18n.t('Enter an API key'));
+			return;
+		}
+		if (!VOICE_CLONE_API_BASE_URL) {
+			toast.error($i18n.t('Enter an API base URL'));
+			return;
+		}
+		if (!VOICE_CLONE_FILE) {
+			toast.error($i18n.t('Select an audio file'));
+			return;
+		}
+		if (!VOICE_CLONE_VOICE_ID.trim()) {
+			toast.error($i18n.t('Enter a voice ID'));
+			return;
+		}
+		if (!VOICE_CLONE_MODEL) {
+			toast.error($i18n.t('Select a model'));
+			return;
+		}
+
+		VOICE_CLONE_LOADING = true;
+		try {
+			if (!(await updateConfigHandler())) {
+				return;
+			}
+
+			const res = await _cloneVoice(
+				localStorage.token,
+				VOICE_CLONE_FILE,
+				VOICE_CLONE_VOICE_ID.trim(),
+				VOICE_CLONE_MODEL
+			);
+			VOICE_CLONE_VOICE_ID = res.voice_id;
+			toast.success($i18n.t('Voice cloned successfully'));
+		} catch (e) {
+			toast.error(`${e}`);
+		} finally {
+			VOICE_CLONE_LOADING = false;
 		}
 	};
 
@@ -212,6 +275,12 @@
 			TTS_AZURE_SPEECH_OUTPUT_FORMAT = res.tts.AZURE_SPEECH_OUTPUT_FORMAT;
 			TTS_MISTRAL_API_KEY = res.tts.MISTRAL_API_KEY;
 			TTS_MISTRAL_API_BASE_URL = res.tts.MISTRAL_API_BASE_URL;
+
+			VOICE_CLONE_API_KEY = res.voice_clone?.API_KEY ?? '';
+			VOICE_CLONE_API_BASE_URL = res.voice_clone?.API_BASE_URL ?? '';
+			VOICE_CLONE_API_BASE_URLS = res.voice_clone?.API_BASE_URLS ?? [];
+			VOICE_CLONE_MODELS = res.voice_clone?.MODELS ?? [];
+			VOICE_CLONE_MODEL = VOICE_CLONE_MODELS[0]?.id ?? '';
 
 			STT_OPENAI_API_BASE_URL = res.stt.OPENAI_API_BASE_URL;
 			STT_OPENAI_API_KEY = res.stt.OPENAI_API_KEY;
@@ -721,6 +790,74 @@
 					{/each}
 				</SettingsSelect>
 			</AdminSettingRow>
+		</AdminSettingSection>
+
+		<AdminSettingSection title={$i18n.t('MiniMax Voice Cloning')}>
+			<div class="grid grid-cols-1 gap-2 sm:grid-cols-2">
+				<AdminSettingField label={$i18n.t('API Base URL')}>
+					<input
+						list="voice-clone-api-base-url-list"
+						class={inputClass}
+						placeholder={$i18n.t('API Base URL')}
+						bind:value={VOICE_CLONE_API_BASE_URL}
+					/>
+					<datalist id="voice-clone-api-base-url-list">
+						{#each VOICE_CLONE_API_BASE_URLS as apiBaseUrl}
+							<option value={apiBaseUrl}></option>
+						{/each}
+					</datalist>
+				</AdminSettingField>
+				<AdminSettingField label={$i18n.t('API Key')}>
+					<SensitiveInput
+						variant="settings"
+						placeholder={$i18n.t('API Key')}
+						bind:value={VOICE_CLONE_API_KEY}
+					/>
+				</AdminSettingField>
+			</div>
+
+			<div class="grid grid-cols-1 gap-2 sm:grid-cols-2">
+				<AdminSettingField label={$i18n.t('Audio File')}>
+					<input
+						class={inputClass}
+						type="file"
+						accept=".mp3,.m4a,.wav,audio/mpeg,audio/mp4,audio/wav"
+						on:change={(event) => {
+							const input = event.currentTarget as HTMLInputElement;
+							VOICE_CLONE_FILE = input.files?.[0] ?? null;
+						}}
+					/>
+				</AdminSettingField>
+				<AdminSettingField label={$i18n.t('Voice ID')}>
+					<input
+						class={inputClass}
+						bind:value={VOICE_CLONE_VOICE_ID}
+						placeholder={$i18n.t('Enter a voice ID')}
+					/>
+				</AdminSettingField>
+			</div>
+
+			<AdminSettingField label={$i18n.t('Model')}>
+				<SettingsSelect bind:value={VOICE_CLONE_MODEL}>
+					{#each VOICE_CLONE_MODELS as model}
+						<option value={model.id}>{model.id}</option>
+					{/each}
+				</SettingsSelect>
+			</AdminSettingField>
+
+			<div class="flex items-center justify-between gap-3">
+				<a class={linkedHelpClass} href={VOICE_CLONE_DOCS_URL} target="_blank" rel="noreferrer">
+					{$i18n.t('API documentation')}
+				</a>
+				<button
+					class="min-w-28 px-3.5 py-1.5 text-sm font-normal bg-black hover:bg-gray-900 text-white dark:bg-white dark:text-black dark:hover:bg-gray-100 transition rounded-full disabled:cursor-not-allowed disabled:opacity-50"
+					type="button"
+					disabled={VOICE_CLONE_LOADING}
+					on:click={cloneVoiceHandler}
+				>
+					{VOICE_CLONE_LOADING ? $i18n.t('Cloning...') : $i18n.t('Clone Voice')}
+				</button>
+			</div>
 		</AdminSettingSection>
 	</div>
 	<div class="flex justify-end pt-6 text-sm font-normal">


### PR DESCRIPTION
Reason: Add MiniMax voice cloning to the configurable audio workflow.

Relates to https://github.com/open-webui/open-webui/discussions/28426

## Changes

- add global and China API endpoint configuration with the supported voice-clone models
- upload clone audio and submit the voice-clone request through an admin-only backend endpoint
- add the matching admin settings and audio upload workflow

## Checks

- `./node_modules/.bin/prettier --check src/lib/apis/audio/index.ts src/lib/components/admin/Settings/Audio.svelte`
- `./node_modules/.bin/eslint src/lib/apis/audio/index.ts src/lib/components/admin/Settings/Audio.svelte`
- `python3 -m py_compile backend/open_webui/config.py backend/open_webui/routers/audio.py`
- `git diff --check origin/dev...HEAD`

## Changelog Entry

### Added

- MiniMax voice cloning configuration, audio upload, clone request handling, and admin controls.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.