### PR TITLE
fix: prevent duplicate uploads during knowledge sync

### DIFF
--- a/backend/open_webui/routers/knowledge.py
+++ b/backend/open_webui/routers/knowledge.py
@@ -47,6 +47,7 @@ from open_webui.utils.access_control import filter_allowed_access_grants, has_pe
 from open_webui.utils.access_control.files import has_access_to_file
 from open_webui.utils.auth import get_admin_user, get_verified_user
 from open_webui.utils.json_codec import JSONCodec
+from open_webui.utils.knowledge_sync import diff_manifest_files
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -1869,6 +1870,9 @@ async def sync_knowledge_diff(
     await _verify_knowledge_write_access(id, user, db)
 
     # ── Index existing state ──
+    # Read pending files first so a file linked between these two queries is
+    # present in at least one index instead of briefly appearing as missing.
+    pending_files = await Files.get_pending_files_for_knowledge(id, db=db)
     knowledge_files = await Knowledges.get_files_with_directory_ids(id, db=db)
     existing_directories = await Knowledges.get_all_directories(id, db=db)
 
@@ -1898,33 +1902,31 @@ async def sync_knowledge_diff(
             'checksum': stored_checksum,
         }
 
+    # Keep exact in-flight matches out of ``added`` so a sync client cannot
+    # re-upload the same content while background processing is still running.
+    # Failed files are intentionally absent from this set and remain retryable.
+    in_flight_files: set[tuple[str, str, str]] = set()
+    for file_model in pending_files:
+        metadata = file_model.meta.model_dump() if file_model.meta else {}
+        upload_metadata = metadata.get('data')
+        if not isinstance(upload_metadata, dict):
+            continue
+
+        directory_id = upload_metadata.get('directory_id')
+        if directory_id and directory_id not in directory_path_by_id:
+            continue
+
+        stored_checksum = metadata.get('file_hash')
+        if stored_checksum:
+            file_path = directory_path_by_id.get(directory_id, '') if directory_id else ''
+            in_flight_files.add((file_path, file_model.filename, stored_checksum))
+
     # ── Diff files ──
-    added: list[dict] = []
-    modified: list[dict] = []
-    deleted: list[dict] = []
-    unmodified_count = 0
-    manifest_keys: set[tuple[str, str]] = set()
-
-    for entry in form_data.manifest:
-        key = (entry.path, entry.filename)
-        manifest_keys.add(key)
-
-        if key not in indexed_files:
-            added.append({'filename': entry.filename, 'path': entry.path})
-        elif indexed_files[key]['checksum'] != entry.checksum:
-            modified.append(
-                {
-                    'filename': entry.filename,
-                    'path': entry.path,
-                    'stale_file_id': indexed_files[key]['file_id'],
-                }
-            )
-        else:
-            unmodified_count += 1
-
-    for key, file_info in indexed_files.items():
-        if key not in manifest_keys:
-            deleted.append({'file_id': file_info['file_id'], 'filename': key[1]})
+    added, modified, deleted, unmodified_count = diff_manifest_files(
+        form_data.manifest,
+        indexed_files,
+        in_flight_files,
+    )
 
     # ── Diff directories ──
     required_directory_paths: set[str] = set()

--- a/backend/open_webui/utils/knowledge_sync.py
+++ b/backend/open_webui/utils/knowledge_sync.py
@@ -1,0 +1,49 @@
+"""Helpers for comparing a local directory manifest with knowledge files."""
+
+from collections.abc import Iterable
+from typing import Protocol
+
+
+class ManifestEntry(Protocol):
+    filename: str
+    path: str
+    checksum: str
+
+
+def diff_manifest_files(
+    manifest: Iterable[ManifestEntry],
+    indexed_files: dict[tuple[str, str], dict],
+    in_flight_files: set[tuple[str, str, str]],
+) -> tuple[list[dict], list[dict], list[dict], int]:
+    """Compare manifest files with linked and currently processing files."""
+    added: list[dict] = []
+    modified: list[dict] = []
+    deleted: list[dict] = []
+    unmodified_count = 0
+    manifest_keys: set[tuple[str, str]] = set()
+
+    for entry in manifest:
+        key = (entry.path, entry.filename)
+        manifest_keys.add(key)
+
+        if key not in indexed_files:
+            if (entry.path, entry.filename, entry.checksum) in in_flight_files:
+                unmodified_count += 1
+            else:
+                added.append({'filename': entry.filename, 'path': entry.path})
+        elif indexed_files[key]['checksum'] != entry.checksum:
+            modified.append(
+                {
+                    'filename': entry.filename,
+                    'path': entry.path,
+                    'stale_file_id': indexed_files[key]['file_id'],
+                }
+            )
+        else:
+            unmodified_count += 1
+
+    for key, file_info in indexed_files.items():
+        if key not in manifest_keys:
+            deleted.append({'file_id': file_info['file_id'], 'filename': key[1]})
+
+    return added, modified, deleted, unmodified_count

--- a/test/backend/test_knowledge_sync.py
+++ b/test/backend/test_knowledge_sync.py
@@ -1,0 +1,84 @@
+from dataclasses import dataclass
+
+from open_webui.utils.knowledge_sync import diff_manifest_files
+
+
+@dataclass
+class ManifestEntry:
+    filename: str
+    path: str
+    checksum: str
+
+
+def test_matching_in_flight_file_is_not_added_again():
+    manifest = [ManifestEntry(filename='guide.md', path='docs', checksum='same-hash')]
+
+    added, modified, deleted, unmodified_count = diff_manifest_files(
+        manifest,
+        indexed_files={},
+        in_flight_files={('docs', 'guide.md', 'same-hash')},
+    )
+
+    assert added == []
+    assert modified == []
+    assert deleted == []
+    assert unmodified_count == 1
+
+
+def test_changed_in_flight_file_can_be_uploaded():
+    manifest = [ManifestEntry(filename='guide.md', path='docs', checksum='new-hash')]
+
+    added, modified, deleted, unmodified_count = diff_manifest_files(
+        manifest,
+        indexed_files={},
+        in_flight_files={('docs', 'guide.md', 'old-hash')},
+    )
+
+    assert added == [{'filename': 'guide.md', 'path': 'docs'}]
+    assert modified == []
+    assert deleted == []
+    assert unmodified_count == 0
+
+
+def test_file_absent_from_in_flight_set_can_be_retried():
+    manifest = [ManifestEntry(filename='failed.md', path='', checksum='file-hash')]
+
+    added, modified, deleted, unmodified_count = diff_manifest_files(
+        manifest,
+        indexed_files={},
+        in_flight_files=set(),
+    )
+
+    assert added == [{'filename': 'failed.md', 'path': ''}]
+    assert modified == []
+    assert deleted == []
+    assert unmodified_count == 0
+
+
+def test_linked_file_changes_are_preserved():
+    manifest = [
+        ManifestEntry(filename='changed.md', path='', checksum='new-hash'),
+        ManifestEntry(filename='same.md', path='', checksum='same-hash'),
+    ]
+    indexed_files = {
+        ('', 'changed.md'): {'file_id': 'changed-id', 'checksum': 'old-hash'},
+        ('', 'same.md'): {'file_id': 'same-id', 'checksum': 'same-hash'},
+        ('', 'deleted.md'): {'file_id': 'deleted-id', 'checksum': 'deleted-hash'},
+    }
+
+    added, modified, deleted, unmodified_count = diff_manifest_files(
+        manifest,
+        indexed_files=indexed_files,
+        in_flight_files=set(),
+    )
+
+    assert added == []
+    assert modified == [
+        {
+            'filename': 'changed.md',
+            'path': '',
+            'stale_file_id': 'changed-id',
+        }
+    ]
+    assert deleted == [{'file_id': 'deleted-id', 'filename': 'deleted.md'}]
+    assert unmodified_count == 1


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Relates to #27987.
- [x] **Target branch:** This PR targets `dev`.
- [x] **Description:** The change and its scope are described below.
- [x] **Changelog:** A Keep a Changelog entry is included below.
- [x] **Documentation:** No documentation update is required; the API shape and user workflow are unchanged.
- [x] **Dependencies:** No dependencies were added or updated.
- [ ] **Testing:** A full manual end-to-end run with a live embedding backend was not performed. Focused regression tests and repository formatting/lint checks pass; exact commands and cases are below.
- [x] **User-facing changes:** There is no UI change, so screenshots are not applicable.
- [ ] **No Unchecked AI Code:** This contribution was AI-assisted and has been self-reviewed and tested, but I am leaving this unchecked rather than representing that an independent human review and full manual end-to-end test have occurred.
- [x] **Self-Review:** The diff was reviewed for behavior, concurrency, and regression risk.
- [x] **Architecture:** The fix reuses the existing pending-file query and adds no setting or API field.
- [x] **Git Hygiene:** The PR is one signed, atomic commit rebased on `dev` with no unrelated changes.
- [x] **Title Prefix:** The title uses the `fix` prefix.

# Changelog Entry

### Description

- Knowledge sync previously indexed only files already linked through `knowledge_file`. An upload still in background processing therefore appeared missing and was returned as `added` on every sync cycle.
- The diff now also indexes exact `(path, filename, checksum)` matches from the existing pending-file query. Matching in-flight uploads count as unmodified, so existing clients skip the duplicate upload without an API contract change.
- Pending files are read before linked files. If an upload finishes between the two queries, it is present in at least one index rather than briefly appearing missing.
- Only `pending` and `processing` files are suppressed. Failed uploads remain absent from the in-flight set and can be retried, and locally changed content remains uploadable.

### Fixed

- Prevented directory sync from repeatedly uploading the same file while its first upload is still being processed, removing the normal sync trigger for orphan accumulation and the duplicate-content race described in #27987.

---

### Additional Information

Focused regression coverage verifies:

1. An exact in-flight match is not returned as added.
2. Changed content at the same path remains uploadable.
3. A file absent from the in-flight set remains retryable.
4. Existing linked-file modified, deleted, and unmodified behavior is preserved.

Verification performed:

```text
PYTHONPATH=backend uvx --from pytest==8.4.1 --with typer --with uvicorn pytest -q test/backend/test_knowledge_sync.py
4 passed

ruff format --check [changed files]
3 files already formatted

ruff check --select=F --ignore=F401,F403,F405,F541,F811,F841 [changed files]
All checks passed
```

### Screenshots or Videos

- Not applicable; this is a backend-only change with no UI output.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.