### PR TITLE
fix: thread api_base_url through SafeMicrosoftWebIQLoader

### DIFF
--- a/backend/open_webui/retrieval/web/microsoft_web_iq.py
+++ b/backend/open_webui/retrieval/web/microsoft_web_iq.py
@@ -4,12 +4,11 @@ import logging
 from urllib.parse import urlparse
 
 import requests
+from open_webui.retrieval.loaders.microsoft_web_iq import DEFAULT_MICROSOFT_WEB_IQ_API_BASE_URL
 from open_webui.retrieval.web.main import SearchResult, get_filtered_results
 from open_webui.utils.headers import include_user_info_headers
 
 log = logging.getLogger(__name__)
-
-DEFAULT_MICROSOFT_WEB_IQ_API_BASE_URL = 'https://api.microsoft.ai/v3'
 
 
 def search_microsoft_web_iq(

--- a/backend/open_webui/retrieval/web/utils.py
+++ b/backend/open_webui/retrieval/web/utils.py
@@ -56,7 +56,10 @@ from open_webui.env import (
     USER_AGENT,
 )
 from open_webui.retrieval.loaders.external_web import ExternalWebLoader
-from open_webui.retrieval.loaders.microsoft_web_iq import MicrosoftWebIQLoader
+from open_webui.retrieval.loaders.microsoft_web_iq import (
+    DEFAULT_MICROSOFT_WEB_IQ_API_BASE_URL,
+    MicrosoftWebIQLoader,
+)
 from open_webui.retrieval.loaders.tavily import TavilyLoader
 from open_webui.retrieval.web.firecrawl import scrape_firecrawl_url
 from open_webui.utils.misc import is_host_allowed
@@ -517,6 +520,7 @@ class SafeMicrosoftWebIQLoader(BaseLoader, RateLimitMixin, URLProcessingMixin):
         self,
         web_paths: Union[str, List[str]],
         api_key: str,
+        api_base_url: str = DEFAULT_MICROSOFT_WEB_IQ_API_BASE_URL,
         language: str = 'en',
         verify_ssl: bool = True,
         trust_env: bool = False,
@@ -526,6 +530,7 @@ class SafeMicrosoftWebIQLoader(BaseLoader, RateLimitMixin, URLProcessingMixin):
     ):
         self.web_paths = web_paths if isinstance(web_paths, list) else [web_paths]
         self.api_key = api_key
+        self.api_base_url = api_base_url
         self.language = language
         self.verify_ssl = verify_ssl
         self.trust_env = trust_env


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #28688
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable - no settings or APIs changed; existing `microsoft_web_iq` engine now works as documented.
- [ ] **Dependencies:** None.
- [x] **Testing:** AST contract checks + behavior simulation (see below); loader construction and inner-loader wiring verified.
- [x] **No Unchecked AI Code:** Reviewed and verified mechanically; minimal diff porting existing in-repo conventions.
- [x] **Self-Review:** Performed.
- [x] **Architecture:** No new settings; default comes from the loader module's existing constant.
- [x] **Git Hygiene:** Single atomic commit, rebased on latest `dev`.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

Make the `microsoft_web_iq` web loader constructible by threading `api_base_url` through `SafeMicrosoftWebIQLoader`, which the underlying `MicrosoftWebIQLoader` requires to build the `{base}/browse` request URL and `host` header.

### Added

- `api_base_url` parameter on `SafeMicrosoftWebIQLoader.__init__` (keyword-compatible with what `get_web_loader` already passes), defaulting to the loader module's `DEFAULT_MICROSOFT_WEB_IQ_API_BASE_URL`.

### Changed

- `DEFAULT_MICROSOFT_WEB_IQ_API_BASE_URL` is now single-sourced from `retrieval/loaders/microsoft_web_iq.py`; the search path (`retrieval/web/microsoft_web_iq.py`) imports it instead of redefining its own copy.

### Deprecated

- None.

### Removed

- None.

### Fixed

- `WEB_LOADER_ENGINE=microsoft_web_iq` browse/loader path no longer fails with `TypeError: SafeMicrosoftWebIQLoader.__init__() got an unexpected keyword argument 'api_base_url'` (raised in `get_web_loader` via `WebLoaderClass(**web_loader_args)`), nor with `AttributeError: 'SafeMicrosoftWebIQLoader' object has no attribute 'api_base_url'` (raised in `lazy_load()` when constructing the inner loader) - closes #28688.

### Security

- None.

### Breaking Changes

- None. `api_base_url` is optional with the same default the search path and `config.MICROSOFT_WEB_IQ_API_BASE_URL` already use.

---

### Additional Information

- This is the mirror image of #27636: there, `api_base_url` was **removed** from `SafeTavilyLoader` because `TavilyLoader` never accepted it; here `MicrosoftWebIQLoader` **requires** it (positional, no default), so it is threaded through instead.
- Verified the wrapper/inner contract by AST: every kwarg `get_web_loader` passes for this engine (`web_paths`, `api_key`, `api_base_url`, `language`, `timeout`) is now accepted by `__init__`, and `lazy_load()`'s inner `MicrosoftWebIQLoader(...)` call provides all of its required params (`urls`, `api_base_url`, `api_key`).
- Bug has existed since the loader's introduction (`ce4a323f4`), not a regression from #27636; the search path (`search_microsoft_web_iq`) was never affected.

### Screenshots or Videos

N/A - backend-only fix; reproduction steps in the linked issue.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.