### PR TITLE
fix: invalidate existing sessions on password change

### DIFF
--- a/backend/open_webui/routers/auths.py
+++ b/backend/open_webui/routers/auths.py
@@ -70,6 +70,7 @@ from open_webui.utils.auth import (
     get_password_hash,
     get_verified_user,
     invalidate_token,
+    revoke_user_tokens,
     validate_password,
     verify_password,
 )
@@ -413,6 +414,16 @@ async def update_password(
                     subject_id=user.id,
                     subject_type='user',
                 )
+                # A password change must not leave old sessions usable. Revoke
+                # every existing JWT for this user so all devices (including
+                # this one) are signed out and must re-authenticate with the
+                # new password.
+                if not await revoke_user_tokens(request.app.state.redis, user.id):
+                    log.warning(
+                        'Password changed for user %s but Redis is not configured; '
+                        'existing sessions cannot be revoked and stay valid until they expire.',
+                        user.id,
+                    )
             return success
         else:
             raise HTTPException(400, detail=ERROR_MESSAGES.INCORRECT_PASSWORD)

--- a/backend/open_webui/routers/users.py
+++ b/backend/open_webui/routers/users.py
@@ -41,6 +41,7 @@ from open_webui.utils.auth import (
     get_admin_user,
     get_password_hash,
     get_verified_user,
+    revoke_user_tokens,
     validate_password,
 )
 from open_webui.utils.chat_variables import ChatVariablesError, normalize_user_variables, validate_user_variables
@@ -966,6 +967,15 @@ async def update_user_by_id(
 
             hashed = await get_password_hash(form_data.password)
             await Auths.update_user_password_by_id(user_id, hashed, db=db)
+            # An admin resetting a user's password must also sign that user out
+            # of every existing session, so a compromised account cannot keep
+            # its old tokens alive.
+            if not await revoke_user_tokens(request.app.state.redis, user_id):
+                log.warning(
+                    'Admin reset password for user %s but Redis is not configured; '
+                    'existing sessions cannot be revoked and stay valid until they expire.',
+                    user_id,
+                )
 
         # Build update dict from only the provided fields
         update_data = {}

--- a/backend/open_webui/test/util/test_auth_revocation.py
+++ b/backend/open_webui/test/util/test_auth_revocation.py
@@ -1,0 +1,56 @@
+import time
+
+import pytest
+
+from open_webui.utils.auth import is_valid_token, revoke_user_tokens
+
+
+class _FakeRedis:
+    """Minimal async stand-in: only get/set are exercised by the auth code."""
+
+    def __init__(self):
+        self._store = {}
+
+    async def get(self, key):
+        return self._store.get(key)
+
+    async def set(self, key, value, ex=None):
+        self._store[key] = value
+
+
+@pytest.mark.asyncio
+async def test_revoke_user_tokens_invalidates_prior_sessions():
+    redis = _FakeRedis()
+    user_id = 'user-123'
+    now = int(time.time())
+
+    # Before any revocation, an existing session token is valid.
+    assert await is_valid_token({'id': user_id, 'iat': now - 10}, redis) is True
+
+    # A password change revokes every existing session for the user.
+    assert await revoke_user_tokens(redis, user_id) is True
+
+    # Any token issued before the revocation is now rejected on its next use.
+    assert await is_valid_token({'id': user_id, 'iat': now - 10}, redis) is False
+
+    # A token issued after the revocation (a fresh login with the new password)
+    # is accepted again.
+    assert await is_valid_token({'id': user_id, 'iat': now + 10}, redis) is True
+
+
+@pytest.mark.asyncio
+async def test_revoke_user_tokens_only_targets_the_given_user():
+    redis = _FakeRedis()
+    now = int(time.time())
+
+    await revoke_user_tokens(redis, 'user-123')
+
+    # Another user's existing sessions are untouched.
+    assert await is_valid_token({'id': 'user-456', 'iat': now - 10}, redis) is True
+
+
+@pytest.mark.asyncio
+async def test_revoke_user_tokens_is_noop_without_redis():
+    # No Redis means there is nowhere to record the revocation, so the helper
+    # reports failure instead of silently pretending the sessions were revoked.
+    assert await revoke_user_tokens(None, 'user-123') is False

--- a/backend/open_webui/utils/auth.py
+++ b/backend/open_webui/utils/auth.py
@@ -279,6 +279,28 @@ async def is_valid_token(decoded, redis=None) -> bool:
     return True
 
 
+async def revoke_user_tokens(redis, user_id: str) -> bool:
+    """
+    Revoke every existing JWT session for a user by recording a per-user
+    `revoked_at` timestamp. `is_valid_token()` rejects any token whose `iat`
+    is at or before this value, so all currently-issued sessions stop working
+    on their next request.
+
+    Mirrors the per-user revocation used by OIDC back-channel logout. Requires
+    Redis: without it there is nowhere to record the timestamp, so this is a
+    no-op that returns False (callers should surface that to the operator).
+    """
+    if not redis:
+        return False
+
+    await redis.set(
+        f'{REDIS_KEY_PREFIX}:auth:user:{user_id}:revoked_at',
+        str(int(datetime.now(UTC).timestamp())),
+        ex=60 * 60 * 24 * 30,
+    )
+    return True
+
+
 async def invalidate_token(request, token):
     decoded = decode_token(token)
 


### PR DESCRIPTION
Changing a password did not revoke a user's existing JWT sessions, so every previously logged-in device stayed authenticated on the old credentials until the token expired (default 4 weeks). The hardening docs already state that, with Redis configured, changing a password revokes the user's tokens - but the code never implemented it for the password-change path. This PR makes the code match the documented behavior.

Record a per-user `revoked_at` timestamp (the same primitive OIDC back-channel logout already uses) on password change, covering both self-service (`/auths/update/password`) and admin reset (`/users/{user_id}/update`). `is_valid_token()` then rejects any token issued before the change, signing the user out of every device. Requires Redis; logs a warning when it is not configured instead of silently doing nothing.

Relates to #28647.

<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Note to first-time contributors: Please open a discussion post in [Discussions](https://github.com/open-webui/open-webui/discussions) to discuss your idea/fix with the community before creating a pull request, and describe your changes before submitting a pull request.

This is to ensure large feature PRs are discussed with the community first, before starting work on it. If the community does not want this feature or it is not relevant for Open WebUI as a project, it can be identified in the discussion before working on the feature and submitting the PR.

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Relates to #28647.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [x] **Documentation:** No docs change needed - the hardening page already documents this behavior (with Redis, a password change revokes the user's tokens); this PR makes the code match the docs.
- [x] **Dependencies:** No new or updated dependencies are introduced.
- [x] **Testing:** Manual testing performed (see Additional Information).
- [x] **No Unchecked AI Code:** This PR has undergone human review and manual testing.
- [x] **Self-Review:** A self-review of the code has been performed.
- [x] **Architecture:** No new settings are added. The change reuses the existing Redis-backed per-user revocation used by OIDC back-channel logout.
- [x] **Git Hygiene:** The PR is atomic (one logical change), based on `dev`, single commit.
- [x] **Title Prefix:** The PR title uses the `fix` prefix.

# Changelog Entry

### Description

- Changing a password now revokes the user's existing session tokens, so all previously logged-in devices are signed out. Closes a gap (noted in the hardening docs) where sessions stayed valid on the old password until the token expired.

### Added

- `revoke_user_tokens()` helper in `utils/auth.py` that records a per-user `revoked_at` timestamp, reusing the primitive already used by OIDC back-channel logout.

### Security

- Existing session tokens are now invalidated on password change - both self-service (`/api/v1/auths/update/password`) and admin reset (`/api/v1/users/{user_id}/update`) - signing out all devices and requiring re-authentication with the new password. Requires Redis; logs a warning when Redis is not configured instead of silently doing nothing.

---

### Additional Information

- Relates to discussion #28647.
- **Design note:** the acting user's current session is also revoked, so they re-authenticate with the new password. Keeping the current device signed in would require reissuing a token plus a small frontend change - happy to follow up if preferred (raised as an open question in #28647).
- **Testing performed:**
  - `ruff format --check` and `ruff check --select=F` (the backend CI checks) pass.
  - Added unit tests in `backend/open_webui/test/util/test_auth_revocation.py`.
  - Live end-to-end run (real Redis + running server): confirmed the old token returns `401` after a password change, the `revoked_at` key is written, and a fresh login with the new password succeeds.

### Screenshots or Videos

- N/A (backend-only change).

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
