### PR TITLE
Fix: reasoning being dropped when replaying Ollama messages

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2038,10 +2038,10 @@ def get_reasoning_format(model: dict) -> str | None:
         'reasoning_content': llama.cpp supports reasoning_content as a top-level field.
         None: skip reasoning (safe default for strict providers).
     """
-    provider = model.get('provider', '')
-    if provider == 'ollama':
+    # owned_by is the same flag that routes to the native Ollama API; provider only exists on OpenAI connections.
+    if model.get('owned_by') == 'ollama':
         return 'think_tags'
-    if provider == 'llama.cpp':
+    if model.get('provider') == 'llama.cpp':
         return 'reasoning_content'
     return None
 


### PR DESCRIPTION
When an Ollama model emits its thinking as structured reasoning deltas rather than inline tags, Open WebUI stores that reasoning separately and rebuilds the assistant message from it on the next turn and inside tool-call loops. Picking the Ollama rebuild format looked for a provider value of "ollama" on the model, but only OpenAI connections ever carry a provider, so the check never matched and the model's own thinking was silently dropped from every follow-up request.

Match on owned_by instead, which is the same field that decides a request goes to Ollama's native API in the first place, so the reasoning is sent back as think tags as intended. The llama.cpp branch keeps reading provider, which is a real value there.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
