### PR TITLE
fix: stop the What's New modal drawing two bullets per changelog entry

### DIFF
--- a/src/lib/components/ChangelogModal.svelte
+++ b/src/lib/components/ChangelogModal.svelte
@@ -154,7 +154,7 @@
 													class="mt-[0.6em] h-1 w-1 shrink-0 rounded-full bg-gray-300 dark:bg-gray-700"
 												></span>
 												<div
-													class="min-w-0 markdown-prose-sm !max-w-none !text-[0.8125rem] text-gray-600 dark:text-gray-300 [&_*]:!my-0 [&_b]:!font-normal [&_strong]:!font-normal"
+													class="min-w-0 markdown-prose-sm list-none !max-w-none !text-[0.8125rem] text-gray-600 dark:text-gray-300 [&_*]:!my-0 [&_b]:!font-normal [&_strong]:!font-normal"
 												>
 													<!-- eslint-disable-next-line svelte/no-at-html-tags -->
 													{@html DOMPurify.sanitize(entry?.raw)}


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked and filled out the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or active, substantive [Discussion](https://github.com/open-webui/open-webui/discussions) - Fixes #28675
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented. No new dependencies.
- [x] **Testing:** **Manual** end-to-end tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **User-facing changes:** I have confirmed whether this PR changes the UI. It does; screenshots below.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

# Changelog Entry

### Description

- Every entry in the What's New modal showed two dots: the modal's own small dot span, and a larger one next to it, lower and in the text color. `/api/changelog` returns each entry's `raw` as `str(li)`, so it is `<li>...</li>` markup, and the modal renders it with `{@html}` beside its own dot. A bare `<li>` keeps `display: list-item` and the initial `list-style-type: disc`, so the browser drew a marker as well.
- The pre-redesign modal suppressed that marker with `!list-none` on the same container; the July redesign (bd406851e) added the custom dot span and dropped the class in the same edit, and with nothing else in `src/` using `list-none`, Tailwind stopped compiling the utility altogether.
- Restores `list-none` on the prose container that wraps `{@html entry.raw}`. `list-style-type` inherits, so the bare `<li>` computes `none`; the modal's own dot is the single bullet again.

### Fixed

- The What's New modal shows one bullet per changelog entry instead of two misaligned ones.

---

### Additional Information

- One class on one element, at the layer that owns the presentation: the modal chose to draw its own bullet, so it suppresses the markup's. The API's `raw` shape has been the contract since 2024 and this component is its only consumer, so it is left alone.

**Manual verification performed:**

1. Reproduced on `dev`: opened the What's New modal and saw two dots per entry; on the live modal markup the entry's `<li>` computes `display: list-item`, `list-style-type: disc`.
2. On this branch, against the live API's actual `raw` for a current entry: `list-style-type` computes `none`, the `<li>` left edge and height are unchanged, and the modal's dot span is the only bullet.
3. Opened the modal in the browser and scrolled through every section: one dot per entry at a consistent height, text and links unaffected.

### Screenshots or Videos

Before is current `dev`. After is this branch.

| Surface | Before | After |
|---|---|---|
| What's New modal, any changelog entry | <img width="2435" height="781" alt="image" src="https://github.com/user-attachments/assets/5498df70-0973-4d20-b0a5-64a0e77a0f5a" /> | <img width="2435" height="781" alt="image" src="https://github.com/user-attachments/assets/152e2aac-cef9-44d9-809c-619f7d63cf08" /> |

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
