### PR TITLE
Fix validate_url rejecting dotless internal hostnames even with local fetch enabled

### DIFF
--- a/backend/open_webui/retrieval/web/utils.py
+++ b/backend/open_webui/retrieval/web/utils.py
@@ -105,7 +105,16 @@ def _is_global_addr(ip: str) -> bool:
 
 def validate_url(url: Union[str, Sequence[str]]):
     if isinstance(url, str):
-        if isinstance(validators.url(url), validators.ValidationError):
+        # simple_host=True: without it, validators.url() requires a dotted
+        # hostname (a TLD-shaped domain), so single-label hostnames like
+        # `apprise` or `ollama` -- the normal way services address each
+        # other on a Docker Compose / Kubernetes network -- are rejected
+        # here unconditionally, before ENABLE_LOCAL_WEB_FETCH is ever
+        # consulted. The actual internal-vs-external decision still happens
+        # below via the resolved-IP check, which is gated on
+        # ENABLE_LOCAL_WEB_FETCH as intended; this only fixes the URL *shape*
+        # check so it stops overriding that gate for dotless hostnames.
+        if isinstance(validators.url(url, simple_host=True), validators.ValidationError):
             raise ValueError(ERROR_MESSAGES.INVALID_URL)
 
         # Reject parser-confusing chars: urlparse and requests/aiohttp split


### PR DESCRIPTION
Closes #28161.

`validate_url()` calls `validators.url(url)` with the library's default `simple_host=False`, which requires a TLD-shaped, dotted hostname for a URL to be considered valid. Single-label hostnames -- the normal way services address each other on a Docker Compose / Kubernetes network, e.g. `http://apprise:8000` -- were rejected right there, **before `ENABLE_LOCAL_WEB_FETCH` was ever consulted**. So setting a notification webhook target to an internal service by its compose service name failed with "The URL you provided is invalid" even with `ENABLE_LOCAL_WEB_FETCH=true` and `ENABLE_USER_WEBHOOKS=true` -- exactly the repro in the issue.

**Fix:** pass `simple_host=True` to `validators.url()`, so the shape check no longer overrides the `ENABLE_LOCAL_WEB_FETCH` gate for dotless hostnames. The actual internal-vs-external SSRF decision is unchanged -- it still happens a few lines down via `resolve_hostname()` / `_is_global_addr()`, which is already correctly gated on `ENABLE_LOCAL_WEB_FETCH`. This change only stops a blunt hostname-*shape* check from vetoing that gate before it runs.

**Testing**

This repo's backend CI (`.github/workflows/backend.yaml`) runs `ruff format --check` and `ruff check` only -- there's no pytest suite under `backend/`. I verified manually by loading the patched module in isolation (stubbing only the heavy unrelated imports like `langchain_community`/`playwright`) and exercising `validate_url()` directly:

- `http://apprise:8000/notify` and `http://ollama:11434` are now **accepted** when `ENABLE_LOCAL_WEB_FETCH=True` (previously rejected -- the reported bug).
- Normal domains (`http://example.com`) are unaffected in both states.
- SSRF protection still holds when `ENABLE_LOCAL_WEB_FETCH=False`: dotless hostnames (`localhost`) and loopback IP literals (`127.0.0.1`) are still blocked.
- Malformed URLs, non-http(s) schemes, and parser-confusing characters (the existing `\`/tab/CR/LF check) are still rejected regardless of the flag.

Reverting the fix reproduces the exact reported failure while all other cases stay green (11/11 checks pass with the fix, 9/11 without it -- the 2 that fail are exactly the dotless-hostname-with-local-fetch-enabled cases from the issue).

`ruff format --check` and `ruff check --select=F ...` (the project's actual backend CI gate) are both clean on the changed file.