### PR TITLE
fix: honor bypass_system_prompt on the pipe route

### DIFF
--- a/backend/open_webui/functions.py
+++ b/backend/open_webui/functions.py
@@ -212,6 +212,9 @@ async def generate_function_chat_completion(request, form_data, user, models: di
 
         return params
 
+    # Set server-side by utils/chat.py, never by client input. Mirrors the routers.
+    bypass_system_prompt = getattr(request.state, 'bypass_system_prompt', False)
+
     # Copy so the base-model substitution below doesn't leak into the caller's
     # payload, which the tool-call continuation re-submits. Mirrors the routers.
     form_data = {**form_data}
@@ -291,7 +294,8 @@ async def generate_function_chat_completion(request, form_data, user, models: di
         if params:
             system = params.pop('system', None)
             form_data = apply_model_params_to_body_openai(params, form_data)
-            form_data = await apply_system_prompt_to_body(system, form_data, metadata, user)
+            if not bypass_system_prompt:
+                form_data = await apply_system_prompt_to_body(system, form_data, metadata, user)
 
     pipe_id = get_pipe_id(form_data)
     function_module = await get_function_module_by_id(request, pipe_id)


### PR DESCRIPTION
The tool-call continuation re-submits with bypass_system_prompt=True, but only routers/openai.py and routers/ollama.py checked it, so pipe and manifold models had the system prompt applied again on every continuation. Since add_or_update_system_message() prepends rather than replaces, N tool-call rounds left N+1 copies of the system prompt in the payload.

Fixes: https://github.com/open-webui/open-webui/issues/28736

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
