### PR TITLE
feat: anchor overview edges to node sides in the horizontal layout

### DIFF
--- a/src/lib/components/chat/Overview/Node.svelte
+++ b/src/lib/components/chat/Overview/Node.svelte
@@ -13,6 +13,10 @@
 	type $$Props = NodeProps;
 	export let data: $$Props['data'];
 
+	$: horizontal = data?.direction === 'horizontal';
+	$: targetPosition = horizontal ? Position.Left : Position.Top;
+	$: sourcePosition = horizontal ? Position.Right : Position.Bottom;
+
 	const getMessageContent = (nodeData: any) =>
 		getOutputText(nodeData?.message?.output) || nodeData?.message?.content || '';
 
@@ -89,6 +93,6 @@
 			</div>
 		{/if}
 	</Tooltip>
-	<Handle type="target" position={Position.Top} class="w-2 rounded-full dark:bg-gray-900" />
-	<Handle type="source" position={Position.Bottom} class="w-2 rounded-full dark:bg-gray-900" />
+	<Handle type="target" position={targetPosition} class="w-2 rounded-full dark:bg-gray-900" />
+	<Handle type="source" position={sourcePosition} class="w-2 rounded-full dark:bg-gray-900" />
 </div>

--- a/src/lib/components/chat/Overview/View.svelte
+++ b/src/lib/components/chat/Overview/View.svelte
@@ -105,7 +105,8 @@
 				data: {
 					user: chatUser ?? $user,
 					message: history.messages[id],
-					model: $models.find((model) => model.id === history.messages[id].model)
+					model: $models.find((model) => model.id === history.messages[id].model),
+					direction
 				},
 				position: { x, y }
 			});


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked and filled out the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or active, substantive [Discussion](https://github.com/open-webui/open-webui/discussions) - Relates to #28639, requested by a community member on Discord (linked in the discussion)
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented. No new dependencies.
- [x] **Testing:** **Manual** end-to-end tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **User-facing changes:** I have confirmed whether this PR changes the UI. It does; screenshots are below.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **feat**: New features or enhancements

# Changelog Entry

### Description

- In the chat Overview, the horizontal layout moved the nodes side by side but left every edge anchored to the top and bottom of its nodes, so each edge left the bottom of one node and entered the top of the next. Between nodes on the same row that draws a staircase, and across a longer chat a repeated squiggle along the row.
- `Overview/Node.svelte` hard coded `Position.Top` and `Position.Bottom` on its handles regardless of layout. `Overview/View.svelte` already knows the direction when it builds each node, so it now passes it in the node data, and `Node.svelte` derives the handle positions from it (`Right` and `Left` for horizontal, `Bottom` and `Top` for vertical).
- Vertical mode is unchanged. Discussion: #28639

### Changed

- Overview edges attach to the sides of nodes in the horizontal layout, giving a straight line from each node to the next; the vertical layout keeps its top and bottom anchors.

---

### Additional Information

- The direction is carried in node `data` rather than through the node level `sourcePosition` and `targetPosition` props, and that choice is about the cost of the layout toggle. Setting those props makes xyflow re-measure each node through a per node hook that schedules its own `requestAnimationFrame` and a forced single node update, so a toggle on a longer chat pays N separate store updates and gets noticeably slower than `dev`. Carrying the direction in `data` leaves that hook inert; the redraw then re-measures exactly the way `dev` does, through the resize observer, which delivers every node in one callback and one batched update. The toggle therefore costs what it costs on `dev`.
- Known limitation, stated so it is not mistaken for a regression in review: in Firefox, after switching layouts, an edge can meet its handle dot a few pixels off center until the next redraw. First paint is exact in Firefox and Chromium, and every state is exact in Chromium; the offset comes from Firefox re-measuring reused nodes after their handle changed side, which is the library's measurement, not this change's geometry. The variants that avoid it were tried and rejected: the per node props are correct but slow as above, an explicit batched `updateNodeInternals` after the redraw mis-anchors in Firefox as well, and remounting every node on toggle anchors correctly but re-fires the flow's initialization on each switch and runs away. Toggle speed was judged the higher priority.
- The horizontal spacing already leaves a gap between nodes on the x axis; the straight edge now runs through that gap instead of routing around it, so no spacing change was needed.
- Related, not overlapping: #27995 derives Overview node spacing from rem so sibling nodes never overlap. That change is about where nodes sit; this one is about where edges attach.

**Manual verification performed:**

1. Opened a chat with several turns and at least one regenerated response, so the graph has a branch, then opened Overview.
2. Toggled to the horizontal layout: edges run straight from each node's right side into the next node's left side, and sibling nodes fan out from the parent's right edge.
3. Toggled back to vertical: layout and edges are identical to current `dev`.
4. Toggled between the two several times in Firefox and Chromium and confirmed the toggle is as fast as on `dev` on a chat with around 60 turns.
5. Measured the edge start against the handle center in screen pixels: zero offset in Chromium in both layouts and across repeated toggles; zero offset in Firefox on first paint, with the post toggle offset described under the known limitation.

### Screenshots or Videos

Before is current `dev`. After is this branch. Same chat, Overview panel, horizontal layout.

| Surface | Before | After |
|---|---|---|
| Overview, horizontal layout | <img width="1626" height="1280" alt="image" src="https://github.com/user-attachments/assets/0831f03e-f8e7-4aa7-b78a-61c228c9e78f" /> | <img width="1626" height="1280" alt="image" src="https://github.com/user-attachments/assets/e2a77efb-fc0a-4bc5-9541-d7b9ff84b2b3" /> |
| Overview, horizontal layout with a branched response | <img width="1626" height="1280" alt="image" src="https://github.com/user-attachments/assets/24508b22-70af-4ae8-ab4c-9b9b82b0cf12" /> | <img width="1626" height="1280" alt="image" src="https://github.com/user-attachments/assets/e5e82d37-ba26-4ee1-b593-f71cc62c3e05" /> |

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.



