### PR TITLE
fix: restore iOS 27 voice mode audio playback

### DIFF
--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -64,6 +64,7 @@
 	import { getSessionUser } from '$lib/apis/auths';
 
 	import { WEBUI_BASE_URL, WEBUI_API_BASE_URL, PASTED_TEXT_CHARACTER_LIMIT } from '$lib/constants';
+	import { unlockIOSCallAudio } from '$lib/utils/ios-call-audio';
 	import { initiateOAuthRedirect } from '$lib/apis/configs';
 	import { matchKeybinding, Shortcut } from '$lib/shortcuts';
 
@@ -2520,6 +2521,11 @@
 
 																return;
 															}
+															// iOS requires audio to be unlocked while the original
+															// Voice Mode user gesture is still active. This must
+															// happen before getUserMedia() or any awaited operation.
+															unlockIOSCallAudio();
+
 															// check if user has access to getUserMedia
 															try {
 																let stream = await navigator.mediaDevices.getUserMedia({

--- a/src/lib/components/chat/MessageInput/CallOverlay.svelte
+++ b/src/lib/components/chat/MessageInput/CallOverlay.svelte
@@ -14,6 +14,11 @@
 	import VideoInputMenu from './CallOverlay/VideoInputMenu.svelte';
 	import { KokoroWorker } from '$lib/workers/KokoroWorker';
 	import { WEBUI_API_BASE_URL } from '$lib/constants';
+	import {
+		canUseIOSCallAudio,
+		playIOSCallAudio,
+		stopIOSCallAudio
+	} from '$lib/utils/ios-call-audio';
 
 	const i18n = getContext('i18n');
 
@@ -427,39 +432,61 @@
 		}
 	};
 
-	const playAudio = (audio) => {
-		if ($showCallOverlay) {
-			return new Promise((resolve) => {
-				const audioElement = document.getElementById('audioElement') as HTMLAudioElement;
-
-				if (audioElement) {
-					audioElement.src = audio.src;
-					audioElement.muted = true;
-					audioElement.playbackRate = $settings.audio?.tts?.playbackRate ?? 1;
-
-					audioElement
-						.play()
-						.then(() => {
-							audioElement.muted = false;
-						})
-						.catch((error) => {
-							console.error(error);
-						});
-
-					audioElement.onended = async (e) => {
-						await new Promise((r) => setTimeout(r, 100));
-						resolve(e);
-					};
-				}
-			});
-		} else {
-			return Promise.resolve();
+	const playAudio = async (audio) => {
+		if (!$showCallOverlay) {
+			return;
 		}
+
+		const playbackRate = $settings.audio?.tts?.playbackRate ?? 1;
+
+		// iOS can reject delayed HTMLMediaElement playback after the
+		// original Voice Mode user activation has expired. The
+		// AudioContext was unlocked synchronously when Voice Mode was
+		// entered, so use it for delayed call TTS.
+		if (canUseIOSCallAudio()) {
+			try {
+				await playIOSCallAudio(audio.src, playbackRate);
+				await new Promise((resolve) => setTimeout(resolve, 100));
+				return;
+			} catch (error) {
+				console.error('iOS call WebAudio playback failed, falling back:', error);
+			}
+		}
+
+		return await new Promise((resolve) => {
+			const audioElement = document.getElementById('audioElement') as HTMLAudioElement;
+
+			if (!audioElement) {
+				resolve(undefined);
+				return;
+			}
+
+			audioElement.src = audio.src;
+			audioElement.muted = true;
+			audioElement.playbackRate = playbackRate;
+
+			audioElement
+				.play()
+				.then(() => {
+					audioElement.muted = false;
+				})
+				.catch((error) => {
+					console.error(error);
+					resolve(error);
+				});
+
+			audioElement.onended = async (e) => {
+				await new Promise((r) => setTimeout(r, 100));
+				resolve(e);
+			};
+		});
 	};
 
 	const stopAllAudio = async () => {
 		assistantSpeaking = false;
 		interrupted = true;
+
+		stopIOSCallAudio();
 
 		if (chatStreaming) {
 			stopResponse();

--- a/src/lib/utils/ios-call-audio.ts
+++ b/src/lib/utils/ios-call-audio.ts
@@ -1,0 +1,190 @@
+type WebKitWindow = Window &
+	typeof globalThis & {
+		webkitAudioContext?: typeof AudioContext;
+	};
+
+let audioContext: AudioContext | null = null;
+let activeSource: AudioBufferSourceNode | null = null;
+let activeGain: GainNode | null = null;
+let activeResolve: (() => void) | null = null;
+
+const isIOS = () => {
+	if (typeof navigator === 'undefined') {
+		return false;
+	}
+
+	return (
+		/iPad|iPhone|iPod/.test(navigator.userAgent) ||
+		(navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)
+	);
+};
+
+const getAudioContextConstructor = () => {
+	if (typeof window === 'undefined') {
+		return null;
+	}
+
+	return (
+		window.AudioContext ??
+		(window as WebKitWindow).webkitAudioContext ??
+		null
+	);
+};
+
+/**
+ * Unlock a persistent AudioContext while the browser is still handling
+ * the user's Voice Mode gesture.
+ *
+ * This must be called synchronously from the click/touch handler, before
+ * getUserMedia(), network requests, or any other awaited operation.
+ */
+export const unlockIOSCallAudio = () => {
+	if (!isIOS()) {
+		return;
+	}
+
+	const AudioContextConstructor = getAudioContextConstructor();
+
+	if (!AudioContextConstructor) {
+		return;
+	}
+
+	if (!audioContext || audioContext.state === 'closed') {
+		audioContext = new AudioContextConstructor();
+
+		// Start a silent buffer while user activation is still available.
+		const buffer = audioContext.createBuffer(1, 1, audioContext.sampleRate);
+		const source = audioContext.createBufferSource();
+
+		source.buffer = buffer;
+		source.connect(audioContext.destination);
+		source.start();
+	}
+
+	if (audioContext.state === 'suspended') {
+		void audioContext.resume().catch((error) => {
+			console.debug('Unable to resume iOS call AudioContext:', error);
+		});
+	}
+};
+
+export const canUseIOSCallAudio = () =>
+	isIOS() && audioContext !== null && audioContext.state !== 'closed';
+
+export const stopIOSCallAudio = () => {
+	const resolve = activeResolve;
+	activeResolve = null;
+
+	if (activeSource) {
+		activeSource.onended = null;
+
+		try {
+			activeSource.stop();
+		} catch {
+			// Source may already have ended.
+		}
+
+		try {
+			activeSource.disconnect();
+		} catch {
+			// Already disconnected.
+		}
+
+		activeSource = null;
+	}
+
+	if (activeGain) {
+		try {
+			activeGain.disconnect();
+		} catch {
+			// Already disconnected.
+		}
+
+		activeGain = null;
+	}
+
+	// Allow callers waiting for playback to continue after interruption.
+	resolve?.();
+};
+
+export const playIOSCallAudio = async (
+	url: string,
+	playbackRate = 1,
+	volume = 1
+) => {
+	if (!audioContext || audioContext.state === 'closed') {
+		throw new Error('iOS call AudioContext has not been unlocked');
+	}
+
+	if (audioContext.state === 'suspended') {
+		await audioContext.resume();
+	}
+
+	const response = await fetch(url);
+
+	if (!response.ok) {
+		throw new Error(`Unable to load call audio: HTTP ${response.status}`);
+	}
+
+	const encodedAudio = await response.arrayBuffer();
+	const decodedAudio = await audioContext.decodeAudioData(encodedAudio.slice(0));
+
+	stopIOSCallAudio();
+
+	return await new Promise<void>((resolve, reject) => {
+		if (!audioContext) {
+			reject(new Error('iOS call AudioContext became unavailable'));
+			return;
+		}
+
+		const source = audioContext.createBufferSource();
+		const gain = audioContext.createGain();
+
+		source.buffer = decodedAudio;
+		source.playbackRate.value = playbackRate;
+		gain.gain.value = volume;
+
+		source.connect(gain);
+		gain.connect(audioContext.destination);
+
+		activeSource = source;
+		activeGain = gain;
+		activeResolve = resolve;
+
+		source.onended = () => {
+			if (activeSource === source) {
+				activeSource = null;
+			}
+
+			if (activeGain === gain) {
+				activeGain = null;
+			}
+
+			activeResolve = null;
+
+			try {
+				source.disconnect();
+			} catch {
+				// Already disconnected.
+			}
+
+			try {
+				gain.disconnect();
+			} catch {
+				// Already disconnected.
+			}
+
+			resolve();
+		};
+
+		try {
+			source.start();
+		} catch (error) {
+			activeSource = null;
+			activeGain = null;
+			activeResolve = null;
+
+			reject(error);
+		}
+	});
+};


### PR DESCRIPTION
## Summary

Fixes silent Voice Mode TTS playback on iOS 27 by unlocking a persistent `AudioContext` synchronously during the original Voice Mode user gesture and using that context for delayed assistant audio playback.

Related discussion:
https://github.com/open-webui/open-webui/discussions/28672

## Problem

On iOS 27, Voice Mode can successfully:

- capture microphone input
- transcribe speech
- generate the assistant response
- generate TTS audio

but the assistant response is silent.

The issue was isolated with a standalone reproduction:

- immediate `HTMLAudioElement.play()` from a user gesture works
- microphone + immediate playback works
- Web Audio playback works while the microphone is active
- `fetch()` followed by immediate playback works
- playback delayed approximately 5 seconds after the original user gesture fails with `NotAllowedError`
- fetching audio and then delaying playback approximately 5 seconds also fails with `NotAllowedError`

Open WebUI naturally has this delay during:

Voice Mode gesture → microphone → STT → model generation → TTS → playback

By the time the existing `HTMLMediaElement.play()` call runs, iOS 27 no longer considers it associated with the original user activation.

## Fix

This change:

- unlocks a persistent `AudioContext` synchronously when Voice Mode is entered
- does so before `getUserMedia()` or any awaited operation
- uses the already-unlocked context for delayed iOS call TTS
- decodes TTS audio using `decodeAudioData()`
- plays it through an `AudioBufferSourceNode`
- stops Web Audio playback correctly when call audio is interrupted/stopped
- preserves the existing HTML media playback path as the fallback for other platforms

Creating the `AudioContext` after awaiting `getUserMedia()` was tested and does not resolve the issue. The context must be unlocked during the original user gesture.

## Testing

Tested against the current `dev` branch.

- Production frontend Docker build succeeds
- `npm run test:frontend -- --run`: 8/8 tests pass
- `git diff --check` passes
- No `svelte-check` diagnostics reference the new iOS audio helper/functions
- Tested on a physical iPhone running iOS 27
- Voice Mode assistant TTS is audible
- Microphone remains active while assistant audio plays
- Existing non-iOS playback path remains unchanged

## Notes

Repository-wide `svelte-check` currently reports unrelated existing diagnostics across many files. The diagnostics observed in `CallOverlay.svelte` are also present in unmodified `origin/dev`; none reference the new iOS audio helper or functions.
