### PR TITLE
fix: dispatch every completed call-mode TTS sentence

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -56,6 +56,7 @@
 		convertMessagesToHistory,
 		copyToClipboard,
 		getMessageContentParts,
+	selectCallOverlayAudioParts,
 		createMessagesList,
 		sanitizeHistory,
 		getPromptVariables,
@@ -1922,23 +1923,25 @@
 			messageContentParts.pop();
 		}
 
-		const nextContentPart = messageContentParts.at(-1) ?? '';
-		if (!nextContentPart || (!final && nextContentPart === message.lastSentence)) {
-			return;
-		}
-
-		if (!final) {
-			message.lastSentence = nextContentPart;
-		}
-
-		eventTarget.dispatchEvent(
-			new CustomEvent('chat', {
-				detail: {
-					id: message.id,
-					content: nextContentPart
-				}
-			})
+		// Dispatch every newly completed part in order. The previous
+		// lastSentence/at(-1) path dropped earlier sentences when a chunk
+		// completed more than one part at once.
+		const { parts, nextSent } = selectCallOverlayAudioParts(
+			messageContentParts,
+			message.ttsSent ?? 0,
+			final
 		);
+		for (const part of parts) {
+			eventTarget.dispatchEvent(
+				new CustomEvent('chat', {
+					detail: {
+						id: message.id,
+						content: part
+					}
+				})
+			);
+		}
+		message.ttsSent = nextSent;
 	};
 
 	const getContents = () => {

--- a/src/lib/utils/call-overlay-audio.test.ts
+++ b/src/lib/utils/call-overlay-audio.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { selectCallOverlayAudioParts } from './index';
+
+describe('selectCallOverlayAudioParts', () => {
+	it('dispatches every newly completed part when a chunk finishes multiple sentences', () => {
+		const parts = [
+			'This is the first complete sentence prepared for speech playback now.',
+			'This is the second complete sentence prepared for speech playback now.',
+			'This is the third complete sentence prepared for speech playback now.'
+		];
+
+		const first = selectCallOverlayAudioParts(parts, 0, false);
+		expect(first.parts).toEqual(parts);
+		expect(first.nextSent).toBe(3);
+
+		const second = selectCallOverlayAudioParts(parts, first.nextSent, false);
+		expect(second.parts).toEqual([]);
+		expect(second.nextSent).toBe(3);
+	});
+
+	it('holds a still-short trailing part until it is long enough or final', () => {
+		const streaming = [
+			'This is a long enough first sentence prepared for speech playback.',
+			'Hi there'
+		];
+		const held = selectCallOverlayAudioParts(streaming, 0, false);
+		expect(held.parts).toEqual([streaming[0]]);
+		expect(held.nextSent).toBe(1);
+
+		const finalized = selectCallOverlayAudioParts(streaming, held.nextSent, true);
+		expect(finalized.parts).toEqual([streaming[1]]);
+		expect(finalized.nextSent).toBe(2);
+	});
+});

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -1141,6 +1141,26 @@ export const extractParagraphsForAudio = (text: string) => {
 	return paragraphs.map(cleanText).filter(Boolean);
 };
 
+export const selectCallOverlayAudioParts = (
+	messageContentParts: string[],
+	alreadySent: number = 0,
+	final: boolean = false
+) => {
+	let n = alreadySent;
+	const parts: string[] = [];
+	for (; n < messageContentParts.length; n++) {
+		const part = messageContentParts[n];
+		if (!part) {
+			continue;
+		}
+		if (!final && (part.split(/\s+/).length < 4 || part.length < 50)) {
+			break;
+		}
+		parts.push(part);
+	}
+	return { parts, nextSent: n };
+};
+
 export const extractSentencesForAudio = (text: string) => {
 	return extractSentences(text).reduce((mergedTexts, currentText) => {
 		const lastIndex = mergedTexts.length - 1;


### PR DESCRIPTION
## Summary

Fixes #28730.

In call mode, `dispatchCallOverlayAudio` previously kept only the last completed content part for each streamed chunk. When a chunk completed more than one sentence, earlier sentences were never spoken.

This change tracks how many parts have already been dispatched and speaks every newly completed part in order. A still-short trailing part is held until it is long enough or the message is final, matching the existing short-part merge behavior in `extractSentencesForAudio`.

## Validation

- `npx vitest run src/lib/utils/call-overlay-audio.test.ts` — 2 passed
