### PR TITLE
Add Intel macOS (x86_64) support by relaxing ML-dependency pins with platform markers

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -61,9 +61,12 @@ chromadb==1.5.9
 weaviate-client==4.20.3
 opensearch-py==3.2.0
 
-transformers==5.5.4
-sentence-transformers==5.5.1
-accelerate==1.13.0
+transformers==5.5.4; sys_platform != 'darwin' or platform_machine == 'arm64'
+transformers==4.57.3; sys_platform == 'darwin' and platform_machine == 'x86_64'
+sentence-transformers==5.5.1; sys_platform != 'darwin' or platform_machine == 'arm64'
+sentence-transformers==5.2.0; sys_platform == 'darwin' and platform_machine == 'x86_64'
+accelerate==1.13.0; sys_platform != 'darwin' or platform_machine == 'arm64'
+accelerate==1.14.0; sys_platform == 'darwin' and platform_machine == 'x86_64'
 pyarrow==20.0.0 # fix: pin pyarrow version to 20 for rpi compatibility #15897
 einops==0.8.2 
 
@@ -96,7 +99,8 @@ opencv-python-headless==4.13.0.92
 rapidocr==3.9.2
 rank-bm25==0.2.2
 
-onnxruntime==1.26.0
+onnxruntime==1.26.0; sys_platform != 'darwin' or platform_machine == 'arm64'
+onnxruntime==1.23.2; sys_platform == 'darwin' and platform_machine == 'x86_64'
 faster-whisper==1.2.1
 
 black==26.5.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,9 +70,12 @@ dependencies = [
     "PyMySQL==1.2.0",
     "boto3==1.42.62",
     
-    "transformers==5.5.4",
-    "sentence-transformers==5.5.1",
-    "accelerate==1.13.0",
+    "transformers==5.5.4; sys_platform != 'darwin' or platform_machine == 'arm64'",
+    "transformers==4.57.3; sys_platform == 'darwin' and platform_machine == 'x86_64'",
+    "sentence-transformers==5.5.1; sys_platform != 'darwin' or platform_machine == 'arm64'",
+    "sentence-transformers==5.2.0; sys_platform == 'darwin' and platform_machine == 'x86_64'",
+    "accelerate==1.13.0; sys_platform != 'darwin' or platform_machine == 'arm64'",
+    "accelerate==1.14.0; sys_platform == 'darwin' and platform_machine == 'x86_64'",
     "pyarrow==20.0.0", # fix: pin pyarrow version to 20 for rpi compatibility #15897
     "einops==0.8.2",
 
@@ -104,7 +107,8 @@ dependencies = [
     "rapidocr==3.9.2",
     "rank-bm25==0.2.2",
 
-    "onnxruntime==1.26.0",
+    "onnxruntime==1.26.0; sys_platform != 'darwin' or platform_machine == 'arm64'",
+    "onnxruntime==1.23.2; sys_platform == 'darwin' and platform_machine == 'x86_64'",
     "faster-whisper==1.2.1",
 
     "black==26.5.1",


### PR DESCRIPTION
## What
Allow Open WebUI to install and run on **Intel macOS (x86_64)** by selecting Intel-compatible versions of four ML dependencies **only on that platform**, via environment markers. Apple-silicon (arm64) and Linux are untouched.

Fixes #28609.

## Problem
Since v0.8.0 the pinned ML dependencies have no macOS `x86_64` wheels, so `pip`/`uv` cannot resolve on Intel Macs:
- `onnxruntime==1.26.0` — no `macosx_*_x86_64` wheel
- `transformers==5.5.4` requires `torch>=2.4`, but PyTorch has no `x86_64` macOS wheels beyond `2.2.2` (forcing `torch==2.2.2` crashes transformers with `NameError: name 'nn' is not defined`)

## Change
In `pyproject.toml` and `backend/requirements.txt`, the following pins become platform-conditional. On `darwin + x86_64` the Intel-compatible versions are used; everywhere else the original pins are kept:

| Package | Original (arm64/linux) | Intel macOS (x86_64) |
|---|---|---|
| `onnxruntime` | `==1.26.0` | `==1.23.2` (ships `macosx_13_0_x86_64` wheel) |
| `transformers` | `==5.5.4` | `==4.57.3` (compatible with `torch==2.2.2`) |
| `sentence-transformers` | `==5.5.1` | `==5.2.0` |
| `accelerate` | `==1.13.0` | `==1.14.0` |

## Why these versions
They are the exact combination already used by the last Intel-mac-compatible release (v0.7.2) and are proven to work together with `torch==2.2.2`.

## Verification (performed on an Intel Mac, macOS, Python 3.12)
- `uv pip install` resolves with no platform error
- Open WebUI v0.11.0 boots (HTTP 200), DB migrations complete
- Local embedding model (`all-MiniLM-L6-v2`) loads via `sentence-transformers`
- Chat through an OpenAI-compatible provider (OpenRouter) responds correctly
- Image generation via `openai/gpt-image-2` produces a valid image

## Notes / scope
This is intentionally a minimal, non-invasive change. It does **not** enable the heavier local ML features on Intel (those remain limited by the torch 2.2.2 ceiling); it makes the app installable and usable, primarily for remote-provider workflows. Happy to adjust the approach (e.g. moving these to an optional extra) if maintainers prefer.

Co-authored-by: Pedro Arenas <29845048+pedroarenes-blip@users.noreply.github.com>