### PR TITLE
fix(tools): treat missing Redis cache as a cache miss, not a JSON decode error

### DIFF
--- a/backend/open_webui/utils/tools.py
+++ b/backend/open_webui/utils/tools.py
@@ -1172,11 +1172,13 @@ async def get_tool_servers(request: Request):
     try:
         tool_servers = []
         if request.app.state.redis is not None:
-            try:
-                tool_servers = JSONCodec.loads(await request.app.state.redis.get(f'{REDIS_KEY_PREFIX}:tool_servers'))
-                request.app.state.TOOL_SERVERS = tool_servers
-            except Exception as e:
-                log.error(f'Error fetching tool_servers from Redis: {e}')
+            cached = await request.app.state.redis.get(f'{REDIS_KEY_PREFIX}:tool_servers')
+            if cached is not None:
+                try:
+                    tool_servers = JSONCodec.loads(cached)
+                    request.app.state.TOOL_SERVERS = tool_servers
+                except Exception as e:
+                    log.error(f'Error decoding cached tool_servers from Redis: {e}')
 
         if not tool_servers:
             tool_servers = await set_tool_servers(request)
@@ -1315,11 +1317,13 @@ async def get_terminal_servers(request: Request):
     """Return cached terminal server specs, loading if needed."""
     terminal_servers = []
     if request.app.state.redis is not None:
-        try:
-            terminal_servers = JSONCodec.loads(await request.app.state.redis.get(f'{REDIS_KEY_PREFIX}:terminal_servers'))
-            request.app.state.TERMINAL_SERVERS = terminal_servers
-        except Exception as e:
-            log.error(f'Error fetching terminal_servers from Redis: {e}')
+        cached = await request.app.state.redis.get(f'{REDIS_KEY_PREFIX}:terminal_servers')
+        if cached is not None:
+            try:
+                terminal_servers = JSONCodec.loads(cached)
+                request.app.state.TERMINAL_SERVERS = terminal_servers
+            except Exception as e:
+                log.error(f'Error decoding cached terminal_servers from Redis: {e}')
 
     if not terminal_servers:
         terminal_servers = await set_terminal_servers(request)


### PR DESCRIPTION
Closes #28568

`get_tool_servers()` and `get_terminal_servers()` in `backend/open_webui/utils/tools.py` call `JSONCodec.loads(await request.app.state.redis.get(...))` directly. `redis.get()` returns `None` on a cache miss, and `JSONCodec.loads(None)` raises a `TypeError`. The exception is caught and logged as `Error fetching tool_servers from Redis: ...` once per request, on every cold start and every key eviction. The fallback to `set_tool_servers()` still works (`tool_servers` stays `[]`, the `if not tool_servers:` branch kicks in), but the error log is misleading — it isn't a Redis or decode failure, it's a normal cache miss.

Fix: read into a local first, only attempt to decode when there is something to decode. Same change applied symmetrically to `get_terminal_servers()`. The decode-failure `try/except` is preserved for the (now genuinely exceptional) case of a corrupt cached value.

```diff
 async def get_tool_servers(request: Request):
     try:
         tool_servers = []
         if request.app.state.redis is not None:
-            try:
-                tool_servers = JSONCodec.loads(await request.app.state.redis.get(f'{REDIS_KEY_PREFIX}:tool_servers'))
-                request.app.state.TOOL_SERVERS = tool_servers
-            except Exception as e:
-                log.error(f'Error fetching tool_servers from Redis: {e}')
+            cached = await request.app.state.redis.get(f'{REDIS_KEY_PREFIX}:tool_servers')
+            if cached is not None:
+                try:
+                    tool_servers = JSONCodec.loads(cached)
+                    request.app.state.TOOL_SERVERS = tool_servers
+                except Exception as e:
+                    log.error(f'Error decoding cached tool_servers from Redis: {e}')

         if not tool_servers:
             tool_servers = await set_tool_servers(request)
```

# Manual end-to-end verification

`backend/open_webui/utils/tools.py` was extracted as-is into a standalone script that mocks `redis.get()` and runs both the OLD and NEW code paths against three cases. No open-webui install required; uses stdlib `json` (which `JSONCodec` falls back to when `ENABLE_ORJSON` is unset, the default).

Script: `verify-cache-miss-fix.py` (attached). Output (truncated):

```
Reproducing the bug under OLD code path:
  CONFIRMED: json.loads(None) raises TypeError: the JSON object must be str, bytes or bytearray, not NoneType

Running cases:

[cache miss (cached is None)]
  --- OLD ---
  OLD: ERROR logged -> TypeError: the JSON object must be str, bytes or bytearray, not NoneType
  result: []
  --- NEW ---
  NEW: cache miss, no error log, fall through to loader.
  result: []

[cache hit (valid JSON list)]
  --- OLD ---  result: [{'id': 'srv-a'}, {'id': 'srv-b'}]
  --- NEW ---  result: [{'id': 'srv-a'}, {'id': 'srv-b'}]

[cache hit (corrupt JSON)]
  --- OLD ---
  OLD: ERROR logged -> JSONDecodeError: Expecting value: line 1 column 10 (char 9)
  --- NEW ---
  NEW: ERROR logged (corrupt cache) -> JSONDecodeError: Expecting value: line 1 column 10 (char 9)

All cases produced the expected results.
```

Conclusions:
- Cache miss: OLD emits a misleading `TypeError` log on every request; NEW stays silent and falls through to `set_tool_servers()`.
- Cache hit, valid JSON: identical behavior in both versions.
- Cache hit, corrupt JSON: identical behavior in both versions — both still log the decode error, but now the log message accurately describes a real cache corruption rather than a normal miss.

Full live end-to-end (cold-start + `FLUSHDB` between requests) was not run by this contributor because no Open WebUI instance with Redis is available locally; the reporter in #28568 is invited to confirm.

# Changelog Entry

### Fixed

- `backend/open_webui/utils/tools.py`: `get_tool_servers()` and `get_terminal_servers()` no longer log a misleading `TypeError` on every Redis cache miss.

### Additional Information

- Diff is +14 / -10 across one file; touches only `get_tool_servers()` and `get_terminal_servers()`. No imports, no signature changes, no behavioral change for the cache-hit path.

### Screenshots or Videos

- N/A (server-side log behavior; no UI change).

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.