### PR TITLE
fix(ui): show inherited interface scale

### DIFF
--- a/src/lib/components/common/InterfaceSettings.svelte
+++ b/src/lib/components/common/InterfaceSettings.svelte
@@ -413,10 +413,13 @@
 								}
 							}}
 						>
-							{#if textScale === null || (isDefaultSetting('textScale') && !showTextScaleSlider)}
+							{#if textScale === null}
 								<span>{$i18n.t('Default')}</span>
 							{:else}
 								<span>{textScale}x</span>
+								{#if isDefaultSetting('textScale') && !showTextScaleSlider}
+									<span class="text-[0.6875rem] text-gray-400 dark:text-gray-600">{$i18n.t('Default')}</span>
+								{/if}
 							{/if}
 						</button>
 					</div>


### PR DESCRIPTION
Fixes #28561

When UI Scale is inherited from the system-wide defaults, the collapsed control now shows the effective scale together with the existing Default indicator. Personal overrides and the expandable slider behavior are unchanged.

# Pull Request Checklist

- [x] Linked Issue/Discussion: this PR fixes #28561.
- [x] Target branch: `dev`.
- [x] Description: provided above.
- [ ] Changelog: this focused bug fix does not add a separate changelog entry.
- [ ] Documentation: no documentation change is needed for this UI-only fix.
- [x] Dependencies: no dependencies changed.
- [ ] Testing: the repository-wide `npm run check` was run, but the current `dev` checkout reports 8,070 pre-existing diagnostics in unrelated files. `git diff --check` passes; no diagnostic was reported for `InterfaceSettings.svelte` before the checker output was truncated.
- [x] User-facing changes: the effective inherited value is now visible in the existing control; no interaction or API contract changed.
- [x] No Unchecked AI Code: the change was reviewed against the issue reproduction and surrounding component behavior.
- [x] Self-Review: completed.
- [x] Architecture: local UI state and existing inheritance helper are reused.
- [x] Git Hygiene: one atomic commit, based on `dev`.
- [x] Title Prefix: `fix`.

### Changelog Entry

#### Fixed

- Show the effective inherited UI Scale value in the collapsed interface settings control.

### Additional Information

The issue's reproduction and source links document the inherited setting behavior. The change keeps the existing `Default` indicator and only changes the collapsed display from `Default` alone to the effective value plus `Default`.

### Screenshots or Videos

- Not attached: the local checkout cannot be run end-to-end without the full backend/configuration environment; the issue includes the original reproduction screenshots.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> The CLA confirmation is intentionally retained verbatim from the repository template.
