### PR TITLE
feat: add /api/v1/responses endpoint

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -836,6 +836,15 @@ if ENABLE_SCIM:
 ##################################
 
 
+@app.post('/api/v1/responses')  # Compatibility with OpenAI Responses API
+async def responses(
+    request: Request,
+    form_data: openai.ResponsesForm,
+    user=Depends(get_verified_user),
+):
+    return await openai.responses(request, form_data, user)
+
+
 @app.get('/api/models')
 @app.get('/api/v1/models')  # Experimental: Compatibility with OpenAI API
 async def get_models(request: Request, refresh: bool = False, user=Depends(get_verified_user)):


### PR DESCRIPTION
# Add `/api/v1/responses` OpenAI-compatible endpoint

## Description

This pull request exposes the existing OpenAI Responses API handler at:

`POST /api/v1/responses`

The endpoint delegates to the existing `/openai/responses` implementation, preserving its request validation, authentication, streaming behavior, and response format. The existing `/openai/responses` route remains unchanged for backward compatibility.

## Pull Request Checklist

- [x] **Linked Issue/Discussion:** #26700
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided.
- [x] **Changelog:** A changelog entry is included below.
- [x] **Documentation:** No documentation changes are required for this endpoint alias.
- [x] **Dependencies:** No dependencies were added or updated.
- [x] **Testing:** Python compilation and application build checks were performed.
- [x] **No Unchecked AI Code:** The change has undergone review and testing.
- [x] **Self-Review:** The implementation was reviewed for project conventions and scope.
- [x] **Architecture:** The endpoint reuses the existing Responses API handler without duplicating its implementation or introducing configuration.
- [ ] **Git Hygiene:** The PR is atomic and rebased onto `dev`.
- [x] **Title Prefix:** `feat: add /api/v1/responses endpoint`

# Changelog Entry

### Description

- Expose the existing OpenAI-compatible Responses API through the standard `/api/v1/responses` path.

### Added

- Added `POST /api/v1/responses` as an authenticated alias for the existing Responses API handler.

### Changed

- None.

### Deprecated

- None.

### Removed

- None.

### Fixed

- None.

### Security

- No security behavior was changed. The new route uses the same verified-user authentication and request handling as the existing endpoint.

### Breaking Changes

- None.

---

### Additional Information

- The existing `POST /openai/responses` endpoint remains available and unchanged.
- No frontend behavior, direct-connections functionality, or dependencies are affected.

### Screenshots or Videos

- Not applicable; this is a backend API-only change.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.