### PR TITLE
fix: only send Authorization header when embedding API key is set

### DIFF
--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -872,10 +872,9 @@ def generate_openai_batch_embeddings(
     if isinstance(RAG_EMBEDDING_PREFIX_FIELD_NAME, str) and isinstance(prefix, str):
         json_data[RAG_EMBEDDING_PREFIX_FIELD_NAME] = prefix
 
-    headers = {
-        'Content-Type': 'application/json',
-        'Authorization': f'Bearer {key}',
-    }
+    headers = {'Content-Type': 'application/json'}
+    if key:
+        headers['Authorization'] = f'Bearer {key}'
     if ENABLE_FORWARD_USER_INFO_HEADERS and user:
         headers = include_user_info_headers(headers, user)
 
@@ -905,10 +904,9 @@ async def agenerate_openai_batch_embeddings(
     if isinstance(RAG_EMBEDDING_PREFIX_FIELD_NAME, str) and isinstance(prefix, str):
         form_data[RAG_EMBEDDING_PREFIX_FIELD_NAME] = prefix
 
-    headers = {
-        'Content-Type': 'application/json',
-        'Authorization': f'Bearer {key}',
-    }
+    headers = {'Content-Type': 'application/json'}
+    if key:
+        headers['Authorization'] = f'Bearer {key}'
     if ENABLE_FORWARD_USER_INFO_HEADERS and user:
         headers = include_user_info_headers(headers, user)
 
@@ -1024,10 +1022,9 @@ def generate_ollama_batch_embeddings(
     if isinstance(RAG_EMBEDDING_PREFIX_FIELD_NAME, str) and isinstance(prefix, str):
         json_data[RAG_EMBEDDING_PREFIX_FIELD_NAME] = prefix
 
-    headers = {
-        'Content-Type': 'application/json',
-        'Authorization': f'Bearer {key}',
-    }
+    headers = {'Content-Type': 'application/json'}
+    if key:
+        headers['Authorization'] = f'Bearer {key}'
     if ENABLE_FORWARD_USER_INFO_HEADERS and user:
         headers = include_user_info_headers(headers, user)
 
@@ -1060,10 +1057,9 @@ async def agenerate_ollama_batch_embeddings(
     if isinstance(RAG_EMBEDDING_PREFIX_FIELD_NAME, str) and isinstance(prefix, str):
         form_data[RAG_EMBEDDING_PREFIX_FIELD_NAME] = prefix
 
-    headers = {
-        'Content-Type': 'application/json',
-        'Authorization': f'Bearer {key}',
-    }
+    headers = {'Content-Type': 'application/json'}
+    if key:
+        headers['Authorization'] = f'Bearer {key}'
     if ENABLE_FORWARD_USER_INFO_HEADERS and user:
         headers = include_user_info_headers(headers, user)
 


### PR DESCRIPTION
## Problem

The OpenAI and Ollama batch embedding functions in `backend/open_webui/retrieval/utils.py` unconditionally send `Authorization: Bearer {key}` even when `key` is empty. This breaks two common self-hosted configurations:

1. **Basic-auth endpoints reached via URL userinfo** (e.g. `https://user:pass@host`): aiohttp raises `ValueError: Cannot combine AUTHORIZATION header with AUTH argument or credentials encoded in URL`.

2. **Basic-auth endpoints with an empty key**: the dangling `Bearer ` header makes the server return `401` with a `text/html` login page, and `r.json()` then raises `aiohttp.client_exceptions.ContentTypeError`.

This prevents documents from being embedded/vectorized (upload fails with `ContentTypeError`), breaking RAG ingestion and retrieval.

## Fix

Initialize the headers dict with `Content-Type` only, and add the `Authorization` header conditionally when `key` is non-empty:

```python
headers = {Content-Type: application/json}
if key:
    headers[Authorization] = fBearer {key}
```

Applied to all four batch embedding functions:
- `generate_openai_batch_embeddings` / `agenerate_openai_batch_embeddings`
- `generate_ollama_batch_embeddings` / `agenerate_ollama_batch_embeddings`

When no API key is configured, credentials can be supplied via the URL (Basic auth), which aiohttp/requests handle transparently.

## Impact

Zero risk: when `key` is non-empty the behavior is unchanged. When `key` is empty (previously broken), requests now work with URL-based Basic auth and no longer send a dangling `Bearer ` header.