### PR TITLE
refac: sandbox terminal port previews and move their auth into the URL

### DIFF
--- a/backend/open_webui/routers/terminals.py
+++ b/backend/open_webui/routers/terminals.py
@@ -1,15 +1,20 @@
 """Reverse proxy for admin-configured terminal servers.
 
 Routes:
-  GET  /                         — list terminals the user has access to
-  *    /{server_id}/{path:path}  — proxy request to terminal server
+  GET  /                                                         — list terminals the user has access to
+  POST /{server_id}/port-preview/{port}                          — mint a port preview credential
+  *    /{server_id}/port-preview/{port}/{preview_token}/{path}   — serve a port, sandboxed
+  *    /{server_id}/{path:path}                                  — proxy request to terminal server
 """
 
+import datetime as dt
+import hashlib
 import logging
 import posixpath
 from urllib.parse import unquote
 
 import aiohttp
+import jwt
 from fastapi import APIRouter, Depends, Request, Response, WebSocket
 from fastapi.responses import JSONResponse, StreamingResponse
 from open_webui.config import TERMINAL_PROXY_HEADERS
@@ -18,9 +23,17 @@ from open_webui.events import EVENTS, publish_event
 from open_webui.models.config import Config
 from open_webui.models.groups import Groups
 from open_webui.utils.access_control import has_connection_access
-from open_webui.utils.auth import get_verified_user
+from open_webui.utils.auth import (
+    ALGORITHM,
+    SESSION_SECRET,
+    decode_token,
+    get_verified_user,
+    get_verified_user_by_id,
+    is_valid_token,
+)
 from open_webui.utils.headers import bearer_auth_header, normalize_bearer_token
 from open_webui.utils.json_codec import JSONCodec
+from open_webui.utils.security_headers import MANAGED_HEADER_NAMES
 from open_webui.utils.terminals import (
     TERMINAL_CONTEXT_HEADER,
     get_terminal_server_url,
@@ -39,7 +52,35 @@ log = logging.getLogger(__name__)
 router = APIRouter()
 
 STREAMING_CONTENT_TYPES = ('application/octet-stream', 'image/', 'application/pdf')
-STRIPPED_RESPONSE_HEADERS = frozenset(('transfer-encoding', 'connection', 'content-encoding', 'content-length'))
+STRIPPED_RESPONSE_HEADERS = frozenset(
+    (
+        'transfer-encoding',
+        'connection',
+        'content-encoding',
+        'content-length',
+        # Responses come back on our own origin, so a terminal server writing cookies or clearing
+        # site data here would be doing it to the application.
+        'set-cookie',
+        'clear-site-data',
+    )
+)
+
+PORT_PREVIEW_TTL = dt.timedelta(hours=1)
+# The preview credential travels in a URL the previewed page can read, so it is signed with its own
+# key: presented anywhere else it fails signature verification rather than authenticating a session.
+PORT_PREVIEW_SECRET = hashlib.sha256(f'{SESSION_SECRET}:terminal-port-preview'.encode()).hexdigest()
+# A port server's response is written by whoever uses the terminal, so it must never run with the
+# application's own privileges. The sandbox denies it the application origin; the credential rides in
+# the URL instead of a cookie because a sandboxed document is no longer same-site with the application.
+PORT_PREVIEW_HEADERS = {
+    'Content-Security-Policy': 'sandbox allow-scripts allow-forms allow-popups allow-modals allow-downloads',
+    'Referrer-Policy': 'no-referrer',
+    'X-Content-Type-Options': 'nosniff',
+    'Cache-Control': 'no-store',
+    # The preview loads at an opaque origin, so its own assets are cross-origin to it and an
+    # operator's stricter default would leave the page unable to load anything it references.
+    'Cross-Origin-Resource-Policy': 'cross-origin',
+}
 
 
 def _sanitize_proxy_path(path: str) -> str | None:
@@ -99,6 +140,84 @@ async def list_terminal_servers(request: Request, user=Depends(get_verified_user
 PROXY_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS']
 
 
+@router.post('/{server_id}/port-preview/{port}')
+async def create_port_preview_token(server_id: str, port: int, request: Request, user=Depends(get_verified_user)):
+    """Mint a credential that authorises previewing one port on one terminal server."""
+    connections = await Config.get('terminal_server.connections', []) or []
+    connection = next((c for c in connections if c.get('id') == server_id and c.get('enabled', True)), None)
+    if connection is None or not await has_connection_access(user, connection):
+        return JSONResponse({'error': 'Access denied'}, status_code=403)
+
+    # These auth types forward the caller's own credential upstream, and a sandboxed preview carries
+    # none, so refuse here rather than serving a page whose every asset then fails.
+    if connection.get('auth_type', 'bearer') in ('session', 'system_oauth'):
+        return JSONResponse({'error': 'Port preview is unavailable for this terminal server'}, status_code=403)
+
+    # Tied to a session so it can inherit that session's lifetime and revocation. An API key has
+    # neither, and nothing in the UI mints this with one.
+    session_claims = decode_token(getattr(request.state.token, 'credentials', ''))
+    if not session_claims:
+        return JSONResponse({'error': 'Port preview requires a session'}, status_code=403)
+
+    now = dt.datetime.now(dt.UTC)
+    # Never outlive the session it was minted from, however long that session has left.
+    expires_at = now + PORT_PREVIEW_TTL
+    session_expiry = session_claims.get('exp')
+    if session_expiry:
+        expires_at = min(expires_at, dt.datetime.fromtimestamp(session_expiry, dt.UTC))
+    token = jwt.encode(
+        {
+            'user_id': user.id,
+            'server_id': server_id,
+            'port': port,
+            # Carried so signing out, which revokes by jti, revokes the previews minted from it too.
+            'session_jti': session_claims.get('jti'),
+            'iat': now,
+            'exp': expires_at,
+        },
+        PORT_PREVIEW_SECRET,
+        algorithm=ALGORITHM,
+    )
+    return {'token': token}
+
+
+@router.api_route('/{server_id}/port-preview/{port}/{preview_token}/{path:path}', methods=PROXY_METHODS)
+async def preview_port(server_id: str, port: int, preview_token: str, path: str, request: Request):
+    """Serve a port server's response as sandboxed content, authorised by the credential in the path."""
+    try:
+        claims = jwt.decode(preview_token, PORT_PREVIEW_SECRET, algorithms=[ALGORITHM])
+    except jwt.PyJWTError:
+        return JSONResponse({'error': 'Invalid preview token'}, status_code=403)
+
+    if claims.get('server_id') != server_id or claims.get('port') != port:
+        return JSONResponse({'error': 'Invalid preview token'}, status_code=403)
+
+    # The dependency chain is bypassed here, so re-apply what it would have checked: an approved
+    # role, and the revocation that signing out and back-channel logout write.
+    user = await get_verified_user_by_id(claims.get('user_id'))
+    if user is None:
+        return JSONResponse({'error': 'Invalid preview token'}, status_code=403)
+
+    revocation_claims = {'id': user.id, 'iat': claims.get('iat'), 'jti': claims.get('session_jti')}
+    if not await is_valid_token(revocation_claims, getattr(request.app.state, 'redis', None)):
+        return JSONResponse({'error': 'Invalid preview token'}, status_code=403)
+
+    # An empty sub-path is the port's root, which the sanitizer would reject as a bare '.'.
+    safe_path = _sanitize_proxy_path(path) if path else ''
+    if safe_path is None:
+        return JSONResponse({'error': 'Invalid path'}, status_code=400)
+
+    response = await _proxy(server_id, f'proxy/{port}/{safe_path}', request, user, sandboxed=True)
+
+    # This response keeps its own security headers, so drop the ones the terminal server sent: they
+    # would be a third party deciding what the browser enforces on our origin.
+    for name in MANAGED_HEADER_NAMES:
+        del response.headers[name]
+    response.headers.update(PORT_PREVIEW_HEADERS)
+    request.state.owns_security_headers = True
+    return response
+
+
 @router.api_route('/{server_id}/{path:path}', methods=PROXY_METHODS)
 async def proxy_terminal(
     server_id: str,
@@ -107,6 +226,19 @@ async def proxy_terminal(
     user=Depends(get_verified_user),
 ):
     """Proxy a request to the admin terminal server identified by *server_id*."""
+    safe_path = _sanitize_proxy_path(path)
+    if safe_path is None:
+        return JSONResponse({'error': 'Invalid path'}, status_code=400)
+
+    # Port traffic is reachable only through preview_port, which sandboxes what comes back. Preview
+    # URLs are rejected too, so a malformed one cannot hand its credential to the terminal server.
+    if safe_path.lower().startswith(('proxy/', 'port-preview/')):
+        return JSONResponse({'error': 'Not found'}, status_code=404)
+
+    return await _proxy(server_id, safe_path, request, user)
+
+
+async def _proxy(server_id: str, safe_path: str, request: Request, user, sandboxed: bool = False):
     connections = await Config.get('terminal_server.connections', []) or []
     connection = next((c for c in connections if c.get('id') == server_id), None)
 
@@ -120,13 +252,14 @@ async def proxy_terminal(
     if not await has_connection_access(user, connection, user_group_ids):
         return JSONResponse({'error': 'Access denied'}, status_code=403)
 
+    # A sandboxed caller carries none of the credentials these auth types forward upstream. The mint
+    # refuses them too; this also covers a connection switched to one after a token was issued.
+    if sandboxed and connection.get('auth_type', 'bearer') in ('session', 'system_oauth'):
+        return JSONResponse({'error': 'Port preview is unavailable for this terminal server'}, status_code=403)
+
     base_url = get_terminal_server_url(connection)
     if not base_url:
         return JSONResponse({'error': 'Terminal server URL not configured'}, status_code=503)
-
-    safe_path = _sanitize_proxy_path(path)
-    if safe_path is None:
-        return JSONResponse({'error': 'Invalid path'}, status_code=400)
 
     target_url = f'{base_url}/{safe_path}'
 

--- a/backend/open_webui/utils/asgi_middleware.py
+++ b/backend/open_webui/utils/asgi_middleware.py
@@ -105,7 +105,7 @@ class AppHTTPMiddleware:
         start_time = time.monotonic()
         request = Request(scope)
         self._set_token(request)
-        send_with_headers = self._send_with_headers(send, start_time)
+        send_with_headers = self._send_with_headers(scope, send, start_time)
 
         try:
             if await self._redirect_legacy_url(scope, receive, send_with_headers):
@@ -131,12 +131,17 @@ class AppHTTPMiddleware:
             token = HTTPAuthorizationCredentials(scheme='Bearer', credentials=api_key)
         request.state.token = token
 
-    def _send_with_headers(self, send: Send, start_time: float) -> Send:
+    def _send_with_headers(self, scope: Scope, send: Send, start_time: float) -> Send:
         async def send_with_headers(message: Message) -> None:
             if message['type'] == 'http.response.start':
+                # A route serving untrusted content sets this, having chosen headers stricter than
+                # the operator's, which are written for first-party pages.
+                owned = scope.get('state', {}).get('owns_security_headers')
                 headers = MutableHeaders(scope=message)
                 headers['X-Process-Time'] = f'{time.monotonic() - start_time:.6f}'
                 for key, value in self._security_headers:
+                    if owned and key in headers:
+                        continue
                     headers[key] = value
             await send(message)
 

--- a/backend/open_webui/utils/security_headers.py
+++ b/backend/open_webui/utils/security_headers.py
@@ -32,24 +32,7 @@ def set_security_headers() -> Dict[str, str]:
         dict: A dictionary containing the security headers and their values.
     """
     options = {}
-    header_setters = {
-        'CACHE_CONTROL': set_cache_control,
-        'HSTS': set_hsts,
-        'PERMISSIONS_POLICY': set_permissions_policy,
-        'REFERRER_POLICY': set_referrer,
-        'XCONTENT_TYPE': set_xcontent_type,
-        'XDOWNLOAD_OPTIONS': set_xdownload_options,
-        'XFRAME_OPTIONS': set_xframe,
-        'XPERMITTED_CROSS_DOMAIN_POLICIES': set_xpermitted_cross_domain_policies,
-        'CONTENT_SECURITY_POLICY': set_content_security_policy,
-        'CONTENT_SECURITY_POLICY_REPORT_ONLY': set_content_security_policy_report_only,
-        'CROSS_ORIGIN_EMBEDDER_POLICY': set_cross_origin_embedder_policy,
-        'CROSS_ORIGIN_OPENER_POLICY': set_cross_origin_opener_policy,
-        'CROSS_ORIGIN_RESOURCE_POLICY': set_cross_origin_resource_policy,
-        'REPORTING_ENDPOINTS': set_reporting_endpoints,
-    }
-
-    for env_var, setter in header_setters.items():
+    for env_var, setter in HEADER_SETTERS.items():
         value = os.environ.get(env_var, None)
         if value:
             header = setter(value)
@@ -168,3 +151,26 @@ def set_cross_origin_resource_policy(value: str):
 # Set Reporting-Endpoints response header
 def set_reporting_endpoints(value: str):
     return {'Reporting-Endpoints': value}
+
+
+HEADER_SETTERS = {
+    'CACHE_CONTROL': set_cache_control,
+    'HSTS': set_hsts,
+    'PERMISSIONS_POLICY': set_permissions_policy,
+    'REFERRER_POLICY': set_referrer,
+    'XCONTENT_TYPE': set_xcontent_type,
+    'XDOWNLOAD_OPTIONS': set_xdownload_options,
+    'XFRAME_OPTIONS': set_xframe,
+    'XPERMITTED_CROSS_DOMAIN_POLICIES': set_xpermitted_cross_domain_policies,
+    'CONTENT_SECURITY_POLICY': set_content_security_policy,
+    'CONTENT_SECURITY_POLICY_REPORT_ONLY': set_content_security_policy_report_only,
+    'CROSS_ORIGIN_EMBEDDER_POLICY': set_cross_origin_embedder_policy,
+    'CROSS_ORIGIN_OPENER_POLICY': set_cross_origin_opener_policy,
+    'CROSS_ORIGIN_RESOURCE_POLICY': set_cross_origin_resource_policy,
+    'REPORTING_ENDPOINTS': set_reporting_endpoints,
+}
+
+# Every header name this module can emit. A proxy route strips these from upstream responses so a
+# third party cannot decide what the browser enforces on our own origin. Derived from the setters
+# above, which return their header name whatever value they are given, so the two cannot drift.
+MANAGED_HEADER_NAMES = frozenset(name.lower() for setter in HEADER_SETTERS.values() for name in setter(''))

--- a/src/lib/apis/terminal/index.ts
+++ b/src/lib/apis/terminal/index.ts
@@ -470,8 +470,36 @@ export const getListeningPorts = async (
 	return json?.ports ?? [];
 };
 
-export const getPortProxyUrl = (baseUrl: string, port: number, path: string = ''): string => {
-	return `${baseUrl.replace(/\/$/, '')}/proxy/${port}/${path}`;
+// A system terminal proxies through the application's own origin, so its port previews are served
+// sandboxed and carry their credential in the path. A user's own terminal server is already a
+// separate origin and keeps the plain proxy URL.
+export const isSystemTerminal = (baseUrl: string): boolean =>
+	baseUrl.startsWith(`${WEBUI_API_BASE_URL}/terminals/`);
+
+export const createPortPreviewToken = async (
+	baseUrl: string,
+	apiKey: string,
+	port: number
+): Promise<string | null> => {
+	const base = baseUrl.replace(/\/$/, '');
+	const res = await fetch(`${base}/port-preview/${port}`, {
+		method: 'POST',
+		headers: bearerHeaders(apiKey)
+	}).catch(() => null);
+	if (!res || !res.ok) return null;
+	const json = await res.json().catch(() => null);
+	return json?.token ?? null;
+};
+
+export const getPortPreviewUrl = (
+	baseUrl: string,
+	port: number,
+	previewToken: string | null,
+	path: string = ''
+): string => {
+	const base = baseUrl.replace(/\/$/, '');
+	if (!isSystemTerminal(base)) return `${base}/proxy/${port}/${path}`;
+	return previewToken ? `${base}/port-preview/${port}/${previewToken}/${path}` : '';
 };
 
 // ---------------------------------------------------------------------------

--- a/src/lib/components/chat/FileNav.svelte
+++ b/src/lib/components/chat/FileNav.svelte
@@ -1722,6 +1722,7 @@
 			{#if previewPort !== null}
 				<PortPreview
 					baseUrl={selectedTerminal?.url ?? ''}
+					apiKey={selectedTerminal?.key ?? ''}
 					port={previewPort}
 					overlay={overlay || isDraggingHandle}
 					onClose={() => {

--- a/src/lib/components/chat/FileNav/PortList.svelte
+++ b/src/lib/components/chat/FileNav/PortList.svelte
@@ -1,7 +1,13 @@
 <script lang="ts">
 	import { onDestroy, getContext, createEventDispatcher } from 'svelte';
 	import type { ListeningPort } from '$lib/apis/terminal';
-	import { getListeningPorts, getPortProxyUrl } from '$lib/apis/terminal';
+	import { toast } from 'svelte-sonner';
+	import {
+		createPortPreviewToken,
+		getListeningPorts,
+		getPortPreviewUrl,
+		isSystemTerminal
+	} from '$lib/apis/terminal';
 	import Tooltip from '$lib/components/common/Tooltip.svelte';
 	import Icon from './Icon.svelte';
 
@@ -39,9 +45,29 @@
 		dispatch('previewPort', port);
 	};
 
-	const openPortExternal = (port: number) => {
-		const url = getPortProxyUrl(baseUrl, port);
-		window.open(url, '_blank', 'noopener,noreferrer');
+	const openPortExternal = async (port: number) => {
+		if (!isSystemTerminal(baseUrl)) {
+			window.open(getPortPreviewUrl(baseUrl, port, null), '_blank', 'noopener,noreferrer');
+			return;
+		}
+
+		// Opened up front because awaiting the credential first would put this outside the user
+		// gesture and get the popup blocked. `noopener` cannot be used here, it makes window.open
+		// return null; disowning the tab achieves the same thing.
+		const tab = window.open('', '_blank');
+		if (!tab) {
+			toast.error($i18n.t('Failed to open port {{port}}', { port }));
+			return;
+		}
+		tab.opener = null;
+
+		const previewToken = await createPortPreviewToken(baseUrl, apiKey, port);
+		if (!previewToken) {
+			tab.close();
+			toast.error($i18n.t('Failed to open port {{port}}', { port }));
+			return;
+		}
+		tab.location = getPortPreviewUrl(baseUrl, port, previewToken);
 	};
 
 	// Start polling when baseUrl is available

--- a/src/lib/components/chat/FileNav/PortPreview.svelte
+++ b/src/lib/components/chat/FileNav/PortPreview.svelte
@@ -1,20 +1,24 @@
 <script lang="ts">
 	import { getContext } from 'svelte';
-	import { getPortProxyUrl } from '$lib/apis/terminal';
+	import { toast } from 'svelte-sonner';
+	import { createPortPreviewToken, getPortPreviewUrl, isSystemTerminal } from '$lib/apis/terminal';
 	import Tooltip from '$lib/components/common/Tooltip.svelte';
 
 	const i18n = getContext('i18n');
 
 	export let baseUrl: string;
+	export let apiKey: string = '';
 	export let port: number;
 	export let path: string = '';
 	export let onClose: () => void = () => {};
 	export let overlay = false;
 
-	let iframeEl: HTMLIFrameElement;
 	let urlInput: string = '';
 	let iframeKey = 0;
 	let isLoading = false;
+	let previewToken: string | null = null;
+	let tokenReady = false;
+	let tokenError = false;
 
 	// ── Navigation history ──────────────────────────────────────────────
 	let history: string[] = [path];
@@ -31,12 +35,20 @@
 		historyIndex = history.length - 1;
 	};
 
+	const reloadFrame = () => {
+		// Drop the cached key so an expired credential is re-minted rather than reloaded into a 403.
+		tokenKey = '';
+		ensurePreviewToken(baseUrl, port);
+		isLoading = true;
+		iframeKey += 1;
+	};
+
 	const goBack = () => {
 		if (!canGoBack) return;
 		historyIndex -= 1;
 		path = history[historyIndex];
 		syncUrlBar();
-		iframeKey += 1;
+		reloadFrame();
 	};
 
 	const goForward = () => {
@@ -44,19 +56,47 @@
 		historyIndex += 1;
 		path = history[historyIndex];
 		syncUrlBar();
-		iframeKey += 1;
+		reloadFrame();
 	};
 
 	// ── URLs ─────────────────────────────────────────────────────────────
-	$: proxyUrl = getPortProxyUrl(baseUrl, port, path);
+	// A system terminal's preview comes from the application's own origin, so it must be denied that
+	// origin. A user's own terminal server is a separate origin already and keeps its own.
+	$: iframeSandbox = isSystemTerminal(baseUrl)
+		? 'allow-scripts allow-forms allow-popups allow-modals allow-downloads'
+		: 'allow-scripts allow-forms allow-popups allow-modals allow-downloads allow-same-origin';
 
-	$: proxyPathPrefix = (() => {
-		try {
-			return new URL(getPortProxyUrl(baseUrl, port, ''), window.location.origin).pathname;
-		} catch {
-			return `/proxy/${port}/`;
+	// Denied that origin, the preview's own requests cannot carry the session cookie and are
+	// authorised by the token in the path instead. Wait for it before pointing the iframe anywhere,
+	// and keep it across unrelated prop reassignments so the frame is not torn down mid-load.
+	$: ensurePreviewToken(baseUrl, port);
+
+	let tokenKey = '';
+	let latestRequest = 0;
+	const ensurePreviewToken = async (terminalUrl: string, previewPort: number) => {
+		const key = `${terminalUrl}|${previewPort}`;
+		if (key === tokenKey) return;
+		tokenKey = key;
+		const request = ++latestRequest;
+		tokenReady = false;
+		tokenError = false;
+		previewToken = null;
+		isLoading = true;
+
+		if (!isSystemTerminal(terminalUrl)) {
+			tokenReady = true;
+			return;
 		}
-	})();
+		const token = await createPortPreviewToken(terminalUrl, apiKey, previewPort);
+		// A newer request took over while this one was in flight.
+		if (request !== latestRequest) return;
+		previewToken = token;
+		tokenError = token === null;
+		if (tokenError) isLoading = false;
+		tokenReady = true;
+	};
+
+	$: previewUrl = getPortPreviewUrl(baseUrl, port, previewToken, path);
 
 	const makeDisplayUrl = (p: string) => `localhost:${port}${p ? '/' + p : ''}`;
 	const syncUrlBar = () => {
@@ -64,12 +104,12 @@
 	};
 	urlInput = makeDisplayUrl(path);
 
-	const refresh = () => {
-		iframeKey += 1;
-	};
-
 	const openExternal = () => {
-		window.open(proxyUrl, '_blank', 'noopener,noreferrer');
+		if (!tokenReady || tokenError) {
+			toast.error($i18n.t('Failed to open port {{port}}', { port }));
+			return;
+		}
+		window.open(previewUrl, '_blank', 'noopener,noreferrer');
 	};
 
 	const navigateUrl = () => {
@@ -88,34 +128,13 @@
 			pushHistory(path);
 		}
 		syncUrlBar();
-		iframeKey += 1;
+		reloadFrame();
 	};
 
-	/**
-	 * Read the iframe's current location and sync the URL bar.
-	 * If the iframe escaped the proxy prefix, redirect it back.
-	 */
+	// The sandboxed frame is opaque-origin, so its location is unreadable and the URL bar only
+	// reflects paths entered here.
 	const onIframeLoad = () => {
 		isLoading = false;
-		if (!iframeEl) return;
-		try {
-			const loc = iframeEl.contentWindow?.location;
-			if (!loc) return;
-			const iframePath = loc.pathname ?? '';
-			const iframeSearch = loc.search ?? '';
-			const iframeHash = loc.hash ?? '';
-
-			if (iframePath.startsWith(proxyPathPrefix)) {
-				const relativePath = iframePath.slice(proxyPathPrefix.length) + iframeSearch + iframeHash;
-				if (relativePath !== path) {
-					path = relativePath;
-					pushHistory(path);
-					syncUrlBar();
-				}
-			}
-		} catch {
-			// Cross-origin — can't access
-		}
 	};
 </script>
 
@@ -178,7 +197,7 @@
 		<Tooltip content={$i18n.t('Refresh')}>
 			<button
 				class="p-1 rounded text-gray-500 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-800 hover:text-gray-700 dark:hover:text-gray-300 transition"
-				on:click={refresh}
+				on:click={reloadFrame}
 				aria-label={$i18n.t('Refresh')}
 			>
 				<svg
@@ -262,16 +281,21 @@
 		{#if overlay}
 			<div class="absolute inset-0 z-10"></div>
 		{/if}
-		{#key iframeKey}
-			<iframe
-				bind:this={iframeEl}
-				src={proxyUrl}
-				title="Port {port} preview"
-				class="w-full h-full border-0 bg-white"
-				sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-modals allow-downloads"
-				on:load={onIframeLoad}
-			/>
-		{/key}
+		{#if tokenError}
+			<div class="flex h-full items-center justify-center px-4 text-xs text-gray-500">
+				{$i18n.t('Failed to open port {{port}}', { port })}
+			</div>
+		{:else if tokenReady}
+			{#key iframeKey}
+				<iframe
+					src={previewUrl}
+					title="Port {port} preview"
+					class="w-full h-full border-0 bg-white"
+					sandbox={iframeSandbox}
+					on:load={onIframeLoad}
+				/>
+			{/key}
+		{/if}
 	</div>
 </div>
 

--- a/src/lib/i18n/locales/en-US/translation.json
+++ b/src/lib/i18n/locales/en-US/translation.json
@@ -1194,6 +1194,7 @@
 	"Failed to load PPTX file. Please try downloading it instead.": "",
 	"Failed to load usage": "",
 	"Failed to move chat": "",
+	"Failed to open port {{port}}": "",
 	"Failed to process URL: {{url}}": "",
 	"Failed to read clipboard contents": "",
 	"Failed to refresh terminals: {{error}}": "",


### PR DESCRIPTION
Port previews now render at an opaque origin: responses under the port proxy carry a Content-Security-Policy sandbox directive alongside no-store, no-referrer and nosniff, so a previewed page is isolated from the application displaying it no matter how it is opened.

Those requests are therefore no longer same-site, and the session cookie does not reach them, so the preview authorises itself with a credential carried in its URL path, which the page's own relative requests inherit. That credential is signed with a separate key so it is only ever accepted here, is scoped to a single server and port, inherits the minting session's expiry and revocation, and is refused for the connection auth types whose upstream credential a sandboxed request cannot carry.

The terminal proxy also stops forwarding Set-Cookie and Clear-Site-Data, which would act on our own origin rather than the terminal server's, and SecurityHeadersMiddleware now lets a route keep security headers it chose for itself instead of overwriting them with the deployment-wide defaults.

One behaviour change worth knowing: the preview's address bar no longer follows navigation inside the page, because reading the framed location needs the origin the sandbox removes.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
