### PR TITLE
fix: keep the viewport in place when older messages load above it

### DIFF
--- a/src/lib/components/chat/Messages.svelte
+++ b/src/lib/components/chat/Messages.svelte
@@ -66,11 +66,8 @@
 	});
 
 	const loadMoreMessages = async () => {
-		// scroll slightly down to disable continuous loading
 		const element = getMessagesContainer();
-		if (element) {
-			element.scrollTop = element.scrollTop + 100;
-		}
+		const previousScrollHeight = element?.scrollHeight ?? 0;
 
 		messagesLoading = true;
 		messagesCount += 8;
@@ -78,6 +75,10 @@
 		buildMessages();
 
 		await tick();
+
+		if (element) {
+			element.scrollTop += element.scrollHeight - previousScrollHeight;
+		}
 
 		messagesLoading = false;
 	};


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked and filled out the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or active, substantive [Discussion](https://github.com/open-webui/open-webui/discussions) - Fixes #28656
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented. No new dependencies.
- [x] **Testing:** **Manual** end-to-end tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **User-facing changes:** I have confirmed whether this PR changes the UI. It changes scroll behavior only; the visible difference is where a chat opens and how the view behaves while older messages load, captured below.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

# Changelog Entry

### Description

- Opening a chat whose recent messages are short landed the view mid conversation rather than at the latest message. The last 8 messages fit on screen together with the load-more sentinel above them, so the sentinel fired immediately and prepended older messages, and nothing preserved the viewport across the prepend; the view ended wherever that cascade stopped. Chats with ordinary length messages start with the sentinel off screen and never hit this on open, though the same missing anchoring shows as a jump whenever older messages load while scrolling up.
- `loadMoreMessages` now records `scrollHeight` before the prepend and adds the difference to `scrollTop` after it, so the viewport stays on the same messages while older ones load above. The `scrollTop += 100` nudge, whose only purpose was to push the sentinel out of view to stop it firing, is removed as unnecessary.

### Fixed

- Chats open at the latest message regardless of how short the recent messages are, and loading older messages while scrolling up no longer shifts the view.

---

### Additional Information

- The `Loader` sentinel fires on a 100ms interval for as long as it is at least 10% visible, guarded by `messagesLoading`. Removing the nudge means the sentinel stays in view after a load when the messages are short, and it correctly fires again until it scrolls off screen or the root message is reached. It terminates because the `Loader` only renders while the first loaded message has a parent, so it unmounts once the root is loaded. On a chat that fits on screen entirely, that means it loads to the root and stops.
- On open, the view stays pinned to the latest messages through the initial cascade, which is what fixes the reported symptom without any change to the initial scroll-to-bottom.

**Manual verification performed:**

1. Reproduced on `dev`: a chat of short generated turns opened mid conversation.
2. On this branch the same chat opens at the latest message.
3. On a long chat with ordinary messages, scrolled up through several batches of older messages: each batch loads above the view without shifting it.
4. On a chat short enough to fit on screen entirely, confirmed it loads through to the first message and the loader disappears.

### Screenshots or Videos

Before is current `dev`. After is this branch. Same chat of short generated turns, opened fresh.

| Surface | Before | After |
|---|---|---|
| Opening a chat with many short messages | https://github.com/user-attachments/assets/128f7565-5495-495e-b661-b25a50f8f3c7 | https://github.com/user-attachments/assets/da132bba-5904-407f-9ba8-d42d16722842 |

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
