### PR TITLE
fix(openai): preserve loose tool schemas in Responses conversion

### DIFF
--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -1400,8 +1400,11 @@ def convert_to_responses_payload(payload: dict) -> dict:
                         converted_tool['description'] = func['description']
                     if 'parameters' in func:
                         converted_tool['parameters'] = func['parameters']
-                    if 'strict' in func:
-                        converted_tool['strict'] = func['strict']
+                    # Responses tools default to strict mode when the field is
+                    # omitted. Preserve the loose-schema semantics of Chat,
+                    # MCP, and OpenAPI function tools unless strictness was
+                    # explicitly requested by the caller.
+                    converted_tool['strict'] = func.get('strict', False)
                 converted_tools.append(converted_tool)
             else:
                 # Already in correct format or unknown format, pass through


### PR DESCRIPTION
Fixes #27750

## What changed
- Set `strict: false` when converting a Chat Completions function tool that does not specify strictness.
- Preserve explicit `strict: true` and `strict: false` values.
- Leave already-native Responses tools unchanged.

This keeps optional MCP/OpenAPI tool parameters optional when the payload is sent to the Responses API.

## Validation
- AST compilation of `backend/open_webui/routers/openai.py`
- Behavior checks for omitted, explicit true/false, and native Responses tools
- `ruff format --check backend/open_webui/routers/openai.py`
- `git diff --check`