### PR TITLE
fix(openai): preserve image detail and default to auto in convert_to_responses_payload (#28286)

### DIFF
--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -1351,8 +1351,13 @@ def convert_to_responses_payload(payload: dict) -> dict:
                     content_parts.append({'type': text_type, 'text': part.get('text', '')})
                 elif part.get('type') == 'image_url':
                     url_data = part.get('image_url', {})
-                    url = url_data.get('url', '') if isinstance(url_data, dict) else url_data
-                    content_parts.append({'type': 'input_image', 'image_url': url})
+                    if isinstance(url_data, dict):
+                        url = url_data.get('url', '')
+                        detail = url_data.get('detail') or 'auto'
+                    else:
+                        url = url_data
+                        detail = 'auto'
+                    content_parts.append({'type': 'input_image', 'image_url': url, 'detail': detail})
         else:
             content_parts = [{'type': text_type, 'text': str(content)}]
 

--- a/backend/test/test_responses_image_detail.py
+++ b/backend/test/test_responses_image_detail.py
@@ -1,0 +1,77 @@
+import pytest
+from open_webui.routers.openai import convert_to_responses_payload
+
+
+def test_convert_to_responses_payload_preserves_image_detail():
+    # 1. Test image_url dict with explicit detail="high"
+    payload_high = {
+        "model": "test-vision-model",
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Describe this image."},
+                    {
+                        "type": "image_url",
+                        "image_url": {
+                            "url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+                            "detail": "high",
+                        },
+                    },
+                ],
+            }
+        ],
+    }
+
+    res_high = convert_to_responses_payload(payload_high)
+    parts_high = res_high["input"][0]["content"]
+    assert len(parts_high) == 2
+    assert parts_high[1]["type"] == "input_image"
+    assert parts_high[1]["detail"] == "high"
+    assert "data:image/png;base64" in parts_high[1]["image_url"]
+
+    # 2. Test image_url dict without detail -> defaults to "auto"
+    payload_no_detail = {
+        "model": "test-vision-model",
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image_url",
+                        "image_url": {
+                            "url": "https://example.com/test.png",
+                        },
+                    }
+                ],
+            }
+        ],
+    }
+
+    res_no_detail = convert_to_responses_payload(payload_no_detail)
+    parts_no_detail = res_no_detail["input"][0]["content"]
+    assert parts_no_detail[0]["type"] == "input_image"
+    assert parts_no_detail[0]["detail"] == "auto"
+    assert parts_no_detail[0]["image_url"] == "https://example.com/test.png"
+
+    # 3. Test string image_url form -> defaults to "auto"
+    payload_str_url = {
+        "model": "test-vision-model",
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image_url",
+                        "image_url": "https://example.com/string-url.png",
+                    }
+                ],
+            }
+        ],
+    }
+
+    res_str_url = convert_to_responses_payload(payload_str_url)
+    parts_str_url = res_str_url["input"][0]["content"]
+    assert parts_str_url[0]["type"] == "input_image"
+    assert parts_str_url[0]["detail"] == "auto"
+    assert parts_str_url[0]["image_url"] == "https://example.com/string-url.png"


### PR DESCRIPTION
# Description
Fixes an issue where convert_to_responses_payload() dropped the detail parameter when converting Chat Completions image_url content parts to Responses API input_image items, causing strict OpenAI-compatible backends (such as vLLM) to reject multimodal requests with HTTP 400 validation errors.

Closes #28286

## Changes Made
- Updated ackend/open_webui/routers/openai.py:
  - When image_url is a dictionary, extract and preserve detail (defaulting to "auto" if absent).
  - When image_url is a string URL, include "detail": "auto".
- Added unit tests in ackend/test/test_responses_image_detail.py verifying explicit detail: "high", dictionary without detail ("auto"), and string image URL forms.

## Verification
- python -m pytest test/test_responses_image_detail.py -v (100% passed).

## Checklist
- [x] I have read the [Contributing Guidelines](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTING.md).
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective.
- [x] Contributor License Agreement (CLA) signed.