### PR TITLE
Fix/google OpenAI compat tool calls

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -4479,6 +4479,15 @@ async def streaming_chat_response_handler(response, ctx):
                                                         'name': func.get('name', ''),
                                                         'arguments': func.get('arguments', '{}'),
                                                         'status': 'in_progress',
+                                                        # Provider-specific payload that must survive the
+                                                        # round trip: Gemini 3 rejects a follow-up request
+                                                        # whose functionCall lacks the thought_signature it
+                                                        # returned here (HTTP 400 INVALID_ARGUMENT).
+                                                        **(
+                                                            {'extra_content': tc['extra_content']}
+                                                            if tc.get('extra_content')
+                                                            else {}
+                                                        ),
                                                     }
                                                 )
 
@@ -4902,6 +4911,15 @@ async def streaming_chat_response_handler(response, ctx):
                                     'name': func.get('name', ''),
                                     'arguments': func.get('arguments', '{}'),
                                     'status': 'in_progress',
+                                    # Provider-specific payload that must survive the round
+                                    # trip: Gemini 3 rejects a follow-up request whose
+                                    # functionCall lacks the thought_signature it returned
+                                    # here (HTTP 400 INVALID_ARGUMENT).
+                                    **(
+                                        {'extra_content': tc['extra_content']}
+                                        if tc.get('extra_content')
+                                        else {}
+                                    ),
                                 }
                             )
 

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -4403,6 +4403,24 @@ async def streaming_chat_response_handler(response, ctx):
                                         for delta_tool_call in delta_tool_calls:
                                             tool_call_index = delta_tool_call.get('index')
 
+                                            if tool_call_index is None:
+                                                # Some OpenAI-compatible providers omit 'index' on
+                                                # streamed tool calls (e.g. Google's
+                                                # generativelanguage.googleapis.com/v1beta/openai,
+                                                # which sends each call complete in a single chunk).
+                                                # Without a fallback the call is dropped silently:
+                                                # no tool runs and the turn ends with empty content.
+                                                delta_function = delta_tool_call.get('function') or {}
+                                                if delta_function.get('name'):
+                                                    # Named call: a new entry.
+                                                    tool_call_index = len(response_tool_calls)
+                                                elif response_tool_calls:
+                                                    # Unnamed fragment: continuation of the last call.
+                                                    tool_call_index = response_tool_calls[-1].get('index')
+
+                                                if tool_call_index is not None:
+                                                    delta_tool_call['index'] = tool_call_index
+
                                             if tool_call_index is not None:
                                                 # Check if the tool call already exists
                                                 current_response_tool_call = None

--- a/backend/open_webui/utils/misc.py
+++ b/backend/open_webui/utils/misc.py
@@ -368,6 +368,10 @@ def convert_output_to_messages(
                         'name': item.get('name', ''),
                         'arguments': arguments,
                     },
+                    # Echo back provider-specific payload captured with the call.
+                    # Gemini 3 requires its thought_signature on every functionCall
+                    # replayed in the history, otherwise the request is rejected.
+                    **({'extra_content': item['extra_content']} if item.get('extra_content') else {}),
                 }
             )
 


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Closes #___` / `Relates to #___`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [x] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **BREAKING CHANGE**: Changes affecting backward compatibility
  - **build**: Build system or dependency changes
  - **ci**: CI/CD workflow changes
  - **chore**: Refactoring, cleanup, or non-functional changes
  - **docs**: Documentation additions or updates
  - **feat**: New features or enhancements
  - **fix**: Bug fixes or corrections
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvements
  - **refactor**: Code restructuring
  - **style**: Formatting changes (whitespace, semicolons, etc.)
  - **test**: Test additions or corrections
  - **WIP**: Work in progress

# Changelog Entry

### Description

- Native function calling was broken end to end against Google's OpenAI-compatible endpoint, leaving an empty assistant message and nothing in the logs. Two independent causes, each hiding the next: a tool call arriving without an `index` was silently discarded, and Gemini 3's `thought_signature` was not sent back on the follow-up request.

### Fixed

- 🛠️ **Tool calls with Google models.** Tools now run when a model is served through Google's OpenAI-compatible endpoint, where a tool call was thrown away and the reply came back blank.
- 🧠 **Replies after a tool runs.** The assistant now answers once a tool has finished on Gemini 3, instead of the request being rejected because the thought signature it had asked for was missing.

---

### Additional Information

**Root cause 1 — dropped tool calls.** The accumulation loop in `middleware.py` reads `delta_tool_call.get('index')` and does all its work inside `if tool_call_index is not None:`, with no `else`. The OpenAI streaming spec always sends `index`, but `generativelanguage.googleapis.com/v1beta/openai` emits each tool call complete in a single chunk and omits it. The call was dropped without a log line: no tool ran, no `function_call` item reached the output, and the turn ended empty. Fixed by deriving the index from position — a call carrying a function name starts a new entry, an unnamed fragment continues the last one.

**Root cause 2 — lost thought signature.** Gemini 3 returns a `thought_signature` in `extra_content` on each tool call and requires it back on the corresponding `functionCall`, otherwise the follow-up request fails with `HTTP 400 INVALID_ARGUMENT - Function call is missing a thought_signature in functionCall parts`. `extra_content` was discarded at three points that rebuild the dict field by field: both `function_call` output item constructions in `middleware.py` and the `tool_calls` rebuild in `misc.py`. All three had to change — the signature has to survive every copy between the incoming chunk and the outgoing request.

**Reproducing the provider behaviour**

```bash
curl -s -N -X POST "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions" \
  -H "Authorization: Bearer $GEMINI_API_KEY" -H "Content-Type: application/json" \
  -d '{"model":"models/gemini-3.6-flash","stream":true,
       "messages":[{"role":"user","content":"Remember that I prefer short answers."}],
       "tools":[{"type":"function","function":{"name":"add_memory","parameters":{"type":"object",
                 "properties":{"content":{"type":"string"}},"required":["content"]}}}]}'
```

The tool call chunk has no `index`, and carries `extra_content`:

```json
{"choices":[{"delta":{"role":"assistant","tool_calls":[{
  "extra_content":{"google":{"thought_signature":"EpoECpcEARFNMg..."}},
  "function":{"name":"add_memory","arguments":"{\"content\":\"...\"}"},
  "id":"nNf0SGo6","type":"function"}]},"index":0}]}
```

**Testing**

- `gemini-3.6-flash` with builtin tools enabled: before, empty message and `output: []` with no error; after, the tool runs, `extra_content` is present on the output item and on the replayed `tool_calls`, no 400, and the model answers normally.
- Accumulation loop regression checks: `index` present with arguments split across two deltas still concatenates into one call; two unnamed calls in one chunk get indices 0 and 1; an orphan fragment with no name and no prior call is still ignored rather than crashing; dict-valued `arguments` are still serialized.


### Screenshots or Videos

- [attach before: empty assistant bubble]
- [attach after: tool result card followed by the model's answer]

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.