### PR TITLE
fix: only send Authorization header when embedding API key is set

### DIFF
--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -871,10 +871,9 @@ def generate_openai_batch_embeddings(
     if isinstance(RAG_EMBEDDING_PREFIX_FIELD_NAME, str) and isinstance(prefix, str):
         json_data[RAG_EMBEDDING_PREFIX_FIELD_NAME] = prefix
 
-    headers = {
-        'Content-Type': 'application/json',
-        'Authorization': f'Bearer {key}',
-    }
+    headers = {'Content-Type': 'application/json'}
+    if key:
+        headers['Authorization'] = f'Bearer {key}'
     if ENABLE_FORWARD_USER_INFO_HEADERS and user:
         headers = include_user_info_headers(headers, user)
 
@@ -904,10 +903,9 @@ async def agenerate_openai_batch_embeddings(
     if isinstance(RAG_EMBEDDING_PREFIX_FIELD_NAME, str) and isinstance(prefix, str):
         form_data[RAG_EMBEDDING_PREFIX_FIELD_NAME] = prefix
 
-    headers = {
-        'Content-Type': 'application/json',
-        'Authorization': f'Bearer {key}',
-    }
+    headers = {'Content-Type': 'application/json'}
+    if key:
+        headers['Authorization'] = f'Bearer {key}'
     if ENABLE_FORWARD_USER_INFO_HEADERS and user:
         headers = include_user_info_headers(headers, user)
 
@@ -1023,10 +1021,9 @@ def generate_ollama_batch_embeddings(
     if isinstance(RAG_EMBEDDING_PREFIX_FIELD_NAME, str) and isinstance(prefix, str):
         json_data[RAG_EMBEDDING_PREFIX_FIELD_NAME] = prefix
 
-    headers = {
-        'Content-Type': 'application/json',
-        'Authorization': f'Bearer {key}',
-    }
+    headers = {'Content-Type': 'application/json'}
+    if key:
+        headers['Authorization'] = f'Bearer {key}'
     if ENABLE_FORWARD_USER_INFO_HEADERS and user:
         headers = include_user_info_headers(headers, user)
 
@@ -1059,10 +1056,9 @@ async def agenerate_ollama_batch_embeddings(
     if isinstance(RAG_EMBEDDING_PREFIX_FIELD_NAME, str) and isinstance(prefix, str):
         form_data[RAG_EMBEDDING_PREFIX_FIELD_NAME] = prefix
 
-    headers = {
-        'Content-Type': 'application/json',
-        'Authorization': f'Bearer {key}',
-    }
+    headers = {'Content-Type': 'application/json'}
+    if key:
+        headers['Authorization'] = f'Bearer {key}'
     if ENABLE_FORWARD_USER_INFO_HEADERS and user:
         headers = include_user_info_headers(headers, user)
 


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Linked Issue/Discussion:** This PR references issue [Relates to #28683](https://github.com/open-webui/open-webui/issues/28683)
- [x] **Target branch:** This PR targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [ ] **Changelog:** N/A (bug fix, changelog maintained by maintainers)

## Description

The OpenAI and Ollama batch embedding functions in `backend/open_webui/retrieval/utils.py` unconditionally set `Authorization: Bearer {key}` even when `key` is empty. This breaks two common self-hosted configurations:

1. **Basic-auth endpoints reached via URL userinfo** (e.g. `https://user:pass@host`): aiohttp raises `ValueError: Cannot combine AUTHORIZATION header with AUTH argument or credentials encoded in URL`.

2. **Basic-auth endpoints with an empty key**: the dangling `Bearer ` header makes the server return `401` with a `text/html` login page, and `r.json()` then raises `aiohttp.client_exceptions.ContentTypeError`.

**Impact:** document upload/embedding fails (ContentTypeError), so RAG ingestion and retrieval break for users who protect their Ollama/OpenAI-compatible embedding service with HTTP Basic auth (e.g. behind a reverse proxy).

## Changes

Applied to all four batch embedding functions:
- `generate_openai_batch_embeddings` / `agenerate_openai_batch_embeddings`
- `generate_ollama_batch_embeddings` / `agenerate_ollama_batch_embeddings`

The headers dict is initialized with `Content-Type` only, and the `Authorization` header is added conditionally when `key` is non-empty:

```python
headers = {'Content-Type': 'application/json'}
if key:
    headers['Authorization'] = f'Bearer {key}'
```

## Impact

Zero risk: when `key` is non-empty the behavior is unchanged. When `key` is empty (previously broken), requests now work with URL-based Basic auth and no longer send a dangling `Bearer ` header.

### Screenshots or Videos

N/A (backend logic change)

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
