### PR TITLE
fix: persist Anthropic reasoning signature so Claude chats survive turn 2

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -203,6 +203,31 @@ def output_id(prefix: str) -> str:
     return f'{prefix}_{uuid4().hex[:24]}'
 
 
+
+def extract_reasoning_details(payload) -> list:
+    """Read reasoning_details from the message or OpenRouter-style provider_specific_fields.
+
+    Anthropic-via-OpenRouter puts the thinking signature on
+    message.provider_specific_fields.reasoning_details, not the top-level
+    reasoning_details key. Missing that copy drops the signature on save and
+    the next turn 400s (issue #27467).
+    """
+    if not isinstance(payload, dict):
+        return []
+
+    details = payload.get('reasoning_details')
+    if not details:
+        provider = payload.get('provider_specific_fields') or {}
+        if isinstance(provider, dict):
+            details = provider.get('reasoning_details')
+
+    if isinstance(details, list):
+        return [item for item in details if isinstance(item, dict)]
+    if isinstance(details, dict):
+        return [details]
+    return []
+
+
 def merge_streamed_reasoning_details(target: list, details) -> None:
     items = details if isinstance(details, list) else [details]
     for item in items:
@@ -3898,7 +3923,7 @@ async def non_streaming_chat_response_handler(response, ctx):
                     if not response_output:
                         choice_message = choices[0].get('message', {})
                         reasoning_content = choice_message.get('reasoning_content') or choice_message.get('reasoning')
-                        reasoning_details = choice_message.get('reasoning_details')
+                        reasoning_details = extract_reasoning_details(choice_message)
                         response_output = []
                         if reasoning_content or reasoning_details:
                             reasoning_item = {
@@ -4939,14 +4964,7 @@ async def streaming_chat_response_handler(response, ctx):
                                         or delta.get('reasoning')
                                         or delta.get('thinking')
                                     )
-                                    reasoning_details = delta.get('reasoning_details')
-                                    reasoning_detail_items = (
-                                        [item for item in reasoning_details if isinstance(item, dict)]
-                                        if isinstance(reasoning_details, list)
-                                        else [reasoning_details]
-                                        if isinstance(reasoning_details, dict)
-                                        else []
-                                    )
+                                    reasoning_detail_items = extract_reasoning_details(delta)
                                     existing_reasoning_item = next(
                                         (item for item in reversed(output) if item.get('type') == 'reasoning'),
                                         None,

--- a/backend/open_webui/utils/misc.py
+++ b/backend/open_webui/utils/misc.py
@@ -258,6 +258,27 @@ def reconcile_tool_pairs(messages: list[dict]) -> list[dict]:
     return reconciled_messages
 
 
+
+def usable_reasoning_details(details) -> list:
+    """Drop Anthropic reasoning entries that cannot be replayed.
+
+    A stored `reasoning.text` with format anthropic-claude-v1 and no
+    `signature` is rejected by the provider on the next turn.
+    """
+    if not details:
+        return []
+    items = details if isinstance(details, list) else [details]
+    usable = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        fmt = str(item.get('format') or '')
+        if 'anthropic' in fmt and not item.get('signature'):
+            continue
+        usable.append(item)
+    return usable
+
+
 def convert_output_to_messages(
     output: list,
     raw: bool = False,
@@ -441,7 +462,7 @@ def convert_output_to_messages(
             pending_tool_outputs.append(item)
 
         elif item_type == 'reasoning':
-            reasoning_details = item.get('reasoning_details') if raw else None
+            reasoning_details = usable_reasoning_details(item.get('reasoning_details')) if raw else []
             if not reasoning_format and not reasoning_details:
                 continue
 


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

**Before submitting, make sure you've checked and filled out the following:**

- [x] **Linked Issue/Discussion:** Closes #27467
- [x] **Target branch:** `dev`
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following Keep a Changelog format is included at the bottom.
- [x] **Documentation:** No docs change. This is a backend persist/replay fix with no user-facing settings or UI.
- [x] **Dependencies:** None added or changed.
- [ ] **Testing:** I did not run a live Docker + OpenRouter Claude turn-2 session. I traced both persist paths and the replay filter against the wire evidence in #27467 (signature present on `provider_specific_fields.reasoning_details`, absent after save).
- [x] **User-facing changes:** No UI change. No screenshots.
- [x] **Self-Review:** The two persist call sites and the replay filter were reviewed against nearby patterns (`merge_streamed_reasoning_details`, `convert_output_to_messages`).
- [x] **Architecture:** No new setting. Persist the signature when the provider sent it; omit only unsigned Anthropic reasoning on replay so already-broken chats can recover.
- [x] **Git Hygiene:** Two commits on top of current `dev`, scoped to this bug.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

- Persist Anthropic thinking `signature` when the provider puts `reasoning_details` under `provider_specific_fields` (OpenRouter / Claude).
- On replay, drop Anthropic `reasoning_details` entries that have no `signature`, so already-saved chats stop 400ing on turn 2.

### Added

- `extract_reasoning_details()` in middleware: read `reasoning_details` from the message or `provider_specific_fields`.
- `usable_reasoning_details()` in misc: skip anthropic-format entries that cannot be replayed.

### Changed

- Non-streaming and streaming persist paths both use `extract_reasoning_details()`.
- `convert_output_to_messages(..., raw=True)` only reinjects replayable reasoning details.

### Deprecated

- N/A

### Removed

- N/A

### Fixed

- Reasoning-enabled Claude conversations dying on the second turn with `Invalid signature in thinking block` (#27467).

### Security

- N/A

### Breaking Changes

- None. Same-model Claude turns that already stored a signature keep working. Unsigned stored Anthropic reasoning is omitted on replay instead of being sent and rejected.

---

### Additional Information

Issue #27467 shows the provider response includes:

`choices[0].message.provider_specific_fields.reasoning_details[0].signature`

Open WebUI only read `message.reasoning_details` / `delta.reasoning_details`, so the signature never reached `webui.db`. The next turn rebuilt a thinking block without it and every upstream (Anthropic, Bedrock, Vertex, Azure via OpenRouter) returned 400.

This is the ordinary multi-turn persist path, not the tool-step path fixed in #19328, and not the mid-chat model-switch filter in #28245 / #28240.

Related: Discussion #18077, #23339.

### Screenshots or Videos

- N/A (no UI change)

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.