### PR TITLE
fix: surface upstream errors returned during tool-call continuation rounds

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -5760,6 +5760,19 @@ async def streaming_chat_response_handler(response, ctx):
                             output[:0] = prior_output
                             prior_output = []
                         else:
+                            if getattr(res, 'status_code', 200) >= 400:
+                                try:
+                                    error_body = JSONCodec.loads(res.body.decode('utf-8', 'replace'))
+                                    detail = (
+                                        error_body.get('error', error_body)
+                                        if isinstance(error_body, dict)
+                                        else error_body
+                                    )
+                                    if isinstance(detail, dict):
+                                        detail = detail.get('message', detail.get('detail', str(detail)))
+                                except Exception:
+                                    detail = f'Provider returned HTTP {res.status_code}'
+                                await emit_message_error(get_message_error_content(detail))
                             break
                     except Exception as e:
                         error_content = get_message_error_content(e)


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or [Discussion](https://github.com/open-webui/open-webui/discussions) — `Closes #___` / `Relates to #___`. If one does not exist, create one first. PRs without a linked issue or discussion may be closed without review.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** Manual tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **BREAKING CHANGE**: Changes affecting backward compatibility
  - **build**: Build system or dependency changes
  - **ci**: CI/CD workflow changes
  - **chore**: Refactoring, cleanup, or non-functional changes
  - **docs**: Documentation additions or updates
  - **feat**: New features or enhancements
  - **fix**: Bug fixes or corrections
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvements
  - **refactor**: Code restructuring
  - **style**: Formatting changes (whitespace, semicolons, etc.)
  - **test**: Test additions or corrections
  - **WIP**: Work in progress

# Changelog Entry

### Description

Closes #28633

- #27411 reported that errors during tool-call continuation rounds were silently swallowed,
  leaving an empty assistant message. The fix for it added error reporting to the `except`
  block in `streaming_chat_response_handler` and is present on current `dev`.

- That covers errors that are **raised**. On the OpenAI-compatible path
  `generate_chat_completion` does not raise on a non-2xx, it **returns** the error. The
  continuation loop tests `isinstance(res, StreamingResponse)`, finds it `False`, and hits a
  bare `break`, so that `except` never runs and the message is still blank.

- Reproduced on the stock `ghcr.io/open-webui/open-webui:dev` image (commit `31d08d5`), with
  the #27411 fix already in the build: the tool call succeeds, then the assistant message is
  empty and no error is shown or stored. The backend logs the upstream failure.

- This adds the same reporting to the `else` branch, using the check `main.py` already makes
  on the initial response for exactly this reason.

### Fixed

- Errors from the follow-up request after a tool call are now shown on the assistant message
  instead of leaving it blank. Completes the fix for #27411, which covered only errors that
  were raised.

---

### Additional Information

**Duplication.** The same extraction exists in `main.py`, the only other occurrence. This PR is
kept to the single site so it stays one logical change. A follow-up PR moves the extraction into
`get_response_error_detail()` in `utils/misc.py` and calls it from both, so the two copies cannot
drift; I will open it once this lands.

### Screenshots or Videos

Before the fix:

<img width="955" height="222" alt="screenshot-1" src="https://github.com/user-attachments/assets/ebd3085f-f63f-4880-b07e-ad435a3c0bd8" />


After the fix:

<img width="928" height="255" alt="screenshot-2" src="https://github.com/user-attachments/assets/3d2a97d6-ce92-4513-9ebf-6ee32a34fc1f" />

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.