### PR TITLE
fix: fetch sidebar folders once per refresh instead of three times

### DIFF
--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -308,10 +308,6 @@
 		folders = folderMap;
 	};
 
-	const initSharedFolders = async () => {
-		await initFolders();
-	};
-
 	const createFolder = async ({ name, data, parent_id }) => {
 		name = name?.trim();
 		if (!name) {
@@ -384,8 +380,6 @@
 		allChatsLoaded = false;
 		chatListReady = false;
 
-		initFolders();
-		initSharedFolders();
 		await Promise.all([
 			(async () => {
 				console.log('Init tags');


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked and filled out the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or active, substantive [Discussion](https://github.com/open-webui/open-webui/discussions) - Fixes #28661
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented. No new dependencies.
- [x] **Testing:** **Manual** end-to-end tests have been performed to verify the fix/feature works correctly and does not introduce regressions.
- [x] **User-facing changes:** I have confirmed whether this PR changes the UI. It does not; the sidebar renders identically, with fewer requests behind it.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

# Changelog Entry

### Description

- Every sidebar refresh issued `GET /folders/` and `GET /folders/shared` three times. `initChatList` fetched folders through three paths on each call: a leading `initFolders()`, then `initSharedFolders()`, whose entire body was `await initFolders()`, and then `refreshChatRows()`, which calls `initFolders()` again once the chat rows have landed. Each `initFolders` fetches both endpoints, so that was three full pairs per refresh, on page load and on every action that refreshes the sidebar.
- The first two are removed. `refreshChatRows` is the single remaining caller, which is also the correct ordering: folders load after the chat rows, so folder items reflect fresh state. `initSharedFolders` is deleted with its one call site.

### Fixed

- The sidebar fetches its folder list once per refresh instead of three times.

---

### Additional Information

- Pure deletion, six lines. `initSharedFolders` had no other callers and did nothing `initFolders` does not.
- `refreshChatRows` skips its `initFolders` call only when a newer refresh has superseded the current one (`generation !== requestGeneration` in `chatList.ts`); that newer refresh fetches folders itself, so folders always load on the refresh that wins. Nothing inside `initChatList`'s parallel branches (tags, pinned notes) reads folder state, so nothing depended on folders being fetched first.
- Measured with a fetch counter keyed on the full URL. On `dev`, one drag and drop of a chat back into place produced `folders/` x3 and `folders/shared` x3, in three distinct waves matching the three call sites. On this branch the same action produces one of each.

**Manual verification performed:**

1. Reproduced on `dev` with a full URL fetch counter: `folders/` x3, `folders/shared` x3 per sidebar refresh.
2. On this branch: x1 each, on page load and after a drag and drop in the sidebar.
3. Confirmed folders and their contents render correctly on page load, and after moving a chat into and out of a folder.

### Screenshots or Videos

#### Before

<img width="2558" height="427" alt="image" src="https://github.com/user-attachments/assets/09851b86-6918-42f8-9e52-74c3cb5af1d4" />

#### After

<img width="2558" height="427" alt="image" src="https://github.com/user-attachments/assets/6df27c97-d9dc-4473-b0c7-7e20db993d71" />

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
