### PR TITLE
refac: apply the caller metadata filter in vector search

### DIFF
--- a/backend/open_webui/retrieval/vector/dbs/elasticsearch.py
+++ b/backend/open_webui/retrieval/vector/dbs/elasticsearch.py
@@ -3,7 +3,7 @@ NOTE: This vector database integration is community-supported and maintained on 
 """
 
 import ssl
-from typing import Optional
+from typing import Any, Optional
 
 from elasticsearch import BadRequestError, Elasticsearch
 from elasticsearch.helpers import bulk, scan
@@ -24,6 +24,15 @@ from open_webui.retrieval.vector.main import (
     VectorItem,
 )
 from open_webui.retrieval.vector.utils import process_metadata
+
+
+def _metadata_filter(key: str, value: Any) -> dict:
+    # Callers pass either a plain value or a Mongo-style {'$in': [...]} set.
+    if isinstance(value, dict):
+        if set(value) != {'$in'}:
+            raise ValueError(f"Unsupported filter value for field '{key}': {value}")
+        return {'terms': {f'metadata.{key}': list(value['$in'])}}
+    return {'term': {f'metadata.{key}': value}}
 
 
 class ElasticsearchClient(VectorDBBase):
@@ -161,12 +170,16 @@ class ElasticsearchClient(VectorDBBase):
         filter: Optional[dict] = None,
         limit: int = 10,
     ) -> Optional[SearchResult]:
+        filters = [{'term': {'collection': collection_name}}]
+        if filter:
+            filters.extend(_metadata_filter(key, value) for key, value in filter.items())
+
         query = {
             'size': limit,
             '_source': ['text', 'metadata'],
             'query': {
                 'script_score': {
-                    'query': {'bool': {'filter': [{'term': {'collection': collection_name}}]}},
+                    'query': {'bool': {'filter': filters}},
                     'script': {
                         'source': "cosineSimilarity(params.vector, 'vector') + 1.0",
                         'params': {'vector': vectors[0]},  # Assuming single query vector

--- a/backend/open_webui/retrieval/vector/dbs/milvus.py
+++ b/backend/open_webui/retrieval/vector/dbs/milvus.py
@@ -3,7 +3,8 @@ NOTE: This vector database integration is community-supported and maintained on 
 """
 
 import logging
-from typing import Optional
+import re
+from typing import Any, Optional
 
 from open_webui.config import (
     MILVUS_DB,
@@ -24,7 +25,6 @@ from open_webui.retrieval.vector.main import (
     VectorItem,
 )
 from open_webui.retrieval.vector.utils import process_metadata
-from open_webui.utils.json_codec import JSONCodec
 from pymilvus import DataType
 from pymilvus import MilvusClient as Client
 from pymilvus.exceptions import MilvusException
@@ -35,6 +35,43 @@ log = logging.getLogger(__name__)
 # field). Clamp long chunks before insert so one oversized chunk can't fail the
 # whole batch and leave the file with zero embeddings.
 MILVUS_TEXT_MAX_LENGTH = 65535
+
+# Milvus expressions are SQL-like strings with no parameterized-query API; values
+# get interpolated into single-quoted literals. Shared with milvus_multitenancy.
+_SAFE_METADATA_KEY_RE = re.compile(r'^[A-Za-z_][A-Za-z0-9_]{0,63}$')
+
+
+def escape_milvus_string(value: str) -> str:
+    if not isinstance(value, str):
+        raise TypeError(f'Expected str for Milvus expression value, got {type(value).__name__}')
+    return value.replace('\\', '\\\\').replace("'", "\\'")
+
+
+def _milvus_literal(key: str, value: Any) -> str:
+    if isinstance(value, str):
+        return f"'{escape_milvus_string(value)}'"
+    if isinstance(value, bool):
+        return str(value).lower()
+    if isinstance(value, (int, float)):
+        return str(value)
+    raise TypeError(f'Unsupported Milvus filter value type for key {key!r}: {type(value).__name__}')
+
+
+def metadata_expressions(filter: Optional[dict]) -> list[str]:
+    """Metadata filter -> Milvus boolean expression parts, for plain values and {'$in': [...]}."""
+    expressions = []
+    for key, value in (filter or {}).items():
+        if not isinstance(key, str) or not _SAFE_METADATA_KEY_RE.fullmatch(key):
+            raise ValueError(f'Invalid Milvus metadata filter key: {key!r}')
+        if isinstance(value, dict):
+            if set(value) != {'$in'}:
+                raise ValueError(f'Unsupported Milvus filter operator for key {key!r}: {sorted(value)}')
+            # Milvus rejects `in` against a JSON subfield, so expand it to an OR chain.
+            options = [f"metadata['{key}'] == {_milvus_literal(key, item)}" for item in value['$in']]
+            expressions.append(f'({" or ".join(options)})' if options else 'false')
+        else:
+            expressions.append(f"metadata['{key}'] == {_milvus_literal(key, value)}")
+    return expressions
 
 
 class MilvusClient(VectorDBBase):
@@ -193,6 +230,7 @@ class MilvusClient(VectorDBBase):
     ) -> Optional[SearchResult]:
         # Search for the nearest neighbor items based on the vectors and return 'limit' number of results.
         collection_name = collection_name.replace('-', '_')
+        filter_string = ' and '.join(metadata_expressions(filter))
         # For some index types like IVF_FLAT, search params like nprobe can be set.
         # Example: search_params = {"nprobe": 10} if using IVF_FLAT
         # For simplicity, not adding configurable search_params here, but could be extended.
@@ -200,6 +238,7 @@ class MilvusClient(VectorDBBase):
             collection_name=f'{self.collection_prefix}_{collection_name}',
             data=vectors,
             limit=limit,
+            filter=filter_string,
             output_fields=['data', 'metadata'],
             # search_params=search_params # Potentially add later if needed
         )
@@ -211,14 +250,7 @@ class MilvusClient(VectorDBBase):
             log.warning(f'Query attempted on non-existent collection: {self.collection_prefix}_{collection_name}')
             return None
 
-        filter_expressions = []
-        for key, value in filter.items():
-            if isinstance(value, str):
-                filter_expressions.append(f'metadata["{key}"] == "{value}"')
-            else:
-                filter_expressions.append(f'metadata["{key}"] == {value}')
-
-        filter_string = ' && '.join(filter_expressions)
+        filter_string = ' and '.join(metadata_expressions(filter))
 
         self.client.load_collection(collection_name=f'{self.collection_prefix}_{collection_name}')
 
@@ -364,7 +396,7 @@ class MilvusClient(VectorDBBase):
                 ids=ids,
             )
         elif filter:
-            filter_string = ' && '.join([f'metadata["{key}"] == {JSONCodec.dumps(value)}' for key, value in filter.items()])
+            filter_string = ' and '.join(metadata_expressions(filter))
             log.info(
                 'Deleting items by filter from %s_%s. Filter: %s',
                 self.collection_prefix,

--- a/backend/open_webui/retrieval/vector/dbs/milvus_multitenancy.py
+++ b/backend/open_webui/retrieval/vector/dbs/milvus_multitenancy.py
@@ -17,6 +17,10 @@ from open_webui.config import (
     MILVUS_TOKEN,
     MILVUS_URI,
 )
+from open_webui.retrieval.vector.dbs.milvus import (
+    escape_milvus_string,
+    metadata_expressions,
+)
 from open_webui.retrieval.vector.main import (
     GetResult,
     SearchResult,
@@ -35,29 +39,15 @@ RESOURCE_ID_FIELD = 'resource_id'
 # can't fail the whole batch (and leave the file with zero embeddings).
 MILVUS_TEXT_MAX_LENGTH = 65535
 
-# Milvus expressions are SQL-like strings with no parameterized-query API;
-# values get interpolated into single-quoted literals. Reject anything that
+# Interpolated into single-quoted expression literals; reject anything that
 # can't be a legitimate Open WebUI collection name.
 _SAFE_RESOURCE_ID_RE = re.compile(r'^[A-Za-z0-9_-]{1,255}$')
-_SAFE_METADATA_KEY_RE = re.compile(r'^[A-Za-z_][A-Za-z0-9_]{0,63}$')
 
 
 def _validate_resource_id(resource_id: str) -> str:
     if not isinstance(resource_id, str) or not _SAFE_RESOURCE_ID_RE.match(resource_id):
         raise ValueError(f'Invalid Milvus resource_id (collection name): {resource_id!r}')
     return resource_id
-
-
-def _validate_metadata_key(key: str) -> str:
-    if not isinstance(key, str) or not _SAFE_METADATA_KEY_RE.match(key):
-        raise ValueError(f'Invalid Milvus metadata filter key: {key!r}')
-    return key
-
-
-def _escape_milvus_string(value: str) -> str:
-    if not isinstance(value, str):
-        raise TypeError(f'Expected str for Milvus expression value, got {type(value).__name__}')
-    return value.replace('\\', '\\\\').replace("'", "\\'")
 
 
 class MilvusClient(VectorDBBase):
@@ -221,13 +211,16 @@ class MilvusClient(VectorDBBase):
 
         self.client.load_collection(mt_collection)
 
+        expr = [f"{RESOURCE_ID_FIELD} == '{resource_id}'"]
+        expr.extend(metadata_expressions(filter))
+
         results = self.client.search(
             collection_name=mt_collection,
             data=vectors,
             anns_field='vector',
             search_params={'metric_type': MILVUS_METRIC_TYPE, 'params': {}},
             limit=limit,
-            filter=f"{RESOURCE_ID_FIELD} == '{resource_id}'",
+            filter=' and '.join(expr),
             output_fields=['id', 'text', 'metadata'],
         )
 
@@ -261,13 +254,10 @@ class MilvusClient(VectorDBBase):
         expr = [f"{RESOURCE_ID_FIELD} == '{resource_id}'"]
         if ids:
             # Milvus expects a string list for 'in' operator
-            id_list_str = ', '.join([f"'{_escape_milvus_string(str(id_val))}'" for id_val in ids])
+            id_list_str = ', '.join([f"'{escape_milvus_string(str(id_val))}'" for id_val in ids])
             expr.append(f'id in [{id_list_str}]')
 
-        if filter:
-            for key, value in filter.items():
-                _validate_metadata_key(key)
-                expr.append(f"metadata['{key}'] == '{_escape_milvus_string(str(value))}'")
+        expr.extend(metadata_expressions(filter))
 
         self.client.delete(collection_name=mt_collection, filter=' and '.join(expr))
 
@@ -293,17 +283,7 @@ class MilvusClient(VectorDBBase):
         self.client.load_collection(mt_collection)
 
         expr = [f"{RESOURCE_ID_FIELD} == '{resource_id}'"]
-        if filter:
-            for key, value in filter.items():
-                _validate_metadata_key(key)
-                if isinstance(value, str):
-                    expr.append(f"metadata['{key}'] == '{_escape_milvus_string(value)}'")
-                elif isinstance(value, bool):
-                    expr.append(f"metadata['{key}'] == {str(value).lower()}")
-                elif isinstance(value, (int, float)):
-                    expr.append(f"metadata['{key}'] == {value}")
-                else:
-                    raise TypeError(f'Unsupported Milvus filter value type for key {key!r}: {type(value).__name__}')
+        expr.extend(metadata_expressions(filter))
 
         iterator = self.client.query_iterator(
             collection_name=mt_collection,

--- a/backend/open_webui/retrieval/vector/dbs/opengauss.py
+++ b/backend/open_webui/retrieval/vector/dbs/opengauss.py
@@ -86,6 +86,19 @@ class DocumentChunk(Base):
     vmetadata = Column(MutableDict.as_mutable(JSONB), nullable=True)
 
 
+def _metadata_clauses(filter: Optional[Dict[str, Any]]) -> list:
+    """Metadata filter -> SQLAlchemy where-clauses, for plain values and {"$in": [...]}."""
+    clauses = []
+    for key, value in (filter or {}).items():
+        if isinstance(value, dict):
+            if set(value) != {'$in'}:
+                raise ValueError(f"Unsupported filter operator for '{key}': {sorted(value)}")
+            clauses.append(DocumentChunk.vmetadata[key].astext.in_([str(v) for v in value['$in']]))
+        else:
+            clauses.append(DocumentChunk.vmetadata[key].astext == str(value))
+    return clauses
+
+
 class OpenGaussClient(VectorDBBase):
     def __init__(self) -> None:
         if not OPENGAUSS_DB_URL:
@@ -218,6 +231,9 @@ class OpenGaussClient(VectorDBBase):
         filter: Optional[Dict[str, Any]] = None,
         limit: int = 10,
     ) -> Optional[SearchResult]:
+        # Built outside the try so an unsupported filter shape raises instead of being swallowed as "no results".
+        metadata_clauses = _metadata_clauses(filter)
+
         try:
             if not vectors:
                 return None
@@ -243,9 +259,11 @@ class OpenGaussClient(VectorDBBase):
                 (DocumentChunk.vector.cosine_distance(query_vectors.c.q_vector)).label('distance'),
             ]
 
+            where_clauses = [DocumentChunk.collection_name == collection_name, *metadata_clauses]
+
             subq = (
                 select(*result_fields)
-                .where(DocumentChunk.collection_name == collection_name)
+                .where(*where_clauses)
                 .order_by(DocumentChunk.vector.cosine_distance(query_vectors.c.q_vector))
             )
             if limit is not None:

--- a/backend/open_webui/retrieval/vector/dbs/opensearch.py
+++ b/backend/open_webui/retrieval/vector/dbs/opensearch.py
@@ -2,7 +2,7 @@
 NOTE: This vector database integration is community-supported and maintained on a best-effort basis.
 """
 
-from typing import Optional
+from typing import Any, Optional
 
 from open_webui.config import (
     OPENSEARCH_CERT_VERIFY,
@@ -20,6 +20,16 @@ from open_webui.retrieval.vector.main import (
 from open_webui.retrieval.vector.utils import process_metadata
 from opensearchpy import OpenSearch
 from opensearchpy.helpers import bulk
+
+
+def _metadata_filter(key: str, value: Any) -> dict:
+    # Callers pass either a plain value or a Mongo-style {'$in': [...]} set.
+    field = f'metadata.{key}.keyword'
+    if isinstance(value, dict):
+        if set(value) != {'$in'}:
+            raise ValueError(f"Unsupported filter value for field '{key}': {value}")
+        return {'terms': {field: list(value['$in'])}}
+    return {'term': {field: value}}
 
 
 class OpenSearchClient(VectorDBBase):
@@ -121,6 +131,9 @@ class OpenSearchClient(VectorDBBase):
         filter: Optional[dict] = None,
         limit: int = 10,
     ) -> Optional[SearchResult]:
+        # Built outside the try so an unsupported filter shape raises instead of being swallowed as "no results".
+        filter_clauses = [_metadata_filter(key, value) for key, value in filter.items()] if filter else []
+
         try:
             if not self.has_collection(collection_name):
                 return None
@@ -130,7 +143,7 @@ class OpenSearchClient(VectorDBBase):
                 '_source': ['text', 'metadata'],
                 'query': {
                     'script_score': {
-                        'query': {'match_all': {}},
+                        'query': {'bool': {'filter': filter_clauses}} if filter_clauses else {'match_all': {}},
                         'script': {
                             'source': '(cosineSimilarity(params.query_value, doc[params.field]) + 1.0) / 2.0',
                             'params': {

--- a/backend/open_webui/retrieval/vector/dbs/oracle23ai.py
+++ b/backend/open_webui/retrieval/vector/dbs/oracle23ai.py
@@ -32,6 +32,7 @@ import array
 import json
 import logging
 import os
+import re
 import threading
 import time
 from decimal import Decimal
@@ -59,6 +60,37 @@ from open_webui.retrieval.vector.main import (
 from open_webui.utils.json_codec import JSONCodec
 
 log = logging.getLogger(__name__)
+
+# Filter values are bound, but the metadata key lands inside the JSON path of JSON_VALUE, which cannot be bound.
+_SAFE_METADATA_KEY_RE = re.compile(r'^[A-Za-z_][A-Za-z0-9_]{0,63}$')
+
+
+def _metadata_where_clause(filter: dict[str, Any]) -> tuple[str, dict[str, Any]]:
+    """Metadata filter -> WHERE fragment plus bind parameters, for plain values and {"$in": [...]}."""
+    clause = ''
+    params: dict[str, Any] = {}
+
+    for i, (key, value) in enumerate(filter.items()):
+        if not isinstance(key, str) or not _SAFE_METADATA_KEY_RE.fullmatch(key):
+            raise ValueError(f'Invalid Oracle metadata filter key: {key!r}')
+        json_value = f"JSON_VALUE(dc.vmetadata, '$.{key}' RETURNING VARCHAR2(4096))"
+
+        if isinstance(value, dict):
+            if set(value) != {'$in'}:
+                raise ValueError(f"Unsupported filter operator for '{key}': {sorted(value)}")
+            options = list(value['$in'])
+            if not options:
+                clause += ' AND 1 = 0'  # an empty allow-list matches nothing
+                continue
+            names = [f'value_{i}_{j}' for j in range(len(options))]
+            clause += f' AND {json_value} IN ({", ".join(f":{name}" for name in names)})'
+            params.update({name: str(option) for name, option in zip(names, options)})
+        else:
+            name = f'value_{i}'
+            clause += f' AND {json_value} = :{name}'
+            params[name] = str(value)
+
+    return clause, params
 
 
 class Oracle23aiClient(VectorDBBase):
@@ -527,6 +559,7 @@ class Oracle23aiClient(VectorDBBase):
         Args:
             collection_name (str): Name of the collection to search
             vectors (List[List[Union[float, int]]]): Query vectors to find similar items for
+            filter (Optional[dict]): Metadata filters restricting which chunks may be returned
             limit (int): Maximum number of results to return per query
 
         Returns:
@@ -550,6 +583,8 @@ class Oracle23aiClient(VectorDBBase):
 
             num_queries = len(vectors)
 
+            filter_clause, filter_params = _metadata_where_clause(filter) if filter else ('', {})
+
             ids = [[] for _ in range(num_queries)]
             distances = [[] for _ in range(num_queries)]
             documents = [[] for _ in range(num_queries)]
@@ -561,12 +596,12 @@ class Oracle23aiClient(VectorDBBase):
                         vector_blob = self._vector_to_blob(vector)
 
                         cursor.execute(
-                            """
-                            SELECT dc.id, dc.text, 
+                            f"""
+                            SELECT dc.id, dc.text,
                                 JSON_SERIALIZE(dc.vmetadata RETURNING VARCHAR2(4096)) as vmetadata,
                                 VECTOR_DISTANCE(dc.vector, :query_vector, COSINE) as distance
                             FROM document_chunk dc
-                            WHERE dc.collection_name = :collection_name
+                            WHERE dc.collection_name = :collection_name{filter_clause}
                             ORDER BY VECTOR_DISTANCE(dc.vector, :query_vector, COSINE)
                             FETCH APPROX FIRST :limit ROWS ONLY
                         """,
@@ -574,6 +609,7 @@ class Oracle23aiClient(VectorDBBase):
                                 'query_vector': vector_blob,
                                 'collection_name': collection_name,
                                 'limit': limit,
+                                **filter_params,
                             },
                         )
 
@@ -630,6 +666,8 @@ class Oracle23aiClient(VectorDBBase):
             params = {'collection_name': collection_name}
 
             for i, (key, value) in enumerate(filter.items()):
+                if not isinstance(key, str) or not _SAFE_METADATA_KEY_RE.fullmatch(key):
+                    raise ValueError(f'Invalid Oracle metadata filter key: {key!r}')
                 param_name = f'value_{i}'
                 query += f" AND JSON_VALUE(vmetadata, '$.{key}' RETURNING VARCHAR2(4096)) = :{param_name}"
                 params[param_name] = str(value)
@@ -762,6 +800,8 @@ class Oracle23aiClient(VectorDBBase):
 
             if filter:
                 for i, (key, value) in enumerate(filter.items()):
+                    if not isinstance(key, str) or not _SAFE_METADATA_KEY_RE.fullmatch(key):
+                        raise ValueError(f'Invalid Oracle metadata filter key: {key!r}')
                     param_name = f'value_{i}'
                     query += f" AND JSON_VALUE(vmetadata, '$.{key}' RETURNING VARCHAR2(4096)) = :{param_name}"
                     params[param_name] = str(value)

--- a/backend/open_webui/retrieval/vector/dbs/pinecone.py
+++ b/backend/open_webui/retrieval/vector/dbs/pinecone.py
@@ -373,12 +373,17 @@ class PineconeClient(VectorDBBase):
             # Search using the first vector (assuming this is the intended behavior)
             query_vector = vectors[0]
 
+            # Combine user filter with collection_name, which is set last so a
+            # caller-supplied key cannot widen the collection scope
+            pinecone_filter = dict(filter) if filter else {}
+            pinecone_filter['collection_name'] = collection_name_with_prefix
+
             # Perform the search
             query_response = self.index.query(
                 vector=query_vector,
                 top_k=limit,
                 include_metadata=True,
-                filter={'collection_name': collection_name_with_prefix},
+                filter=pinecone_filter,
             )
 
             matches = getattr(query_response, 'matches', []) or []
@@ -418,10 +423,10 @@ class PineconeClient(VectorDBBase):
             # Create a zero vector for the dimension as Pinecone requires a vector
             zero_vector = [0.0] * self.dimension
 
-            # Combine user filter with collection_name
-            pinecone_filter = {'collection_name': collection_name_with_prefix}
-            if filter:
-                pinecone_filter.update(filter)
+            # Combine user filter with collection_name, which is set last so a
+            # caller-supplied key cannot widen the collection scope
+            pinecone_filter = dict(filter) if filter else {}
+            pinecone_filter['collection_name'] = collection_name_with_prefix
 
             # Perform metadata-only query
             query_response = self.index.query(
@@ -484,10 +489,10 @@ class PineconeClient(VectorDBBase):
                 log.info("Successfully deleted %s vectors by ID from '%s'", len(ids), collection_name_with_prefix)
 
             elif filter:
-                # Combine user filter with collection_name
-                pinecone_filter = {'collection_name': collection_name_with_prefix}
-                if filter:
-                    pinecone_filter.update(filter)
+                # Combine user filter with collection_name, which is set last so a
+                # caller-supplied key cannot widen the collection scope
+                pinecone_filter = dict(filter)
+                pinecone_filter['collection_name'] = collection_name_with_prefix
                 # Delete by metadata filter
                 self.index.delete(filter=pinecone_filter)
                 log.info("Successfully deleted vectors by filter from '%s'", collection_name_with_prefix)

--- a/backend/open_webui/retrieval/vector/dbs/qdrant.py
+++ b/backend/open_webui/retrieval/vector/dbs/qdrant.py
@@ -3,7 +3,7 @@ NOTE: This vector database integration is community-supported and maintained on 
 """
 
 import logging
-from typing import Optional
+from typing import Any, Optional
 from urllib.parse import urlparse
 
 from open_webui.config import (
@@ -29,6 +29,17 @@ from qdrant_client.models import models
 NO_LIMIT = 999999999
 
 log = logging.getLogger(__name__)
+
+
+def _metadata_filter(key: str, value: Any) -> models.FieldCondition:
+    # Callers pass either a plain value or a Mongo-style {'$in': [...]} set.
+    if isinstance(value, dict):
+        if set(value) != {'$in'}:
+            raise ValueError(f"Unsupported filter operator for '{key}': {sorted(value)}")
+        match = models.MatchAny(any=list(value['$in']))
+    else:
+        match = models.MatchValue(value=value)
+    return models.FieldCondition(key=f'metadata.{key}', match=match)
 
 
 class QdrantClient(VectorDBBase):
@@ -152,10 +163,15 @@ class QdrantClient(VectorDBBase):
         if limit is None:
             limit = NO_LIMIT  # otherwise qdrant would set limit to 10!
 
+        query_filter = None
+        if filter:
+            query_filter = models.Filter(must=[_metadata_filter(key, value) for key, value in filter.items()])
+
         query_response = self.client.query_points(
             collection_name=f'{self.collection_prefix}_{collection_name}',
             query=vectors[0],
             limit=limit,
+            query_filter=query_filter,
         )
         get_result = self._result_to_get_result(query_response.points)
         return SearchResult(
@@ -174,11 +190,7 @@ class QdrantClient(VectorDBBase):
             if limit is None:
                 limit = NO_LIMIT  # otherwise qdrant would set limit to 10!
 
-            field_conditions = []
-            for key, value in filter.items():
-                field_conditions.append(
-                    models.FieldCondition(key=f'metadata.{key}', match=models.MatchValue(value=value))
-                )
+            field_conditions = [_metadata_filter(key, value) for key, value in filter.items()]
 
             points = self.client.scroll(
                 collection_name=f'{self.collection_prefix}_{collection_name}',
@@ -225,15 +237,7 @@ class QdrantClient(VectorDBBase):
                 points_selector=models.PointIdsList(points=ids),
             )
 
-        field_conditions = []
-        if filter:
-            for key, value in filter.items():
-                field_conditions.append(
-                    models.FieldCondition(
-                        key=f'metadata.{key}',
-                        match=models.MatchValue(value=value),
-                    )
-                )
+        field_conditions = [_metadata_filter(key, value) for key, value in filter.items()] if filter else []
 
         return self.client.delete(
             collection_name=f'{self.collection_prefix}_{collection_name}',

--- a/backend/open_webui/retrieval/vector/dbs/qdrant_multitenancy.py
+++ b/backend/open_webui/retrieval/vector/dbs/qdrant_multitenancy.py
@@ -40,7 +40,14 @@ def _tenant_filter(tenant_id: str) -> models.FieldCondition:
 
 
 def _metadata_filter(key: str, value: Any) -> models.FieldCondition:
-    return models.FieldCondition(key=f'metadata.{key}', match=models.MatchValue(value=value))
+    # Callers pass either a plain value or a Mongo-style {'$in': [...]} set.
+    if isinstance(value, dict):
+        if set(value) != {'$in'}:
+            raise ValueError(f"Unsupported filter operator for '{key}': {sorted(value)}")
+        match = models.MatchAny(any=list(value['$in']))
+    else:
+        match = models.MatchValue(value=value)
+    return models.FieldCondition(key=f'metadata.{key}', match=match)
 
 
 class QdrantClient(VectorDBBase):
@@ -258,12 +265,14 @@ class QdrantClient(VectorDBBase):
             log.debug("Collection %s doesn't exist, search returns None", mt_collection)
             return None
 
-        tenant_filter = _tenant_filter(tenant_id)
+        conditions = [_tenant_filter(tenant_id)]
+        if filter:
+            conditions.extend(_metadata_filter(key, value) for key, value in filter.items())
         query_response = self.client.query_points(
             collection_name=mt_collection,
             query=vectors[0],
             limit=limit,
-            query_filter=models.Filter(must=[tenant_filter]),
+            query_filter=models.Filter(must=conditions),
         )
         get_result = self._result_to_get_result(query_response.points)
         return SearchResult(

--- a/backend/open_webui/retrieval/vector/dbs/s3vector.py
+++ b/backend/open_webui/retrieval/vector/dbs/s3vector.py
@@ -324,14 +324,20 @@ class S3VectorClient(VectorDBBase):
                 query_vector_dict = {'float32': [float(x) for x in query_vector]}
 
                 # Call S3 Vector query API
-                response = self.client.query_vectors(
-                    vectorBucketName=self.bucket_name,
-                    indexName=collection_name,
-                    topK=limit,
-                    queryVector=query_vector_dict,
-                    returnMetadata=True,
-                    returnDistance=True,
-                )
+                request_params = {
+                    'vectorBucketName': self.bucket_name,
+                    'indexName': collection_name,
+                    'topK': limit,
+                    'queryVector': query_vector_dict,
+                    'returnMetadata': True,
+                    'returnDistance': True,
+                }
+
+                # Filter server-side so topK is applied to matching vectors only
+                if filter:
+                    request_params['filter'] = filter
+
+                response = self.client.query_vectors(**request_params)
 
                 # Process results for this query
                 query_ids = []
@@ -345,6 +351,10 @@ class S3VectorClient(VectorDBBase):
                     vector_id = vector.get('key')
                     vector_metadata = vector.get('metadata', {})
                     vector_distance = vector.get('distance', 0.0)
+
+                    # Re-check client-side with the same matcher query() uses
+                    if filter and not self._matches_filter(vector_metadata, filter):
+                        continue
 
                     # Extract document text from metadata
                     document_text = ''

--- a/backend/open_webui/retrieval/vector/dbs/weaviate.py
+++ b/backend/open_webui/retrieval/vector/dbs/weaviate.py
@@ -54,6 +54,34 @@ def _convert_uuids_to_strings(obj: Any) -> Any:
         return obj
 
 
+def _build_metadata_filter(filter: dict) -> Any:
+    """Build a Weaviate filter from a non-empty metadata filter dict."""
+    weaviate_filter = None
+    for key, value in filter.items():
+        if isinstance(value, dict):
+            # Callers pass either a plain value or a Mongo-style {'$in': [...]} set.
+            if set(value) != {'$in'}:
+                raise ValueError(f'Unsupported filter operators for property {key!r}: {sorted(value)}')
+
+            allowed_values = list(value['$in'])
+            if not allowed_values:
+                raise ValueError(f'Empty $in filter for property {key!r} cannot be expressed in Weaviate')
+
+            prop_filter = weaviate.classes.query.Filter.any_of(
+                [weaviate.classes.query.Filter.by_property(name=key).equal(item) for item in allowed_values]
+            )
+        else:
+            prop_filter = weaviate.classes.query.Filter.by_property(name=key).equal(value)
+
+        weaviate_filter = (
+            prop_filter
+            if weaviate_filter is None
+            else weaviate.classes.query.Filter.all_of([weaviate_filter, prop_filter])
+        )
+
+    return weaviate_filter
+
+
 class WeaviateClient(VectorDBBase):
     def __init__(self):
         self.url = WEAVIATE_HTTP_HOST
@@ -169,6 +197,9 @@ class WeaviateClient(VectorDBBase):
 
         collection = self.client.collections.get(sane_collection_name)
 
+        # Built outside the loop so an unsupported filter shape raises instead of degrading to an unfiltered search.
+        weaviate_filter = _build_metadata_filter(filter) if filter else None
+
         result_ids, result_documents, result_metadatas, result_distances = (
             [],
             [],
@@ -181,6 +212,7 @@ class WeaviateClient(VectorDBBase):
                 response = collection.query.near_vector(
                     near_vector=vector_embedding,
                     limit=limit,
+                    filters=weaviate_filter,
                     return_metadata=weaviate.classes.query.MetadataQuery(distance=True),
                 )
 


### PR DESCRIPTION
Every vector client now applies the metadata filter passed to search(), combined with the collection or tenant scoping that method already performed, so search() and query() agree on the same filter for a given client.

Filter builders that could express only single-value equality were extended to express set membership, since that is the shape callers send. Metadata keys that land inside a query string rather than a bound parameter are now validated against a conservative pattern, and a filter shape a client cannot fully express raises instead of being applied in part.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
