### PR TITLE
perf: strip the request echo from forwarded Responses API lifecycle events

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -817,6 +817,18 @@ def handle_responses_streaming_event(
         return current_output, None
 
 
+def slim_response_lifecycle_event(event: dict) -> dict:
+    # Lifecycle events echo the request back (instructions, tool schemas); only these fields are read downstream.
+    response = event.get('response')
+    if not isinstance(response, dict):
+        return event
+
+    return {
+        **event,
+        'response': {key: value for key, value in response.items() if key in {'error', 'id', 'output', 'usage'}},
+    }
+
+
 def get_source_context(sources: list, source_ids: dict = None, include_content: bool = True) -> str:
     """
     Build <source> tag context string from citation sources.
@@ -4558,7 +4570,7 @@ async def streaming_chat_response_handler(response, ctx):
                         await event_emitter(
                             {
                                 'type': 'response:completion',
-                                'data': response_data,
+                                'data': slim_response_lifecycle_event(response_data),
                             }
                         )
                         await save_current_response_stream(stream_output)


### PR DESCRIPTION
The Responses API embeds the whole response object in its lifecycle events, and that object echoes the request back: the full system prompt in instructions, every tool's JSON schema in tools. Open WebUI forwards those events verbatim, so each one crosses the socket layer, and Redis pub/sub on multi-instance deployments, carrying tens of KB nothing reads. There are at least three per assistant message, and a deployment with a large system prompt measured roughly 22KB each.

Lifecycle events now keep only the four fields anything reads: handle_responses_streaming_event takes output, usage and id, response.failed takes error, and the frontend reducer reads response.output on response.completed. Delta events and events without a response envelope pass through untouched, and the raw event still reaches handle_responses_streaming_event before the emit, so stateful continuation and usage merging are unaffected.

Replayed against a response object with a 6KB system prompt and eight tool schemas, one event drops from 11,603 to 277 bytes. response.completed keeps its output, so its size still tracks the answer length; the echo is what goes.

A whitelist rather than dropping instructions and tools by name, since OpenAI keeps adding fields to the response object and a blocklist would quietly let the next one through.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
