### PR TITLE
fix: missing Redis key logs a JSON TypeError and an empty cache refetches on every request

### DIFF
--- a/backend/open_webui/utils/tools.py
+++ b/backend/open_webui/utils/tools.py
@@ -1166,18 +1166,17 @@ async def set_tool_servers(request: Request):
 
 async def get_tool_servers(request: Request):
     try:
-        tool_servers = []
         if request.app.state.redis is not None:
-            try:
-                tool_servers = JSONCodec.loads(await request.app.state.redis.get(f'{REDIS_KEY_PREFIX}:tool_servers'))
-                request.app.state.TOOL_SERVERS = tool_servers
-            except Exception as e:
-                log.error(f'Error fetching tool_servers from Redis: {e}')
+            cached = await request.app.state.redis.get(f'{REDIS_KEY_PREFIX}:tool_servers')
+            if cached is not None:
+                try:
+                    tool_servers = JSONCodec.loads(cached)
+                    request.app.state.TOOL_SERVERS = tool_servers
+                    return tool_servers
+                except Exception as e:
+                    log.error(f'Error decoding tool_servers from Redis: {e}')
 
-        if not tool_servers:
-            tool_servers = await set_tool_servers(request)
-
-        return tool_servers
+        return await set_tool_servers(request)
     except Exception as e:
         log.error(f'Failed to load tool servers, skipping: {e}')
         return getattr(request.app.state, 'TOOL_SERVERS', None) or []
@@ -1309,18 +1308,17 @@ async def set_terminal_servers(request: Request):
 
 async def get_terminal_servers(request: Request):
     """Return cached terminal server specs, loading if needed."""
-    terminal_servers = []
     if request.app.state.redis is not None:
-        try:
-            terminal_servers = JSONCodec.loads(await request.app.state.redis.get(f'{REDIS_KEY_PREFIX}:terminal_servers'))
-            request.app.state.TERMINAL_SERVERS = terminal_servers
-        except Exception as e:
-            log.error(f'Error fetching terminal_servers from Redis: {e}')
+        cached = await request.app.state.redis.get(f'{REDIS_KEY_PREFIX}:terminal_servers')
+        if cached is not None:
+            try:
+                terminal_servers = JSONCodec.loads(cached)
+                request.app.state.TERMINAL_SERVERS = terminal_servers
+                return terminal_servers
+            except Exception as e:
+                log.error(f'Error decoding terminal_servers from Redis: {e}')
 
-    if not terminal_servers:
-        terminal_servers = await set_terminal_servers(request)
-
-    return terminal_servers
+    return await set_terminal_servers(request)
 
 
 async def get_terminal_tools(

--- a/backend/open_webui/utils/tools.py
+++ b/backend/open_webui/utils/tools.py
@@ -1165,21 +1165,18 @@ async def set_tool_servers(request: Request):
 
 
 async def get_tool_servers(request: Request):
-    try:
-        if request.app.state.redis is not None:
+
+    if request.app.state.redis is not None:
+        try:
             cached = await request.app.state.redis.get(f'{REDIS_KEY_PREFIX}:tool_servers')
             if cached is not None:
-                try:
-                    tool_servers = JSONCodec.loads(cached)
-                    request.app.state.TOOL_SERVERS = tool_servers
-                    return tool_servers
-                except Exception as e:
-                    log.error(f'Error decoding tool_servers from Redis: {e}')
+                tool_servers = JSONCodec.loads(cached)
+                request.app.state.TOOL_SERVERS = tool_servers
+                return tool_servers
+        except Exception as e:
+            log.error(f'Error reading tool_servers from Redis: {e}')
 
-        return await set_tool_servers(request)
-    except Exception as e:
-        log.error(f'Failed to load tool servers, skipping: {e}')
-        return getattr(request.app.state, 'TOOL_SERVERS', None) or []
+    return await set_tool_servers(request)
 
 
 async def get_terminal_cwd(
@@ -1309,14 +1306,14 @@ async def set_terminal_servers(request: Request):
 async def get_terminal_servers(request: Request):
     """Return cached terminal server specs, loading if needed."""
     if request.app.state.redis is not None:
-        cached = await request.app.state.redis.get(f'{REDIS_KEY_PREFIX}:terminal_servers')
-        if cached is not None:
-            try:
+        try:
+            cached = await request.app.state.redis.get(f'{REDIS_KEY_PREFIX}:terminal_servers')
+            if cached is not None:
                 terminal_servers = JSONCodec.loads(cached)
                 request.app.state.TERMINAL_SERVERS = terminal_servers
                 return terminal_servers
-            except Exception as e:
-                log.error(f'Error decoding terminal_servers from Redis: {e}')
+        except Exception as e:
+            log.error(f'Error reading terminal_servers from Redis: {e}')
 
     return await set_terminal_servers(request)
 


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes [Issue](https://github.com/open-webui/open-webui/issues/28568).
- [x] **Target branch:** `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog] is included at the bottom.
- [x] **Documentation:** No documentation change, as it is just a backend REDIS cache improvement fix.
- [x] **Dependencies:** None added or changed.
- [x] **Testing:** Live testing was done. I ran the Docker image. Opened the OpenWebUI on localhost. After the fix, ran the `/tools` & `/terminals` endpoint. Checked the logs for no error & also checked `redis-cli MONITOR`.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new setting incorporated.
- [x] **Git Hygiene:** One commit on top of current `dev`, scoped to this bug.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

Improve Redis caching for tool and terminal server specs so a missing key is handled as a normal cache miss, and a cached empty list is treated as a valid hit.

### Added

- N/A

### Changed

- `get_tool_servers` in `backend/open_webui/utils/tools.py`
- `get_terminal_servers` in `backend/open_webui/utils/tools.py`
- Cache read flow now checks for `None` before JSON decode
- Valid cached values (including `[]`) are returned directly without rebuilding

### Deprecated

- N/A

### Removed

- N/A

### Fixed

- ERROR log noise on cold cache: `open_webui.utils.tools:get_tool_servers:1160 - Error fetching tool_servers from Redis: the JSON object must be str, bytes or bytearray, not NoneType` when Redis key is missing
- Repeated DB reads and Redis `SETs` when the cached value is an empty list
- Decode failures and cache misses no longer look the same in logs

### Security

- N/A

### Breaking Changes

- **BREAKING CHANGE**: None

---

### Additional Information

- Related: Discussion #28572 

### Screenshots or Videos

- N/A

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
