### PR TITLE
fix: don't double-count cached tokens when deciding to compact context

### DIFF
--- a/backend/open_webui/utils/context_compaction.py
+++ b/backend/open_webui/utils/context_compaction.py
@@ -279,7 +279,6 @@ async def get_chat_context_usage(chat: Any, model_id: str | None = None) -> dict
                     or usage.get('predicted_n')
                     or 0
                 )
-                + int(usage.get('cache_n') or 0)
             )
         ):
             tokens += _estimate_messages_tokens(messages[idx + 1 :])
@@ -336,7 +335,6 @@ def _exceeds_token_threshold(messages: list[dict], system_prompt: str, summary: 
                     or usage.get('predicted_n')
                     or 0
                 )
-                + int(usage.get('cache_n') or 0)
             )
         ):
             return tokens + _estimate_messages_tokens(messages[idx + 1 :]) > threshold


### PR DESCRIPTION
Context compaction fired at roughly half the configured threshold on backends that report prompt caching. With a 70k threshold, a chat showing 39k tokens in the UI was already being compacted, and the more the cache helped, the earlier it happened.

llama.cpp's `timings` are merged into `usage`, so the same dict carries both `prompt_tokens` and `cache_n`, where `prompt_tokens` already includes `cache_n` (38153 cached + 43 new = 38196 prompt). The threshold check added `cache_n` on top of that, counting every cached token twice.

Dropping the extra `cache_n` term makes the backend agree with the number the UI shows, which is what the threshold is configured against.

Fixes #28590

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
