### PR TITLE
fix: show inherited UI scale value next to Default badge

### DIFF
--- a/src/lib/components/common/InterfaceSettings.svelte
+++ b/src/lib/components/common/InterfaceSettings.svelte
@@ -414,7 +414,14 @@
 							}}
 						>
 							{#if textScale === null || (isDefaultSetting('textScale') && !showTextScaleSlider)}
-								<span>{$i18n.t('Default')}</span>
+								{#if isDefaultSetting('textScale') && defaultSettings.textScale != null}
+									<span class="text-[0.6875rem] text-gray-400 dark:text-gray-600"
+										>{$i18n.t('Default')}</span
+									>
+									<span aria-hidden="true">{defaultSettings.textScale}x</span>
+								{:else}
+									<span>{$i18n.t('Default')}</span>
+								{/if}
 							{:else}
 								<span>{textScale}x</span>
 							{/if}


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Closes #28561
- [x] **Target branch:** This PR targets the `dev` branch.
- [x] **Description:** Provided below.
- [x] **Changelog:** Included at the bottom.
- [x] **Documentation:** Not needed (display-only change, no new user-facing setting).
- [x] **Dependencies:** None.
- [x] **Testing:** Manual end-to-end verification with before/after screenshots below (dev server + mock backend config with `default_interface_settings.textScale = 1.25`).
- [x] **User-facing changes:** Yes — screenshots included.
- [x] **No Unchecked AI Code:** The change has been human-reviewed against the surrounding component logic and manually verified in the browser.
- [x] **Self-Review:** Performed; diff is a single file, single logical change.
- [x] **Architecture:** No new settings; reuses `isDefaultSetting()` and `defaultSettings` already present in the component.
- [x] **Git Hygiene:** Atomic change, single commit rebased on `dev`.
- [x] **Title Prefix:** `fix`

# Description

When an administrator configures a system-wide default interface scale (**Default Interface Settings**), a user who inherits it saw the collapsed UI Scale control read only **"Default"** — identical to an instance with no defaults configured — while the page around it rendered at the inherited scale. The inherited value was only discoverable after expanding the slider. Switch rows (e.g. Widescreen Mode) already surface inherited values with a **Default** badge without any interaction; this aligns the UI Scale row with that pattern.

## Before (collapsed, system default 1.25x active — shows only "Default")

![before](https://github.com/ach3rry/open-webui/releases/download/screenshot-assets/before-fix.png)

## After (shows "Default 1.25x" — inherited value surfaced next to the badge)

![after](https://github.com/ach3rry/open-webui/releases/download/screenshot-assets/after-fix.png)

# Changelog Entry

### Changed

- `src/lib/components/common/InterfaceSettings.svelte`: in the collapsed state, when `isDefaultSetting('textScale')` is true and `defaultSettings.textScale` exists, render a "Default" label (same styling as the Switch badge) followed by the inherited value (e.g. `1.25x`). Behavior unchanged when no default is configured.

### Fixed

- UI Scale collapsed control now shows the effective inherited value instead of a bare "Default" (closes #28561).

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
