### PR TITLE
fix(chat): preserve reasoning 'Thinking...' indicator when fade streaming is disabled

### DIFF
--- a/src/lib/components/chat/Messages/Markdown/MarkdownInlineTokens/CodespanToken.svelte
+++ b/src/lib/components/chat/Messages/Markdown/MarkdownInlineTokens/CodespanToken.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { copyToClipboard, unescapeHtml } from '$lib/utils';
 	import { toast } from 'svelte-sonner';
+	import { settings } from '$lib/stores';
 
 	import { getContext } from 'svelte';
 
@@ -13,7 +14,7 @@
 <!-- svelte-ignore a11y-click-events-have-key-events -->
 <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
 <code
-	class="codespan cursor-pointer {!done ? 'fade-in-token' : ''}"
+	class="codespan cursor-pointer {!done && ($settings?.chatFadeStreamingText ?? true) ? 'fade-in-token' : ''}"
 	on:click={() => {
 		copyToClipboard(unescapeHtml(token.text));
 		toast.success($i18n.t('Copied to clipboard'));

--- a/src/lib/components/chat/Messages/Markdown/MarkdownInlineTokens/TextToken.svelte
+++ b/src/lib/components/chat/Messages/Markdown/MarkdownInlineTokens/TextToken.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
+	import { settings } from '$lib/stores';
+
 	export let token;
 	export let done = true;
 
 	$: raw = token?.raw ?? '';
 </script>
 
-{#if done}
+{#if done || !($settings?.chatFadeStreamingText ?? true)}
 	{raw}
 {:else}
 	{#each raw.split(' ') as text}

--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -830,9 +830,7 @@
 									{compactPreview}
 									{editCodeBlock}
 									{topPadding}
-									done={($settings?.chatFadeStreamingText ?? true)
-										? (message?.done ?? false)
-										: true}
+									done={message?.done ?? false}
 									{model}
 									onTaskClick={async (e) => {
 										console.log(e);


### PR DESCRIPTION
Fixes #28559

## Problem

With Settings → Interface → Fade Effect for Streaming Text turned off, the reasoning collapsible header immediately renders as 'Thought' instead of 'Thinking...' with a spinner, even on a model that's still reasoning. The user sees the final-state label before any reasoning has actually completed.

## Root cause

`ResponseMessage.svelte` passes a single `done` flag downstream. That same flag drives both:
- The per-token fade animation in TextToken.svelte / CodespanToken.svelte.
- The completion state (`messageDone`) consumed by Collapsible.svelte / ConsecutiveDetailsGroup.svelte to decide between Thinking... / Thought / Thought for N seconds.

When `chatFadeStreamingText` is off, the ternary pins `done=true`, so `messageDone` is permanently true inside the collapsibles. `hasPending` is therefore always false and the Thinking... branch is unreachable — regardless of what the model is actually doing.

The regression came in across two commits: `18adb28d` introduced the ternary, then `1cf1b2c` added `messageDone` into every completion check and OR'd it into the conditions.

## Fix

Stop overloading `done`. Each consumer now reads the setting it actually depends on:

- `ResponseMessage.svelte`: `done={message?.done ?? false}` — the real completion state. messageDone propagates correctly.
- `TextToken.svelte`: skip the fade-in spans when either the message is done OR the fade preference is off.
- `CodespanToken.svelte`: only apply `fade-in-token` when both `!done` AND fade is on.

End-to-end, disabling **Fade Effect for Streaming Text** leaves the per-token fade animation off (text appears all-at-once) while preserving the Thinking... → Thought → Thought for N seconds lifecycle on reasoning-capable models.

`svelte-check --no-tsconfig` reports the same pre-existing module-resolution errors before and after this change; no new diagnostics introduced.