### PR TITLE
fix: preserve image detail when converting to Responses payload

### DIFF
--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -1084,8 +1084,20 @@ def convert_to_responses_payload(payload: dict) -> dict:
                     content_parts.append({'type': text_type, 'text': part.get('text', '')})
                 elif part.get('type') == 'image_url':
                     url_data = part.get('image_url', {})
-                    url = url_data.get('url', '') if isinstance(url_data, dict) else url_data
-                    content_parts.append({'type': 'input_image', 'image_url': url})
+                    if isinstance(url_data, dict):
+                        url = url_data.get('url', '')
+                        image_item = {
+                            'type': 'input_image',
+                            'image_url': url,
+                            'detail': url_data.get('detail') or 'auto',
+                        }
+                    else:
+                        image_item = {
+                            'type': 'input_image',
+                            'image_url': url_data,
+                            'detail': 'auto',
+                        }
+                    content_parts.append(image_item)
         else:
             content_parts = [{'type': text_type, 'text': str(content)}]
 

--- a/backend/test/test_convert_to_responses_payload.py
+++ b/backend/test/test_convert_to_responses_payload.py
@@ -1,0 +1,65 @@
+"""
+Regression test for issue #28286:
+convert_to_responses_payload() drops the source `detail` value when converting a Chat
+Completions `image_url` content part to a Responses API `input_image` part, and emits
+no compatibility default. Strict Responses implementations (e.g. vLLM 0.26.0) reject
+the converted request with HTTP 400 during Pydantic validation.
+
+This test replicates the image_url handling branch of
+backend/open_webui/routers/openai.py (must stay in sync) because importing the router
+module requires the full application dependency stack.
+"""
+
+import pytest
+
+
+def convert_image_url_part(part: dict) -> dict:
+    """Replicated image_url branch from convert_to_responses_payload (keep in sync)."""
+    url_data = part.get('image_url', {})
+    if isinstance(url_data, dict):
+        url = url_data.get('url', '')
+        image_item = {
+            'type': 'input_image',
+            'image_url': url,
+            'detail': url_data.get('detail') or 'auto',
+        }
+    else:
+        image_item = {
+            'type': 'input_image',
+            'image_url': url_data,
+            'detail': 'auto',
+        }
+    return image_item
+
+
+class TestImageUrlDetail:
+    def test_preserves_source_detail_value(self):
+        part = {
+            'type': 'image_url',
+            'image_url': {'url': 'data:image/png;base64,AAAA', 'detail': 'high'},
+        }
+        assert convert_image_url_part(part) == {
+            'type': 'input_image',
+            'image_url': 'data:image/png;base64,AAAA',
+            'detail': 'high',
+        }
+
+    def test_defaults_detail_to_auto_when_absent(self):
+        part = {'type': 'image_url', 'image_url': {'url': 'data:image/png;base64,AAAA'}}
+        assert convert_image_url_part(part)['detail'] == 'auto'
+
+    def test_defaults_detail_to_auto_for_string_form(self):
+        part = {'type': 'image_url', 'image_url': 'data:image/png;base64,AAAA'}
+        assert convert_image_url_part(part) == {
+            'type': 'input_image',
+            'image_url': 'data:image/png;base64,AAAA',
+            'detail': 'auto',
+        }
+
+    def test_treats_null_detail_as_absent(self):
+        part = {
+            'type': 'image_url',
+            'image_url': {'url': 'data:image/png;base64,AAAA', 'detail': None},
+        }
+        assert convert_image_url_part(part)['detail'] == 'auto'
+


### PR DESCRIPTION
## Description

`convert_to_responses_payload()` dropped the source `detail` value when converting a Chat Completions `image_url` content part to a Responses API `input_image` part, and emitted no compatibility default. Strict Responses implementations such as vLLM 0.26.0 reject the converted request during Pydantic validation with HTTP 400 (`ResponseInputImageParam.detail: Field required`) before inference begins.

Fixes #28286.

## Changes

The `input_image` item now carries `detail`: the source value is preserved when present, and `auto` is emitted otherwise, including for the simplified string form of `image_url`.

## Tests

New `backend/test/test_convert_to_responses_payload.py` replicates the image_url branch (importing the router requires the full application dependency stack, following the existing `test_retrieval_embedding_forms.py` convention) and covers: source detail preserved, absent detail defaults to auto, string form defaults to auto, null detail treated as absent.

```
python3 -m pytest backend/test/test_convert_to_responses_payload.py -q
4 passed
```
