### PR TITLE
fix(openai): preserve image detail in convert_to_responses_payload (#28286)

### DIFF
--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -1351,8 +1351,13 @@ def convert_to_responses_payload(payload: dict) -> dict:
                     content_parts.append({'type': text_type, 'text': part.get('text', '')})
                 elif part.get('type') == 'image_url':
                     url_data = part.get('image_url', {})
-                    url = url_data.get('url', '') if isinstance(url_data, dict) else url_data
-                    content_parts.append({'type': 'input_image', 'image_url': url})
+                    if isinstance(url_data, dict):
+                        url = url_data.get('url', '')
+                        detail = url_data.get('detail') or 'auto'
+                    else:
+                        url = url_data
+                        detail = 'auto'
+                    content_parts.append({'type': 'input_image', 'image_url': url, 'detail': detail})
         else:
             content_parts = [{'type': text_type, 'text': str(content)}]
 

--- a/backend/test/test_responses_image_detail.py
+++ b/backend/test/test_responses_image_detail.py
@@ -1,0 +1,77 @@
+import pytest
+from open_webui.routers.openai import convert_to_responses_payload
+
+
+def test_convert_to_responses_payload_preserves_image_detail():
+    # 1. Test image_url dict with explicit detail="high"
+    payload_high = {
+        "model": "test-vision-model",
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Describe this image."},
+                    {
+                        "type": "image_url",
+                        "image_url": {
+                            "url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+                            "detail": "high",
+                        },
+                    },
+                ],
+            }
+        ],
+    }
+
+    res_high = convert_to_responses_payload(payload_high)
+    parts_high = res_high["input"][0]["content"]
+    assert len(parts_high) == 2
+    assert parts_high[1]["type"] == "input_image"
+    assert parts_high[1]["detail"] == "high"
+    assert "data:image/png;base64" in parts_high[1]["image_url"]
+
+    # 2. Test image_url dict without detail -> defaults to "auto"
+    payload_no_detail = {
+        "model": "test-vision-model",
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image_url",
+                        "image_url": {
+                            "url": "https://example.com/test.png",
+                        },
+                    }
+                ],
+            }
+        ],
+    }
+
+    res_no_detail = convert_to_responses_payload(payload_no_detail)
+    parts_no_detail = res_no_detail["input"][0]["content"]
+    assert parts_no_detail[0]["type"] == "input_image"
+    assert parts_no_detail[0]["detail"] == "auto"
+    assert parts_no_detail[0]["image_url"] == "https://example.com/test.png"
+
+    # 3. Test string image_url form -> defaults to "auto"
+    payload_str_url = {
+        "model": "test-vision-model",
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image_url",
+                        "image_url": "https://example.com/string-url.png",
+                    }
+                ],
+            }
+        ],
+    }
+
+    res_str_url = convert_to_responses_payload(payload_str_url)
+    parts_str_url = res_str_url["input"][0]["content"]
+    assert parts_str_url[0]["type"] == "input_image"
+    assert parts_str_url[0]["detail"] == "auto"
+    assert parts_str_url[0]["image_url"] == "https://example.com/string-url.png"


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked and filled out the following:**

- [x] **Linked Issue/Discussion:** Closes #28286
- [x] **Target branch:** The pull request targets the dev branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [x] **Documentation:** Relevant documentation has been added or updated.
- [x] **Dependencies:** No new dependencies added.
- [x] **Testing:** Automated pytest unit tests added in ackend/test/test_responses_image_detail.py.
- [x] **User-facing changes:** Backend API converter fix, no UI changes.
- [x] **No Unchecked AI Code:** This PR has undergone thorough human review and automated test verification.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Minimal surgical fix preserving schema defaults.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on dev, and contains no unrelated commits.
- [x] **Title Prefix:** Uses ix: prefix.

# Changelog Entry

### Description

- Fix convert_to_responses_payload() dropping detail parameter on image_url items when converting to Responses API format, ensuring strict OpenAI-compatible backends (such as vLLM) accept multimodal requests without validation errors.

### Fixed

- Preserved explicit detail on image_url dictionary inputs and added "detail": "auto" default fallback in ackend/open_webui/routers/openai.py.

---

### Additional Information

- Relates to #28286
- Unit tests added in ackend/test/test_responses_image_detail.py.

### Contributor License Agreement

<!--
?? DO NOT DELETE THE TEXT BELOW ??
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.