### PR TITLE
fix: stop concurrent chat writes from dropping messages and chat fields

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -1470,15 +1470,13 @@ async def chat_completion(
                     # The old frontend saveChatHandler did this on every message;
                     # now the backend owns persistence.
                     chat_files = metadata.get('files')
-                    if chat_files is not None or selected_chat_models:
-                        existing_chat = await Chats.get_chat_by_id(chat_id)
-                        if existing_chat:
-                            updated = {**existing_chat.chat}
-                            if chat_files is not None:
-                                updated['files'] = chat_files
-                            if selected_chat_models:
-                                updated['models'] = selected_chat_models
-                            await Chats.update_chat_by_id(chat_id, updated, touch=False)
+                    chat_fields = {}
+                    if chat_files is not None:
+                        chat_fields['files'] = chat_files
+                    if selected_chat_models:
+                        chat_fields['models'] = selected_chat_models
+                    if chat_fields:
+                        await Chats.update_chat_by_id(chat_id, chat_fields, touch=False)
 
                     await Chats.update_chat_variables_by_id(chat_id, chat_variables)
 

--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -664,6 +664,15 @@ class ChatTable:
 
             return [ChatModel.model_validate(chat) for chat in chats]
 
+    @staticmethod
+    async def get_chat_for_update(session: AsyncSession, id: str) -> Chat | None:
+        """Load a chat row for a read-modify-write of its blob, locked so concurrent writers serialize."""
+        # populate_existing: a caller's session may already hold a stale copy of this row.
+        stmt = select(Chat).where(Chat.id == id).execution_options(populate_existing=True)
+        if session.bind.dialect.name == 'postgresql':
+            stmt = stmt.with_for_update()  # SQLite has no FOR UPDATE, so writers there stay unserialized
+        return (await session.execute(stmt)).scalar_one_or_none()
+
     async def update_chat_by_id(
         self,
         id: str,
@@ -672,17 +681,31 @@ class ChatTable:
         *,
         touch: bool = True,
     ) -> ChatModel | None:
-        """Persist updated chat content, sanitizing null bytes."""
-        try:  # load the chat record for in-place mutation
+        """Apply top-level chat keys onto the stored blob: history is merged into it, every other key overwrites.
+
+        Values must not alias the stored blob's own nested objects; an in-place edit of one writes nothing.
+        """
+        try:
             async with get_async_db_context(db) as session:
-                chat_item = await session.get(Chat, id)
+                chat_item = await self.get_chat_for_update(session, id)
                 if chat_item is None:
                     return None
 
-                chat_item.chat = self._clean_null_bytes(chat)
-                chat_item.title = self._clean_null_bytes(chat['title']) if 'title' in chat else 'New Chat'
+                stored = chat_item.chat or {}
+                updated = {**stored, **chat}
+                merged_history = 'history' in chat
+                if merged_history:
+                    # The caller built its history from an earlier read; merge so messages saved since then survive.
+                    updated['history'] = self.merge_history(stored.get('history'), chat['history'])
+
+                updated = self._clean_null_bytes(updated)
+                chat_item.chat = updated
+                if merged_history:
+                    # merge_history rewrote the stored message dicts in place, so the new blob compares equal to them.
+                    flag_modified(chat_item, 'chat')
+                chat_item.title = updated.get('title', 'New Chat')
                 if any(key in chat for key in ('history', 'messages', 'currentId', 'branchPointMessageId')):
-                    chat_item.current_message_id = self.get_current_message_id(chat)
+                    chat_item.current_message_id = self.get_current_message_id(updated)
 
                 if touch:
                     chat_item.updated_at = int(time.time())
@@ -789,7 +812,7 @@ class ChatTable:
     async def update_chat_title_by_id(self, id: str, title: str) -> ChatModel | None:
         try:
             async with get_async_db_context() as session:
-                chat_item = await session.get(Chat, id)
+                chat_item = await self.get_chat_for_update(session, id)
                 if chat_item is None:
                     return None
                 clean_title = self._clean_null_bytes(title)
@@ -1061,7 +1084,7 @@ class ChatTable:
 
         try:
             async with get_async_db_context() as session:
-                chat_item = await session.get(Chat, id)
+                chat_item = await self.get_chat_for_update(session, id)
                 if chat_item is None:
                     return None
 
@@ -1103,7 +1126,7 @@ class ChatTable:
     async def delete_message_from_chat_by_id_and_message_id(self, id: str, message_id: str) -> ChatModel | None:
         try:
             async with get_async_db_context() as session:
-                chat_item = await session.get(Chat, id)
+                chat_item = await self.get_chat_for_update(session, id)
                 if chat_item is None:
                     return None
 
@@ -1148,7 +1171,7 @@ class ChatTable:
     ) -> ChatModel | None:
         try:
             async with get_async_db_context() as session:
-                chat_item = await session.get(Chat, id)
+                chat_item = await self.get_chat_for_update(session, id)
                 if chat_item is None:
                     return None
 
@@ -1174,25 +1197,36 @@ class ChatTable:
         except Exception:
             return None
 
-    async def add_message_files_by_id_and_message_id(self, id: str, message_id: str, files: list[dict]) -> list[dict]:
-        async with get_async_db_context() as session:
-            chat = await self.get_chat_by_id(id, db=session)
-            if chat is None:
-                return None
+    async def add_message_files_by_id_and_message_id(
+        self, id: str, message_id: str, files: list[dict]
+    ) -> list[dict] | None:
+        try:
+            async with get_async_db_context() as session:
+                chat_item = await self.get_chat_for_update(session, id)
+                if chat_item is None:
+                    return None
 
-            chat = chat.chat
-            history = chat.get('history', {})
+                chat = chat_item.chat or {}
+                history = chat.get('history', {})
 
-            message_files = []
+                message_files = []
 
-            if message_id in history.get('messages', {}):
-                message_files = history['messages'][message_id].get('files', [])
-                message_files = message_files + files
-                history['messages'][message_id]['files'] = message_files
+                if message_id in history.get('messages', {}):
+                    message_files = history['messages'][message_id].get('files', [])
+                    message_files = message_files + files
+                    history['messages'][message_id]['files'] = message_files
 
-            chat['history'] = history
-            await self.update_chat_by_id(id, chat, db=session)
-            return message_files
+                # Written here rather than through update_chat_by_id: with session sharing off that opens a second
+                # connection, which then blocks on the lock this one holds.
+                chat['history'] = history
+                chat_item.chat = self._clean_null_bytes(chat)
+                # History was mutated in place, so the new blob compares equal to the loaded one.
+                flag_modified(chat_item, 'chat')
+                chat_item.updated_at = int(time.time())
+                await session.commit()
+                return message_files
+        except Exception:
+            return None
 
     async def insert_shared_chat_by_chat_id(self, chat_id: str, db: AsyncSession | None = None) -> ChatModel | None:
         """Create a shared snapshot for a chat. Returns the original chat with share_id set."""

--- a/backend/open_webui/routers/chats.py
+++ b/backend/open_webui/routers/chats.py
@@ -1384,15 +1384,8 @@ async def update_chat_by_id(
 ):
     chat = await Chats.get_chat_by_id_and_user_id(id, user.id, db=db)
     if chat:
-        updated_chat = {**chat.chat, **form_data.chat}
-        if 'history' in form_data.chat:
-            updated_chat['history'] = Chats.merge_history(
-                chat.chat.get('history'),
-                form_data.chat.get('history'),
-            )
-
         touch = 'history' in form_data.chat or 'messages' in form_data.chat
-        chat = await Chats.update_chat_by_id(id, updated_chat, db=db, touch=touch)
+        chat = await Chats.update_chat_by_id(id, form_data.chat, db=db, touch=touch)
         if form_data.variables is not None:
             chat = (
                 await Chats.update_chat_variables_by_id(
@@ -1406,7 +1399,7 @@ async def update_chat_by_id(
 
         # Reconcile chat_message rows without inferring deletes from missing IDs.
         # Message deletion has its own endpoint below.
-        messages = (updated_chat.get('history') or {}).get('messages') or {}
+        messages = ((chat.chat or {}).get('history') or {}).get('messages') or {}
         if messages:
             await Chats.reconcile_messages_by_chat_id(id, user.id, messages)
 

--- a/backend/open_webui/routers/notes.py
+++ b/backend/open_webui/routers/notes.py
@@ -339,12 +339,8 @@ async def get_note_chat_by_id(
     chat = await Chats.get_internal_chat_by_note_id(note.id, user.id, db=db)
     if chat:
         log.info('[note-chat] reusing hidden chat note_id=%s chat_id=%s user_id=%s', note.id, chat.id, user.id)
-        payload = {**(chat.chat or {})}
-        params = {**(payload.get('params') or {})}
-        changed = False
-
-        if params.pop('note_id', None) is not None:
-            changed = True
+        params = {**((chat.chat or {}).get('params') or {})}
+        changed = params.pop('note_id', None) is not None
 
         system = (
             f'CONTEXT:\nCurrent note id: {note.id}\n'
@@ -356,12 +352,8 @@ async def get_note_chat_by_id(
             params['system'] = system
             changed = True
 
-        if payload.pop('system', None) is not None:
-            changed = True
-
-        payload['params'] = params
         if changed:
-            updated_chat = await Chats.update_chat_by_id(chat.id, payload, db=db, touch=False)
+            updated_chat = await Chats.update_chat_by_id(chat.id, {'params': params}, db=db, touch=False)
             if updated_chat:
                 return updated_chat
 
@@ -434,12 +426,8 @@ async def get_note_chats_by_id(
     chats = await Chats.get_internal_chats_by_note_id(note.id, user.id, db=db)
     normalized_chats = []
     for chat in chats:
-        payload = {**(chat.chat or {})}
-        params = {**(payload.get('params') or {})}
-        changed = False
-
-        if params.pop('note_id', None) is not None:
-            changed = True
+        params = {**((chat.chat or {}).get('params') or {})}
+        changed = params.pop('note_id', None) is not None
 
         system = (
             f'CONTEXT:\nCurrent note id: {note.id}\n'
@@ -451,12 +439,8 @@ async def get_note_chats_by_id(
             params['system'] = system
             changed = True
 
-        if payload.pop('system', None) is not None:
-            changed = True
-
-        payload['params'] = params
         if changed:
-            chat = await Chats.update_chat_by_id(chat.id, payload, db=db, touch=False) or chat
+            chat = await Chats.update_chat_by_id(chat.id, {'params': params}, db=db, touch=False) or chat
 
         normalized_chats.append(chat)
 


### PR DESCRIPTION
Messages could disappear from a chat while still being sent to the model. Every writer read the whole chat JSON, changed it in Python and wrote all of it back without a lock, so whichever write committed last silently discarded everything committed in between. A message lost that way stayed in the chat_message table, so it kept counting toward the model's context while vanishing from the screen, and later replies pointed at a parent that no longer existed. The same overwrite wiped chat-level fields: a file attached during a completion was gone after the browser's next chat save.

Writers now take a row lock before they read (PostgreSQL; SQLite has no equivalent, so there the history merge below is what protects it), and message history is merged against the freshly read row instead of replacing it.

Locking alone was not enough. The completion handler, the chat-save endpoint and the note chats all built their replacement chat from a read taken earlier, so the value being written was already stale before any lock could be taken. They now pass down only the keys they actually change, and applying those keys onto the stored blob is what the single remaining writer does.

Fixes #28742

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
