### PR TITLE
fix: preserve adjacent inline data: URIs in OpenAPI tool results

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -1049,6 +1049,7 @@ async def process_tool_result(
                             tool_response.append(resource.get('uri'))
             tool_result = tool_response[0] if len(tool_response) == 1 else tool_response
         else:  # OpenAPI
+            kept_items = []
             for item in tool_result:
                 if isinstance(item, str) and item.startswith('data:'):
                     tool_result_files.append(
@@ -1057,7 +1058,9 @@ async def process_tool_result(
                             'content': item,
                         }
                     )
-                    tool_result.remove(item)
+                else:
+                    kept_items.append(item)
+            tool_result[:] = kept_items
 
     if isinstance(tool_result, list):
         tool_result = {'results': tool_result}


### PR DESCRIPTION
# Pull Request

**Closes #28394**

### Description

`process_tool_result()` in `backend/open_webui/utils/middleware.py` iterated over `tool_result` while calling `tool_result.remove(item)` inside the same loop (OpenAPI branch). `list.remove()` shifts every later element down by one, so the iterator skipped the element immediately after each extracted `data:` URI.

When an OpenAPI tool returned two or more **adjacent** inline `data:` URIs, only the first was moved into `tool_result_files`; the second survived into the text payload and was `json.dumps()`'d into the model context as a raw base64 blob — wasting a large amount of context window and leaving the image unrendered.

The fix collects non-`data:` items into a new list and assigns it back in place (`tool_result[:] = kept_items`) instead of mutating the list during iteration.

### Verification

Validated the corrected loop against several inputs, including the ones the old code got wrong:

| input | old (buggy) files | new files |
|---|---|---|
| `[data:A, data:B, "text"]` | `[data:A]` | `[data:A, data:B]` |
| `[data:1, data:2, data:3]` | `[data:1, data:3]` | `[data:1, data:2, data:3]` |
| `["x", data:1, "y", data:2, "z"]` | `[data:1, data:2]` (already ok) | `[data:1, data:2]` |

Non-adjacent and no-`data:` cases are unchanged.

### Changelog Entry

### Fixed
- Preserve every inline `data:` URI in OpenAPI tool results. Previously, when a tool returned two or more adjacent `data:` URIs, every second one leaked into the text payload instead of becoming an attachment.

---

### Contributor License Agreement

- [ ] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
