### PR TITLE
fix: allow None for MessageStats.tags so chat stats export stops silently zeroing counts

### DIFF
--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -340,7 +340,7 @@ class MessageStats(BaseModel):
     token_count: int | None = None
     timestamp: int | None = None
     rating: int | None = None  # Derived from message.annotation.rating
-    tags: list[str | None] = None  # Derived from message.annotation.tags
+    tags: list[str | None] | None = None  # Derived from message.annotation.tags
 
 
 class ChatHistoryStats(BaseModel):


### PR DESCRIPTION
Closes #28504

**Before submitting, make sure you've checked and filled out the following:**

- [x] **Linked Issue/Discussion:** Closes #28504
- [x] **Target branch:** This PR targets `dev`.
- [x] **Description:** See below.
- [x] **Changelog:** Included at the bottom.
- [ ] **Documentation:** Not applicable — no user-facing behavior or configuration is added; this restores documented response fields to their intended values.
- [x] **Dependencies:** None added or changed.
- [x] **Testing:** See "Testing" below.
- [x] **No Unchecked AI Code:** The change was drafted with AI assistance and has been read and reviewed by me line by line, with the failure mode reproduced and the fix verified before submitting.
- [x] **Self-Review:** Performed.
- [x] **Architecture:** One-line type annotation correction; no new settings, no architectural change.

### Description

`MessageStats.tags` is annotated `list[str | None]` but defaults to `None`. Pydantic does not validate defaults, so the declaration itself is accepted — but `_process_chat_for_export` passes the value **explicitly**:

```python
tags = message.get('annotation', {}).get('tags')   # None when the message has no annotation
message_stat = MessageStats(..., rating=rating, tags=tags)
```

`list[str | None]` does not admit `None`, so every message without an `annotation` raises `ValidationError`. That exception is swallowed by the per-message `except Exception: continue` inside the same loop, so `export_messages`, `history_user_messages` and `history_assistant_messages` are never populated.

Net effect on `GET /api/v1/chats/stats/export` and `/stats/export/{chat_id}`, for virtually every chat:

| field | returned | expected |
|---|---|---|
| `stats.history_user_message_count` | `0` | real count |
| `stats.history_assistant_message_count` | `0` | real count |
| `stats.history_models` | `{}` | model histogram |
| `stats.average_user_message_content_length` | `0` | real average |
| `stats.average_assistant_message_content_length` | `0` | real average |
| `stats.average_response_time` | `0` | real average |
| `chat.history.messages` | `{}` | one entry per message |

`stats.message_count` and `stats.models` are computed on a separate path (`get_message_list`) and stay correct, which makes the response look populated and the bug easy to miss. Nothing is surfaced to the caller; the only trace is a `log.debug` line per skipped message.

The fix widens the annotation to match both the declared default and the values actually passed:

```diff
-    tags: list[str | None] = None  # Derived from message.annotation.tags
+    tags: list[str | None] | None = None  # Derived from message.annotation.tags
```

### Related paths checked

- `_process_chat_for_export` (`routers/chats.py`) — the only place `MessageStats` is constructed; `rating` is already `int | None`, so `tags` was the sole offender in that call.
- `calculate_chat_stats` / `generate_chat_stats_jsonl_generator` — both delegate to `_process_chat_for_export`, so the list, single-chat and streaming export endpoints are all affected and all fixed by this change.
- `ChatHistoryStats.messages` consumers — the field type is unchanged; entries simply stop being dropped.

### Testing

Manual, on `dev` @ `ab41dcc48`:

1. Reproduced the validation failure in isolation — `M(tags=None)` on a model declared `tags: list[str | None] = None` raises `ValidationError: Input should be a valid list [type=list_type, input_value=None]`, while `M(tags=['x'])` passes.
2. Simulated the `_process_chat_for_export` per-message loop with four unannotated messages (2 user / 2 assistant), before and after the change:

```
BEFORE: export_messages=0  history_user_message_count=0  history_assistant_message_count=0
AFTER:  export_messages=4  history_user_message_count=2  history_assistant_message_count=2
```

3. Confirmed against a live deployment that the pre-fix response shape matches the bug exactly: `message_count` and `models` populated, every history-derived aggregate `0`, `chat.history.messages` empty.

No screenshots — the change is not user-facing beyond restoring correct numbers in the existing stats export.

### Changelog

```
### Fixed

- **📊 Chat Stats Export Counts**: Chat stats export no longer silently returns zeroed user/assistant message counts, empty model histograms and an empty message map for chats whose messages have no annotations.
```

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [ ] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
