### PR TITLE
fix: detect and convert HEIF-family images regardless of MIME type

### DIFF
--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -110,6 +110,24 @@
 	import QueuedMessageItem from './MessageInput/QueuedMessageItem.svelte';
 	import TaskList from './Messages/ResponseMessage/TaskList.svelte';
 
+	const isHeifFamily = (file) => {
+	const type = (file?.type || '').toLowerCase();
+	if (
+		type === 'image/heic' ||
+		type === 'image/heif' ||
+		type === 'image/heic-sequence' ||
+		type === 'image/heif-sequence'
+	) {
+		return true;
+	}
+	// Fallback: some browsers/OSes send an empty or generic type for HEIC files.
+	// Fall back to checking the filename extension in that case.
+	if (!type || type === 'application/octet-stream') {
+		return /\.(heic|heif)$/i.test(file?.name || '');
+	}
+	return false;
+    };
+
 	const i18n = getContext('i18n');
 
 	export let onUpload: Function = (e) => {};
@@ -972,7 +990,7 @@
 				return;
 			}
 
-			if (file['type'].startsWith('image/')) {
+			if (file['type'].startsWith('image/') || isHeifFamily(file))  {
 				if (visionCapableModels.length === 0) {
 					toast.error($i18n.t('Selected model(s) do not support image inputs'));
 					return;
@@ -1013,6 +1031,7 @@
 					}
 					return imageUrl;
 				};
+				
 
 				let reader = new FileReader();
 
@@ -1032,13 +1051,13 @@
 						];
 					} else {
 						const blob = await (await fetch(imageUrl)).blob();
-						const compressedFile = new File([blob], file.name, { type: file.type });
+						const compressedFile = new File([blob], file.name, { type: blob.type });
 
 						uploadFileHandler(compressedFile, false);
 					}
 				};
 
-				reader.readAsDataURL(file['type'] === 'image/heic' ? await convertHeicToJpeg(file) : file);
+				reader.readAsDataURL(isHeifFamily(file) ? await convertHeicToJpeg(file) : file);
 			} else {
 				uploadFileHandler(file);
 			}


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) — `Closes #28411  `
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [x] **Documentation:** Not applicable — internal bugfix, no user-facing docs affected.
- [x] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Manual tests performed locally to verify the fix works correctly. Generated real HEIC and HEIF test files, uploaded both through the chat UI, and confirmed via the stored message payload that `content_type` correctly shows `image/jpeg` after conversion (previously `application/octet-stream`/unconverted). Screenshots included below.
- [x] **No Unchecked AI Code:** This PR is human-written, self-reviewed, and manually tested by me.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new settings introduced; fix reuses the existing image-conversion pipeline and introduces no UX changes.
- [x] **Git Hygiene:** The PR is atomic (one logical change, single file), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

Fixes HEIC/HEIF image uploads reaching the backend in a state the model cannot use. Three related defects in `MessageInput.svelte`'s upload handling caused HEIC/HEIF files to either be skipped entirely (uploaded unconverted) or, when converted, mislabeled with the original pre-conversion MIME type.

### Added

- N/A

### Changed

- N/A

### Deprecated

- N/A

### Removed

- N/A

### Fixed

- The outer image-detection gate (`file['type'].startsWith('image/')`) previously skipped HEIC/HEIF files whenever the browser reported an empty or non-`image/*` MIME type for them, which is common since HEIC/HEIF are not universally registered MIME types. Such files fell through to the plain upload path completely unconverted.
- The inline HEIC conversion check only matched the exact string `image/heic`, missing `image/heif`, `image/heic-sequence`, and `image/heif-sequence` variants.
- Successfully converted images were re-tagged with the original (pre-conversion) `file.type` instead of the converted blob's actual type, so a correctly converted JPEG still appeared as `image/heic` to downstream consumers that validate declared MIME type.

### Security

- N/A

### Breaking Changes

- N/A

---

### Additional Information

Introduced a shared `isHeifFamily()` helper that checks MIME type variants (`image/heic`, `image/heif`, `image/heic-sequence`, `image/heif-sequence`) with a filename-extension fallback (`.heic`/`.heif`) for files with an empty or generic (`application/octet-stream`) type. This helper is used both at the outer image-detection gate and the inline conversion check, replacing the narrow literal-string comparison. The `File` constructor at the end of the conversion path now uses `blob.type` (the converted type) instead of `file.type` (the original type).

### Screenshots or Videos

- [Attach your before/after screenshots here: the stored file payload showing `content_type: "application/octet-stream"` before the fix, and `content_type: "image/jpeg"` after the fix, for both `.heic` and `.heif` uploads]

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.