### PR TITLE
fix: settle playAudio promise on play() rejection and stopAllAudio

### DIFF
--- a/src/lib/components/chat/MessageInput/CallOverlay.svelte
+++ b/src/lib/components/chat/MessageInput/CallOverlay.svelte
@@ -427,30 +427,40 @@
 		}
 	};
 
+	let pendingAudioResolve: ((e: any) => void) | null = null;
+
 	const playAudio = (audio) => {
 		if ($showCallOverlay) {
 			return new Promise((resolve) => {
 				const audioElement = document.getElementById('audioElement') as HTMLAudioElement;
 
-				if (audioElement) {
-					audioElement.src = audio.src;
-					audioElement.muted = true;
-					audioElement.playbackRate = $settings.audio?.tts?.playbackRate ?? 1;
-
-					audioElement
-						.play()
-						.then(() => {
-							audioElement.muted = false;
-						})
-						.catch((error) => {
-							console.error(error);
-						});
-
-					audioElement.onended = async (e) => {
-						await new Promise((r) => setTimeout(r, 100));
-						resolve(e);
-					};
+				if (!audioElement) {
+					resolve(null);
+					return;
 				}
+
+				pendingAudioResolve = resolve;
+
+				audioElement.src = audio.src;
+				audioElement.muted = true;
+				audioElement.playbackRate = $settings.audio?.tts?.playbackRate ?? 1;
+
+				audioElement
+					.play()
+					.then(() => {
+						audioElement.muted = false;
+					})
+					.catch((error) => {
+						console.error(error);
+						pendingAudioResolve = null;
+						resolve(error);
+					});
+
+				audioElement.onended = async (e) => {
+					await new Promise((r) => setTimeout(r, 100));
+					pendingAudioResolve = null;
+					resolve(e);
+				};
 			});
 		} else {
 			return Promise.resolve();
@@ -475,6 +485,11 @@
 			audioElement.muted = true;
 			audioElement.pause();
 			audioElement.currentTime = 0;
+		}
+
+		if (pendingAudioResolve) {
+			pendingAudioResolve(null);
+			pendingAudioResolve = null;
 		}
 	};
 


### PR DESCRIPTION
## Description

Closes #28681

`playAudio` returned a Promise that resolved only from `audioElement.onended`. When `play()` rejected with `NotAllowedError` (autoplay policy), the `.catch` only `console.error`\d and the promise never settled. `monitorAndPlayAudio` does `await playAudio(audio)` inside its while loop, so the speaking loop wedged permanently on the first rejected clip — every subsequent reply was silently dropped until page reload.

`stopAllAudio` also paused the element without resolving the pending promise, so barge-in could wedge the loop too.

The fix tracks the pending `resolve` and settles it on:
- `play()` rejection (skip the clip, continue the loop)
- missing `audioElement` (resolve immediately)
- `stopAllAudio` (resolve so barge-in doesn't wedge)

## Changelog

### Fixed

- Call mode no longer goes permanently silent when `play()` is rejected by the autoplay policy; `stopAllAudio` also unblocks the speaking loop.

## Testing

- `npx vitest --run` passes (existing test suite).
- The fix follows the issue's root-cause analysis and suggested direction.

## Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.