### PR TITLE
fix: add heading semantics for screen reader navigation (chat greeting, message senders, auth title)

### DIFF
--- a/src/lib/components/chat/ChatPlaceholder.svelte
+++ b/src/lib/components/chat/ChatPlaceholder.svelte
@@ -89,13 +89,13 @@
 			class=" mt-2 mb-4 text-3xl text-gray-800 dark:text-gray-100 text-left flex items-center gap-4"
 		>
 			<div>
-				<div class=" capitalize line-clamp-1" in:fade={{ duration: 200 }}>
+				<h1 class=" capitalize line-clamp-1 m-0 text-3xl font-inherit" in:fade={{ duration: 200 }}>
 					{#if models[selectedModelIdx]?.name}
 						{models[selectedModelIdx]?.name}
 					{:else}
 						{$i18n.t('Hello, {{name}}', { name: $user?.name })}
 					{/if}
-				</div>
+				</h1>
 
 				<div in:fade={{ duration: 200, delay: 200 }}>
 					{#if models[selectedModelIdx]?.info?.meta?.description ?? null}

--- a/src/lib/components/chat/Messages/Name.svelte
+++ b/src/lib/components/chat/Messages/Name.svelte
@@ -1,3 +1,5 @@
-<div class=" self-center text-[0.9375rem] font-normal line-clamp-1 flex gap-1 items-center">
+<h3
+	class=" self-center text-[0.9375rem] font-normal line-clamp-1 flex gap-1 items-center m-0"
+>
 	<slot />
-</div>
+</h3>

--- a/src/routes/auth/+page.svelte
+++ b/src/routes/auth/+page.svelte
@@ -269,7 +269,7 @@
 								}}
 							>
 								<div class="mb-1">
-									<div class=" text-2xl font-normal">
+									<h1 class=" text-2xl font-normal m-0">
 										{#if $config?.onboarding ?? false}
 											{$i18n.t(`Get started with {{WEBUI_NAME}}`, { WEBUI_NAME: $WEBUI_NAME })}
 										{:else if mode === 'ldap'}
@@ -279,7 +279,7 @@
 										{:else}
 											{$i18n.t(`Sign up to {{WEBUI_NAME}}`, { WEBUI_NAME: $WEBUI_NAME })}
 										{/if}
-									</div>
+									</h1>
 
 									{#if $config?.onboarding ?? false}
 										<div class="mt-1 text-xs font-normal text-gray-600 dark:text-gray-500">


### PR DESCRIPTION
## What this does

Converts three purely visual headings into semantic heading elements so screen reader users can orient by heading navigation:

- `ChatPlaceholder.svelte`: the "Hello, {name}" / model-name greeting `div` becomes an `h1`, giving the empty chat state a page heading (WCAG 1.3.1, 2.4.6)
- `Messages/Name.svelte`: message sender names become `h3`, so users can jump message-to-message through a conversation with the H key - the same pattern ChatGPT uses (WCAG 1.3.1, 2.4.6)
- `routes/auth/+page.svelte`: the "Sign in / Sign up" title `div` becomes an `h1` (WCAG 1.3.1, 2.4.6)

## Zero visual change

Each element carries its existing CSS classes forward with `m-0` added to neutralize UA heading margins. Before/after screenshots will be attached.

## Testing

- `npm run check`: zero errors and zero warnings in the three edited files (tree-wide totals match the current `dev` baseline)
- NVDA + keyboard pass: in progress; results and screenshots will be posted here before this PR is marked ready for review

## Context

Part of the accessibility effort discussed in #23212. This is the first of a planned series of small, single-purpose PRs; happy to adjust scope or approach to whatever the maintainers prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
