### PR TITLE
refac: restrict explicit backend index selection to admins

### DIFF
--- a/backend/open_webui/routers/ollama.py
+++ b/backend/open_webui/routers/ollama.py
@@ -34,7 +34,7 @@ from open_webui.models.groups import Groups
 from open_webui.models.models import Models
 from open_webui.models.users import UserModel
 from open_webui.utils.access_control import check_model_access
-from open_webui.utils.auth import get_admin_user, get_verified_user
+from open_webui.utils.auth import get_admin_user, get_verified_user, require_admin_for_backend_idx
 from open_webui.utils.headers import get_custom_headers, include_user_info_headers
 from open_webui.utils.json_codec import JSONCodec
 from open_webui.utils.misc import calculate_sha256
@@ -478,6 +478,8 @@ async def get_ollama_tags(
     user=Depends(get_verified_user),
 ):
     """List Ollama model tags, optionally from a specific backend."""
+    require_admin_for_backend_idx(url_idx, user)
+
     if not await Config.get('ollama.enable'):
         raise HTTPException(status_code=503, detail=ERROR_MESSAGES.OLLAMA_API_DISABLED)
 
@@ -541,6 +543,8 @@ async def get_ollama_versions(
     url_idx: int | None = None,
 ):
     """Return the lowest Ollama version across all configured backends."""
+    require_admin_for_backend_idx(url_idx, user)
+
     if not await Config.get('ollama.enable'):
         return {'version': False}
 
@@ -1053,7 +1057,7 @@ class GenerateChatCompletionForm(BaseModel):
 async def validate_ollama_backend_idx(request: Request, model: str, url_idx: int | None, user) -> None:
     # A caller-supplied url_idx must point to a backend the model is actually
     # served from; the None path is already constrained to that allow-list.
-    if url_idx is None or user is None or getattr(user, 'role', None) == 'admin' or BYPASS_MODEL_ACCESS_CONTROL:
+    if url_idx is None or user is None or getattr(user, 'role', None) == 'admin':
         return
     models = request.app.state.OLLAMA_MODELS
     if not models or model not in models:
@@ -1480,6 +1484,8 @@ async def get_openai_models(
     db: AsyncSession = Depends(get_async_session),
 ) -> dict:
     """List models in the OpenAI-compatible format."""
+    require_admin_for_backend_idx(url_idx, user)
+
     if url_idx is None:
         model_list = await get_all_models(request, user=user)
         raw_models = model_list['models']

--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -40,7 +40,7 @@ from open_webui.models.models import Models
 from open_webui.models.users import UserModel
 from open_webui.utils.access_control import check_model_access, has_connection_access, has_permission
 from open_webui.utils.anthropic import get_anthropic_models, is_anthropic_url
-from open_webui.utils.auth import get_admin_user, get_verified_user
+from open_webui.utils.auth import get_admin_user, get_verified_user, require_admin_for_backend_idx
 from open_webui.utils.headers import get_custom_headers, include_user_info_headers
 from open_webui.utils.json_codec import JSONCodec
 from open_webui.utils.misc import (
@@ -863,6 +863,8 @@ async def get_all_models(request: Request, user: UserModel) -> dict[str, list]:
 @router.get('/models')
 @router.get('/models/{url_idx}')
 async def get_models(request: Request, url_idx: int | None = None, user=Depends(get_verified_user)):
+    require_admin_for_backend_idx(url_idx, user)
+
     if not await Config.get('openai.enable'):
         raise HTTPException(status_code=503, detail='OpenAI API is disabled')
 

--- a/backend/open_webui/utils/auth.py
+++ b/backend/open_webui/utils/auth.py
@@ -561,6 +561,12 @@ def get_admin_user(user=Depends(get_current_user)):
     return user
 
 
+def require_admin_for_backend_idx(url_idx: int | None, user) -> None:
+    # Admin-only even under BYPASS_MODEL_ACCESS_CONTROL, which relaxes per-model access rather than backend selection.
+    if url_idx is not None and user.role != 'admin':
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=ERROR_MESSAGES.ACCESS_PROHIBITED)
+
+
 async def create_admin_user(email: str, password: str, name: str = 'Admin'):
     """
     Create an admin user from environment variables.


### PR DESCRIPTION
Model provider listing routes that accept an explicit backend index now require an administrator, consistent with the model management routes beside them. Backend index selection on the inference routes keeps its existing per-model check in every configuration.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
