### PR TITLE
fix: preserve image detail when converting to Responses payload

### DIFF
--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -1351,8 +1351,20 @@ def convert_to_responses_payload(payload: dict) -> dict:
                     content_parts.append({'type': text_type, 'text': part.get('text', '')})
                 elif part.get('type') == 'image_url':
                     url_data = part.get('image_url', {})
-                    url = url_data.get('url', '') if isinstance(url_data, dict) else url_data
-                    content_parts.append({'type': 'input_image', 'image_url': url})
+                    if isinstance(url_data, dict):
+                        url = url_data.get('url', '')
+                        image_item = {
+                            'type': 'input_image',
+                            'image_url': url,
+                            'detail': url_data.get('detail') or 'auto',
+                        }
+                    else:
+                        image_item = {
+                            'type': 'input_image',
+                            'image_url': url_data,
+                            'detail': 'auto',
+                        }
+                    content_parts.append(image_item)
         else:
             content_parts = [{'type': text_type, 'text': str(content)}]
 

--- a/backend/test/test_convert_to_responses_payload.py
+++ b/backend/test/test_convert_to_responses_payload.py
@@ -1,0 +1,65 @@
+"""
+Regression test for issue #28286:
+convert_to_responses_payload() drops the source `detail` value when converting a Chat
+Completions `image_url` content part to a Responses API `input_image` part, and emits
+no compatibility default. Strict Responses implementations (e.g. vLLM 0.26.0) reject
+the converted request with HTTP 400 during Pydantic validation.
+
+This test replicates the image_url handling branch of
+backend/open_webui/routers/openai.py (must stay in sync) because importing the router
+module requires the full application dependency stack.
+"""
+
+import pytest
+
+
+def convert_image_url_part(part: dict) -> dict:
+    """Replicated image_url branch from convert_to_responses_payload (keep in sync)."""
+    url_data = part.get('image_url', {})
+    if isinstance(url_data, dict):
+        url = url_data.get('url', '')
+        image_item = {
+            'type': 'input_image',
+            'image_url': url,
+            'detail': url_data.get('detail') or 'auto',
+        }
+    else:
+        image_item = {
+            'type': 'input_image',
+            'image_url': url_data,
+            'detail': 'auto',
+        }
+    return image_item
+
+
+class TestImageUrlDetail:
+    def test_preserves_source_detail_value(self):
+        part = {
+            'type': 'image_url',
+            'image_url': {'url': 'data:image/png;base64,AAAA', 'detail': 'high'},
+        }
+        assert convert_image_url_part(part) == {
+            'type': 'input_image',
+            'image_url': 'data:image/png;base64,AAAA',
+            'detail': 'high',
+        }
+
+    def test_defaults_detail_to_auto_when_absent(self):
+        part = {'type': 'image_url', 'image_url': {'url': 'data:image/png;base64,AAAA'}}
+        assert convert_image_url_part(part)['detail'] == 'auto'
+
+    def test_defaults_detail_to_auto_for_string_form(self):
+        part = {'type': 'image_url', 'image_url': 'data:image/png;base64,AAAA'}
+        assert convert_image_url_part(part) == {
+            'type': 'input_image',
+            'image_url': 'data:image/png;base64,AAAA',
+            'detail': 'auto',
+        }
+
+    def test_treats_null_detail_as_absent(self):
+        part = {
+            'type': 'image_url',
+            'image_url': {'url': 'data:image/png;base64,AAAA', 'detail': None},
+        }
+        assert convert_image_url_part(part)['detail'] == 'auto'
+


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Closes #28286
- [x] **Target branch:** dev
- [x] **Description:** `convert_to_responses_payload()` dropped the source `detail` value when converting a Chat Completions `image_url` content part to a Responses API `input_image` part, and emitted no compatibility default. Strict Responses implementations such as vLLM 0.26.0 reject the converted request during Pydantic validation with HTTP 400 (`ResponseInputImageParam.detail: Field required`) before inference begins. The `input_image` item now preserves the source detail and defaults to `auto` when absent, including the string form of `image_url`.
- [x] **Testing:** New `backend/test/test_convert_to_responses_payload.py` (4 tests, all pass) covers source detail preserved, absent detail defaults to auto, string form defaults to auto, and null detail treated as absent. The test replicates the image_url branch because importing the router requires the full application dependency stack, following the existing `test_retrieval_embedding_forms.py` convention.
- [x] **No Unchecked AI Code:** This PR has undergone thorough human review and manual testing of the changed lines.
- [x] **Self-Review:** Performed; the change is isolated to the image_url conversion branch plus its tests.
- [x] **Architecture:** No new settings; smart default (`auto`) matches the upstream Responses API convention.
- [x] **Git Hygiene:** Atomic single commit, based on dev.
- [x] **Title Prefix:** fix

# Changelog Entry

### Description

- Preserve the image `detail` value when converting Chat Completions payloads to the Responses API format, defaulting to `auto` so strict implementations like vLLM 0.26.0 no longer reject multimodal requests with HTTP 400.

### Fixed

- `convert_to_responses_payload()` now emits `detail` for every `input_image` part (preserving the source value or defaulting to `auto`).

---

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
