### PR TITLE
fix: resolve generated image urls against the api base url in the Images playground

### DIFF
--- a/src/lib/components/playground/Images.svelte
+++ b/src/lib/components/playground/Images.svelte
@@ -5,6 +5,7 @@
 
 	import { user } from '$lib/stores';
 	import { imageGenerations, imageEdits } from '$lib/apis/images';
+	import { WEBUI_BASE_URL } from '$lib/constants';
 
 	import Spinner from '$lib/components/common/Spinner.svelte';
 
@@ -97,6 +98,8 @@
 		}
 	};
 
+	const resolveImageUrl = (url: string) => (url.startsWith('/') ? `${WEBUI_BASE_URL}${url}` : url);
+
 	const downloadImage = async (url: string, index: number) => {
 		try {
 			const response = await fetch(url);
@@ -136,10 +139,10 @@
 								{#each generatedImages as image, index}
 									<button
 										class="relative group cursor-pointer"
-										on:click={() => downloadImage(image.url, index)}
+										on:click={() => downloadImage(resolveImageUrl(image.url), index)}
 									>
 										<img
-											src={image.url}
+											src={resolveImageUrl(image.url)}
 											alt=""
 											class="w-full aspect-square object-cover rounded-lg border border-gray-100/30 dark:border-gray-850/30"
 										/>


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) - Fixes #28487
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented. No new dependencies.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes

# Changelog Entry

### Description

- Generated images render as blank tiles in the Images playground whenever the frontend is served from a different origin than the backend, which is the default when running the frontend with `npm run dev`.
- The component rendered the URL from the generations endpoint as is. That value comes from `url_path_for`, so it is a root relative path like `/api/v1/files/<id>/content`, and the browser resolves it against the page origin rather than the backend.
- This resolves it through `WEBUI_BASE_URL`, which is the backend host in a dev build and an empty string in a production build, so the value is correct in both.

### Fixed

- Generated images now load in the Images playground when the frontend and backend are on different origins.
- The download action on a generated image now fetches the resolved URL, so it works in that setup too.

---

### Additional Information

- The prefix is applied only to root relative paths, so an absolute URL or a data URL returned by a backend passes through untouched.
- Source image thumbnails were already correct and are unchanged. Those are FileReader data URLs rather than backend paths.
- The playground was the only place rendering file content without the base URL. `MessageInput.svelte`, `UserMessage.svelte`, `FileItem.svelte`, `CitationModal.svelte` and `QueuedMessageItem.svelte` all build their URLs from `WEBUI_API_BASE_URL` already.
- Production and container deployments were never affected, because the frontend and backend share an origin there and `WEBUI_BASE_URL` is empty, which leaves the relative path working. This is why the fault only appears in a split origin development setup.

**Manual verification performed:**

1. Ran the frontend on `:5173` with the backend on `:8080`, generated an image in Playground > Images, and confirmed the tiles render rather than staying blank.
2. Confirmed the image requests now go to the backend origin and return 200, where they previously went to the frontend origin and returned 404.
3. Used the download action on a generated image and confirmed the file downloads.
4. Confirmed source image thumbnails still render after adding an image through Add Image.

### Screenshots or Videos

Before is current `dev`. After is this branch. Both with the frontend and backend on different origins.

| Surface | Before | After |
|---|---|---|
| Playground > Images, after generating | _paste image_ | _paste image_ |

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
