### PR TITLE
fix(auth): preserve OAuth signout redirect

### DIFF
--- a/src/lib/components/layout/Sidebar/UserMenu.svelte
+++ b/src/lib/components/layout/Sidebar/UserMenu.svelte
@@ -6,6 +6,7 @@
 
 	import { getUsage } from '$lib/apis';
 	import { getSessionUser, userSignOut } from '$lib/apis/auths';
+	import { getSignOutRedirect, shouldPreserveUserForRedirect } from '$lib/utils/signout';
 
 	import { showSettings, mobile, showSidebar, user, config, settings } from '$lib/stores';
 
@@ -571,10 +572,17 @@
 				type="button"
 				on:click={async () => {
 					const res = await userSignOut();
-					user.set(null);
+					const redirectUrl = getSignOutRedirect(res);
 					localStorage.removeItem('token');
 
-					location.href = res?.redirect_url ?? '/auth';
+					if (shouldPreserveUserForRedirect(res)) {
+						location.href = redirectUrl;
+						return;
+					}
+
+					user.set(null);
+
+					location.href = redirectUrl;
 					show = false;
 				}}
 			>

--- a/src/lib/utils/signout.test.ts
+++ b/src/lib/utils/signout.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { getSignOutRedirect, shouldPreserveUserForRedirect } from './signout';
+
+describe('sign-out redirect handling', () => {
+	it('preserves the user state while navigating to an external identity provider', () => {
+		const response = { redirect_url: 'https://idp.example.com/logout' };
+
+		expect(getSignOutRedirect(response)).toBe(response.redirect_url);
+		expect(shouldPreserveUserForRedirect(response)).toBe(true);
+	});
+
+	it('clears the user state for local sign-out fallback', () => {
+		expect(getSignOutRedirect(null)).toBe('/auth');
+		expect(shouldPreserveUserForRedirect(null)).toBe(false);
+	});
+});

--- a/src/lib/utils/signout.ts
+++ b/src/lib/utils/signout.ts
@@ -1,0 +1,6 @@
+export type SignOutResponse = { redirect_url?: string | null } | null;
+
+export const getSignOutRedirect = (response: SignOutResponse) => response?.redirect_url ?? '/auth';
+
+export const shouldPreserveUserForRedirect = (response: SignOutResponse) =>
+	Boolean(response?.redirect_url);


### PR DESCRIPTION
Closes #28320

## Summary

OAuth/OIDC sign-out can be interrupted by the app layout's reactive auth guard. The guard observes `user.set(null)` and navigates to `/auth` before the browser reaches the identity provider's `end_session_endpoint`.

This change preserves the user store while an external `redirect_url` is being navigated to, while still clearing the local token. The local `/auth` fallback keeps the existing state-clearing behavior. A focused unit test covers both redirect branches.

## Compatibility

No API or dependency changes. External OAuth logout navigation is allowed to complete; local logout behavior is unchanged.

## Testing

- `git diff --check` — passed.
- `npm run test:frontend -- --run src/lib/utils/signout.test.ts` — not run successfully because the repository dependencies could not finish installing in this environment; `vitest` was unavailable.
- `npm run check` and build — not run for the same dependency limitation.

## Changelog

### Fixed

- Prevent OAuth/OIDC sign-out redirects from being cancelled by the reactive authentication guard.

## Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the Contributor License Agreement (CLA), and I am providing my contributions under its terms.
