### PR TITLE
fix: thinking indicator never shows when streaming text fade is disabled

### DIFF
--- a/src/lib/components/chat/Messages/Markdown/MarkdownInlineTokens/CodespanToken.svelte
+++ b/src/lib/components/chat/Messages/Markdown/MarkdownInlineTokens/CodespanToken.svelte
@@ -4,16 +4,20 @@
 
 	import { getContext } from 'svelte';
 
+	import { settings } from '$lib/stores';
+
 	const i18n = getContext('i18n');
 
 	export let token;
 	export let done = true;
+
+	$: fade = !done && ($settings?.chatFadeStreamingText ?? true);
 </script>
 
 <!-- svelte-ignore a11y-click-events-have-key-events -->
 <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
 <code
-	class="codespan cursor-pointer {!done ? 'fade-in-token' : ''}"
+	class="codespan cursor-pointer {fade ? 'fade-in-token' : ''}"
 	on:click={() => {
 		copyToClipboard(unescapeHtml(token.text));
 		toast.success($i18n.t('Copied to clipboard'));

--- a/src/lib/components/chat/Messages/Markdown/MarkdownInlineTokens/TextToken.svelte
+++ b/src/lib/components/chat/Messages/Markdown/MarkdownInlineTokens/TextToken.svelte
@@ -1,11 +1,14 @@
 <script lang="ts">
+	import { settings } from '$lib/stores';
+
 	export let token;
 	export let done = true;
 
 	$: raw = token?.raw ?? '';
+	$: fade = !done && ($settings?.chatFadeStreamingText ?? true);
 </script>
 
-{#if done}
+{#if !fade}
 	{raw}
 {:else}
 	{#each raw.split(' ') as text}

--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -826,9 +826,7 @@
 									{compactPreview}
 									{editCodeBlock}
 									{topPadding}
-									done={($settings?.chatFadeStreamingText ?? true)
-										? (message?.done ?? false)
-										: true}
+									done={message?.done ?? false}
 									{model}
 									onTaskClick={async (e) => {
 										console.log(e);


### PR DESCRIPTION
Closes #28559

**Before submitting, make sure you've checked and filled out the following:**

- [x] **Linked Issue/Discussion:** `Closes #28559`
- [x] **Target branch:** targets `dev`
- [x] **Description:** provided below
- [x] **Changelog:** included below
- [ ] **Documentation:** n/a — no documented behaviour changes; this restores the previously intended behaviour
- [ ] **Dependencies:** n/a — no dependency changes
- [ ] **Testing:** _pending — see "Status" below_
- [ ] **User-facing changes:** _pending — screenshots to be added_
- [ ] **No Unchecked AI Code:** _pending review_
- [ ] **Self-Review:** _pending_
- [x] **Architecture:** no new settings introduced; the existing `chatFadeStreamingText` preference is simply read where the fade is applied instead of being conflated with completion state
- [x] **Git Hygiene:** single atomic commit, branched from `dev`
- [x] **Title Prefix:** `fix`

### Status

Opened as a **draft**: the root cause and the behavioural difference are confirmed against a live instance (see #28559 for stream frames and console traces), but this specific patch has not yet been through a manual end-to-end run on a build. Will add screenshots and mark ready for review once tested.

# Changelog Entry

### Description

- Fixes the reasoning/tool-call "Thinking..." indicator and its spinner never appearing when **Settings → Interface → Fade Effect for Streaming Text** is disabled.

### Fixed

- The `done` prop passed from `ResponseMessage` to `ContentRenderer` was overloaded: it drives the streaming fade animation, and is also threaded down as `messageDone` to `Collapsible` / `ConsecutiveDetailsGroup`, where it gates the reasoning completion label and the pending shimmer.

  It was computed as:

  ```svelte
  done={($settings?.chatFadeStreamingText ?? true) ? (message?.done ?? false) : true}
  ```

  so with the fade preference off, `done` was pinned to `true` for the whole stream. `messageDone` was then permanently true, `hasPending` permanently false, and the `{:else}` `Thinking...` branch unreachable — reasoning blocks jumped straight to `Thought` and no spinner ever rendered, even though the stream correctly reported `status: "in_progress"` with no `duration`.

- The two concerns are now separated: `ResponseMessage` passes the real `message.done` for completion state, and the fade preference is read where the fade is actually applied (`TextToken.svelte`, `CodespanToken.svelte`).

### Changed

- `ResponseMessage.svelte`: `done={message?.done ?? false}`.
- `TextToken.svelte` / `CodespanToken.svelte`: derive `fade = !done && ($settings?.chatFadeStreamingText ?? true)` locally and use it for the `fade-in-token` class.

### Notes for reviewers

- Fade behaviour is unchanged in both states: with the preference on, tokens fade while streaming and not once done; with it off, they never fade.
- One incidental side effect: `Markdown.svelte` uses `done` to decide between parsing immediately and throttling to an animation frame. Previously, with the fade off, `done` was always `true`, so content was re-parsed synchronously on every update. It now takes the throttled path while streaming, which is what the throttle was there for.
- The regression is only visible to users who have turned the fade off, which is likely why it went unreported. It dates to `1cf1b2c` (the fix for #22968), which introduced `messageDone`; the overloaded ternary itself predates it (`18adb28`) and was harmless until then.

### Screenshots or Videos

Fade Effect for Streaming Text **OFF**:
<img width="1293" height="434" alt="image" src="https://github.com/user-attachments/assets/35a837cb-4df8-4237-bd67-c959be2acdbb" />


Fade Effect for Streaming Text turned **ON**:
<img width="1195" height="417" alt="image" src="https://github.com/user-attachments/assets/6b5622c1-f871-4b5f-a532-2f08e0fae50a" />


### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
