### PR TITLE
fix: omit includeDomains from Exa API request when no filters specified

### DIFF
--- a/backend/open_webui/retrieval/web/exa.py
+++ b/backend/open_webui/retrieval/web/exa.py
@@ -38,10 +38,12 @@ def search_exa(
     payload = {
         'query': query,
         'numResults': count or 5,
-        'includeDomains': filter_list,
         'contents': {'text': True, 'highlights': True},
         'type': 'auto',  # Use the auto search type (keyword or neural)
     }
+
+    if filter_list:
+        payload['includeDomains'] = filter_list
 
     try:
         response = requests.post(f'{EXA_API_BASE}/search', headers=headers, json=payload)


### PR DESCRIPTION
This PR addresses: omit includeDomains from Exa API request when no filters specified