### PR TITLE
fix: say why OAuth client data failed to decrypt instead of logging an empty error

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -614,7 +614,11 @@ async def initialize_runtime_config(app: FastAPI):
                         OAuthClientInformationFull(**oauth_client_info),
                     )
                 except Exception as e:
-                    log.error(f'Error adding OAuth client for MCP tool server {server_id}: {e}')
+                    log.error(
+                        'Error adding OAuth client for MCP tool server %s: %s',
+                        server_id,
+                        f'{type(e).__name__}: {e}' if str(e) else type(e).__name__,
+                    )
 
     arena_models = await Config.get('evaluation.arena.models', []) or []
     if any('access_control' in m.get('meta', {}) for m in arena_models):

--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -19,7 +19,7 @@ import jwt
 from authlib.integrations.starlette_client import OAuth
 from authlib.oauth2.rfc6749.errors import OAuth2Error
 from authlib.oidc.core import UserInfo
-from cryptography.fernet import Fernet
+from cryptography.fernet import Fernet, InvalidToken
 from fastapi import (
     HTTPException,
     status,
@@ -279,8 +279,15 @@ def decrypt_data(data: str):
     try:
         decrypted = FERNET.decrypt(data.encode()).decode()
         return JSONCodec.loads(decrypted)
+    except InvalidToken:
+        log.error(
+            'Error decrypting data: the stored value is not a valid token for the current key. '
+            'If WEBUI_SECRET_KEY or OAUTH_CLIENT_INFO_ENCRYPTION_KEY changed, the affected '
+            'OAuth client must be registered again.'
+        )
+        raise
     except Exception as e:
-        log.error(f'Error decrypting data: {e}')
+        log.error('Error decrypting data: %s: %s', type(e).__name__, e)
         raise
 
 


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked and filled out the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or active, substantive [Discussion](https://github.com/open-webui/open-webui/discussions) - Fixes #28665
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented. No new dependencies; `InvalidToken` comes from `cryptography.fernet`, already imported in the same file for `Fernet`.
- [x] **Testing:** **Manual** end-to-end tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Verified by executing the shipped module against both failure modes; details below.
- [x] **User-facing changes:** I have confirmed whether this PR changes the UI. It does not; backend log output only.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

# Changelog Entry

### Description

- When a stored MCP OAuth client blob could not be decrypted at startup, the backend logged `Error decrypting data:` and `Error adding OAuth client for MCP tool server <id>:` with nothing after either colon, on every startup, while the server's OAuth client silently failed to register. The exception in that case is `cryptography.fernet.InvalidToken`, whose `str()` is empty by design, so `f'... {e}'` printed nothing for the most common failure.
- `decrypt_data` now catches `InvalidToken` and logs what it means and what to do: the stored value is not a valid token for the current key, and if `WEBUI_SECRET_KEY` or `OAUTH_CLIENT_INFO_ENCRYPTION_KEY` changed the affected OAuth client must be registered again. The generic path names the exception type, matching how `utils/valves.py` already handles the same failure. The caller in `initialize_runtime_config` includes the exception type, without a trailing colon when the exception carries no message.

### Fixed

- OAuth client decryption failures at startup now say why they failed and how to recover, instead of logging an empty error twice.

---

### Additional Information

- The message reads "not a valid token for the current key" rather than "encrypted with a different key" on purpose: executing the code showed that a corrupt or non token string raises the same `InvalidToken` as a wrong key blob, so the wider wording is the accurate one for both.
- The caller line formats as `<id>: InvalidToken` when the exception has no message and `<id>: ValueError: boom` when it does, so neither shape ends in a dangling colon.
- No behavior change beyond logging: `decrypt_data` still re-raises, and the same key round trip still decrypts with nothing logged.

**Manual verification performed:**

1. Reproduced the reported failure on `dev`: an MCP server whose OAuth blob was encrypted under a previous `WEBUI_SECRET_KEY` logged both empty lines on every startup; re-registering the server's OAuth cleared them, confirming the key mismatch as the cause.
2. Verified the fix by importing the shipped `open_webui.utils.oauth` module from this branch in the backend's own interpreter and calling `decrypt_data` on a blob genuinely encrypted under a different key: it logs the new actionable message and raises `InvalidToken`, and the caller expression renders `ntn: InvalidToken`.
3. Same harness on a corrupt non token string: same `InvalidToken` path and message.
4. Same harness on an `encrypt_data` then `decrypt_data` round trip under one key: decrypts correctly with no error logged.

### Screenshots or Videos

Not applicable; backend log output only. Before and after log lines are shown in the description.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.

