### PR TITLE
fix: add missing db parameter to filter_allowed_access_grants in update_note_access_by_id

### DIFF
--- a/backend/open_webui/routers/notes.py
+++ b/backend/open_webui/routers/notes.py
@@ -348,6 +348,7 @@ async def update_note_access_by_id(
         user.role,
         form_data.access_grants,
         'sharing.public_notes',
+        db=db,
     )
 
     AccessGrants.set_access_grants('note', id, form_data.access_grants, db=db)


### PR DESCRIPTION
This PR addresses: add missing db parameter to filter_allowed_access_grants in update_note_access_by_id