### PR TITLE
fix: restore iOS 27 voice mode audio playback

### DIFF
--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -64,6 +64,7 @@
 	import { getSessionUser } from '$lib/apis/auths';
 
 	import { WEBUI_BASE_URL, WEBUI_API_BASE_URL, PASTED_TEXT_CHARACTER_LIMIT } from '$lib/constants';
+	import { unlockIOSCallAudio } from '$lib/utils/ios-call-audio';
 	import { initiateOAuthRedirect } from '$lib/apis/configs';
 	import { matchKeybinding, Shortcut } from '$lib/shortcuts';
 
@@ -2520,6 +2521,11 @@
 
 																return;
 															}
+															// iOS requires audio to be unlocked while the original
+															// Voice Mode user gesture is still active. This must
+															// happen before getUserMedia() or any awaited operation.
+															unlockIOSCallAudio();
+
 															// check if user has access to getUserMedia
 															try {
 																let stream = await navigator.mediaDevices.getUserMedia({

--- a/src/lib/components/chat/MessageInput/CallOverlay.svelte
+++ b/src/lib/components/chat/MessageInput/CallOverlay.svelte
@@ -14,6 +14,11 @@
 	import VideoInputMenu from './CallOverlay/VideoInputMenu.svelte';
 	import { KokoroWorker } from '$lib/workers/KokoroWorker';
 	import { WEBUI_API_BASE_URL } from '$lib/constants';
+	import {
+		canUseIOSCallAudio,
+		playIOSCallAudio,
+		stopIOSCallAudio
+	} from '$lib/utils/ios-call-audio';
 
 	const i18n = getContext('i18n');
 
@@ -427,39 +432,61 @@
 		}
 	};
 
-	const playAudio = (audio) => {
-		if ($showCallOverlay) {
-			return new Promise((resolve) => {
-				const audioElement = document.getElementById('audioElement') as HTMLAudioElement;
-
-				if (audioElement) {
-					audioElement.src = audio.src;
-					audioElement.muted = true;
-					audioElement.playbackRate = $settings.audio?.tts?.playbackRate ?? 1;
-
-					audioElement
-						.play()
-						.then(() => {
-							audioElement.muted = false;
-						})
-						.catch((error) => {
-							console.error(error);
-						});
-
-					audioElement.onended = async (e) => {
-						await new Promise((r) => setTimeout(r, 100));
-						resolve(e);
-					};
-				}
-			});
-		} else {
-			return Promise.resolve();
+	const playAudio = async (audio) => {
+		if (!$showCallOverlay) {
+			return;
 		}
+
+		const playbackRate = $settings.audio?.tts?.playbackRate ?? 1;
+
+		// iOS can reject delayed HTMLMediaElement playback after the
+		// original Voice Mode user activation has expired. The
+		// AudioContext was unlocked synchronously when Voice Mode was
+		// entered, so use it for delayed call TTS.
+		if (canUseIOSCallAudio()) {
+			try {
+				await playIOSCallAudio(audio.src, playbackRate);
+				await new Promise((resolve) => setTimeout(resolve, 100));
+				return;
+			} catch (error) {
+				console.error('iOS call WebAudio playback failed, falling back:', error);
+			}
+		}
+
+		return await new Promise((resolve) => {
+			const audioElement = document.getElementById('audioElement') as HTMLAudioElement;
+
+			if (!audioElement) {
+				resolve(undefined);
+				return;
+			}
+
+			audioElement.src = audio.src;
+			audioElement.muted = true;
+			audioElement.playbackRate = playbackRate;
+
+			audioElement
+				.play()
+				.then(() => {
+					audioElement.muted = false;
+				})
+				.catch((error) => {
+					console.error(error);
+					resolve(error);
+				});
+
+			audioElement.onended = async (e) => {
+				await new Promise((r) => setTimeout(r, 100));
+				resolve(e);
+			};
+		});
 	};
 
 	const stopAllAudio = async () => {
 		assistantSpeaking = false;
 		interrupted = true;
+
+		stopIOSCallAudio();
 
 		if (chatStreaming) {
 			stopResponse();

--- a/src/lib/utils/ios-call-audio.ts
+++ b/src/lib/utils/ios-call-audio.ts
@@ -1,0 +1,190 @@
+type WebKitWindow = Window &
+	typeof globalThis & {
+		webkitAudioContext?: typeof AudioContext;
+	};
+
+let audioContext: AudioContext | null = null;
+let activeSource: AudioBufferSourceNode | null = null;
+let activeGain: GainNode | null = null;
+let activeResolve: (() => void) | null = null;
+
+const isIOS = () => {
+	if (typeof navigator === 'undefined') {
+		return false;
+	}
+
+	return (
+		/iPad|iPhone|iPod/.test(navigator.userAgent) ||
+		(navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)
+	);
+};
+
+const getAudioContextConstructor = () => {
+	if (typeof window === 'undefined') {
+		return null;
+	}
+
+	return (
+		window.AudioContext ??
+		(window as WebKitWindow).webkitAudioContext ??
+		null
+	);
+};
+
+/**
+ * Unlock a persistent AudioContext while the browser is still handling
+ * the user's Voice Mode gesture.
+ *
+ * This must be called synchronously from the click/touch handler, before
+ * getUserMedia(), network requests, or any other awaited operation.
+ */
+export const unlockIOSCallAudio = () => {
+	if (!isIOS()) {
+		return;
+	}
+
+	const AudioContextConstructor = getAudioContextConstructor();
+
+	if (!AudioContextConstructor) {
+		return;
+	}
+
+	if (!audioContext || audioContext.state === 'closed') {
+		audioContext = new AudioContextConstructor();
+
+		// Start a silent buffer while user activation is still available.
+		const buffer = audioContext.createBuffer(1, 1, audioContext.sampleRate);
+		const source = audioContext.createBufferSource();
+
+		source.buffer = buffer;
+		source.connect(audioContext.destination);
+		source.start();
+	}
+
+	if (audioContext.state === 'suspended') {
+		void audioContext.resume().catch((error) => {
+			console.debug('Unable to resume iOS call AudioContext:', error);
+		});
+	}
+};
+
+export const canUseIOSCallAudio = () =>
+	isIOS() && audioContext !== null && audioContext.state !== 'closed';
+
+export const stopIOSCallAudio = () => {
+	const resolve = activeResolve;
+	activeResolve = null;
+
+	if (activeSource) {
+		activeSource.onended = null;
+
+		try {
+			activeSource.stop();
+		} catch {
+			// Source may already have ended.
+		}
+
+		try {
+			activeSource.disconnect();
+		} catch {
+			// Already disconnected.
+		}
+
+		activeSource = null;
+	}
+
+	if (activeGain) {
+		try {
+			activeGain.disconnect();
+		} catch {
+			// Already disconnected.
+		}
+
+		activeGain = null;
+	}
+
+	// Allow callers waiting for playback to continue after interruption.
+	resolve?.();
+};
+
+export const playIOSCallAudio = async (
+	url: string,
+	playbackRate = 1,
+	volume = 1
+) => {
+	if (!audioContext || audioContext.state === 'closed') {
+		throw new Error('iOS call AudioContext has not been unlocked');
+	}
+
+	if (audioContext.state === 'suspended') {
+		await audioContext.resume();
+	}
+
+	const response = await fetch(url);
+
+	if (!response.ok) {
+		throw new Error(`Unable to load call audio: HTTP ${response.status}`);
+	}
+
+	const encodedAudio = await response.arrayBuffer();
+	const decodedAudio = await audioContext.decodeAudioData(encodedAudio.slice(0));
+
+	stopIOSCallAudio();
+
+	return await new Promise<void>((resolve, reject) => {
+		if (!audioContext) {
+			reject(new Error('iOS call AudioContext became unavailable'));
+			return;
+		}
+
+		const source = audioContext.createBufferSource();
+		const gain = audioContext.createGain();
+
+		source.buffer = decodedAudio;
+		source.playbackRate.value = playbackRate;
+		gain.gain.value = volume;
+
+		source.connect(gain);
+		gain.connect(audioContext.destination);
+
+		activeSource = source;
+		activeGain = gain;
+		activeResolve = resolve;
+
+		source.onended = () => {
+			if (activeSource === source) {
+				activeSource = null;
+			}
+
+			if (activeGain === gain) {
+				activeGain = null;
+			}
+
+			activeResolve = null;
+
+			try {
+				source.disconnect();
+			} catch {
+				// Already disconnected.
+			}
+
+			try {
+				gain.disconnect();
+			} catch {
+				// Already disconnected.
+			}
+
+			resolve();
+		};
+
+		try {
+			source.start();
+		} catch (error) {
+			activeSource = null;
+			activeGain = null;
+			activeResolve = null;
+
+			reject(error);
+		}
+	});
+};


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing Issue or Discussion — Relates to #28672.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following Keep a Changelog format is included below.
- [ ] **Documentation:** No documentation changes are required for this bug fix.
- [x] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Manual tests have been performed to verify the fix works correctly.
- [x] **No Unchecked AI Code:** The changes have undergone manual review and real-device testing.
- [x] **Self-Review:** A self-review of the code has been performed.
- [x] **Architecture:** The change is narrowly scoped to iOS Voice Mode audio playback and introduces no new settings.
- [x] **Git Hygiene:** The PR is atomic, based on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** Uses the `fix` prefix.

Relates to #28672

## Description

Fixes silent Voice Mode TTS playback on iOS 27.

On affected iOS 27 devices, microphone capture, STT, model generation, and TTS generation all succeed, but delayed assistant audio playback is rejected after the original user activation expires.

Standalone testing isolated the behavior:

- Immediate `HTMLAudioElement.play()` from a user gesture works.
- Microphone capture and immediate audio playback work simultaneously.
- Web Audio works while the microphone is active.
- `fetch()` followed by immediate playback works.
- Playback delayed approximately 5 seconds fails with `NotAllowedError`.
- Fetching the audio and then delaying playback approximately 5 seconds also fails.

The working sequence is to create and unlock an `AudioContext` synchronously during the original Voice Mode user gesture, before `getUserMedia()` or any awaited operation, then use that already-unlocked context for delayed TTS playback.

This PR implements that behavior while preserving the existing HTML media playback path as the fallback for other platforms.

## Testing

Tested against the current `dev` branch:

- Production frontend Docker build succeeds.
- `npm run test:frontend -- --run`: 8/8 tests pass.
- `git diff --check` passes.
- No `svelte-check` diagnostics reference the new iOS audio helper/functions.
- Existing unrelated `CallOverlay.svelte` diagnostics are also present in unmodified `origin/dev`.
- Tested successfully on a physical iPhone running iOS 27.
- Assistant TTS remains audible while the microphone stays active.

# Changelog Entry

### Description

- Restore Voice Mode assistant audio playback on iOS 27 when delayed media playback loses the original browser user activation.

### Added

- iOS-specific persistent Web Audio playback helper for Voice Mode.

### Changed

- Voice Mode unlocks its iOS AudioContext synchronously before asynchronous microphone access.

### Deprecated

- None.

### Removed

- None.

### Fixed

- Silent delayed Voice Mode TTS playback on iOS 27.

### Security

- None.

### Breaking Changes

- None.

---

### Additional Information

- Related discussion: #28672
- No new dependencies.
- Existing non-iOS playback behavior remains unchanged.

### Screenshots or Videos

- Not applicable; this is an audio playback regression.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->
- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
