### PR TITLE
fix(retrieval): prevent BM25 full-collection OOM when native hybrid search fails

### DIFF
--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -455,7 +455,7 @@ async def query_doc_with_native_hybrid_search(
             'metadatas': [metadatas],
         }
     except Exception as e:
-        log.debug('Native hybrid search failed for %s, falling back to legacy hybrid search: %s', collection_name, e)
+        log.warning('Native hybrid search failed for %s: %s', collection_name, e)
         return None
 
 
@@ -705,7 +705,7 @@ async def query_collection(
                 enable_enriched_texts=config.get('rag.enable_hybrid_search_enriched_texts'),
             )
         except Exception as e:
-            log.debug('Hybrid search failed, falling back to vector search: %s', e)
+            log.warning('Hybrid search failed, falling back to vector search: %s', e)
 
     results = []
     error = False
@@ -791,13 +791,35 @@ async def query_collection_with_hybrid_search(
         if native_task_results and all(result is not None for result in native_task_results):
             return merge_and_sort_query_results(native_task_results, k=k)
 
+        # The vector DB supports native hybrid search but one or more tasks
+        # returned None (embedding failure, reranker error, transient DB error,
+        # etc.).  Rather than falling through to the BM25 path that reads every
+        # collection in full — which can balloon to multiple GBs and trigger an
+        # OOM kill on large collections — raise so the caller can fall back to
+        # the bounded vector-only search path.
+        if native_task_results:
+            none_count = sum(1 for r in native_task_results if r is None)
+            log.warning(
+                'query_collection_with_hybrid_search: native hybrid search returned '
+                'None for %d/%d task(s); raising to trigger vector-only fallback '
+                'and prevent unbounded full-collection BM25 prefetch.',
+                none_count,
+                len(native_task_results),
+            )
+            raise RuntimeError(
+                f'Native hybrid search failed for {none_count}/{len(native_task_results)} task(s)'
+            )
+
     # Fetch every collection's contents once up front so the
     # per-query/per-document loop below can reuse them. Each fetch
     # offloads to a worker thread, so run them concurrently with
     # `asyncio.gather` instead of awaiting them serially — otherwise
     # latency scales linearly with `len(collection_names)`.
+    # NOTE: This path is reached only when native hybrid search is not
+    # available for this vector backend (e.g. Chroma) or when enriched
+    # texts are requested; it is intentional in those cases.
     log.debug(
-        'query_collection_with_hybrid_search: prefetching %d collections',
+        'query_collection_with_hybrid_search: prefetching %d collections (BM25 path)',
         len(collection_names),
     )
 

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -3061,41 +3061,47 @@ async def query_collection_handler(
 
     try:
         if config.ENABLE_RAG_HYBRID_SEARCH and (form_data.hybrid is None or form_data.hybrid):
-            return await query_collection_with_hybrid_search(
-                collection_names=form_data.collection_names,
-                queries=[form_data.query],
-                embedding_function=lambda query, prefix: request.app.state.EMBEDDING_FUNCTION(
-                    query, prefix=prefix, user=user
-                ),
-                k=form_data.k if form_data.k else config.TOP_K,
-                reranking_function=(
-                    (lambda query, documents: request.app.state.RERANKING_FUNCTION(query, documents, user=user))
-                    if request.app.state.RERANKING_FUNCTION
-                    else None
-                ),
-                k_reranker=form_data.k_reranker or config.TOP_K_RERANKER,
-                r=(form_data.r if form_data.r else config.RELEVANCE_THRESHOLD),
-                hybrid_bm25_weight=(
-                    form_data.hybrid_bm25_weight
-                    if form_data.hybrid_bm25_weight is not None
-                    else config.HYBRID_BM25_WEIGHT
-                ),
-                enable_enriched_texts=(
-                    form_data.enable_enriched_texts
-                    if form_data.enable_enriched_texts is not None
-                    else config.ENABLE_RAG_HYBRID_SEARCH_ENRICHED_TEXTS
-                ),
-            )
-        else:
-            return await query_collection(
-                request,
-                collection_names=form_data.collection_names,
-                queries=[form_data.query],
-                embedding_function=lambda query, prefix: request.app.state.EMBEDDING_FUNCTION(
-                    query, prefix=prefix, user=user
-                ),
-                k=form_data.k if form_data.k else config.TOP_K,
-            )
+            try:
+                return await query_collection_with_hybrid_search(
+                    collection_names=form_data.collection_names,
+                    queries=[form_data.query],
+                    embedding_function=lambda query, prefix: request.app.state.EMBEDDING_FUNCTION(
+                        query, prefix=prefix, user=user
+                    ),
+                    k=form_data.k if form_data.k else config.TOP_K,
+                    reranking_function=(
+                        (lambda query, documents: request.app.state.RERANKING_FUNCTION(query, documents, user=user))
+                        if request.app.state.RERANKING_FUNCTION
+                        else None
+                    ),
+                    k_reranker=form_data.k_reranker or config.TOP_K_RERANKER,
+                    r=(form_data.r if form_data.r else config.RELEVANCE_THRESHOLD),
+                    hybrid_bm25_weight=(
+                        form_data.hybrid_bm25_weight
+                        if form_data.hybrid_bm25_weight is not None
+                        else config.HYBRID_BM25_WEIGHT
+                    ),
+                    enable_enriched_texts=(
+                        form_data.enable_enriched_texts
+                        if form_data.enable_enriched_texts is not None
+                        else config.ENABLE_RAG_HYBRID_SEARCH_ENRICHED_TEXTS
+                    ),
+                )
+            except Exception as hybrid_exc:
+                log.warning(
+                    'Hybrid search failed for /query/collection, falling back to vector-only search: %s',
+                    hybrid_exc,
+                )
+
+        return await query_collection(
+            request,
+            collection_names=form_data.collection_names,
+            queries=[form_data.query],
+            embedding_function=lambda query, prefix: request.app.state.EMBEDDING_FUNCTION(
+                query, prefix=prefix, user=user
+            ),
+            k=form_data.k if form_data.k else config.TOP_K,
+        )
 
     except HTTPException:
         raise


### PR DESCRIPTION
Closes #28679.

## Summary

When the vector DB supports native hybrid search (e.g. pgvector) but a per-collection native search task returns `None` — due to an embedding failure, a reranker error, or any other transient exception — the previous code fell through to the legacy BM25 path, which calls `ASYNC_VECTOR_DB_CLIENT.get()` to prefetch **every collection in full**. On large collections (hundreds of thousands of chunks) this ballooned to multiple GBs and triggered OOM kills. The failure was also swallowed at `DEBUG` level, invisible at default log verbosity.

## Root Cause

`query_collection_with_hybrid_search` (`retrieval/utils.py`):

```python
native_task_results = await asyncio.gather(...)
if native_task_results and all(result is not None for result in native_task_results):
    return merge_and_sort_query_results(native_task_results, k=k)

# ← falls through here when ANY native task returns None
#   and unconditionally prefetches ALL collections into memory
```

When even one native task returns `None`, the code fell through to a path that read every collection in full to build an in-process BM25 retriever. For large collections this is unbounded and OOM-kills the server. The native failure log in `query_doc_with_native_hybrid_search` was at `DEBUG` level, so operators saw nothing until the OOM.

## Changes

### `backend/open_webui/retrieval/utils.py`

- **`query_doc_with_native_hybrid_search`** (exception handler): `log.debug` → `log.warning` so individual collection failures are visible without enabling debug logging.
- **`query_collection_with_hybrid_search`**: after attempting native search for all `(collection, query)` pairs, when the DB *supports* native hybrid search but one or more tasks returned `None`, log `WARNING` and raise `RuntimeError` instead of falling through to the BM25 full-collection prefetch. The raise bubbles to `query_collection`'s `except` clause, which already falls back to the bounded vector-only path.
- **`query_collection`** (except clause): `log.debug` → `log.warning` so the vector-only fallback is visible in production logs.

### `backend/open_webui/routers/retrieval.py`

- **`query_collection_handler`**: wrap the direct `query_collection_with_hybrid_search` call in a try/except that falls back to vector-only search on failure, matching the behaviour of the internal `query_collection` helper. Previously a `RuntimeError` would propagate to the outer except and return HTTP 400; now the endpoint gracefully degrades.

## No regression for:

| Scenario | Behaviour |
|---|---|
| Chroma / backends without `hybrid_search` | Native returns `None` via the `not _supports_native_hybrid_search()` branch **before** any network call; falls through to BM25 as before (intentional). |
| `enable_enriched_texts=True` | Native attempt is skipped entirely; BM25 path as before (intentional). |
| Successful native hybrid search | Early return path unchanged. |

## Testing

- `python3 -m py_compile backend/open_webui/retrieval/utils.py` — passes.
- `python3 -m py_compile backend/open_webui/routers/retrieval.py` — passes.
- Logic verified by code inspection: the new guard is gated on `native_task_results` being non-empty and truthy (skips the raise for the empty-list edge case). The BM25 path is only suppressed when `_supports_native_hybrid_search()` is True (i.e., the vector DB has `hybrid_search`) — Chroma users are unaffected. Live E2E on a pgvector backend with a large collection was not run (environment limitation); disclosed here.

---

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
