### PR TITLE
fix(tools): handle redis cache miss gracefully and preserve empty list hits (#28568)

### DIFF
--- a/backend/open_webui/utils/tools.py
+++ b/backend/open_webui/utils/tools.py
@@ -1151,15 +1151,17 @@ async def set_tool_servers(request: Request):
 
 async def get_tool_servers(request: Request):
     try:
-        tool_servers = []
+        tool_servers = None
         if request.app.state.redis is not None:
             try:
-                tool_servers = json.loads(await request.app.state.redis.get(f'{REDIS_KEY_PREFIX}:tool_servers'))
-                request.app.state.TOOL_SERVERS = tool_servers
+                cached = await request.app.state.redis.get(f'{REDIS_KEY_PREFIX}:tool_servers')
+                if cached is not None:
+                    tool_servers = json.loads(cached)
+                    request.app.state.TOOL_SERVERS = tool_servers
             except Exception as e:
                 log.error(f'Error fetching tool_servers from Redis: {e}')
 
-        if not tool_servers:
+        if tool_servers is None:
             tool_servers = await set_tool_servers(request)
 
         return tool_servers
@@ -1294,15 +1296,17 @@ async def set_terminal_servers(request: Request):
 
 async def get_terminal_servers(request: Request):
     """Return cached terminal server specs, loading if needed."""
-    terminal_servers = []
+    terminal_servers = None
     if request.app.state.redis is not None:
         try:
-            terminal_servers = json.loads(await request.app.state.redis.get(f'{REDIS_KEY_PREFIX}:terminal_servers'))
-            request.app.state.TERMINAL_SERVERS = terminal_servers
+            cached = await request.app.state.redis.get(f'{REDIS_KEY_PREFIX}:terminal_servers')
+            if cached is not None:
+                terminal_servers = json.loads(cached)
+                request.app.state.TERMINAL_SERVERS = terminal_servers
         except Exception as e:
             log.error(f'Error fetching terminal_servers from Redis: {e}')
 
-    if not terminal_servers:
+    if terminal_servers is None:
         terminal_servers = await set_terminal_servers(request)
 
     return terminal_servers

--- a/backend/test/test_tools_redis_cache.py
+++ b/backend/test/test_tools_redis_cache.py
@@ -1,0 +1,151 @@
+import json
+import logging
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Ensure required env var is set for open_webui imports
+os.environ.setdefault('WEBUI_SECRET_KEY', 'test-secret-key-for-unit-tests-12345')
+
+import pytest
+from open_webui.env import REDIS_KEY_PREFIX
+from open_webui.utils.tools import get_terminal_servers, get_tool_servers
+
+
+class DummyAppState:
+    def __init__(self, redis_client=None):
+        self.redis = redis_client
+        self.TOOL_SERVERS = None
+        self.TERMINAL_SERVERS = None
+
+
+class DummyApp:
+    def __init__(self, state):
+        self.state = state
+
+
+class DummyRequest:
+    def __init__(self, app_state):
+        self.app = DummyApp(app_state)
+
+
+@pytest.mark.asyncio
+async def test_get_tool_servers_cache_miss_no_type_error(caplog):
+    """Test Redis cache miss returns None, fetches via set_tool_servers without logging TypeError."""
+    mock_redis = MagicMock()
+    mock_redis.get = AsyncMock(return_value=None)
+    mock_redis.set = AsyncMock()
+
+    app_state = DummyAppState(redis_client=mock_redis)
+    request = DummyRequest(app_state)
+
+    fetched_servers = [{'id': 'server-1', 'url': 'http://localhost:8000'}]
+    with patch('open_webui.utils.tools.set_tool_servers', new=AsyncMock(return_value=fetched_servers)) as mock_set:
+        with caplog.at_level(logging.ERROR):
+            result = await get_tool_servers(request)
+
+        mock_redis.get.assert_awaited_once_with(f'{REDIS_KEY_PREFIX}:tool_servers')
+        mock_set.assert_awaited_once_with(request)
+        assert result == fetched_servers
+        # Assert no JSON TypeError was logged during cache miss
+        for record in caplog.records:
+            assert 'the JSON object must be str' not in record.message
+            assert 'Error fetching tool_servers from Redis' not in record.message
+
+
+@pytest.mark.asyncio
+async def test_get_tool_servers_cache_hit_empty_list():
+    """Test Redis cache hit with empty list does NOT call set_tool_servers."""
+    mock_redis = MagicMock()
+    mock_redis.get = AsyncMock(return_value=json.dumps([]))
+
+    app_state = DummyAppState(redis_client=mock_redis)
+    request = DummyRequest(app_state)
+
+    with patch('open_webui.utils.tools.set_tool_servers', new=AsyncMock()) as mock_set:
+        result = await get_tool_servers(request)
+
+        mock_redis.get.assert_awaited_once_with(f'{REDIS_KEY_PREFIX}:tool_servers')
+        mock_set.assert_not_awaited()
+        assert result == []
+        assert app_state.TOOL_SERVERS == []
+
+
+@pytest.mark.asyncio
+async def test_get_tool_servers_cache_hit_populated():
+    """Test Redis cache hit with populated server list."""
+    cached_servers = [{'id': 'srv1', 'url': 'https://api.tools.com'}]
+    mock_redis = MagicMock()
+    mock_redis.get = AsyncMock(return_value=json.dumps(cached_servers))
+
+    app_state = DummyAppState(redis_client=mock_redis)
+    request = DummyRequest(app_state)
+
+    with patch('open_webui.utils.tools.set_tool_servers', new=AsyncMock()) as mock_set:
+        result = await get_tool_servers(request)
+
+        mock_redis.get.assert_awaited_once_with(f'{REDIS_KEY_PREFIX}:tool_servers')
+        mock_set.assert_not_awaited()
+        assert result == cached_servers
+        assert app_state.TOOL_SERVERS == cached_servers
+
+
+@pytest.mark.asyncio
+async def test_get_terminal_servers_cache_miss_no_type_error(caplog):
+    """Test Redis cache miss for terminal_servers fetches via set_terminal_servers without TypeError."""
+    mock_redis = MagicMock()
+    mock_redis.get = AsyncMock(return_value=None)
+    mock_redis.set = AsyncMock()
+
+    app_state = DummyAppState(redis_client=mock_redis)
+    request = DummyRequest(app_state)
+
+    fetched_terminals = [{'id': 'term-1', 'url': 'http://localhost:9000'}]
+    with patch(
+        'open_webui.utils.tools.set_terminal_servers', new=AsyncMock(return_value=fetched_terminals)
+    ) as mock_set:
+        with caplog.at_level(logging.ERROR):
+            result = await get_terminal_servers(request)
+
+        mock_redis.get.assert_awaited_once_with(f'{REDIS_KEY_PREFIX}:terminal_servers')
+        mock_set.assert_awaited_once_with(request)
+        assert result == fetched_terminals
+        for record in caplog.records:
+            assert 'the JSON object must be str' not in record.message
+            assert 'Error fetching terminal_servers from Redis' not in record.message
+
+
+@pytest.mark.asyncio
+async def test_get_terminal_servers_cache_hit_empty_list():
+    """Test Redis cache hit with empty list for terminal_servers does NOT call set_terminal_servers."""
+    mock_redis = MagicMock()
+    mock_redis.get = AsyncMock(return_value=json.dumps([]))
+
+    app_state = DummyAppState(redis_client=mock_redis)
+    request = DummyRequest(app_state)
+
+    with patch('open_webui.utils.tools.set_terminal_servers', new=AsyncMock()) as mock_set:
+        result = await get_terminal_servers(request)
+
+        mock_redis.get.assert_awaited_once_with(f'{REDIS_KEY_PREFIX}:terminal_servers')
+        mock_set.assert_not_awaited()
+        assert result == []
+        assert app_state.TERMINAL_SERVERS == []
+
+
+@pytest.mark.asyncio
+async def test_get_terminal_servers_cache_hit_populated():
+    """Test Redis cache hit with populated terminal server list."""
+    cached_terminals = [{'id': 'term1', 'url': 'https://terminal.tools.com'}]
+    mock_redis = MagicMock()
+    mock_redis.get = AsyncMock(return_value=json.dumps(cached_terminals))
+
+    app_state = DummyAppState(redis_client=mock_redis)
+    request = DummyRequest(app_state)
+
+    with patch('open_webui.utils.tools.set_terminal_servers', new=AsyncMock()) as mock_set:
+        result = await get_terminal_servers(request)
+
+        mock_redis.get.assert_awaited_once_with(f'{REDIS_KEY_PREFIX}:terminal_servers')
+        mock_set.assert_not_awaited()
+        assert result == cached_terminals
+        assert app_state.TERMINAL_SERVERS == cached_terminals


### PR DESCRIPTION
## Description
Fixes an issue where a Redis cache miss in get_tool_servers and get_terminal_servers caused a TypeError to be logged (	he JSON object must be str, bytes or bytearray, not NoneType), and where an empty cached list [] was falsely treated as a cache miss causing a database/network re-fetch on every subsequent request.

## Root Cause
1. When a key is missing from Redis, 
equest.app.state.redis.get() returns None. Passing None directly into json.loads() raises a TypeError, which was caught and logged as an error despite cache misses being expected/normal.
2. In Python, an empty list [] evaluates to False. The check if not tool_servers: / if not terminal_servers: caused valid cached empty server lists to trigger set_tool_servers() / set_terminal_servers() on every single request, defeating cache efficiency.

## Solution
1. Check if the raw Redis return value is not None before parsing with json.loads().
2. Initialize 	ool_servers and 	erminal_servers to None and check if tool_servers is None: / if terminal_servers is None: so that empty list hits ([]) are preserved without unnecessary re-fetching.
3. Added unit tests covering cache misses (without error logs), cache hits with empty lists [], and cache hits with populated server lists.

Resolves #28568
Closes #28568

## Local Validation
Executed unit tests with pytest:
\test/test_tools_redis_cache.py::test_get_tool_servers_cache_miss_no_type_error PASSED [ 16%]
test/test_tools_redis_cache.py::test_get_tool_servers_cache_hit_empty_list PASSED [ 33%]
test/test_tools_redis_cache.py::test_get_tool_servers_cache_hit_populated PASSED [ 50%]
test/test_tools_redis_cache.py::test_get_terminal_servers_cache_miss_no_type_error PASSED [ 66%]
test/test_tools_redis_cache.py::test_get_terminal_servers_cache_hit_empty_list PASSED [ 83%]
test/test_tools_redis_cache.py::test_get_terminal_servers_cache_hit_populated PASSED [100%]
6 passed
\