### PR TITLE
build: add Intel macOS (x86_64) dependency support via platform markers

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -61,9 +61,12 @@ chromadb==1.5.9
 weaviate-client==4.20.3
 opensearch-py==3.2.0
 
-transformers==5.5.4
-sentence-transformers==5.5.1
-accelerate==1.13.0
+transformers==5.5.4; sys_platform != 'darwin' or platform_machine == 'arm64'
+transformers==4.57.3; sys_platform == 'darwin' and platform_machine == 'x86_64'
+sentence-transformers==5.5.1; sys_platform != 'darwin' or platform_machine == 'arm64'
+sentence-transformers==5.2.0; sys_platform == 'darwin' and platform_machine == 'x86_64'
+accelerate==1.13.0; sys_platform != 'darwin' or platform_machine == 'arm64'
+accelerate==1.14.0; sys_platform == 'darwin' and platform_machine == 'x86_64'
 pyarrow==20.0.0 # fix: pin pyarrow version to 20 for rpi compatibility #15897
 einops==0.8.2 
 
@@ -96,7 +99,8 @@ opencv-python-headless==4.13.0.92
 rapidocr==3.9.2
 rank-bm25==0.2.2
 
-onnxruntime==1.26.0
+onnxruntime==1.26.0; sys_platform != 'darwin' or platform_machine == 'arm64'
+onnxruntime==1.23.2; sys_platform == 'darwin' and platform_machine == 'x86_64'
 faster-whisper==1.2.1
 
 black==26.5.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,9 +70,12 @@ dependencies = [
     "PyMySQL==1.2.0",
     "boto3==1.42.62",
     
-    "transformers==5.5.4",
-    "sentence-transformers==5.5.1",
-    "accelerate==1.13.0",
+    "transformers==5.5.4; sys_platform != 'darwin' or platform_machine == 'arm64'",
+    "transformers==4.57.3; sys_platform == 'darwin' and platform_machine == 'x86_64'",
+    "sentence-transformers==5.5.1; sys_platform != 'darwin' or platform_machine == 'arm64'",
+    "sentence-transformers==5.2.0; sys_platform == 'darwin' and platform_machine == 'x86_64'",
+    "accelerate==1.13.0; sys_platform != 'darwin' or platform_machine == 'arm64'",
+    "accelerate==1.14.0; sys_platform == 'darwin' and platform_machine == 'x86_64'",
     "pyarrow==20.0.0", # fix: pin pyarrow version to 20 for rpi compatibility #15897
     "einops==0.8.2",
 
@@ -104,7 +107,8 @@ dependencies = [
     "rapidocr==3.9.2",
     "rank-bm25==0.2.2",
 
-    "onnxruntime==1.26.0",
+    "onnxruntime==1.26.0; sys_platform != 'darwin' or platform_machine == 'arm64'",
+    "onnxruntime==1.23.2; sys_platform == 'darwin' and platform_machine == 'x86_64'",
     "faster-whisper==1.2.1",
 
     "black==26.5.1",


### PR DESCRIPTION
## Description

This PR enables Open WebUI to be **installed and run on Intel macOS (x86_64)**, which is currently impossible since v0.8.0.

Closes #28609

### Motivation

On Intel Macs the pinned ML dependencies have no macOS `x86_64` wheels, so `pip`/`uv` cannot resolve the package:

- `onnxruntime==1.26.0` — no `macosx_*_x86_64` wheel exists.
- `transformers==5.5.4` requires `torch>=2.4`, but PyTorch stopped shipping `x86_64` macOS wheels after `2.2.2`. Forced to `torch==2.2.2`, `transformers 5.5.4` crashes at import with `NameError: name 'nn' is not defined`.

The last installable release on Intel macOS was **v0.7.2**.

### Change

In `pyproject.toml` and `backend/requirements.txt`, the following pins become **platform-conditional** using environment markers. On `darwin` + `x86_64` the Intel-compatible versions are selected; everywhere else (Apple Silicon, Linux, Windows) the original pins are preserved:

| Package | Original (arm64 / linux / win) | Intel macOS (x86_64) |
|---|---|---|
| `onnxruntime` | `==1.26.0` | `==1.23.2` (ships `macosx_13_0_x86_64` wheel) |
| `transformers` | `==5.5.4` | `==4.57.3` (compatible with `torch==2.2.2`) |
| `sentence-transformers` | `==5.5.1` | `==5.2.0` |
| `accelerate` | `==1.13.0` | `==1.14.0` |

These versions are the exact combination used by v0.7.2 and are proven to work together with `torch==2.2.2`.

### Verification

Tested end-to-end on an Intel Mac (macOS, Python 3.12):

- `uv pip install` resolves cleanly, no platform error.
- Open WebUI **v0.11.0** boots successfully (HTTP 200), DB migrations complete.
- Local embedding model (`sentence-transformers/all-MiniLM-L6-v2`) loads correctly.
- Chat via an OpenAI-compatible provider (OpenRouter) responds correctly.
- Image generation via `openai/gpt-image-2` produces a valid image.

### Scope

This is a minimal, non-invasive change. It does not unlock the heavier local-ML features on Intel (those remain capped by the torch 2.2.2 ceiling); it makes the app installable and usable, primarily for remote-provider workflows. Happy to adjust (e.g. moving these to an optional extra) if the maintainers prefer.

## Changelog Entry

### Added

- Intel macOS (x86_64) install support via platform-conditional ML dependency pins.

### Changed

- `onnxruntime`, `transformers`, `sentence-transformers` and `accelerate` now resolve to Intel-compatible versions on `darwin + x86_64` only.

### Fixed

- Install failure on Intel macOS caused by `onnxruntime==1.26.0` and `torch>=2.4` having no `x86_64` wheels.

### Contributor License Agreement

- [ ] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
