### PR TITLE
feat: configurable Tavily API base URL (egress proxy / Tavily-compatible endpoints)

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -1271,6 +1271,8 @@ SOUGOU_API_SK = os.getenv('SOUGOU_API_SK', '')
 
 TAVILY_API_KEY = os.getenv('TAVILY_API_KEY', '')
 
+TAVILY_API_BASE_URL = os.getenv('TAVILY_API_BASE_URL', 'https://api.tavily.com')
+
 TAVILY_EXTRACT_DEPTH = os.getenv('TAVILY_EXTRACT_DEPTH', 'basic')
 
 PLAYWRIGHT_WS_URL = os.getenv('PLAYWRIGHT_WS_URL', '')
@@ -2988,6 +2990,7 @@ DEFAULT_CONFIG = {
     'web.search.sougou_api_sid': SOUGOU_API_SID,
     'web.search.sougou_api_sk': SOUGOU_API_SK,
     'web.search.tavily_api_key': TAVILY_API_KEY,
+    'web.search.tavily_api_base_url': TAVILY_API_BASE_URL,
     'web.search.tavily_extract_depth': TAVILY_EXTRACT_DEPTH,
     'web.loader.playwright_ws_url': PLAYWRIGHT_WS_URL,
     'web.loader.playwright_timeout': PLAYWRIGHT_TIMEOUT,

--- a/backend/open_webui/retrieval/loaders/tavily.py
+++ b/backend/open_webui/retrieval/loaders/tavily.py
@@ -7,6 +7,8 @@ from langchain_core.documents import Document
 
 log = logging.getLogger(__name__)
 
+DEFAULT_TAVILY_API_BASE_URL = 'https://api.tavily.com'
+
 
 class TavilyLoader(BaseLoader):
     """Extract web page content from URLs using Tavily Extract API.
@@ -18,6 +20,7 @@ class TavilyLoader(BaseLoader):
         urls: URL or list of URLs to extract content from.
         api_key: The Tavily API key.
         extract_depth: Depth of extraction, either "basic" or "advanced".
+        api_base_url: Base URL of the Tavily API, for self-hosted or proxied endpoints.
         continue_on_failure: Whether to continue if extraction of a URL fails.
     """
 
@@ -26,6 +29,7 @@ class TavilyLoader(BaseLoader):
         urls: Union[str, List[str]],
         api_key: str,
         extract_depth: Literal['basic', 'advanced'] = 'basic',
+        api_base_url: str = DEFAULT_TAVILY_API_BASE_URL,
         continue_on_failure: bool = True,
     ) -> None:
         """Initialize Tavily Extract client.
@@ -39,6 +43,7 @@ class TavilyLoader(BaseLoader):
                 embedded content, with higher success but may increase latency.
                 basic costs 1 credit per 5 successful URL extractions,
                 advanced costs 2 credits per 5 successful URL extractions.
+            api_base_url: Base URL of the Tavily API, for self-hosted or proxied endpoints.
             continue_on_failure: Whether to continue if extraction of a URL fails.
         """
         if not urls:
@@ -48,7 +53,7 @@ class TavilyLoader(BaseLoader):
         self.urls = urls if isinstance(urls, list) else [urls]
         self.extract_depth = extract_depth
         self.continue_on_failure = continue_on_failure
-        self.api_url = 'https://api.tavily.com/extract'
+        self.api_url = f'{(api_base_url or DEFAULT_TAVILY_API_BASE_URL).rstrip("/")}/extract'
 
     def lazy_load(self) -> Iterator[Document]:
         """Extract and yield documents from the URLs using Tavily Extract API."""

--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -80,6 +80,7 @@ LOADER_CONFIG_KEYS = {
     'firecrawl_api_url': 'web.loader.firecrawl_api_url',
     'firecrawl_timeout': 'web.loader.firecrawl_timeout',
     'tavily_api_key': 'web.search.tavily_api_key',
+    'tavily_api_base_url': 'web.search.tavily_api_base_url',
     'tavily_extract_depth': 'web.search.tavily_extract_depth',
     'microsoft_web_iq_api_base_url': 'web.search.microsoft_web_iq_api_base_url',
     'microsoft_web_iq_api_key': 'web.search.microsoft_web_iq_api_key',

--- a/backend/open_webui/retrieval/web/tavily.py
+++ b/backend/open_webui/retrieval/web/tavily.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 
 import requests
+from open_webui.retrieval.loaders.tavily import DEFAULT_TAVILY_API_BASE_URL
 from open_webui.retrieval.web.main import SearchResult, get_filtered_results
 
 log = logging.getLogger(__name__)
@@ -13,6 +14,7 @@ def search_tavily(
     query: str,
     count: int,
     filter_list: list[str | None] = None,
+    api_base_url: str = DEFAULT_TAVILY_API_BASE_URL,
     # **kwargs,
 ) -> list[SearchResult]:
     """Search using Tavily's Search API and return the results as a list of SearchResult objects.
@@ -21,11 +23,12 @@ def search_tavily(
         api_key (str): A Tavily Search API key
         query (str): The query to search for
         count (int): The maximum number of results to return
+        api_base_url (str): Base URL of the Tavily API, for self-hosted or proxied endpoints
 
     Returns:
         A list of SearchResult objects.
     """
-    url = 'https://api.tavily.com/search'
+    url = f'{(api_base_url or DEFAULT_TAVILY_API_BASE_URL).rstrip("/")}/search'
     headers = {
         'Content-Type': 'application/json',
         'Authorization': f'Bearer {api_key}',

--- a/backend/open_webui/retrieval/web/utils.py
+++ b/backend/open_webui/retrieval/web/utils.py
@@ -42,6 +42,7 @@ from open_webui.config import (
     MICROSOFT_WEB_IQ_LANGUAGE,
     PLAYWRIGHT_TIMEOUT,
     PLAYWRIGHT_WS_URL,
+    TAVILY_API_BASE_URL,
     TAVILY_API_KEY,
     TAVILY_EXTRACT_DEPTH,
     WEB_FETCH_FILTER_LIST,
@@ -57,7 +58,7 @@ from open_webui.env import (
 )
 from open_webui.retrieval.loaders.external_web import ExternalWebLoader
 from open_webui.retrieval.loaders.microsoft_web_iq import MicrosoftWebIQLoader
-from open_webui.retrieval.loaders.tavily import TavilyLoader
+from open_webui.retrieval.loaders.tavily import DEFAULT_TAVILY_API_BASE_URL, TavilyLoader
 from open_webui.retrieval.web.firecrawl import scrape_firecrawl_url
 from open_webui.utils.misc import is_host_allowed
 
@@ -406,6 +407,7 @@ class SafeTavilyLoader(BaseLoader, RateLimitMixin, URLProcessingMixin):
         web_paths: Union[str, List[str]],
         api_key: str,
         extract_depth: Literal['basic', 'advanced'] = 'basic',
+        api_base_url: str = DEFAULT_TAVILY_API_BASE_URL,
         continue_on_failure: bool = True,
         requests_per_second: Optional[float] = None,
         verify_ssl: bool = True,
@@ -418,6 +420,7 @@ class SafeTavilyLoader(BaseLoader, RateLimitMixin, URLProcessingMixin):
             web_paths: List of URLs/paths to process.
             api_key: The Tavily API key.
             extract_depth: Depth of extraction ("basic" or "advanced").
+            api_base_url: Base URL of the Tavily API, for self-hosted or proxied endpoints.
             continue_on_failure: Whether to continue if extraction of a URL fails.
             requests_per_second: Number of requests per second to limit to.
             verify_ssl: If True, verify SSL certificates.
@@ -439,6 +442,7 @@ class SafeTavilyLoader(BaseLoader, RateLimitMixin, URLProcessingMixin):
         self.web_paths = web_paths if isinstance(web_paths, list) else [web_paths]
         self.api_key = api_key
         self.extract_depth = extract_depth
+        self.api_base_url = api_base_url
         self.continue_on_failure = continue_on_failure
         self.verify_ssl = verify_ssl
         self.trust_env = trust_env
@@ -469,6 +473,7 @@ class SafeTavilyLoader(BaseLoader, RateLimitMixin, URLProcessingMixin):
                 urls=valid_urls,
                 api_key=self.api_key,
                 extract_depth=self.extract_depth,
+                api_base_url=self.api_base_url,
                 continue_on_failure=self.continue_on_failure,
             )
             yield from loader.lazy_load()
@@ -501,6 +506,7 @@ class SafeTavilyLoader(BaseLoader, RateLimitMixin, URLProcessingMixin):
                 urls=valid_urls,
                 api_key=self.api_key,
                 extract_depth=self.extract_depth,
+                api_base_url=self.api_base_url,
                 continue_on_failure=self.continue_on_failure,
             )
             async for document in loader.alazy_load():
@@ -940,6 +946,7 @@ def get_web_loader(
         WebLoaderClass = SafeTavilyLoader
         web_loader_args['api_key'] = cfg('tavily_api_key', TAVILY_API_KEY)
         web_loader_args['extract_depth'] = cfg('tavily_extract_depth', TAVILY_EXTRACT_DEPTH)
+        web_loader_args['api_base_url'] = cfg('tavily_api_base_url', TAVILY_API_BASE_URL)
 
     if engine == 'microsoft_web_iq':
         WebLoaderClass = SafeMicrosoftWebIQLoader

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -384,6 +384,7 @@ RETRIEVAL_CONFIG_KEYS = {
     'SOUGOU_API_SID': 'web.search.sougou_api_sid',
     'SOUGOU_API_SK': 'web.search.sougou_api_sk',
     'TAVILY_API_KEY': 'web.search.tavily_api_key',
+    'TAVILY_API_BASE_URL': 'web.search.tavily_api_base_url',
     'TAVILY_EXTRACT_DEPTH': 'web.search.tavily_extract_depth',
     'TEXT_SPLITTER': 'rag.text_splitter',
     'TIKA_SERVER_URL': 'rag.tika_server_url',
@@ -741,6 +742,7 @@ async def get_rag_config(request: Request, user=Depends(get_admin_user)):
             'SERPLY_API_KEY': config.SERPLY_API_KEY,
             'DDGS_BACKEND': config.DDGS_BACKEND,
             'TAVILY_API_KEY': config.TAVILY_API_KEY,
+            'TAVILY_API_BASE_URL': config.TAVILY_API_BASE_URL,
             'SEARCHAPI_API_KEY': config.SEARCHAPI_API_KEY,
             'SEARCHAPI_ENGINE': config.SEARCHAPI_ENGINE,
             'SERPAPI_API_KEY': config.SERPAPI_API_KEY,
@@ -820,6 +822,7 @@ class WebConfig(BaseModel):
     SERPLY_API_KEY: str | None = None
     DDGS_BACKEND: str | None = None
     TAVILY_API_KEY: str | None = None
+    TAVILY_API_BASE_URL: str | None = None
     SEARCHAPI_API_KEY: str | None = None
     SEARCHAPI_ENGINE: str | None = None
     SERPAPI_API_KEY: str | None = None
@@ -1296,6 +1299,7 @@ async def update_rag_config(request: Request, form_data: ConfigForm, user=Depend
         config.SERPLY_API_KEY = form_data.web.SERPLY_API_KEY
         config.DDGS_BACKEND = form_data.web.DDGS_BACKEND
         config.TAVILY_API_KEY = form_data.web.TAVILY_API_KEY
+        config.TAVILY_API_BASE_URL = form_data.web.TAVILY_API_BASE_URL
         config.SEARCHAPI_API_KEY = form_data.web.SEARCHAPI_API_KEY
         config.SEARCHAPI_ENGINE = form_data.web.SEARCHAPI_ENGINE
         config.SERPAPI_API_KEY = form_data.web.SERPAPI_API_KEY
@@ -1447,6 +1451,7 @@ async def update_rag_config(request: Request, form_data: ConfigForm, user=Depend
             'SERPHOUSE_DOMAIN': config.SERPHOUSE_DOMAIN,
             'SERPLY_API_KEY': config.SERPLY_API_KEY,
             'TAVILY_API_KEY': config.TAVILY_API_KEY,
+            'TAVILY_API_BASE_URL': config.TAVILY_API_BASE_URL,
             'SEARCHAPI_API_KEY': config.SEARCHAPI_API_KEY,
             'SEARCHAPI_ENGINE': config.SEARCHAPI_ENGINE,
             'SERPAPI_API_KEY': config.SERPAPI_API_KEY,
@@ -2617,6 +2622,7 @@ async def search_web(request: Request, engine: str, query: str, user=None) -> li
                 query,
                 config.WEB_SEARCH_RESULT_COUNT,
                 config.WEB_SEARCH_DOMAIN_FILTER_LIST,
+                api_base_url=config.TAVILY_API_BASE_URL,
             )
         else:
             raise Exception('No TAVILY_API_KEY found in environment variables')

--- a/src/lib/components/admin/Settings/WebSearch.svelte
+++ b/src/lib/components/admin/Settings/WebSearch.svelte
@@ -571,6 +571,24 @@
 									bind:value={webConfig.TAVILY_API_KEY}
 								/>
 							</div>
+
+							<div class="mt-2">
+								<div class=" self-center text-xs text-gray-600 dark:text-gray-400 mb-1">
+									{$i18n.t('Tavily API Base URL')}
+								</div>
+
+								<div class="flex w-full">
+									<div class="flex-1">
+										<input
+											class="w-full rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 py-1.5 text-xs text-gray-700 outline-hidden transition-colors focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:focus:border-blue-500"
+											type="text"
+											placeholder={$i18n.t('Enter Tavily API Base URL')}
+											bind:value={webConfig.TAVILY_API_BASE_URL}
+											autocomplete="off"
+										/>
+									</div>
+								</div>
+							</div>
 						</div>
 					{:else if webConfig.WEB_SEARCH_ENGINE === 'searchapi'}
 						<div class="mb-2.5 flex w-full flex-col">
@@ -1301,6 +1319,24 @@
 									placeholder={$i18n.t('Enter Tavily API Key')}
 									bind:value={webConfig.TAVILY_API_KEY}
 								/>
+							</div>
+
+							<div class="mt-2">
+								<div class=" self-center text-xs text-gray-600 dark:text-gray-400 mb-1">
+									{$i18n.t('Tavily API Base URL')}
+								</div>
+
+								<div class="flex w-full">
+									<div class="flex-1">
+										<input
+											class="w-full rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 py-1.5 text-xs text-gray-700 outline-hidden transition-colors focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:focus:border-blue-500"
+											type="text"
+											placeholder={$i18n.t('Enter Tavily API Base URL')}
+											bind:value={webConfig.TAVILY_API_BASE_URL}
+											autocomplete="off"
+										/>
+									</div>
+								</div>
 							</div>
 						{/if}
 					</div>


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #28701
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Env-var docs for the new setting would belong in the docs repo; the admin UI field is self-documenting.
- [ ] **Dependencies:** None.
- [x] **Testing:** Contract checks on every wiring point + URL construction tests (see below).
- [x] **No Unchecked AI Code:** Reviewed and mechanically verified; pattern is a 1:1 port of the existing FIRECRAWL_API_BASE_URL wiring.
- [x] **Self-Review:** Performed.
- [x] **Architecture:** Smart default (`https://api.tavily.com`); no new settings beyond the single base URL knob.
- [x] **Git Hygiene:** Single atomic commit, rebased on latest `dev`.
- [x] **Title Prefix:** `feat`

# Changelog Entry

### Description

Make the Tavily API endpoint configurable so outbound Tavily traffic can be routed through a dedicated **API proxy / gateway** - the standard pattern for locked-down or air-gapped deployments where Open WebUI has no direct internet access and all egress flows through an approved proxy that also centralizes key management - or pointed at a **Tavily-compatible endpoint**, following the existing `FIRECRAWL_API_BASE_URL` pattern exactly.

### Added

- `TAVILY_API_BASE_URL` env var (default `https://api.tavily.com`).
- Persistent config key `web.search.tavily_api_base_url` (shared by the search and loader paths, same convention as `tavily_api_key`).
- `api_base_url` parameters on `TavilyLoader`, `SafeTavilyLoader`, and `search_tavily()` (all defaulting to the public endpoint).
- "Tavily API Base URL" input in Admin Settings -> Web Search (search-engine section and web-loader section).

### Changed

- `search_tavily()` now requests `{api_base_url}/search`; `TavilyLoader` requests `{api_base_url}/extract` (trailing slashes on the configured value are tolerated; empty/None falls back to the default).
- `DEFAULT_TAVILY_API_BASE_URL` lives in `retrieval/loaders/tavily.py` and is imported by the search module (single source of truth).

### Deprecated

- None.

### Removed

- None.

### Fixed

- None (feature; closes #28701).

### Security

- None.

### Breaking Changes

- None. Default value is the previously hardcoded URL, so existing deployments behave identically.

---

### Additional Information

Typical setups this enables:

- **Locked-down / air-gapped deployments**: Open WebUI runs without direct internet access; an approved egress proxy (which can also serve as a central point for API-key management) is the only path to external services. Set `TAVILY_API_BASE_URL` (or fill the admin field) and both search and extract requests go through it - no source patching at deploy time.
- **Tavily-compatible endpoints**: third-party services implementing the same `/search` and `/extract` API contract.

Wiring verified end-to-end: env constant -> persistent key -> `LOADER_CONFIG_KEYS` (`tavily_api_base_url` -> `web.search.tavily_api_base_url`) -> `get_web_loader()` `cfg()` lookup -> `SafeTavilyLoader` -> inner `TavilyLoader` (both `lazy_load` and `alazy_load`); plus the admin config payloads (x2), form model, and update-save path in `routers/retrieval.py`, and the search call site (`api_base_url=config.TAVILY_API_BASE_URL`). URL construction tested for default, custom base, trailing slash, and empty/None fallback.

### Screenshots or Videos

N/A - backend + settings form field; markup mirrors the adjacent "Firecrawl API Base URL" / "Microsoft Web IQ API Base URL" inputs.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
