### PR TITLE
fix: keep the sidebar channel settings button inside the row on long channel names

### DIFF
--- a/src/lib/components/layout/Sidebar/ChannelItem.svelte
+++ b/src/lib/components/layout/Sidebar/ChannelItem.svelte
@@ -50,6 +50,9 @@
 			notation: 'compact',
 			compactDisplay: 'short'
 		}).format(count);
+
+	$: hasActions =
+		channel?.type === 'dm' || $user?.role === 'admin' || channel?.user_id === $user?.id;
 </script>
 
 <ChannelModal
@@ -88,7 +91,7 @@
 		: ' dark:text-gray-400 text-gray-600'} cursor-pointer select-none"
 >
 	<a
-		class=" w-full flex"
+		class=" w-full min-w-0 flex {hasActions ? 'group-hover:pr-6 group-focus-within:pr-6' : ''}"
 		href="/channels/{channel.id}"
 		on:click={() => {
 			console.log(channel);
@@ -203,7 +206,7 @@
 	</a>
 
 	{#if ['dm'].includes(channel?.type)}
-		<div class="ml-0.5 mr-1 hover-reveal self-center flex items-center dark:text-gray-300">
+		<div class="hover-reveal absolute right-2 inset-y-0 flex items-center dark:text-gray-300">
 			<button
 				type="button"
 				class="p-0.5 dark:hover:bg-gray-850 rounded-lg touch-auto"
@@ -227,8 +230,8 @@
 				<XMarkIcon className="size-3.5" />
 			</button>
 		</div>
-	{:else if $user?.role === 'admin' || channel.user_id === $user?.id}
-		<div class="ml-0.5 mr-1 hover-reveal self-center flex items-center dark:text-gray-300">
+	{:else if hasActions}
+		<div class="hover-reveal absolute right-2 inset-y-0 flex items-center dark:text-gray-300">
 			<button
 				type="button"
 				class="p-0.5 dark:hover:bg-gray-850 rounded-lg touch-auto"


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked and filled out the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or active, substantive [Discussion](https://github.com/open-webui/open-webui/discussions) - Fixes #28670
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented. No new dependencies.
- [x] **Testing:** **Manual** end-to-end tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **User-facing changes:** I have confirmed whether this PR changes the UI. It does; screenshots below.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

# Changelog Entry

### Description

- In the sidebar Channels section, a channel with a long name showed its hover settings gear pushed past the sidebar edge and clipped, while a short name showed the gear inside the highlight. Since 759369808 the channel name is `truncate` (`white-space: nowrap`) and the two flex boxes around it have `min-w-0`, but the `<a>` wrapping them stayed `w-full flex` with the flex default `min-width: auto`. With no break opportunity its minimum content size is the full name width, so once the name is wider than the row the `<a>` cannot shrink, and the gear wrapper, a flex sibling of the `<a>`, is pushed out of the row and clipped by the sidebar's `overflow-x-hidden`.
- Letting the `<a>` shrink on its own would fix the clipping but cost every row the gear's width permanently, because the wrapper stays in the flex flow at opacity 0 (it is `hover-reveal`, kept in the DOM so keyboard focus can reveal it). Names would truncate earlier than they do on `dev` today.
- This PR instead brings `ChannelItem` in line with `ChatItem`, which already solves this for chat rows: the action wrapper (settings gear, or the leave button on DM rows) becomes an `absolute right-2 inset-y-0` overlay inside the row, the `<a>` gets `min-w-0`, and on rows that render a button the `<a>` takes `group-hover:pr-6 group-focus-within:pr-6` so the name pads itself away from the button while it is shown, the way `ChatItem` applies `pr-12` while its actions are visible. Idle rows keep the full row width for the name; hovering or focusing a long name moves its ellipsis left by the button's width instead of pushing the button out of the sidebar.
- The "does this row have a button" condition is computed once as `hasActions` and used for both the padding and the `{:else if}` that renders the gear, so the two cannot drift.

### Fixed

- Sidebar channel rows keep the settings gear (and the DM leave button) inside the row for long channel names instead of pushing it out of the sidebar, without giving up name width when the row is not hovered.

---

### Additional Information

- Same overlay pattern as `src/lib/components/layout/Sidebar/ChatItem.svelte` (`#sidebar-chat-item-menu`: `hover-reveal absolute right-1 inset-y-0`, title `pr-12` while actions show). Keyboard reveal is unchanged: `hover-reveal` still toggles on `.group:focus-within`, and the padding uses the matching `group-focus-within:` variant.
- Rows with no button (a non admin viewing a channel they do not own) get no hover padding, so their names are untouched.

**Manual verification performed:**

1. Reproduced on `dev` with the exact markup and the compiled Tailwind at a 220px sidebar, in Chrome and Firefox: long names gave `a.right = 209`, `gear.right = 229` (past the sidebar edge at 220); short names gave `a.right = 185`, `gear.right = 205`.
2. On this branch, on a live instance with seven channels of mixed lengths, idle: the `<a>` spans the full row on every row (`right = 199` against the row's inner edge at `203.8`), the gear sits at `172.6..194.2` at opacity 0 on every row, `benchmark-tool-webhook` and `forward-to-channel-testing` show 153px of name where the shrink only variant showed 125px, and `workflow-canvas` and `delete-me-channel` are no longer truncated at all.
3. Same instance, hovered or with the gear focused: the `<a>` gains the padding, the name ends at 170.2, left of the gear at 172.6, and the gear is fully inside the row at the same position on every row.
4. Confirmed in a browser by hovering long and short named channels: the gear appears in the same spot inside the highlight for both, long names truncate under hover and reclaim the width when the pointer leaves, and the gear opens the channel modal.

### Screenshots or Videos

Before is current `dev`. After is this branch.

| Surface | Before | After |
|---|---|---|
| Sidebar Channels section, hovering a channel with a long name | <img width="221" height="282" alt="image" src="https://github.com/user-attachments/assets/6e9a4380-2a0e-41b9-9520-81937bb6808c" /> | <img width="221" height="282" alt="image" src="https://github.com/user-attachments/assets/cd06a198-c17a-4b56-aa21-44720acb76b9" /> |
| Sidebar Channels section, hovering a channel with a short name | <img width="221" height="282" alt="image" src="https://github.com/user-attachments/assets/7ffc661c-539f-48d1-a8e7-9f02bb67950a" /> | <img width="221" height="282" alt="image" src="https://github.com/user-attachments/assets/a7d401c2-7c09-45bd-86b7-b8873136d4fa" /> |
| Sidebar Channels section, not hovered (name width) | <img width="221" height="282" alt="image" src="https://github.com/user-attachments/assets/0a2e8dd4-3c53-4319-8123-e579ae7ffa7c" /> | <img width="221" height="282" alt="image" src="https://github.com/user-attachments/assets/ff5d0ed4-40fb-436b-9478-736ddc709a57" /> |

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
