### PR TITLE
fix(ui): show inherited interface scale

### DIFF
--- a/src/lib/components/common/InterfaceSettings.svelte
+++ b/src/lib/components/common/InterfaceSettings.svelte
@@ -413,10 +413,13 @@
 								}
 							}}
 						>
-							{#if textScale === null || (isDefaultSetting('textScale') && !showTextScaleSlider)}
+							{#if textScale === null}
 								<span>{$i18n.t('Default')}</span>
 							{:else}
 								<span>{textScale}x</span>
+								{#if isDefaultSetting('textScale') && !showTextScaleSlider}
+									<span class="text-[0.6875rem] text-gray-400 dark:text-gray-600">{$i18n.t('Default')}</span>
+								{/if}
 							{/if}
 						</button>
 					</div>


### PR DESCRIPTION
Fixes #28561

When UI Scale is inherited from the system-wide defaults, the collapsed control now shows the effective scale together with the existing Default indicator. Personal overrides and the expandable slider behavior are unchanged.

Validation:
- `git diff --check`
- `npm run check` (baseline currently reports unrelated existing diagnostics outside this change; no new diagnostic was reported for `InterfaceSettings.svelte` before the output was truncated)