### PR TITLE
fix(playground): prefix generated image URLs with WEBUI_BASE_URL

### DIFF
--- a/src/lib/components/playground/Images.svelte
+++ b/src/lib/components/playground/Images.svelte
@@ -3,6 +3,7 @@
 	import { onMount, getContext } from 'svelte';
 	import { goto } from '$app/navigation';
 
+	import { WEBUI_BASE_URL } from '$lib/constants';
 	import { user } from '$lib/stores';
 	import { imageGenerations, imageEdits } from '$lib/apis/images';
 
@@ -136,10 +137,10 @@
 								{#each generatedImages as image, index}
 									<button
 										class="relative group cursor-pointer"
-										on:click={() => downloadImage(image.url, index)}
+										on:click={() => downloadImage(`${WEBUI_BASE_URL}${image.url}`, index)}
 									>
 										<img
-											src={image.url}
+											src={`${WEBUI_BASE_URL}${image.url}`}
 											alt=""
 											class="w-full aspect-square object-cover rounded-lg border border-gray-100/30 dark:border-gray-850/30"
 										/>


### PR DESCRIPTION
Closes #28487.

## Summary

Generated images rendered as blank tiles in the Images playground when the
frontend is served from a different origin than the backend (the default
in local development, where Vite runs on  and the backend on
).

## Root Cause

`src/lib/components/playground/Images.svelte` passed `image.url` directly
to both the `<img src>` attribute and the `downloadImage` helper:

```svelte
<!-- before -->
<img src={image.url} ... />
on:click={() => downloadImage(image.url, index)}
```

The backend always produces root-relative paths (e.g.
`/api/v1/files/<id>/content`) via `url_path_for`. The browser resolves a
root-relative path against the **page** origin. In a dev setup where the
page is on `:5173` and the backend is on `:8080`, the browser therefore
requests from Vite — which returns 404 — and the image appears blank.
`downloadImage` also calls `fetch(url)`, which suffers the same problem.

## Fix

Import `WEBUI_BASE_URL` from `$lib/constants` and prepend it to
`image.url` in both places:

```svelte
<!-- after -->
<img src={`${WEBUI_BASE_URL}${image.url}`} ... />
on:click={() => downloadImage(`${WEBUI_BASE_URL}${image.url}`, index)}
```

`WEBUI_BASE_URL` is `""` in production builds (no behavior change) and
`http://${hostname}:8080` in dev builds (fixes the cross-origin lookup).
Five other components already apply this exact pattern:
`MessageInput.svelte`, `UserMessage.svelte`, `FileItem.svelte`,
`CitationModal.svelte`, `QueuedMessageItem.svelte`.

## Testing

- Manually verified the URL construction logic: `WEBUI_BASE_URL + "/api/v1/files/<id>/content"` produces the correct absolute URL in dev and degrades gracefully to the original relative path in production.
- Confirmed `WEBUI_BASE_URL` is already `""` in non-dev builds, so no production regression.
- Static `tsc --noEmit --skipLibCheck` passes.

## Checklist

- [x] **Linked Issue/Discussion:** Closes #28487
- [x] **Target branch:** Targets `dev`
- [x] **Description:** Concise description provided above
- [x] **Changelog:** See below
- [ ] **Documentation:** No docs change needed (internal URL resolution)
- [x] **Dependencies:** No new dependencies
- [x] **Testing:** Logic verified; cross-origin live test not run (no local Docker backend available — disclosed)
- [x] **User-facing changes:** Images now render correctly in cross-origin dev setups
- [x] **No Unchecked AI Code:** Change reviewed line-by-line; follows identical pattern in 5 existing components
- [x] **Self-Review:** Performed
- [x] **Architecture:** No new settings; uses existing constant
- [x] **Git Hygiene:** Single atomic commit, rebased on `dev`
- [x] **Title Prefix:** Uses `fix` prefix

## Changelog

### Fixed
- Images playground: generated images no longer render blank when the frontend origin differs from the backend origin (e.g. local Vite dev server vs. backend on port 8080). Both the thumbnail display and the download action now use the correct absolute URL.

---
<!-- CLA section — do not delete -->
I have read the CLA Document and I hereby sign the CLA.