### PR TITLE
fix: defer ?call=true overlay to avoid showControlsSubscribe race

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -2187,8 +2187,13 @@
 		}
 
 		if ($page.url.searchParams.get('call') === 'true') {
-			showCallOverlay.set(true);
-			showControls.set(true);
+			// Defer to next macrotask so the call overlay isn't clobbered by
+			// showControlsSubscribe's initial callback (value=false → set(false))
+			// which runs as a pending microtask after this function.
+			setTimeout(() => {
+				showCallOverlay.set(true);
+				showControls.set(true);
+			}, 0);
 		}
 
 		// Consume one-shot desktop event (e.g. Spotlight query, call shortcut)


### PR DESCRIPTION
## Description

Closes #28677

When `?call=true` is in the URL, the call overlay is immediately hidden because `showControlsSubscribe`'s initial callback (value=false → set(false)) runs as a pending microtask after the synchronous `showCallOverlay.set(true)`, overwriting the overlay state.

## Root cause

The `?call=true` URL handler synchronously calls `showCallOverlay.set(true)`, but the Svelte store subscription's initial callback fires as a pending microtask afterward, resetting the overlay to false.

## Fix

Wrap the `showCallOverlay.set(true)` call in `setTimeout(0)` to defer it to the next macrotask, after the subscription's initial callback has settled.

## Testing

- Verified the overlay appears and stays visible with `?call=true` in the URL
- Verified normal call overlay behavior is unaffected

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)