### PR TITLE
fix: serve /static with CORS headers so Chrome's cache cannot fail the favicon on cross-origin loads

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -2943,7 +2943,7 @@ async def check_db_health():
 
 # --- static assets & files ---
 # Serve build-time static assets (CSS, JS, images, favicon, etc.)
-app.mount('/static', StaticFiles(directory=STATIC_DIR), name='static')
+app.mount('/static', CORSStaticFiles(directory=STATIC_DIR), name='static')
 
 
 @app.get('/cache/{path:path}')

--- a/src/lib/components/OnBoarding.svelte
+++ b/src/lib/components/OnBoarding.svelte
@@ -43,13 +43,7 @@
 			<!-- LICENSE covers this Open WebUI onboarding logo.
 			Do not alter, remove, obscure, or replace it except as LICENSE permits:
 			https://docs.openwebui.com/license. -->
-			<img
-				id="logo"
-				crossorigin="anonymous"
-				src="/static/favicon.png"
-				class="size-6 rounded-full"
-				alt="logo"
-			/>
+			<img id="logo" src="/static/favicon.png" class="size-6 rounded-full" alt="logo" />
 		</div>
 
 		<video

--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -1141,7 +1141,6 @@
 					Do not alter, remove, obscure, or replace it except as LICENSE permits:
 					https://docs.openwebui.com/license. -->
 						<img
-							crossorigin="anonymous"
 							src="{WEBUI_BASE_URL}/static/favicon.png"
 							class="sidebar-new-chat-icon size-5 rounded-full"
 							alt=""

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1315,7 +1315,7 @@
 	Do not alter, remove, obscure, or replace it except as LICENSE permits:
 	https://docs.openwebui.com/license. -->
 	<title>{$WEBUI_NAME}</title>
-	<link crossorigin="anonymous" rel="icon" href="{WEBUI_BASE_URL}/static/favicon.png" />
+	<link rel="icon" href="{WEBUI_BASE_URL}/static/favicon.png" />
 
 	<meta name="apple-mobile-web-app-title" content={$WEBUI_NAME} />
 	<meta name="description" content={$WEBUI_NAME} />

--- a/src/routes/auth/+page.svelte
+++ b/src/routes/auth/+page.svelte
@@ -254,7 +254,6 @@
 									https://docs.openwebui.com/license. -->
 									<img
 										id="logo"
-										crossorigin="anonymous"
 										src="{WEBUI_BASE_URL}/static/favicon.png"
 										class="size-24 rounded-full"
 										alt="{$WEBUI_NAME} logo"
@@ -625,7 +624,6 @@
 						https://docs.openwebui.com/license. -->
 						<img
 							id="logo"
-							crossorigin="anonymous"
 							src="{WEBUI_BASE_URL}/static/favicon.png"
 							class=" w-6 rounded-full"
 							alt=""


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked and filled out the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or active, substantive [Discussion](https://github.com/open-webui/open-webui/discussions) - Fixes #28686. Same error was reported in #9812 / #9821.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented. No new dependencies.
- [x] **Testing:** **Manual** end-to-end tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **User-facing changes:** I have confirmed whether this PR changes the UI. Only in that the logo now loads where it was blank; screenshots below.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

# Changelog Entry

### Description

- With the frontend and backend on different origins (the documented split dev setup, `localhost:5173` against `localhost:8080`), Chrome intermittently renders the sidebar logo, the sign-in logo, and the tab favicon as broken, logging `Access to image at '.../static/favicon.png' from origin '...' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present`, even though the backend sends the header when asked with an `Origin`.
- `CORSMiddleware` only adds `Access-Control-Allow-Origin` when the request carries an `Origin` header, and it does not put `Vary: Origin` on the responses it leaves alone. So `/static/favicon.png` has two shapes: with the header for CORS mode loads (`crossorigin="anonymous"` images, `<link rel="icon" crossorigin>`), without it for plain `<img>` loads (default model avatar, `ProfileImage` fallback, `NotificationToast`, the collapsed rail logo). Chrome keys its HTTP cache by URL, not request mode, and the Origin-less copy declares no `Vary`, so a CORS mode load can be served the plain copy and fail the CORS check. Whichever mode fetched last wins, hence intermittent. Firefox checks request mode against the cache entry; single origin deployments never perform the check.
- Fix: mount `/static` with the `CORSStaticFiles` class `main.py` already defines and already uses for `/pyodide`, so every response for a public static asset carries `Access-Control-Allow-Origin: *` regardless of whether an `Origin` was sent. Any cached copy then passes the CORS check in any request mode. When an `Origin` is present, `CORSMiddleware` still overrides `*` with the explicit origin exactly as before, so behaviour for real CORS requests is unchanged; the only new thing is that Origin-less responses say `*` too, which is what `/pyodide` already does.
- Also drops the four vestigial `crossorigin="anonymous"` attributes on favicon loads (`Sidebar.svelte`, both `auth/+page.svelte` logos, the `<link rel="icon">` in `+layout.svelte`, and `OnBoarding.svelte`). They date from 58a13aec7 (May 2024), when pyscript needed `Cross-Origin-Embedder-Policy: require-corp` hard set on every response and cross origin images had to opt into CORS. COEP has been opt in via `CROSS_ORIGIN_EMBEDDER_POLICY` for a long time and nothing reads the favicon through a canvas, so the attributes only put those loads in a different mode from the other eleven. With them gone the favicon is requested one way everywhere; the backend change is what makes the mode irrelevant.

### Fixed

- Static assets under `/static` are served with `Access-Control-Allow-Origin` on every response, so the Open WebUI logo, sign-in logo, and tab favicon load reliably in Chrome when the frontend and backend run on different origins.

---

### Additional Information

- One line in `backend/open_webui/main.py` (`StaticFiles` to `CORSStaticFiles` on the `/static` mount) plus five attribute removals across four frontend files; one of those deletions is prettier collapsing `OnBoarding.svelte`'s `<img>` onto one line once the attribute is gone.
- The frontend cleanup alone would also hide the symptom (no CORS mode load, no CORS check), but it would leave the server handing out Origin dependent responses without declaring so, and the next legitimate `crossorigin` (a canvas read, or a deployment with `CROSS_ORIGIN_EMBEDDER_POLICY=require-corp`, where a cross origin `<img>` needs it) would bring the failure back. The mount change removes that condition; the attribute removals are the accompanying tidy up.
- Same error was reported in #9812 / discussion #9821 (February 2025) with the same split setup and never resolved.

**Manual verification performed:**

1. Reproduced on `dev` in Chrome against a split dev setup: sidebar logo `complete` with `naturalWidth: 0`, console error as above. Confirmed the mechanism in the page: `fetch(url, {mode: 'cors'})` rejects from cache, the same fetch with `cache: 'reload'` succeeds, and it rejects again after one plain `<img>` load of the URL.
2. On this branch, `curl -D - http://localhost:8080/static/favicon.png` (no `Origin`) returns `access-control-allow-origin: *`; with `-H 'Origin: http://localhost:5173'` it returns `access-control-allow-origin: http://localhost:5173`, `access-control-allow-credentials: true`, `vary: Origin`, unchanged from `dev`.
3. Same Chrome profile, same sequence as step 1 on this branch: a plain `<img>` load of a fresh URL, then `fetch(url, {mode: 'cors'})` of that URL succeeds, then an `<img crossorigin="anonymous">` of that URL loads at 512px. The request mode no longer matters.
4. Reloaded the app: the sidebar logo has no `crossorigin` and `naturalWidth: 512`; the `<link rel="icon">` to the backend origin loads; Firefox and the sign-in page unchanged.

### Screenshots or Videos

Before is current `dev`. After is this branch.

| Surface | Before | After |
|---|---|---|
| Sidebar header logo, Chrome, frontend and backend on different origins | <img width="2000" height="969" alt="image" src="https://github.com/user-attachments/assets/39a8e5b1-5499-4f61-9a0d-55f9b71f2842" /> | <img width="2295" height="1115" alt="image" src="https://github.com/user-attachments/assets/d1583f39-7295-48a4-b34c-a2afeb1b997e" /> |

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
