### PR TITLE
fix: download chat file attachments inline with auth

### DIFF
--- a/src/lib/components/common/FileItem.svelte
+++ b/src/lib/components/common/FileItem.svelte
@@ -57,7 +57,7 @@
 		: 'rounded-2xl'} text-left"
 	type="button"
 	on:click={async () => {
-		if (item?.file?.data?.content || item?.type === 'file' || item?.content || modal) {
+		if (item?.file?.data?.content || item?.content || modal) {
 			showModal = !showModal;
 		} else {
 			if (url) {
@@ -65,7 +65,30 @@
 					if (url.startsWith('http')) {
 						window.open(`${url}/content`, '_blank').focus();
 					} else {
-						window.open(`${WEBUI_API_BASE_URL}/files/${url}/content`, '_blank').focus();
+						// The JWT lives in localStorage (sent as an Authorization header
+						// on fetch) and is not available as a cookie on plain navigation,
+						// so opening the file URL in a new tab returns 401. Fetch the
+						// bytes with the token and trigger a direct browser download.
+						try {
+							const res = await fetch(
+								`${WEBUI_API_BASE_URL}/files/${url}/content?attachment=true`,
+								{ headers: { Authorization: `Bearer ${localStorage.token}` } }
+							);
+							if (!res.ok) throw new Error(`HTTP ${res.status}`);
+
+							const blob = await res.blob();
+							const objectUrl = window.URL.createObjectURL(blob);
+							const a = document.createElement('a');
+							a.href = objectUrl;
+							a.download = name;
+							document.body.appendChild(a);
+							a.click();
+							a.remove();
+							window.URL.revokeObjectURL(objectUrl);
+						} catch (err) {
+							console.error(err);
+							window.open(`${WEBUI_API_BASE_URL}/files/${url}/content`, '_blank').focus();
+						}
 					}
 				} else {
 					window.open(`${url}`, '_blank').focus();


### PR DESCRIPTION
## Summary

Clicking a file attachment tile in chat currently either opens a preview
modal (for plain file refs) or a new tab via `window.open` to
`/files/{id}/content`. The JWT is stored in `localStorage` and sent as an
`Authorization` header on fetch — it is **not** available as a cookie on
plain navigation (the `token` cookie is only set in the OAuth redirect
flow), so the new-tab request returns **401** for regular logins and the
file never downloads.

## Changes

`src/lib/components/common/FileItem.svelte`:

1. **Skip the preview modal for plain file refs** — the `item?.type === 'file'`
   clause is removed from the modal condition, so a file without embedded
   content goes straight to the download path instead of opening an empty
   preview modal. Items with embedded content (`item.file.data.content` /
   `item.content`) still open the modal.
2. **Download via authenticated fetch → blob → anchor click** — the file
   bytes are fetched from `/files/{id}/content?attachment=true` with the
   `Authorization: Bearer` header (the same pattern as `downloadDatabase` in
   `src/lib/apis/utils/index.ts`), then saved with the original filename via a
   blob URL. `?attachment=true` forces `Content-Disposition: attachment` for
   all content types (including PDFs, which otherwise serve inline).
3. **Graceful fallback** — on any fetch failure the previous `window.open`
   behavior is preserved.

## Behavior preserved

- External `http(s)` file URLs: unchanged (`window.open`).
- Embedded-content items (images etc.): modal/preview unchanged.
- Message input-box attachment tiles: unchanged (they pass `modal=true`).

## Testing

- Manual: click a file attachment in a chat → the file downloads directly to
  disk with its original filename (regular login, no token cookie present).
- Before this change the same click either opened an empty modal or a 401
  page in a new tab.