### PR TITLE
Add MiniMax image editing support

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -1499,6 +1499,11 @@ IMAGES_EDIT_OPENAI_API_KEY = os.getenv('IMAGES_EDIT_OPENAI_API_KEY', OPENAI_API_
 IMAGES_EDIT_GEMINI_API_BASE_URL = os.getenv('IMAGES_EDIT_GEMINI_API_BASE_URL', GEMINI_API_BASE_URL)
 IMAGES_EDIT_GEMINI_API_KEY = os.getenv('IMAGES_EDIT_GEMINI_API_KEY', GEMINI_API_KEY)
 
+IMAGES_EDIT_MINIMAX_API_BASE_URL = os.getenv(
+    'IMAGES_EDIT_MINIMAX_API_BASE_URL', 'https://api.minimax.io/v1/image_generation'
+)
+IMAGES_EDIT_MINIMAX_API_KEY = os.getenv('IMAGES_EDIT_MINIMAX_API_KEY', '')
+
 
 IMAGES_EDIT_COMFYUI_BASE_URL = os.getenv('IMAGES_EDIT_COMFYUI_BASE_URL', '')
 IMAGES_EDIT_COMFYUI_API_KEY = os.getenv('IMAGES_EDIT_COMFYUI_API_KEY', '')
@@ -3005,6 +3010,8 @@ DEFAULT_CONFIG = {
     'images.edit.openai.api_key': IMAGES_EDIT_OPENAI_API_KEY,
     'images.edit.gemini.api_base_url': IMAGES_EDIT_GEMINI_API_BASE_URL,
     'images.edit.gemini.api_key': IMAGES_EDIT_GEMINI_API_KEY,
+    'images.edit.minimax.api_base_url': IMAGES_EDIT_MINIMAX_API_BASE_URL,
+    'images.edit.minimax.api_key': IMAGES_EDIT_MINIMAX_API_KEY,
     'images.edit.comfyui.base_url': IMAGES_EDIT_COMFYUI_BASE_URL,
     'images.edit.comfyui.api_key': IMAGES_EDIT_COMFYUI_API_KEY,
     'images.edit.comfyui.workflow': IMAGES_EDIT_COMFYUI_WORKFLOW,

--- a/backend/open_webui/routers/images.py
+++ b/backend/open_webui/routers/images.py
@@ -94,6 +94,8 @@ IMAGE_CONFIG_KEYS = {
     'IMAGES_EDIT_OPENAI_API_VERSION': 'images.edit.openai.api_version',
     'IMAGES_EDIT_GEMINI_API_BASE_URL': 'images.edit.gemini.api_base_url',
     'IMAGES_EDIT_GEMINI_API_KEY': 'images.edit.gemini.api_key',
+    'IMAGES_EDIT_MINIMAX_API_BASE_URL': 'images.edit.minimax.api_base_url',
+    'IMAGES_EDIT_MINIMAX_API_KEY': 'images.edit.minimax.api_key',
     'IMAGES_EDIT_COMFYUI_BASE_URL': 'images.edit.comfyui.base_url',
     'IMAGES_EDIT_COMFYUI_API_KEY': 'images.edit.comfyui.api_key',
     'IMAGES_EDIT_COMFYUI_WORKFLOW': 'images.edit.comfyui.workflow',
@@ -262,6 +264,8 @@ class ImagesConfig(BaseModel):
     IMAGES_EDIT_OPENAI_API_VERSION: str
     IMAGES_EDIT_GEMINI_API_BASE_URL: str
     IMAGES_EDIT_GEMINI_API_KEY: str
+    IMAGES_EDIT_MINIMAX_API_BASE_URL: str
+    IMAGES_EDIT_MINIMAX_API_KEY: str
     IMAGES_EDIT_COMFYUI_BASE_URL: str
     IMAGES_EDIT_COMFYUI_API_KEY: str
     IMAGES_EDIT_COMFYUI_WORKFLOW: str
@@ -301,6 +305,7 @@ async def update_config(request: Request, form_data: ImagesConfig, user=Depends(
     updates = config_updates(form_data.model_dump(), IMAGE_CONFIG_KEYS)
     updates['image_generation.comfyui.base_url'] = form_data.COMFYUI_BASE_URL.strip('/')
     updates['images.edit.comfyui.base_url'] = form_data.IMAGES_EDIT_COMFYUI_BASE_URL.strip('/')
+    updates['images.edit.minimax.api_base_url'] = form_data.IMAGES_EDIT_MINIMAX_API_BASE_URL.rstrip('/')
     await Config.upsert(updates)
     await set_image_model(request, form_data.IMAGE_GENERATION_MODEL)
     values = await get_config_values(IMAGE_CONFIG_KEYS)
@@ -1098,6 +1103,53 @@ async def image_edits(
                         )
                         images.append({'url': url})
 
+            return images
+
+        elif image_config.IMAGE_EDIT_ENGINE == 'minimax':
+            headers = {
+                'Authorization': f'Bearer {image_config.IMAGES_EDIT_MINIMAX_API_KEY}',
+                'Content-Type': 'application/json',
+            }
+
+            if ENABLE_FORWARD_USER_INFO_HEADERS:
+                headers = include_user_info_headers(headers, user)
+
+            source_images = [form_data.image] if isinstance(form_data.image, str) else form_data.image
+            data = {
+                'model': model or 'image-01',
+                'prompt': form_data.prompt,
+                'subject_reference': [
+                    {
+                        'type': 'character',
+                        'image_file': image,
+                    }
+                    for image in source_images
+                ],
+                'response_format': 'base64',
+                **({'n': form_data.n} if form_data.n else {}),
+                **({'width': width, 'height': height} if width is not None and height is not None else {}),
+            }
+
+            session = await get_session()
+            async with session.post(
+                url=image_config.IMAGES_EDIT_MINIMAX_API_BASE_URL,
+                json=data,
+                headers=headers,
+                ssl=AIOHTTP_CLIENT_SESSION_SSL,
+            ) as r:
+                r.raise_for_status()
+                res = await r.json(content_type=None)
+
+            base_response = res.get('base_resp', {})
+            if base_response.get('status_code', 0) != 0:
+                raise ValueError(base_response.get('status_msg') or 'Image edit request failed')
+
+            images = []
+            request_metadata = {key: value for key, value in data.items() if key != 'subject_reference'}
+            for image in res.get('data', {}).get('image_base64', []):
+                image_data, content_type = await get_image_data(image)
+                _, url = await upload_image(request, image_data, content_type, {**request_metadata, **metadata}, user)
+                images.append({'url': url})
             return images
 
         elif image_config.IMAGE_EDIT_ENGINE == 'comfyui':

--- a/src/lib/components/admin/Settings/Images.svelte
+++ b/src/lib/components/admin/Settings/Images.svelte
@@ -729,6 +729,7 @@
 							<option value="openai">{$i18n.t('Default (Open AI)')}</option>
 							<option value="comfyui">{$i18n.t('ComfyUI')}</option>
 							<option value="gemini">{$i18n.t('Gemini')}</option>
+							<option value="minimax">MiniMax</option>
 						</SettingsSelect>
 					</AdminSettingRow>
 
@@ -786,6 +787,25 @@
 								bind:value={config.IMAGES_EDIT_OPENAI_API_VERSION}
 							/>
 						</AdminSettingField>
+					{:else if config?.IMAGE_EDIT_ENGINE === 'minimax'}
+						<div class="grid grid-cols-1 gap-2 sm:grid-cols-2">
+							<AdminSettingField label={$i18n.t('API Base URL')}>
+								<input
+									class={inputClass}
+									placeholder={$i18n.t('API Base URL')}
+									bind:value={config.IMAGES_EDIT_MINIMAX_API_BASE_URL}
+								/>
+							</AdminSettingField>
+
+							<AdminSettingField label={$i18n.t('API Key')}>
+								<SensitiveInput
+									variant="settings"
+									placeholder={$i18n.t('API Key')}
+									bind:value={config.IMAGES_EDIT_MINIMAX_API_KEY}
+									required={true}
+								/>
+							</AdminSettingField>
+						</div>
 					{:else if config?.IMAGE_EDIT_ENGINE === 'comfyui'}
 						<AdminSettingField
 							label={$i18n.t('Base URL')}


### PR DESCRIPTION
Reason: Add a native MiniMax image editing route to the existing image edit pipeline.

This adds configurable API credentials and a region-selectable endpoint, exposes the engine in admin settings, maps source images to subject references, and stores base64 results through the existing image upload flow.

Checks:
- `uvx --from ruff==0.15.5 ruff format --check backend/open_webui/config.py backend/open_webui/routers/images.py`
- `python3 -m py_compile backend/open_webui/config.py backend/open_webui/routers/images.py`
- `uvx --from ruff==0.15.5 ruff check --select F821 backend/open_webui/config.py backend/open_webui/routers/images.py`
- `prettier --no-config --use-tabs --single-quote --trailing-comma none --print-width 100 --plugin=prettier-plugin-svelte --check src/lib/components/admin/Settings/Images.svelte`
- `git diff --check`
