### PR TITLE
fix: refresh the sidebar folder tree when a folder is edited from its own page

### DIFF
--- a/src/lib/components/chat/Placeholder.svelte
+++ b/src/lib/components/chat/Placeholder.svelte
@@ -17,7 +17,7 @@
 		temporaryChatEnabled,
 		selectedFolder
 	} from '$lib/stores';
-	import { refreshChatList } from '$lib/stores/chatList';
+	import { refreshChatList, refreshFolders } from '$lib/stores/chatList';
 	import { sanitizeResponseContent, extractCurlyBraceWords } from '$lib/utils';
 	import { WEBUI_API_BASE_URL, WEBUI_BASE_URL } from '$lib/constants';
 
@@ -113,10 +113,10 @@
 					folder={$selectedFolder}
 					readOnly={folderReadOnly}
 					onUpdate={async (folder) => {
-						await refreshChatList(localStorage.token);
+						await Promise.all([refreshChatList(localStorage.token), refreshFolders()]);
 					}}
 					onDelete={async () => {
-						await refreshChatList(localStorage.token);
+						await Promise.all([refreshChatList(localStorage.token), refreshFolders()]);
 
 						selectedFolder.set(null);
 					}}

--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -31,6 +31,7 @@
 		loadNextChatListPage,
 		refreshChatList,
 		registerFolderRefreshHandler,
+		registerFoldersRefreshHandler,
 		setAllChatsRead,
 		setChatActive,
 		setChatReadAt
@@ -720,6 +721,7 @@
 
 			return Promise.all(Object.values(folderRegistry).map((folder) => folder?.setFolderItems?.()));
 		});
+		const unregisterFoldersRefreshHandler = registerFoldersRefreshHandler(initFolders);
 
 		await tick();
 		await initSidebarData();
@@ -744,6 +746,7 @@
 			socketInstance?.off('connect', refreshChatRows);
 
 			unregisterFolderRefreshHandler();
+			unregisterFoldersRefreshHandler();
 		};
 	});
 

--- a/src/lib/stores/chatList.ts
+++ b/src/lib/stores/chatList.ts
@@ -82,6 +82,23 @@ export const refreshFolderChatLists = async (
 	await Promise.all([...folderRefreshHandlers].map((handler) => handler(folderId, chat)));
 };
 
+// The folder tree itself (names, icons, nesting) is likewise sidebar state, rebuilt
+// by its own fetch. Handlers registered here let the folder page request that
+// rebuild after it renames, re-icons, creates, or deletes a folder.
+type FoldersRefreshHandler = () => unknown;
+const foldersRefreshHandlers = new Set<FoldersRefreshHandler>();
+
+export const registerFoldersRefreshHandler = (handler: FoldersRefreshHandler) => {
+	foldersRefreshHandlers.add(handler);
+	return () => {
+		foldersRefreshHandlers.delete(handler);
+	};
+};
+
+export const refreshFolders = async () => {
+	await Promise.all([...foldersRefreshHandlers].map((handler) => handler()));
+};
+
 export const loadNextChatListPage = async (token: string = ''): Promise<ChatListResult> => {
 	if (!paginationReady || allLoaded || loadingNextPage) {
 		return { accepted: false, allLoaded };


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked and filled out the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or active, substantive [Discussion](https://github.com/open-webui/open-webui/discussions) - Fixes #28690
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented. No new dependencies.
- [x] **Testing:** **Manual** end-to-end tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **User-facing changes:** I have confirmed whether this PR changes the UI. It does; the sidebar now reflects folder edits made from the folder page. Screenshots below.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

# Changelog Entry

### Description

- Renaming a folder, changing its icon, or creating a subfolder from the folder's own page updated the backend and the page header, but the sidebar's Folders section kept the old name and icon (and did not show the new subfolder) until something else refreshed the sidebar or the page was reloaded.
- Until 2e9398749 the sidebar ran `initFolders()` whenever `$selectedFolder` changed, and `FolderTitle.svelte` relied on that by setting `selectedFolder` to the refetched folder after each edit. That refac replaced the full refetch with a refresh of the selected folder's chat list, which is right for the sidebar click path, but it also removed the only channel the folder page had into the sidebar's copy of the tree. `Placeholder.svelte`'s `onUpdate`/`onDelete` for `FolderTitle` only call `refreshChatList`, which touches the chat list and nothing about folders.
- Gives the folder page an explicit channel, using the pattern `src/lib/stores/chatList.ts` already has for the sibling problem: `registerFolderRefreshHandler` / `refreshFolderChatLists` let components outside the sidebar refresh a folder's chat list. This adds `registerFoldersRefreshHandler` / `refreshFolders()`, the sidebar registers `initFolders` next to its existing registration (and unregisters with it), and `Placeholder`'s `onUpdate` and `onDelete` call `refreshFolders()` alongside `refreshChatList`.

### Fixed

- The sidebar's Folders section updates immediately when a folder is renamed, given a new icon, or given a subfolder from the folder's own page.

---

### Additional Information

- `+23 −3` across three files. The registry mirrors the one directly above it in `chatList.ts`, including a matching two line comment.
- The rebuild is the sidebar's own `initFolders` (one `folders/` and one `folders/shared` request), the same call every other sidebar refresh uses, and it runs only on these user initiated edits, so the perf intent of 2e9398749 (no full refetch on every folder selection) is kept.
- Delete from the folder page goes through `onDelete`, which gets the same call; the branch was verified on rename, icon, and subfolder creation.

**Manual verification performed:**

1. Reproduced on `dev`: after picking an emoji on a folder page, the backend returned the new `meta.icon` and the header rendered it while the sidebar row for the same folder id still rendered the generic folder `svg`; after Create Folder from the page menu the folders API listed the subfolder and the sidebar tree row count was unchanged.
2. On this branch, same page: picking an emoji updated the sidebar row's icon immediately (`laughing` to `sweat_smile`); renaming through Edit updated the sidebar row's name immediately, and renaming back updated it again.
3. Confirmed in a browser on the folder page: icon and name changes show in the sidebar immediately, and the Folders section stays expanded through the refresh.

### Screenshots or Videos

Before is current `dev`. After is this branch.

| Surface | Before | After |
|---|---|---|
| Folder page after changing the icon from the header, with the sidebar Folders section visible | <img width="2556" height="859" alt="image" src="https://github.com/user-attachments/assets/a594a5c9-edd1-4fbc-b802-7813af1fb8c1" /> | <img width="2556" height="859" alt="image" src="https://github.com/user-attachments/assets/b0fb4333-4fe7-494a-a41d-0d4c153e25f1" /> |
| Folder page after renaming through the page menu's Edit, with the sidebar Folders section visible | <img width="2556" height="859" alt="image" src="https://github.com/user-attachments/assets/de0696f0-30f4-4e59-9738-6869e22f5512" /> | <img width="2556" height="859" alt="image" src="https://github.com/user-attachments/assets/b464c97a-e3d9-4bf7-9c6e-1d6d0663d4b3" /> |

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
