### PR TITLE
fix: keep the pending note save when an update carries no content snapshot

### DIFF
--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -802,11 +802,6 @@ async def yjs_document_update(sid, data):
                 log.warning(f'User {user.get("id")} does not have write access to note {note_id}. Rejecting update.')
                 return
 
-        try:
-            await stop_item_tasks(REDIS, document_id)
-        except Exception:
-            pass
-
         user_id = data.get('user_id', sid)
 
         update = data['update']  # List of bytes from frontend
@@ -834,6 +829,16 @@ async def yjs_document_update(sid, data):
             await document_save_handler(document_id, data.get('data', {}), user)
 
         if data.get('data'):
+            # Only drop the pending save when a new one takes its place.
+            # Updates without a content snapshot (the resync a client sends
+            # after rejoining a document) would otherwise cancel the pending
+            # save without scheduling a replacement, so the edits made just
+            # before the resync never reach the database.
+            try:
+                await stop_item_tasks(REDIS, document_id)
+            except Exception:
+                pass
+
             await create_task(REDIS, debounced_save(), document_id)
 
     except Exception as e:


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #28667
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry is included at the bottom.
- [ ] **Documentation:** Not applicable — no documented behaviour changes.
- [ ] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Manually verified against a running instance, with a control run on the unpatched image. Details below.
- [ ] **No Unchecked AI Code:** *(see note below)*
- [x] **Self-Review:** A self-review of the code has been performed.
- [x] **Architecture:** No new setting and no new behaviour — one condition corrected.
- [x] **Git Hygiene:** Atomic, based on `dev`, no unrelated commits.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

Editing a note can silently lose the most recent keystrokes. The editor keeps showing the full text, but the database holds an older revision, and nothing ever catches up — only typing one more character brings the rest through.

In `yjs_document_update` the cancellation of the pending save and the scheduling of the new one sit under different conditions: `stop_item_tasks()` runs unconditionally, while `create_task()` only runs when the update carries `data`. An update without a content snapshot therefore deletes the pending save without scheduling a replacement.

`SocketIOCollaborationProvider` sends exactly such an update when the server reports an empty document state while the editor already holds content. That happens for notes created outside the collaborative editor (the `write_note` builtin tool, direct `POST /api/v1/notes/create` callers), and on deployments without Redis after a restart, because `YdocManager` keeps its update log in process memory while `note.data.content` survives in the database.

Nothing recovers from it: `NoteEditor.svelte` has no save on unmount (`onDestroy` only detaches listeners), and its REST debounce sends `title`, `data.files` and `access_grants`, never `data.content`. The Yjs path is the only writer of note text.

This change moves the cancellation under the same condition as the scheduling, so a pending save is only dropped when a new one takes its place.

### Fixed

- Note edits are no longer lost when a `ydoc:document:update` without a content snapshot arrives while a save is pending.

---

### Additional Information

Verified against a running instance — same database, same note route, only the image differing:

| scenario | v0.11.0 | with this change |
| --- | --- | --- |
| updates carrying content only | `ABCDEFGHIJKL` | `ABCDEFGHIJKL` |
| same, then one update without `data` | *(empty)* | `ABCDEFGHIJKL` |

The client had "typed" `ABCDEFGHIJKL` in both cases. The control run on the unpatched image is included because a test that cannot fail proves nothing.

This narrows, but does not close, the window behind #28539 — a client state is still written without being reconciled against the stored document. That needs a separate fix on the seeding side, and this PR does not claim to address it.

**On the "No Unchecked AI Code" checkbox:** the change was drafted with AI assistance and is left unchecked until I have reviewed and signed off on it myself. I will tick it once done, rather than have it ticked on my behalf.

### Contributor License Agreement

- [ ] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
