### PR TITLE
fix: only draw overview handles where an edge attaches

### DIFF
--- a/src/lib/components/chat/Overview/Node.svelte
+++ b/src/lib/components/chat/Overview/Node.svelte
@@ -93,6 +93,10 @@
 			</div>
 		{/if}
 	</Tooltip>
-	<Handle type="target" position={targetPosition} class="w-2 rounded-full dark:bg-gray-900" />
-	<Handle type="source" position={sourcePosition} class="w-2 rounded-full dark:bg-gray-900" />
+	{#if data?.message?.parentId}
+		<Handle type="target" position={targetPosition} class="w-2 rounded-full dark:bg-gray-900" />
+	{/if}
+	{#if (data?.message?.childrenIds ?? []).length > 0}
+		<Handle type="source" position={sourcePosition} class="w-2 rounded-full dark:bg-gray-900" />
+	{/if}
 </div>

--- a/src/lib/components/chat/Overview/Node.svelte
+++ b/src/lib/components/chat/Overview/Node.svelte
@@ -13,6 +13,10 @@
 	type $$Props = NodeProps;
 	export let data: $$Props['data'];
 
+	$: horizontal = data?.direction === 'horizontal';
+	$: targetPosition = horizontal ? Position.Left : Position.Top;
+	$: sourcePosition = horizontal ? Position.Right : Position.Bottom;
+
 	const getMessageContent = (nodeData: any) =>
 		getOutputText(nodeData?.message?.output) || nodeData?.message?.content || '';
 
@@ -89,6 +93,6 @@
 			</div>
 		{/if}
 	</Tooltip>
-	<Handle type="target" position={Position.Top} class="w-2 rounded-full dark:bg-gray-900" />
-	<Handle type="source" position={Position.Bottom} class="w-2 rounded-full dark:bg-gray-900" />
+	<Handle type="target" position={targetPosition} class="w-2 rounded-full dark:bg-gray-900" />
+	<Handle type="source" position={sourcePosition} class="w-2 rounded-full dark:bg-gray-900" />
 </div>

--- a/src/lib/components/chat/Overview/View.svelte
+++ b/src/lib/components/chat/Overview/View.svelte
@@ -105,7 +105,8 @@
 				data: {
 					user: chatUser ?? $user,
 					message: history.messages[id],
-					model: $models.find((model) => model.id === history.messages[id].model)
+					model: $models.find((model) => model.id === history.messages[id].model),
+					direction
 				},
 				position: { x, y }
 			});


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked and filled out the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or active, substantive [Discussion](https://github.com/open-webui/open-webui/discussions) - Relates to #28639, follow up to #28640
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented. No new dependencies.
- [x] **Testing:** **Manual** end-to-end tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **User-facing changes:** I have confirmed whether this PR changes the UI. It does; screenshots are below.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

# Changelog Entry

### Description

- Every Overview node rendered both handle dots regardless of whether an edge attached to them. The root of the graph carried a top dot with nothing entering it, and every leaf, meaning each branch's latest response, carried a bottom dot with nothing leaving it. In the horizontal layout those are a stray dot on the left of the first node and on the right of every last node.
- The message object already reaches the node with `parentId` and `childrenIds`, so `Overview/Node.svelte` now renders the target handle only when the message has a parent and the source handle only when it has children. No new data is threaded through and the edges are unchanged; a node's dots now reflect exactly the edges that touch it.
- Follow up to #28640, which anchors edges to node sides in the horizontal layout, and stacked on it because both edit the same two lines. Discussion: #28639

### Fixed

- Overview nodes no longer show a handle dot on a side that has no edge attached: the root loses its incoming dot and leaves lose their outgoing dot, in both layouts.

---

### Additional Information

- Stacked on #28640 and should merge after it. The diff against that branch is the two `{#if}` guards only; the extra commit and lines GitHub shows here belong to #28640 and collapse once it lands.
- Handle styling is untouched. The dots that remain look exactly as they do on `dev`.

**Manual verification performed:**

1. Opened a chat with several turns and a regenerated response, so the graph has a root, a branch point, and multiple leaves.
2. Vertical layout: the root node has no top dot, each leaf has no bottom dot, every other node keeps both, and every remaining dot has an edge attached.
3. Horizontal layout: the same holds with left and right in place of top and bottom.
4. Toggled between layouts and confirmed the dots follow the edges on each switch.

### Screenshots or Videos

Before is the latest `dev` branch. After is this branch. Same chat, Overview panel.

| Surface | Before | After |
|---|---|---|
| Overview, vertical layout, root and leaf nodes | <img width="1456" height="1275" alt="image" src="https://github.com/user-attachments/assets/e88d2ee4-f6e7-4ef9-b755-9798a2739fc7" /> | <img width="1456" height="1275" alt="image" src="https://github.com/user-attachments/assets/3401f803-59e2-4d22-b821-eb7d95388a70" /> |
| Overview, horizontal layout, root and leaf nodes | <img width="1456" height="1275" alt="image" src="https://github.com/user-attachments/assets/0250722f-027d-4434-8832-7db4c798f84b" /> | <img width="1456" height="1275" alt="image" src="https://github.com/user-attachments/assets/8e72cf29-f081-4173-9c2a-6e7d999b6e52" /> |

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.

