### PR TITLE
fix: allow clearing Supported Media MIME Types in Documents settings

### DIFF
--- a/src/lib/components/admin/Settings/Documents.svelte
+++ b/src/lib/components/admin/Settings/Documents.svelte
@@ -71,6 +71,8 @@
 	};
 
 	let RAGConfig: any = null;
+	let mediaMimeTypesConfigured = false;
+
 	const inputClass =
 		'w-full h-7 rounded-lg border border-gray-100/50 bg-gray-50/40 px-2 text-xs text-gray-700 outline-hidden transition-colors placeholder:text-gray-300 focus:border-blue-400 dark:border-white/[0.04] dark:bg-white/[0.03] dark:text-gray-300 dark:placeholder:text-gray-700 dark:focus:border-blue-500';
 	const actionButtonClass =
@@ -260,6 +262,10 @@
 			}
 		}
 
+		const mediaMimeTypes = RAGConfig.CONTENT_EXTRACTION_SUPPORTED_MEDIA_MIME_TYPES.split(',')
+			.map((mimeType: string) => mimeType.trim())
+			.filter((mimeType: string) => mimeType !== '');
+
 		const res = await updateRAGConfig(localStorage.token, {
 			...RAGConfig,
 			// Convert null (from cleared number inputs) to empty string so the backend
@@ -280,12 +286,9 @@
 				RAGConfig.EXTERNAL_DOCUMENT_LOADER_HEADERS.trim() !== ''
 					? JSON.parse(RAGConfig.EXTERNAL_DOCUMENT_LOADER_HEADERS)
 					: {},
+			// Blank clears the list, unless never set (null keeps the external-engine-only default)
 			CONTENT_EXTRACTION_SUPPORTED_MEDIA_MIME_TYPES:
-				RAGConfig.CONTENT_EXTRACTION_SUPPORTED_MEDIA_MIME_TYPES.trim() === ''
-					? undefined
-					: RAGConfig.CONTENT_EXTRACTION_SUPPORTED_MEDIA_MIME_TYPES.split(',')
-							.map((mimeType: string) => mimeType.trim())
-							.filter((mimeType: string) => mimeType !== ''),
+				mediaMimeTypes.length > 0 || mediaMimeTypesConfigured ? mediaMimeTypes : undefined,
 			MINERU_PARAMS:
 				typeof RAGConfig.MINERU_PARAMS === 'string' && RAGConfig.MINERU_PARAMS.trim() !== ''
 					? JSON.parse(RAGConfig.MINERU_PARAMS)
@@ -294,6 +297,10 @@
 				.map((ext) => ext.trim())
 				.filter((ext) => ext !== '')
 		});
+
+		if (res) {
+			mediaMimeTypesConfigured = res.CONTENT_EXTRACTION_SUPPORTED_MEDIA_MIME_TYPES != null;
+		}
 		dispatch('save');
 	};
 
@@ -342,9 +349,9 @@
 				: config.EXTERNAL_DOCUMENT_LOADER_HEADERS;
 
 		config.MINERU_FILE_EXTENSIONS = (config?.MINERU_FILE_EXTENSIONS ?? ['pdf']).join(', ');
-		config.CONTENT_EXTRACTION_SUPPORTED_MEDIA_MIME_TYPES = (
-			config?.CONTENT_EXTRACTION_SUPPORTED_MEDIA_MIME_TYPES ?? []
-		).join(', ');
+		const storedMediaMimeTypes = config.CONTENT_EXTRACTION_SUPPORTED_MEDIA_MIME_TYPES;
+		mediaMimeTypesConfigured = storedMediaMimeTypes != null;
+		config.CONTENT_EXTRACTION_SUPPORTED_MEDIA_MIME_TYPES = (storedMediaMimeTypes ?? []).join(', ');
 		config.RAG_TOKENIZER_MODEL = config?.RAG_TOKENIZER_MODEL ?? '';
 
 		RAGConfig = config;


### PR DESCRIPTION
The Supported Media MIME Types field in Admin Settings > Documents could not be cleared. Emptying it and saving left the previous list in place, so an administrator who had configured it could never turn media extraction back off from the interface.

The setting has three meaningful states: unset keeps the old behavior where only the external engine receives images and video, an empty list disables media extraction for every engine, and a list selects which types are extracted. A blank text box can mean either of the first two, and the admin page always sent "leave unchanged" for a blank box, which made the empty list unreachable.

The page now tracks whether the server actually holds a value, read from the configuration it loads and refreshed from every save response. A blank box clears the list when one was configured, and stays a no-op while the setting has never been set, so instances on the external engine are not silently switched over when an unrelated Documents setting is saved. Always sending an empty list for a blank box would have caused exactly that.

Fixes #28747

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
