### PR TITLE
fix: defer ?call=true overlay to avoid showControlsSubscribe race

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -1876,8 +1876,13 @@
 		}
 
 		if ($page.url.searchParams.get('call') === 'true') {
-			showCallOverlay.set(true);
-			showControls.set(true);
+			// Defer to next macrotask so the call overlay isn't clobbered by
+			// showControlsSubscribe's initial callback (value=false → set(false))
+			// which runs as a pending microtask after this function.
+			setTimeout(() => {
+				showCallOverlay.set(true);
+				showControls.set(true);
+			}, 0);
 		}
 
 		// Consume one-shot desktop event (e.g. Spotlight query, call shortcut)


### PR DESCRIPTION
## Problem

Fixes #28677

When `?call=true` is in the URL, the call overlay is immediately hidden because `showControlsSubscribe`'s initial callback (value=false → set(false)) runs as a pending microtask after the synchronous `showCallOverlay.set(true)`, overwriting the overlay state.

## Root cause

The `?call=true` URL handler synchronously calls `showCallOverlay.set(true)`, but the Svelte store subscription's initial callback fires as a pending microtask afterward, resetting the overlay to false.

## Fix

Wrap the `showCallOverlay.set(true)` call in `setTimeout(0)` to defer it to the next macrotask, after the subscription's initial callback has settled.

## Testing

- Verified the overlay appears and stays visible with `?call=true` in the URL
- Verified normal call overlay behavior is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Replaces #28718, which was auto-closed for exceeding the commit count limit. This PR contains a single squashed commit.)