### PR TITLE
fix: compare folder names for uniqueness with lower() equality instead of a LIKE pattern

### DIFF
--- a/backend/open_webui/models/folders.py
+++ b/backend/open_webui/models/folders.py
@@ -230,7 +230,9 @@ class FolderTable:
             async with get_async_db_context(db) as db:
                 # Check if folder exists
                 result = await db.execute(
-                    select(Folder).filter_by(parent_id=parent_id, user_id=user_id).filter(Folder.name.ilike(name))
+                    select(Folder)
+                    .filter_by(parent_id=parent_id, user_id=user_id)
+                    .filter(func.lower(Folder.name) == func.lower(name))
                 )
                 folder = result.scalars().first()
 


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked and filled out the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing [Issue](https://github.com/open-webui/open-webui/issues) or active, substantive [Discussion](https://github.com/open-webui/open-webui/discussions) - Fixes #28694
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented. No new dependencies.
- [x] **Testing:** **Manual** end-to-end tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **User-facing changes:** I have confirmed whether this PR changes the UI. It does not; backend validation only. Renames that were wrongly refused or failed now succeed.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

# Changelog Entry

### Description

- Renaming a folder to a name ending in a backslash failed on Postgres with three backend errors for the one request (`InvalidEscapeSequence: LIKE pattern must not end with escape character`, then `InFailedSqlTransaction` on the shared session, then `'NoneType' object has no attribute 'name'` in the router) and a 400 `Error updating folder`. Separately, on every database, `_` and `%` in a folder name acted as wildcards in the uniqueness check, so renaming to `a_b` while `a b` existed was refused as `Folder already exists`.
- `get_folder_by_parent_id_and_user_id_and_name` filtered with `Folder.name.ilike(name)`, passing the raw folder name as a LIKE pattern. Its three call sites (create, rename, move) use it as a case-insensitive equality check for the unique-name rule; ILIKE was there only for the case-insensitivity, and the pattern semantics came along uninvited. The method's catch-all returns `None` on the error, the callers read that as "no duplicate", and with `DATABASE_ENABLE_SESSION_SHARING=true` the aborted transaction then fails the update query and the router dereferences the `None`.
- Compares for equality instead: `.filter(func.lower(Folder.name) == func.lower(name))`. Every character of the name is literal, nothing can raise, case-insensitivity is kept.

### Fixed

- Folder names are compared literally (and case-insensitively) for the unique-name rule: names ending in a backslash no longer break renames on Postgres, and `_` or `%` in a name no longer produce false `Folder already exists` refusals.

---

### Additional Information

- Three lines in `backend/open_webui/models/folders.py`; `func` was already imported there.
- `func.lower` on both sides keeps the comparison in the database's own case folding for the column, the same folding SQLAlchemy's `ilike` compiles to on SQLite (`lower(x) LIKE lower(y)`), so behavior on SQLite is unchanged apart from the wildcard fix.

**Manual verification performed:**

1. Reproduced on `dev` by calling the real model function against a Postgres 18.3 database: `get_folder_by_parent_id_and_user_id_and_name(None, user_id, 'zz-claude-y\\')` logged the identical `InvalidEscapeSequence` line from the report and returned `None`; the same call with `'zz-claude-a_b'` returned the folder named `zz-claude-a b`. Through the API, renaming to `zz-claude-a_b` while only `zz-claude-a b` existed returned `400 Folder already exists`.
2. On this branch, same database and function: `'zz-claude-y\\'` found exactly with no error; `'zz-claude-a_b'` and `'zz-claude-%'` return `None`; `'ZZ-CLAUDE-A B'` and `'zz-claude-a b'` both return `zz-claude-a b`.
3. Confirmed in the app: renaming a folder to a name ending in `\` succeeds, and renaming to `a_b` while `a b` exists succeeds.

### Screenshots or Videos

Not applicable; backend validation only. The observable change is that the two renames above succeed instead of failing.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
