### PR TITLE
fix: forward uploaded videos as video_url content parts

### DIFF
--- a/backend/open_webui/test/utils/test_multimodal.py
+++ b/backend/open_webui/test/utils/test_multimodal.py
@@ -1,0 +1,113 @@
+from open_webui.utils.multimodal import (
+    build_media_content_parts,
+    get_media_content_part_type,
+    get_media_content_part_url,
+    is_inline_media_data_url,
+)
+
+
+class TestGetMediaContentPartType:
+    def test_image_by_type(self):
+        assert get_media_content_part_type({'type': 'image'}) == 'image_url'
+
+    def test_image_by_content_type(self):
+        assert get_media_content_part_type({'type': 'file', 'content_type': 'image/png'}) == 'image_url'
+
+    def test_video_by_type(self):
+        assert get_media_content_part_type({'type': 'video'}) == 'video_url'
+
+    def test_video_by_content_type(self):
+        # Videos are uploaded as generic files, so the content type is what identifies them.
+        assert get_media_content_part_type({'type': 'file', 'content_type': 'video/mp4'}) == 'video_url'
+
+    def test_non_media_file(self):
+        assert get_media_content_part_type({'type': 'file', 'content_type': 'application/pdf'}) is None
+
+    def test_missing_content_type(self):
+        assert get_media_content_part_type({'type': 'file'}) is None
+
+    def test_non_dict(self):
+        assert get_media_content_part_type(None) is None
+        assert get_media_content_part_type('video/mp4') is None
+
+
+class TestBuildMediaContentParts:
+    def test_video_file_becomes_video_url_part(self):
+        files = [{'type': 'file', 'content_type': 'video/mp4', 'url': 'file-id-1'}]
+        assert build_media_content_parts(files) == [{'type': 'video_url', 'video_url': {'url': 'file-id-1'}}]
+
+    def test_image_file_becomes_image_url_part(self):
+        files = [{'type': 'image', 'url': 'file-id-1'}]
+        assert build_media_content_parts(files) == [{'type': 'image_url', 'image_url': {'url': 'file-id-1'}}]
+
+    def test_non_media_files_are_ignored(self):
+        files = [
+            {'type': 'file', 'content_type': 'application/pdf', 'url': 'file-id-1'},
+            {'type': 'collection', 'url': 'file-id-2'},
+        ]
+        assert build_media_content_parts(files) == []
+
+    def test_files_without_url_are_skipped(self):
+        files = [
+            {'type': 'file', 'content_type': 'video/mp4'},
+            {'type': 'file', 'content_type': 'video/mp4', 'url': ''},
+        ]
+        assert build_media_content_parts(files) == []
+
+    def test_parts_are_grouped_by_media_kind(self):
+        files = [
+            {'type': 'file', 'content_type': 'video/mp4', 'url': 'video-1'},
+            {'type': 'image', 'url': 'image-1'},
+            {'type': 'file', 'content_type': 'video/webm', 'url': 'video-2'},
+        ]
+        assert build_media_content_parts(files) == [
+            {'type': 'image_url', 'image_url': {'url': 'image-1'}},
+            {'type': 'video_url', 'video_url': {'url': 'video-1'}},
+            {'type': 'video_url', 'video_url': {'url': 'video-2'}},
+        ]
+
+    def test_empty_input(self):
+        assert build_media_content_parts([]) == []
+        assert build_media_content_parts(None) == []
+
+
+class TestGetMediaContentPartUrl:
+    def test_video_part(self):
+        item = {'type': 'video_url', 'video_url': {'url': 'file-id-1'}}
+        assert get_media_content_part_url(item) == ('video_url', 'file-id-1')
+
+    def test_image_part(self):
+        item = {'type': 'image_url', 'image_url': {'url': 'file-id-1'}}
+        assert get_media_content_part_url(item) == ('image_url', 'file-id-1')
+
+    def test_text_part_is_not_media(self):
+        assert get_media_content_part_url({'type': 'text', 'text': 'hello'}) is None
+
+    def test_malformed_media_part(self):
+        assert get_media_content_part_url({'type': 'video_url'}) is None
+        assert get_media_content_part_url({'type': 'video_url', 'video_url': 'file-id-1'}) is None
+
+    def test_missing_url(self):
+        assert get_media_content_part_url({'type': 'video_url', 'video_url': {}}) == ('video_url', '')
+
+    def test_non_dict(self):
+        assert get_media_content_part_url(None) is None
+        assert get_media_content_part_url('video_url') is None
+
+
+class TestIsInlineMediaDataUrl:
+    def test_video_data_url(self):
+        assert is_inline_media_data_url('video_url', 'data:video/mp4;base64,AAAA') is True
+
+    def test_image_data_url(self):
+        assert is_inline_media_data_url('image_url', 'data:image/png;base64,AAAA') is True
+
+    def test_file_id_is_not_inline(self):
+        assert is_inline_media_data_url('video_url', 'file-id-1') is False
+
+    def test_mismatched_media_kind_is_not_inline(self):
+        # An image data URL must not be treated as an already-resolved video.
+        assert is_inline_media_data_url('video_url', 'data:image/png;base64,AAAA') is False
+
+    def test_unknown_part_type(self):
+        assert is_inline_media_data_url('audio_url', 'data:audio/wav;base64,AAAA') is False

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -119,6 +119,11 @@ from open_webui.utils.misc import (
     set_last_user_message_content,
     strip_empty_content_blocks,
 )
+from open_webui.utils.multimodal import (
+    build_media_content_parts,
+    get_media_content_part_url,
+    is_inline_media_data_url,
+)
 from open_webui.utils.payload import apply_params_to_form_data, apply_system_prompt_to_body, resolve_system_prompt
 from open_webui.utils.plugin import load_function_module_by_id
 from open_webui.utils.response import merge_usage, normalize_usage
@@ -1995,7 +2000,7 @@ async def chat_completion_files_handler(
     return body, {'sources': sources}
 
 
-async def convert_url_images_to_base64(form_data, user=None):
+async def convert_url_media_to_base64(form_data, user=None):
     messages = form_data.get('messages', [])
 
     for message in messages:
@@ -2006,28 +2011,31 @@ async def convert_url_images_to_base64(form_data, user=None):
         new_content = []
 
         for item in content:
-            if not isinstance(item, dict) or item.get('type') != 'image_url':
+            media_part = get_media_content_part_url(item)
+            if media_part is None:
                 new_content.append(item)
                 continue
 
-            image_url = item.get('image_url', {}).get('url', '')
-            if image_url.startswith('data:image/'):
+            part_type, media_url = media_part
+            if not media_url or is_inline_media_data_url(part_type, media_url):
                 new_content.append(item)
                 continue
 
             try:
-                base64_data = await get_image_base64_from_url(image_url, user=user)
+                # Resolves both remote URLs and bare file ids (access-checked) to a data URL,
+                # deriving the MIME type from the stored file, so it covers every media kind.
+                base64_data = await get_image_base64_from_url(media_url, user=user)
                 if base64_data:
                     new_content.append(
                         {
-                            'type': 'image_url',
-                            'image_url': {'url': base64_data},
+                            'type': part_type,
+                            part_type: {'url': base64_data},
                         }
                     )
                 else:
                     new_content.append(item)
             except Exception as e:
-                log.debug('Error converting image URL to base64: %s', e)
+                log.debug('Error converting media URL to base64: %s', e)
                 new_content.append(item)
 
         message['content'] = new_content
@@ -2305,26 +2313,15 @@ async def process_chat_payload(request, form_data, user, metadata, model):
             system_message = get_system_message(form_data.get('messages', []))
             form_data['messages'] = [system_message, *db_messages] if system_message else db_messages
 
-            # Inject image files into content as image_url parts (mirrors frontend logic)
+            # Inject media files into content as typed parts (mirrors frontend logic)
             for message in form_data['messages']:
-                image_files = [
-                    f
-                    for f in message.get('files', [])
-                    if f.get('type') == 'image' or (f.get('content_type') or '').startswith('image/')
-                ]
-                if message.get('role') == 'user' and image_files:
+                media_parts = build_media_content_parts(message.get('files', []))
+                if message.get('role') == 'user' and media_parts:
                     text_content = message.get('content', '')
                     if isinstance(text_content, str):
                         message['content'] = [
                             {'type': 'text', 'text': text_content},
-                            *[
-                                {
-                                    'type': 'image_url',
-                                    'image_url': {'url': f['url']},
-                                }
-                                for f in image_files
-                                if f.get('url')
-                            ],
+                            *media_parts,
                         ]
                 # Strip files field — it's been incorporated into content
                 message.pop('files', None)
@@ -2379,7 +2376,7 @@ async def process_chat_payload(request, form_data, user, metadata, model):
         except Exception:
             pass
 
-    form_data = await convert_url_images_to_base64(form_data, user=user)
+    form_data = await convert_url_media_to_base64(form_data, user=user)
 
     event_emitter = await get_event_emitter(metadata)
     event_caller = await get_event_call(metadata)

--- a/backend/open_webui/utils/multimodal.py
+++ b/backend/open_webui/utils/multimodal.py
@@ -1,0 +1,80 @@
+"""Mapping between uploaded files and OpenAI-compatible multimodal content parts.
+
+Uploaded files that a model can consume natively are forwarded as typed content
+parts (``image_url``, ``video_url``) instead of being handed to retrieval as
+plain attachments. This module is intentionally dependency-free so the mapping
+stays reusable and unit-testable without importing the middleware stack.
+"""
+
+from typing import Any
+
+# Ordered mapping of natively supported media kinds.
+# Each entry is (uploaded-file ``type`` value, ``content_type`` prefix, content part type).
+MEDIA_CONTENT_PARTS: tuple[tuple[str, str, str], ...] = (
+    ('image', 'image/', 'image_url'),
+    ('video', 'video/', 'video_url'),
+)
+
+MEDIA_CONTENT_PART_TYPES: tuple[str, ...] = tuple(part_type for _, _, part_type in MEDIA_CONTENT_PARTS)
+
+
+def get_media_content_part_type(file: Any) -> str | None:
+    """Return the content part type for an uploaded file, or None if it is not native media."""
+    if not isinstance(file, dict):
+        return None
+
+    file_type = file.get('type')
+    content_type = file.get('content_type') or ''
+
+    for kind, mime_prefix, part_type in MEDIA_CONTENT_PARTS:
+        if file_type == kind or content_type.startswith(mime_prefix):
+            return part_type
+
+    return None
+
+
+def build_media_content_parts(files: Any) -> list[dict]:
+    """Build OpenAI-compatible media content parts for the given uploaded files.
+
+    Files without a resolvable URL are skipped. Parts are grouped by media kind so
+    the emitted order stays stable regardless of the order the files were attached in.
+    """
+    parts_by_type: dict[str, list[dict]] = {part_type: [] for part_type in MEDIA_CONTENT_PART_TYPES}
+
+    for file in files or []:
+        part_type = get_media_content_part_type(file)
+        if part_type is None:
+            continue
+
+        url = file.get('url')
+        if not url:
+            continue
+
+        parts_by_type[part_type].append({'type': part_type, part_type: {'url': url}})
+
+    return [part for part_type in MEDIA_CONTENT_PART_TYPES for part in parts_by_type[part_type]]
+
+
+def get_media_content_part_url(item: Any) -> tuple[str, str] | None:
+    """Return ``(part_type, url)`` for a media content part, or None for any other part."""
+    if not isinstance(item, dict):
+        return None
+
+    part_type = item.get('type')
+    if part_type not in MEDIA_CONTENT_PART_TYPES:
+        return None
+
+    value = item.get(part_type)
+    if not isinstance(value, dict):
+        return None
+
+    return part_type, value.get('url') or ''
+
+
+def is_inline_media_data_url(part_type: str, url: str) -> bool:
+    """Return True when the URL is already an inline data URL for that media kind."""
+    for _, mime_prefix, candidate_part_type in MEDIA_CONTENT_PARTS:
+        if candidate_part_type == part_type:
+            return url.startswith(f'data:{mime_prefix}')
+
+    return False


### PR DESCRIPTION
Reason: Uploaded `video/*` files were treated as ordinary attachments and never emitted as `video_url` content, so models with native video input could not receive them.

### Context

No existing issue/discussion covers this, so here is the short rationale: the upload path already accepts videos and deliberately stores them for later multimodal use, but nothing downstream ever forwarded them, making that stored state unreachable. This wires up the missing half so video-capable models can actually receive the upload.

## Problem

`backend/open_webui/routers/files.py` already stores videos as-is and marks them `completed`, with an explicit note that they are kept for downstream multimodal processing. Nothing consumed them.

In `process_chat_payload`, only **image** files were promoted into content parts, and the `files` field was then stripped from every message:

```python
image_files = [f for f in message.get('files', []) if f.get('type') == 'image' or ...startswith('image/')]
if message.get('role') == 'user' and image_files:
    ...
message.pop('files', None)   # videos silently discarded here
```

So a video upload was dropped from the request entirely — `video_url` appears nowhere in the codebase today. Videos arrive as `type: 'file'` with `content_type: 'video/*'` (they take the generic-file branch on upload), which is what identifies them.

## Changes

- **`backend/open_webui/utils/multimodal.py` (new)** — one dependency-free place mapping an uploaded file to its OpenAI-compatible content part type. Adding a media kind is a single tuple entry:

  ```python
  MEDIA_CONTENT_PARTS = (
      ('image', 'image/', 'image_url'),
      ('video', 'video/', 'video_url'),
  )
  ```

  Files with no resolvable URL are skipped, and parts are grouped by media kind so emitted order is stable regardless of attach order.

- **`backend/open_webui/utils/middleware.py`** — the injection block emits `video_url` parts next to `image_url` via `build_media_content_parts`, and `convert_url_images_to_base64` becomes `convert_url_media_to_base64` so `video_url` parts are resolved too. Without that second half a bare file id would be forwarded verbatim as the URL.

Resolution reuses the existing `get_image_base64_from_url` / `get_image_base64_from_file_id` pair, which already derives the MIME type from the stored file and enforces the owner/admin/read-grant check, so a video file id resolves to `data:video/mp4;base64,...` under the same access gate as images. No change was needed there.

## Behavior notes

- The image path is behaviorally unchanged: same matching rules, same skip-when-no-URL rule, same inline-data-URL short circuit.
- A media part whose value is not a dict is now passed through instead of raising `AttributeError`, and an inline data URL of a *different* media kind is no longer mistaken for an already-resolved part.
- Files that fail to resolve are preserved rather than dropped, matching the previous fallback.

## Testing

Automated, run from `backend/`:

- `python3 -m pytest open_webui/test/utils/test_multimodal.py -q` — 24 passed. Covers file classification, part construction and ordering, URL extraction, inline-data-URL detection, and malformed input.
- `ruff format --check` on the three touched files — already formatted.
- `ruff check` on the two new files — clean. `middleware.py` reports the same 60 pre-existing findings before and after this change, so no new ones are introduced.

I also exercised the two changed `middleware.py` blocks directly against a stubbed file resolver to confirm the full path: a `video/mp4` upload becomes a `video_url` part, its file id resolves to a `data:video/mp4;base64,...` URL, re-running is idempotent, unresolvable ids are preserved, and the image path is unaffected.

Not run: the full backend suite and frontend checks, which need dependencies unavailable in my environment. This change is backend-only and touches no frontend file. I have not performed manual end-to-end testing against a live video-capable endpoint, so please treat that as unverified.

## Changelog

### Fixed

- Uploaded videos are now forwarded to models as `video_url` content parts instead of being silently dropped from the request, enabling native video input on models that support it.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
