### PR TITLE
ci: auto-label feature requests with the enhancement label

### DIFF
--- a/.github/workflows/issue-label.yaml
+++ b/.github/workflows/issue-label.yaml
@@ -67,3 +67,73 @@ jobs:
               issue_number: issue.number,
               labels: ['bug']
             });
+
+  label-feature-requests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add "enhancement" label to unlabeled feature requests
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+
+            if (issue.labels.some((label) => label.name === 'enhancement')) {
+              return;
+            }
+
+            // A human (or the bug form) already classified this as a bug;
+            // do not stack a second, contradictory classification on it.
+            if (issue.labels.some((label) => label.name === 'bug')) {
+              return;
+            }
+
+            const isEdit = context.payload.action === 'edited';
+            const titleWasEdited = Boolean(context.payload.changes?.title);
+
+            if (isEdit && !titleWasEdited) {
+              return;
+            }
+
+            const title = issue.title ?? '';
+            const body = issue.body ?? '';
+
+            // Feature requests: "feat: ...", "feature: ...", "feature request: ...",
+            // "enhancement: ...", "enh: ...", "[Feature Request] ..." — the feature
+            // request form titles every submission "feat: ", so form submissions are
+            // covered by the same pattern.
+            const featureLikeTitle =
+              /^\s*(\[\s*(feat|feature|enhancement|enh)\b[^\]]*\]|(feat|feature( request)?|enhancement|enh)\s*[:/\-])/i.test(
+                title
+              );
+
+            // API/CLI-created issues that reproduce the feature request form structure.
+            // Only headings distinctive to that form.
+            const featureFormBody = /###\s*(Proposed Solution|Alternatives Considered)/i.test(body);
+
+            if (!featureLikeTitle && !featureFormBody) {
+              return;
+            }
+
+            if (isEdit) {
+              const events = await github.paginate(github.rest.issues.listEvents, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                per_page: 100
+              });
+
+              const enhancementLabelWasRemoved = events.some(
+                (event) => event.event === 'unlabeled' && event.label?.name === 'enhancement'
+              );
+
+              if (enhancementLabelWasRemoved) {
+                return;
+              }
+            }
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              labels: ['enhancement']
+            });


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked and filled out the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or active, substantive [Discussion](https://github.com/open-webui/open-webui/discussions) - Closes #28530
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented. No new dependencies; the job uses `actions/github-script@v7`, already used by the existing job in the same file.
- [x] **Testing:** **Manual** end-to-end tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Verified with live workflow runs on a fork; details below.
- [x] **User-facing changes:** I have confirmed whether this PR changes the UI. It does not; this is a CI workflow change with no visual surface.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **ci**: CI/CD workflow changes

# Changelog Entry

### Description

- Bug reports are auto-labeled, but nothing ever applies `enhancement`: the feature request form applies only `triage`, and freeform or API-created feature requests get no label at all. Of the 67 most recent issues, 17 carry a feature title prefix and none had `enhancement`, so the label cannot be used for triage the way `bug` can.
- This adds a second job to the existing `Issue Labeler` workflow that applies `enhancement` to feature requests, mirroring the bug job's structure: the same title-prefix detection shape, the same form-structure body detection for API-created issues, and the same edit handling from #28333 (label on retitle, ignore non-title edits, never re-apply a manually removed label).
- One guard the bug job does not need: issues already labeled `bug` are skipped, so a human's classification is never contradicted by stacking `enhancement` on top.
- Scope is confined to issues; the `on: issues` trigger never fires for pull requests. The existing bug job is untouched, and the diff is purely additive.

### Added

- The `Issue Labeler` workflow now applies `enhancement` to feature requests: titles matching `feat:`, `feature:`, `feature request:`, `enhancement:`, `enh:` or `[Feature Request]` forms, and bodies reproducing the feature request form structure. The feature request form titles every submission `feat: `, so form submissions are covered by the same pattern.

---

### Additional Information

**Manual verification performed:**

1. Unit: the shipped script, extracted from the YAML rather than copied, passes 19 cases under node covering every branch: all title forms, prose starting with "Feature" not matching, `enhance:` not matching `enh:`, both skip guards, and all four edit semantics.
2. Calibration: the title pattern run over the 67 most recent real issues matches 17, every one a genuine feature request, zero false positives.
3. End to end: the workflow was pushed to a fork's default branch and exercised with live runs, 7 scenarios, 7 successful runs, all correct:

| Scenario | Result |
|---|---|
| `feat:` title on open | `enhancement` applied |
| Plain title, feature form body (API-created) | `enhancement` applied |
| Plain title, plain body | untouched |
| `issue:` title (existing bug job regression check) | `bug` applied, bug job unaffected |
| Plain title later retitled to `feat:` | `enhancement` applied on edit |
| `enhancement` manually removed, then retitled | not re-applied |
| `bug`-labeled issue retitled to `feat:` | not stacked |

The last two are the cases only a live run can prove, since they exercise the real events API and label state at event time.

### Screenshots or Videos

Not applicable; a CI workflow change with no visual surface.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
