### PR TITLE
fix: skip the sidebar refresh when a chat is dropped back where it already is

### DIFF
--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -1436,6 +1436,10 @@
 
 								if (chat) {
 									console.log(chat);
+									if (!chat.folder_id && !chat.pinned) {
+										return;
+									}
+
 									if (chat.folder_id) {
 										const res = await updateChatFolderIdById(
 											localStorage.token,


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked and filled out the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or active, substantive [Discussion](https://github.com/open-webui/open-webui/discussions) - Fixes #28663
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented. No new dependencies.
- [x] **Testing:** **Manual** end-to-end tests have been performed to verify the fix/feature works correctly and does not introduce regressions.
- [x] **User-facing changes:** I have confirmed whether this PR changes the UI. It does not; a no-op drop now leaves the sidebar as it is, which is what it visually did already.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

# Changelog Entry

### Description

- Dropping a chat back onto the sidebar's chats list when it was already there, not in a folder and not pinned, triggered a full `initChatList()` refresh (folders, tags, pinned notes and chats, the chat list, per folder listings) for a drop that wrote nothing.
- The drop handler now returns early when the fetched chat has no `folder_id` and is not pinned, since neither of its two write branches applies and the refresh would have nothing to reflect. Drops that move a chat out of a folder or unpin it still refresh as before.

### Fixed

- A chat dropped back where it already is no longer triggers a sidebar refresh.

---

### Additional Information

- Four lines. The early return follows the shape the handler already uses for the access denied case in the same block, and the only code after the `chat` branch is the `else if (type === 'folder')` arm, so nothing is skipped.
- The single `GET /chats/{id}` that determines whether the drop is a no-op is kept; it is what tells the handler there is nothing to do.
- Independent of #28662, which reduces the cost of a refresh when one does happen; this one avoids a refresh that should not happen at all.

**Manual verification performed:**

1. Reproduced on `dev` with a fetch counter: dragging a root, unpinned chat slightly and dropping it in place issued the full refresh set.
2. On this branch the same drop issues only the single `GET /chats/{id}` and nothing else.
3. Dragged a chat out of a folder onto the chats list and confirmed it moves and the sidebar refreshes as before.

### Screenshots or Videos

#### Before

<img width="2559" height="685" alt="image" src="https://github.com/user-attachments/assets/45ed3b99-27cf-498d-b656-4a8ad4368d10" />

#### After

<img width="2558" height="427" alt="image" src="https://github.com/user-attachments/assets/682dd563-f9cb-464f-beba-94fd2c3cf005" />

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
