### PR TITLE
fix: let the chat column shrink so the collapsed sidebar rail is not pushed off screen

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -3950,7 +3950,7 @@
 		: 'h-screen max-h-[100dvh]'} transition-width duration-200 ease-in-out {$showSidebar &&
 	!embedded
 		? '  md:max-w-[calc(100%-var(--sidebar-width))]'
-		: ' '} w-full max-w-full flex flex-col"
+		: ' '} w-full max-w-full min-w-0 flex flex-col"
 	id={chatContainerId}
 >
 	{#if !loading}


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) - Fixes #28500
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented. No new dependencies.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes

# Changelog Entry

### Description

- With the sidebar collapsed, a chat whose content raises the chat column's content minimum pushes the collapsed sidebar rail off the left edge of the window. Every control that reopens the sidebar is on that rail, so the sidebar cannot be reopened from the UI in that state. A reload does not recover it, since the rail reappears only for as long as the loading spinner shows and is pushed off again once the chat content renders; the only recovery is resizing the window below the mobile breakpoint.
- The chat page root is a direct flex item of the app layout row (`main` is `display: contents`) and had no `min-w-0`, so the flex default `min-width: auto` stopped it from shrinking. The layout row is `justify-end`, so the resulting overflow spills off the left edge, which is unreachable in a scroll container.
- One class on the chat root lets it shrink, and `w-full max-w-full` then govern its size as intended.

### Fixed

- The collapsed sidebar rail stays visible and usable regardless of chat title or content width.

---

### Additional Information

- Measured on a reproduced instance before the fix: the rail sat at `left: -50.4px` with the viewport at 1274px, displaced by exactly its own width (`42px * --app-text-scale`), while the chat column had shrunk by zero pixels. Applying `min-width: 0` to `#chat-container` in devtools on the live broken state restored the rail to `left: 0` with no reload and no other visible change.
- The navbar title itself was never the direct fault, since it is already truncated through `min-w-0 truncate` inside an `overflow-hidden` wrapper. Limiting title length would only hide one trigger, and any sufficiently wide content would reproduce the same displacement.
- Same fix pattern as the settings modal overflow addressed in #27306.

**Manual verification performed:**

1. Reproduced the bug on `dev`: sidebar collapsed, chat with a long generated title open, rail pushed off screen with no way to reopen the sidebar.
2. Confirmed the fix on this branch on the same instance: the rail stays at the left edge with the same chat open, and the layout is otherwise unchanged.
3. Resized across the mobile breakpoint and back, and confirmed the sidebar controls behave normally in both directions.
4. Verified the changed line is byte identical to prettier's output for the file.

### Screenshots or Videos

Before is current `dev`. After is this branch. Same chat, sidebar collapsed.

| Surface | Before | After |
|---|---|---|
| Chat with a long title, sidebar collapsed | <img width="2556" height="1286" alt="image" src="https://github.com/user-attachments/assets/c1526f2c-3ff0-494d-88f8-90332fad5454" /> | <img width="2558" height="1266" alt="image" src="https://github.com/user-attachments/assets/0803e1c8-0d95-44a6-a22e-9d2e2f6c63a5" /> |

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.


