### PR TITLE
fix: use PEP 8 compliant None comparison in title generation

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -3209,7 +3209,7 @@ async def background_tasks_handler(ctx):
                                 }
                             )
 
-                    if title == None and len(messages) == 2 and (not messages_map or len(messages_map) <= 2):
+                    if title is None and len(messages) == 2 and (not messages_map or len(messages_map) <= 2):
                         title = messages[0].get('content', user_message)
 
                         await Chats.update_chat_title_by_id(metadata['chat_id'], title)


### PR DESCRIPTION
Per PEP 8, None comparisons should use 'is None' rather than '== None'. This also protects against overridden __eq__ behavior on custom objects. Single-line change in middleware.py.