### PR TITLE
fix(tools): handle redis cache miss gracefully and preserve empty list hits (#28568)

### DIFF
--- a/backend/open_webui/utils/tools.py
+++ b/backend/open_webui/utils/tools.py
@@ -1170,15 +1170,17 @@ async def set_tool_servers(request: Request):
 
 async def get_tool_servers(request: Request):
     try:
-        tool_servers = []
+        tool_servers = None
         if request.app.state.redis is not None:
             try:
-                tool_servers = JSONCodec.loads(await request.app.state.redis.get(f'{REDIS_KEY_PREFIX}:tool_servers'))
-                request.app.state.TOOL_SERVERS = tool_servers
+                cached = await request.app.state.redis.get(f'{REDIS_KEY_PREFIX}:tool_servers')
+                if cached is not None:
+                    tool_servers = JSONCodec.loads(cached)
+                    request.app.state.TOOL_SERVERS = tool_servers
             except Exception as e:
                 log.error(f'Error fetching tool_servers from Redis: {e}')
 
-        if not tool_servers:
+        if tool_servers is None:
             tool_servers = await set_tool_servers(request)
 
         return tool_servers
@@ -1313,15 +1315,17 @@ async def set_terminal_servers(request: Request):
 
 async def get_terminal_servers(request: Request):
     """Return cached terminal server specs, loading if needed."""
-    terminal_servers = []
+    terminal_servers = None
     if request.app.state.redis is not None:
         try:
-            terminal_servers = JSONCodec.loads(await request.app.state.redis.get(f'{REDIS_KEY_PREFIX}:terminal_servers'))
-            request.app.state.TERMINAL_SERVERS = terminal_servers
+            cached = await request.app.state.redis.get(f'{REDIS_KEY_PREFIX}:terminal_servers')
+            if cached is not None:
+                terminal_servers = JSONCodec.loads(cached)
+                request.app.state.TERMINAL_SERVERS = terminal_servers
         except Exception as e:
             log.error(f'Error fetching terminal_servers from Redis: {e}')
 
-    if not terminal_servers:
+    if terminal_servers is None:
         terminal_servers = await set_terminal_servers(request)
 
     return terminal_servers

--- a/backend/test/test_tools_redis_cache.py
+++ b/backend/test/test_tools_redis_cache.py
@@ -1,0 +1,151 @@
+import json
+import logging
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Ensure required env var is set for open_webui imports
+os.environ.setdefault('WEBUI_SECRET_KEY', 'test-secret-key-for-unit-tests-12345')
+
+import pytest
+from open_webui.env import REDIS_KEY_PREFIX
+from open_webui.utils.tools import get_terminal_servers, get_tool_servers
+
+
+class DummyAppState:
+    def __init__(self, redis_client=None):
+        self.redis = redis_client
+        self.TOOL_SERVERS = None
+        self.TERMINAL_SERVERS = None
+
+
+class DummyApp:
+    def __init__(self, state):
+        self.state = state
+
+
+class DummyRequest:
+    def __init__(self, app_state):
+        self.app = DummyApp(app_state)
+
+
+@pytest.mark.asyncio
+async def test_get_tool_servers_cache_miss_no_type_error(caplog):
+    """Test Redis cache miss returns None, fetches via set_tool_servers without logging TypeError."""
+    mock_redis = MagicMock()
+    mock_redis.get = AsyncMock(return_value=None)
+    mock_redis.set = AsyncMock()
+
+    app_state = DummyAppState(redis_client=mock_redis)
+    request = DummyRequest(app_state)
+
+    fetched_servers = [{'id': 'server-1', 'url': 'http://localhost:8000'}]
+    with patch('open_webui.utils.tools.set_tool_servers', new=AsyncMock(return_value=fetched_servers)) as mock_set:
+        with caplog.at_level(logging.ERROR):
+            result = await get_tool_servers(request)
+
+        mock_redis.get.assert_awaited_once_with(f'{REDIS_KEY_PREFIX}:tool_servers')
+        mock_set.assert_awaited_once_with(request)
+        assert result == fetched_servers
+        # Assert no JSON TypeError was logged during cache miss
+        for record in caplog.records:
+            assert 'the JSON object must be str' not in record.message
+            assert 'Error fetching tool_servers from Redis' not in record.message
+
+
+@pytest.mark.asyncio
+async def test_get_tool_servers_cache_hit_empty_list():
+    """Test Redis cache hit with empty list does NOT call set_tool_servers."""
+    mock_redis = MagicMock()
+    mock_redis.get = AsyncMock(return_value=json.dumps([]))
+
+    app_state = DummyAppState(redis_client=mock_redis)
+    request = DummyRequest(app_state)
+
+    with patch('open_webui.utils.tools.set_tool_servers', new=AsyncMock()) as mock_set:
+        result = await get_tool_servers(request)
+
+        mock_redis.get.assert_awaited_once_with(f'{REDIS_KEY_PREFIX}:tool_servers')
+        mock_set.assert_not_awaited()
+        assert result == []
+        assert app_state.TOOL_SERVERS == []
+
+
+@pytest.mark.asyncio
+async def test_get_tool_servers_cache_hit_populated():
+    """Test Redis cache hit with populated server list."""
+    cached_servers = [{'id': 'srv1', 'url': 'https://api.tools.com'}]
+    mock_redis = MagicMock()
+    mock_redis.get = AsyncMock(return_value=json.dumps(cached_servers))
+
+    app_state = DummyAppState(redis_client=mock_redis)
+    request = DummyRequest(app_state)
+
+    with patch('open_webui.utils.tools.set_tool_servers', new=AsyncMock()) as mock_set:
+        result = await get_tool_servers(request)
+
+        mock_redis.get.assert_awaited_once_with(f'{REDIS_KEY_PREFIX}:tool_servers')
+        mock_set.assert_not_awaited()
+        assert result == cached_servers
+        assert app_state.TOOL_SERVERS == cached_servers
+
+
+@pytest.mark.asyncio
+async def test_get_terminal_servers_cache_miss_no_type_error(caplog):
+    """Test Redis cache miss for terminal_servers fetches via set_terminal_servers without TypeError."""
+    mock_redis = MagicMock()
+    mock_redis.get = AsyncMock(return_value=None)
+    mock_redis.set = AsyncMock()
+
+    app_state = DummyAppState(redis_client=mock_redis)
+    request = DummyRequest(app_state)
+
+    fetched_terminals = [{'id': 'term-1', 'url': 'http://localhost:9000'}]
+    with patch(
+        'open_webui.utils.tools.set_terminal_servers', new=AsyncMock(return_value=fetched_terminals)
+    ) as mock_set:
+        with caplog.at_level(logging.ERROR):
+            result = await get_terminal_servers(request)
+
+        mock_redis.get.assert_awaited_once_with(f'{REDIS_KEY_PREFIX}:terminal_servers')
+        mock_set.assert_awaited_once_with(request)
+        assert result == fetched_terminals
+        for record in caplog.records:
+            assert 'the JSON object must be str' not in record.message
+            assert 'Error fetching terminal_servers from Redis' not in record.message
+
+
+@pytest.mark.asyncio
+async def test_get_terminal_servers_cache_hit_empty_list():
+    """Test Redis cache hit with empty list for terminal_servers does NOT call set_terminal_servers."""
+    mock_redis = MagicMock()
+    mock_redis.get = AsyncMock(return_value=json.dumps([]))
+
+    app_state = DummyAppState(redis_client=mock_redis)
+    request = DummyRequest(app_state)
+
+    with patch('open_webui.utils.tools.set_terminal_servers', new=AsyncMock()) as mock_set:
+        result = await get_terminal_servers(request)
+
+        mock_redis.get.assert_awaited_once_with(f'{REDIS_KEY_PREFIX}:terminal_servers')
+        mock_set.assert_not_awaited()
+        assert result == []
+        assert app_state.TERMINAL_SERVERS == []
+
+
+@pytest.mark.asyncio
+async def test_get_terminal_servers_cache_hit_populated():
+    """Test Redis cache hit with populated terminal server list."""
+    cached_terminals = [{'id': 'term1', 'url': 'https://terminal.tools.com'}]
+    mock_redis = MagicMock()
+    mock_redis.get = AsyncMock(return_value=json.dumps(cached_terminals))
+
+    app_state = DummyAppState(redis_client=mock_redis)
+    request = DummyRequest(app_state)
+
+    with patch('open_webui.utils.tools.set_terminal_servers', new=AsyncMock()) as mock_set:
+        result = await get_terminal_servers(request)
+
+        mock_redis.get.assert_awaited_once_with(f'{REDIS_KEY_PREFIX}:terminal_servers')
+        mock_set.assert_not_awaited()
+        assert result == cached_terminals
+        assert app_state.TERMINAL_SERVERS == cached_terminals


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked and filled out the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) - Resolves #28568.
- [x] **Target branch:** The pull request targets the dev branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following Keep a Changelog format is included at the bottom.
- [x] **Documentation:** Relevant documentation has been checked.
- [x] **Dependencies:** No new dependencies added.
- [x] **Testing:** Manual and automated pytest unit tests (6/6 passing) verified.
- [x] **User-facing changes:** Non-UI backend Redis cache bug fix.
- [x] **No Unchecked AI Code:** This PR has undergone thorough human review and test verification.
- [x] **Self-Review:** A self-review of the code has been performed.
- [x] **Architecture:** Follows existing pattern in utils/tools.py.
- [x] **Git Hygiene:** The PR is atomic, rebased on dev, and contains no unrelated commits.
- [x] **Title Prefix:** Uses ix: prefix.

# Changelog Entry

### Description

- In open_webui/utils/tools.py, distinguish cache miss (None) from a decoded value when fetching 	ool_servers and 	erminal_servers from Redis.
- Preserves valid empty list cache hits ([]), eliminating continuous database re-fetches on every API request.

### Fixed

- Fix TypeError logged at ERROR when Redis key is absent (None).
- Fix continuous cache miss evaluation when cached server list is legitimately empty ([]).

### Contributor License Agreement

<!--
?? DO NOT DELETE THE TEXT BELOW ??
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.