### PR TITLE
fix: GitHub and Feishu OAuth login fails on PostgreSQL

### DIFF
--- a/backend/open_webui/migrations/versions/b7e4c19a2f83_normalize_user_oauth_sub_to_text.py
+++ b/backend/open_webui/migrations/versions/b7e4c19a2f83_normalize_user_oauth_sub_to_text.py
@@ -1,0 +1,59 @@
+"""normalize user oauth sub to text
+
+Revision ID: b7e4c19a2f83
+Revises: e2b7a4c91f05
+Create Date: 2026-08-15 19:40:11.204517
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'b7e4c19a2f83'
+down_revision: Union[str, None] = 'e2b7a4c91f05'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_user = sa.table(
+    'user',
+    sa.column('id', sa.Text),
+    sa.column('oauth', sa.JSON),
+)
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+
+    if 'user' not in inspector.get_table_names():
+        return
+    if 'oauth' not in {c['name'] for c in inspector.get_columns('user')}:
+        return
+
+    rows = conn.execute(sa.select(_user.c.id, _user.c.oauth).where(_user.c.oauth.is_not(None))).fetchall()
+
+    for uid, oauth in rows:
+        if not isinstance(oauth, dict):
+            continue
+
+        updated = {}
+        changed = False
+        for provider, entry in oauth.items():
+            sub = entry.get('sub') if isinstance(entry, dict) else None
+            if sub is None or isinstance(sub, str):
+                updated[provider] = entry
+                continue
+            updated[provider] = {**entry, 'sub': str(sub)}
+            changed = True
+
+        if changed:
+            conn.execute(sa.update(_user).where(_user.c.id == uid).values(oauth=updated))
+
+
+def downgrade() -> None:
+    pass

--- a/backend/open_webui/migrations/versions/e2b7a4c91f05_drop_redundant_chat_message_indexes.py
+++ b/backend/open_webui/migrations/versions/e2b7a4c91f05_drop_redundant_chat_message_indexes.py
@@ -1,0 +1,38 @@
+"""Drop redundant chat_message single-column indexes
+
+Revision ID: e2b7a4c91f05
+Revises: d4c1a8e37b62
+Create Date: 2026-08-03 16:22:10.581294
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = 'e2b7a4c91f05'
+down_revision = 'd4c1a8e37b62'
+branch_labels = None
+depends_on = None
+
+# each is a strict prefix of a composite index that serves the same lookups
+REDUNDANT_INDEXES = {
+    'ix_chat_message_chat_id': 'chat_id',
+    'ix_chat_message_user_id': 'user_id',
+    'ix_chat_message_model_id': 'model_id',
+}
+
+
+def upgrade():
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    existing_indexes = {idx['name'] for idx in inspector.get_indexes('chat_message')}
+
+    # 8452d01d26d7 early-returns on pre-existing tables, so the indexes may be absent
+    for name in REDUNDANT_INDEXES:
+        if name in existing_indexes:
+            op.drop_index(name, table_name='chat_message')
+
+
+def downgrade():
+    for name, column in REDUNDANT_INDEXES.items():
+        op.create_index(name, 'chat_message', [column])

--- a/backend/open_webui/models/chat_messages.py
+++ b/backend/open_webui/models/chat_messages.py
@@ -129,8 +129,8 @@ class ChatMessage(Base):
 
     # Identity
     id = Column(Text, primary_key=True)
-    chat_id = Column(Text, ForeignKey('chat.id', ondelete='CASCADE'), nullable=False, index=True)
-    user_id = Column(Text, index=True)
+    chat_id = Column(Text, ForeignKey('chat.id', ondelete='CASCADE'), nullable=False)
+    user_id = Column(Text)
 
     # Structure
     role = Column(Text, nullable=False)  # user, assistant, system
@@ -141,7 +141,7 @@ class ChatMessage(Base):
     output = Column(JSON, nullable=True)
 
     # Model (for assistant messages)
-    model_id = Column(Text, nullable=True, index=True)
+    model_id = Column(Text, nullable=True)
 
     # Attachments
     files = Column(JSON, nullable=True)

--- a/backend/open_webui/routers/auths.py
+++ b/backend/open_webui/routers/auths.py
@@ -1671,6 +1671,8 @@ async def token_exchange(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Token missing required 'sub' claim",
         )
+    # Providers such as GitHub return a numeric id; store and match it as text.
+    sub = str(sub)
 
     email = user_data.get(email_claim, '')
     if not email:

--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -1922,6 +1922,8 @@ class OAuthManager:
             if not sub:
                 log.warning(f'OAuth callback failed, sub is missing: {user_data}')
                 raise HTTPException(400, detail=ERROR_MESSAGES.INVALID_CRED)
+            # Providers such as GitHub return a numeric id; store and match it as text.
+            sub = str(sub)
 
             oauth_data = {}
             oauth_data[provider] = {
@@ -2362,7 +2364,8 @@ class OAuthManager:
         # 8. Identify users to log out
         users_to_logout = []
         if sub:
-            user = await Users.get_user_by_oauth_sub(matched_provider, sub, db=db)
+            # Match the text form the login paths store.
+            user = await Users.get_user_by_oauth_sub(matched_provider, str(sub), db=db)
             if user:
                 users_to_logout.append(user)
 


### PR DESCRIPTION
GitHub returns its user id as a JSON number and the provider config maps it to the OAuth subject claim, as Feishu does with user_id. Nothing coerced it, so the subject was stored in the user.oauth JSON column as a number and passed to the lookup as an int. On PostgreSQL that lookup is a text comparison, so an int operand raises "operator does not exist: text = integer" and the callback's catch-all turns it into a generic /auth?error= redirect. Login fails every time and the operator gets no useful signal. SQLite matched fine, which is why this went unnoticed.

The subject is now coerced to text where the claim enters, ahead of both the write and the lookup, so the stored and incoming values cannot disagree. The migration normalizes subjects already stored as numbers; without it, existing SQLite deployments would stop matching once the code starts sending strings.

Verified on SQLite and PostgreSQL 16: numeric-subject users resolve on both after the migration, the migration is idempotent, and rows that already hold string subjects are left untouched.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
