### PR TITLE
fix: scroll to the top of a chat on the first click of Scroll to Top

### DIFF
--- a/src/lib/components/chat/Messages.svelte
+++ b/src/lib/components/chat/Messages.svelte
@@ -159,12 +159,17 @@
 		messagesCount = null;
 		buildMessages();
 		await tick();
-		if (messages.length > 0) {
-			const firstMessageEl = document.getElementById(`message-${messages[0].id}`);
-			if (firstMessageEl) {
-				firstMessageEl.scrollIntoView({ behavior: 'smooth', block: 'start' });
-			}
-		}
+
+		const element = getMessagesContainer();
+		if (!element) return;
+
+		element.scrollTo({ top: 0, behavior: 'smooth' });
+		requestAnimationFrame(() => {
+			element.scrollTo({ top: 0, behavior: 'smooth' });
+			requestAnimationFrame(() => {
+				element.scrollTo({ top: 0, behavior: 'smooth' });
+			});
+		});
 	};
 
 	const updateChat = async () => {


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked and filled out the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or active, substantive [Discussion](https://github.com/open-webui/open-webui/discussions) - Fixes #28658
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented. No new dependencies.
- [x] **Testing:** **Manual** end-to-end tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **User-facing changes:** I have confirmed whether this PR changes the UI. It changes scroll behavior only; the visible difference is where the view lands after one click, captured below.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

# Changelog Entry

### Description

- On a chat with more messages than are initially loaded, the first click of Scroll to Top loaded the remaining messages but landed the view below the first message; a second click was needed to reach the top.
- `scrollToTop` rebuilt the full list and then called `scrollIntoView` on the first message element. Newly mounted messages carry `content-visibility: auto` with a 150px intrinsic size estimate until they are laid out, so the target position was computed from estimates, landed short, and moved further away as the real heights resolved.
- It now scrolls the messages container to `top: 0`, which does not depend on any element's estimated position, and repeats the scroll across two animation frames so it re-lands as the heights resolve, matching what `scrollToBottom` in `Chat.svelte` already does for the opposite direction.

### Fixed

- Scroll to Top reaches the first message on the first click, whether or not older messages were already loaded.

---

### Additional Information

- Nothing sits above the message list inside the container except a visually hidden heading and the top padding, so `top: 0` is the first message. Once the full list is built the load-more sentinel is gone as well, since it only renders while the first loaded message has a parent.
- The two-frame re-scroll is the same pattern `scrollToBottom` in `Chat.svelte` uses for the same reason, documented there: `content-visibility: auto` makes the initial scroll geometry an estimate that settles across frames.

**Manual verification performed:**

1. Reproduced on `dev`: on a chat with well over 8 messages, the first Scroll to Top click loaded the rest but stopped short of the first message; the second click reached it.
2. On this branch the first click reaches the first message, on a chat of many short generated turns and on a long chat with ordinary messages.
3. Confirmed a chat that was already fully loaded still scrolls to the top on one click.

### Screenshots or Videos

Before is current `dev`. After is this branch. Same long chat, one click of Scroll to Top from the bottom.

| Surface | Before | After |
|---|---|---|
| View after one click of Scroll to Top | <img width="2331" height="1277" alt="image" src="https://github.com/user-attachments/assets/04ac9345-cd28-4af2-9ef0-7de42077acaa" /> | <img width="2331" height="1277" alt="image" src="https://github.com/user-attachments/assets/c2f208ba-b718-4842-87c2-027a6cadb0be" /> |

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
