### PR TITLE
fix: stop the Files pane reopening on unrelated settings writes while a terminal is selected

### DIFF
--- a/src/lib/components/chat/ChatControls.svelte
+++ b/src/lib/components/chat/ChatControls.svelte
@@ -117,10 +117,11 @@
 	}
 
 	// Auto-open Files tab when a terminal is selected (suppress panel open when full-screen)
+	$: showFilesOnTerminalSelect = $settings?.showFilesOnTerminalSelect ?? true;
 	$: if ($selectedTerminalId && terminalFilesAvailable) {
 		activeTab = 'files';
 		if (largeScreen) {
-			showControls.set($settings?.showFilesOnTerminalSelect ?? true);
+			showControls.set(showFilesOnTerminalSelect);
 		}
 	}
 


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked and filled out the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or active, substantive [Discussion](https://github.com/open-webui/open-webui/discussions) - Fixes #28691
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented. No new dependencies.
- [x] **Testing:** **Manual** end-to-end tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **User-facing changes:** I have confirmed whether this PR changes the UI. It does; the Files pane no longer reopens by itself. No new UI.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

# Changelog Entry

### Description

- With a terminal selected, the Files pane reopened by itself after any user setting was saved, and its tab was forced back to Files. Changing a folder's icon from the folder page was enough, because the emoji picker saves its recently used list to settings; the pane came back on every pick even after being closed.
- In `ChatControls.svelte` the auto-open block reads `$settings?.showFilesOnTerminalSelect` inline, which makes the whole `$settings` store a dependency of the block, so it re-runs on every settings write rather than only when the terminal, its availability, or the screen size changes.
- Hoists that read into `$: showFilesOnTerminalSelect = $settings?.showFilesOnTerminalSelect ?? true;` and uses the boolean in the block. A reactive declaration re-assigned to an equal primitive does not propagate, so the block now runs only when the terminal, its availability, the screen size, or that specific setting changes.

### Fixed

- The Files pane opens when a terminal is selected and then stays closed once closed, instead of reopening after any settings save.

---

### Additional Information

- Two lines. Auto-open on terminal selection and on load with a persisted terminal is unchanged; only the re-fire on unrelated settings writes goes away, and with it the forced tab switch.
- The file has a pre-existing prettier difference on `dev` in an unrelated expression; left untouched to keep the diff to the change.

**Manual verification performed:**

1. Reproduced on `dev` with `open-terminal` selected on a large screen, watching the persisted `localStorage.showControls` mirror: `true` on load, `false` after the pane's close button, `true` again about a second after picking an emoji on a folder page.
2. On this branch, same steps: `true` on load (auto-open on selection still works), `false` after close, still `false` after the emoji pick.
3. Confirmed in a browser with Open Terminal toggled on: the pane opens on load and stays closed after closing it and changing a folder icon.

### Screenshots or Videos

Not applicable beyond the pane state; before, the Files pane is open after the emoji pick, after, it stays closed.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
