### PR TITLE
fix: strip prefix id from model name in /responses endpoint

### DIFF
--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -1847,8 +1847,6 @@ async def responses(
     # Enforce per-model access control
     await check_model_access(user, await Models.get_model_by_id(model_id), BYPASS_MODEL_ACCESS_CONTROL)
 
-    body = JSONCodec.dumps(payload)
-
     if model_id:
         models = request.app.state.OPENAI_MODELS
         if not models or model_id not in models:
@@ -1858,6 +1856,9 @@ async def responses(
             idx = models[model_id]['urlIdx']
 
     url, key, api_config = await get_openai_connection(idx)
+
+    payload['model'] = strip_provider_model_prefix(payload['model'], api_config.get('prefix_id'))
+    body = JSONCodec.dumps(payload)
 
     r = None
     streaming = False


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #28574
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable - no user-facing settings or behavior knobs changed; the endpoint now behaves like `/openai/chat/completions` already does.
- [ ] **Dependencies:** None.
- [x] **Testing:** Manual tests performed (see below).
- [x] **No Unchecked AI Code:** Change was reviewed and manually tested; it is a 3-line port of an existing in-repo pattern (`generate_chat_completion()`).
- [x] **Self-Review:** Performed.
- [x] **Architecture:** No new settings; reuses `strip_provider_model_prefix()` from `open_webui.utils.model_ids`.
- [x] **Git Hygiene:** Single atomic commit, rebased on latest `dev`.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

Strip the configured Prefix ID from the model name before forwarding `POST /openai/responses` to the upstream provider. Mirrors what `generate_chat_completion()` already does for `/openai/chat/completions`.

### Added

- None.

### Changed

- In `responses()` (`backend/open_webui/routers/openai.py`), after `get_openai_connection(idx)` (i.e. after the urlIdx routing, which intentionally uses the prefixed id), call `strip_provider_model_prefix(payload['model'], api_config.get('prefix_id'))` and serialize the body once, after the strip. The earlier body serialization that sat before the routing block was removed, so the payload is serialized exactly once.

### Deprecated

- None.

### Removed

- None.

### Fixed

- `/openai/responses` no longer forwards the prefixed model id (e.g. `myprefix.gpt-4o`) to the upstream provider; the native name (`gpt-4o`) is sent instead (#28574).
- The Azure non-v1 deployment path inside `responses()` now builds `/openai/deployments/{model}/responses` from the stripped (native) model name instead of the prefixed one.

### Security

- None.

### Breaking Changes

- None. Connections without a Prefix ID are unaffected - `strip_provider_model_prefix()` is a no-op when `prefix_id` is `None`.

---

### Additional Information

The same strip pattern already exists in this file in `generate_chat_completion()` and the model-management handlers (`download_provider_model`, `load_provider_model`, `unload_provider_model`, `delete_provider_model`); this PR applies it to the one handler that was missing it. The strip is deliberately placed **after** the urlIdx lookup (which keys on the prefixed id in `OPENAI_MODELS`) and **before** `body` serialization and the Azure deployment-URL construction, which both consume the stripped name.

### Screenshots or Videos

N/A - API-level fix; reproduction via curl in the linked issue.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.