### PR TITLE
fix: resolve generated image URLs in playground

### DIFF
--- a/src/lib/components/playground/Images.svelte
+++ b/src/lib/components/playground/Images.svelte
@@ -5,6 +5,8 @@
 
 	import { user } from '$lib/stores';
 	import { imageGenerations, imageEdits } from '$lib/apis/images';
+	import { WEBUI_BASE_URL } from '$lib/constants';
+	import { resolveImageUrl } from '$lib/utils/imageUrl';
 
 	import Spinner from '$lib/components/common/Spinner.svelte';
 
@@ -99,7 +101,8 @@
 
 	const downloadImage = async (url: string, index: number) => {
 		try {
-			const response = await fetch(url);
+			const imageUrl = resolveImageUrl(url, WEBUI_BASE_URL);
+			const response = await fetch(imageUrl);
 			const blob = await response.blob();
 			const blobUrl = URL.createObjectURL(blob);
 			const a = document.createElement('a');
@@ -139,7 +142,7 @@
 										on:click={() => downloadImage(image.url, index)}
 									>
 										<img
-											src={image.url}
+											src={resolveImageUrl(image.url, WEBUI_BASE_URL)}
 											alt=""
 											class="w-full aspect-square object-cover rounded-lg border border-gray-100/30 dark:border-gray-850/30"
 										/>

--- a/src/lib/utils/imageUrl.test.ts
+++ b/src/lib/utils/imageUrl.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveImageUrl } from './imageUrl';
+
+describe('resolveImageUrl', () => {
+	it('prefixes root-relative paths with the backend base URL', () => {
+		expect(resolveImageUrl('/api/v1/files/image/content', 'http://localhost:8080')).toBe(
+			'http://localhost:8080/api/v1/files/image/content'
+		);
+	});
+
+	it('keeps root-relative paths unchanged for same-origin production builds', () => {
+		expect(resolveImageUrl('/api/v1/files/image/content', '')).toBe('/api/v1/files/image/content');
+	});
+
+	it('does not rewrite absolute URLs', () => {
+		expect(resolveImageUrl('https://cdn.example.com/image.png', 'http://localhost:8080')).toBe(
+			'https://cdn.example.com/image.png'
+		);
+	});
+
+	it('does not rewrite data URLs', () => {
+		const dataUrl = 'data:image/png;base64,AAAA';
+
+		expect(resolveImageUrl(dataUrl, 'http://localhost:8080')).toBe(dataUrl);
+	});
+});

--- a/src/lib/utils/imageUrl.ts
+++ b/src/lib/utils/imageUrl.ts
@@ -1,0 +1,2 @@
+export const resolveImageUrl = (url: string, baseUrl: string): string =>
+	url.startsWith('/') ? `${baseUrl}${url}` : url;


### PR DESCRIPTION
Closes #28487

## Description

When the frontend runs on a different origin during development, generated image responses can contain root-relative backend paths such as `/api/v1/files/<id>/content`. The Images playground used those paths directly, so the browser requested them from the frontend origin and the image tile stayed blank.

This change resolves root-relative image paths with `WEBUI_BASE_URL` before both rendering and downloading. Absolute URLs and data URLs are left unchanged, and the production same-origin path remains relative.

## Testing

- `pnpm exec vitest run --passWithNoTests` - 12 passed
- `pnpm exec prettier --check src/lib/components/playground/Images.svelte src/lib/utils/imageUrl.ts src/lib/utils/imageUrl.test.ts` - passed
- ESLint passed for the new URL helper and its tests
- Full `svelte-check` was run; the current `dev` baseline reports 8,142 existing diagnostics across 349 files, with no diagnostics in the changed helper/test files. `Images.svelte` retains three pre-existing lint errors unrelated to this patch.

This PR was prepared with Codex assistance and reviewed against the issue, the existing URL handling in `Image.svelte`, and the focused test results above.

## Changelog

### Fixed

- Resolve backend-relative generated image URLs in the Images playground when frontend and backend run on different origins.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
