### PR TITLE
fix(openai): preserve loose tool schemas in Responses conversion

### DIFF
--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -1403,8 +1403,12 @@ def convert_to_responses_payload(payload: dict) -> dict:
                     # Responses tools default to strict mode when the field is
                     # omitted. Preserve the loose-schema semantics of Chat,
                     # MCP, and OpenAPI function tools unless strictness was
-                    # explicitly requested by the caller.
-                    converted_tool['strict'] = func.get('strict', False)
+                    # explicitly requested by the caller. Keep the old wire
+                    # format for tools without a parameters schema.
+                    if 'strict' in func:
+                        converted_tool['strict'] = func['strict']
+                    elif 'parameters' in func:
+                        converted_tool['strict'] = False
                 converted_tools.append(converted_tool)
             else:
                 # Already in correct format or unknown format, pass through

--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -1400,8 +1400,11 @@ def convert_to_responses_payload(payload: dict) -> dict:
                         converted_tool['description'] = func['description']
                     if 'parameters' in func:
                         converted_tool['parameters'] = func['parameters']
-                    if 'strict' in func:
-                        converted_tool['strict'] = func['strict']
+                    # Responses tools default to strict mode when the field is
+                    # omitted. Preserve the loose-schema semantics of Chat,
+                    # MCP, and OpenAPI function tools unless strictness was
+                    # explicitly requested by the caller.
+                    converted_tool['strict'] = func.get('strict', False)
                 converted_tools.append(converted_tool)
             else:
                 # Already in correct format or unknown format, pass through

--- a/test/test_openai_responses_payload.py
+++ b/test/test_openai_responses_payload.py
@@ -1,0 +1,29 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parents[1] / 'backend'))
+
+from open_webui.routers.openai import convert_to_responses_payload
+
+
+def _convert_tool(function: dict) -> dict:
+    payload = convert_to_responses_payload(
+        {
+            'messages': [],
+            'tools': [{'type': 'function', 'function': function}],
+        }
+    )
+    return payload['tools'][0]
+
+
+def test_convert_to_responses_payload_preserves_explicit_strict_values():
+    assert _convert_tool({'name': 'strict', 'parameters': {}, 'strict': True})['strict'] is True
+    assert _convert_tool({'name': 'loose', 'parameters': {}, 'strict': False})['strict'] is False
+
+
+def test_convert_to_responses_payload_defaults_schema_tools_to_loose():
+    assert _convert_tool({'name': 'default', 'parameters': {}})['strict'] is False
+
+
+def test_convert_to_responses_payload_omits_strict_for_tools_without_parameters():
+    assert 'strict' not in _convert_tool({'name': 'no-schema'})


### PR DESCRIPTION
Fixes #27750

## What changed
- Set `strict: false` when converting a Chat Completions function tool that does not specify strictness.
- Preserve explicit `strict: true` and `strict: false` values.
- Leave already-native Responses tools unchanged.

This keeps optional MCP/OpenAPI tool parameters optional when the payload is sent to the Responses API. The OpenAI [Responses API reference](https://platform.openai.com/docs/api-reference/responses/create) documents `strict` for function tools and its default behavior.

## Validation
- AST compilation of `backend/open_webui/routers/openai.py`
- Behavior checks for omitted, explicit true/false, and native Responses tools
- `ruff format --check backend/open_webui/routers/openai.py`
- `git diff --check`

## Changelog

### Fixed

- Preserve loose tool schema semantics when converting Chat Completions tools to Responses API tools.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.