### PR TITLE
fix(documents): allow clearing supported media MIME types in settings

### DIFF
--- a/src/lib/components/admin/Settings/Documents.svelte
+++ b/src/lib/components/admin/Settings/Documents.svelte
@@ -274,7 +274,7 @@
 					: {},
 			CONTENT_EXTRACTION_SUPPORTED_MEDIA_MIME_TYPES:
 				RAGConfig.CONTENT_EXTRACTION_SUPPORTED_MEDIA_MIME_TYPES.trim() === ''
-					? undefined
+					? []
 					: RAGConfig.CONTENT_EXTRACTION_SUPPORTED_MEDIA_MIME_TYPES.split(',')
 							.map((mimeType: string) => mimeType.trim())
 							.filter((mimeType: string) => mimeType !== ''),


### PR DESCRIPTION
### Problem
The "Supported Media MIME Types" setting in **Admin Settings → Documents** cannot be cleared through the UI once a value (e.g. `image/*`) has been saved. Clearing the field and saving does not remove it, causing the previous value to reappear upon reopening settings.

### Root cause
In `src/lib/components/admin/Settings/Documents.svelte`, a blank field is serialized as `undefined` in the payload:
```ts
CONTENT_EXTRACTION_SUPPORTED_MEDIA_MIME_TYPES:
    RAGConfig.CONTENT_EXTRACTION_SUPPORTED_MEDIA_MIME_TYPES.trim() === ''
        ? undefined
        : ...
```
Because the retrieval config update endpoint treats `None` as "keep the existing value", omitting the key or sending `undefined` does not update the stored configuration.

### Change
Updated the ternary expression in `src/lib/components/admin/Settings/Documents.svelte` to serialize an empty array (`[]`) instead of `undefined` when the field is blank. The backend accepts `[]` and properly clears the stored MIME types list.

### Proof

#### Test Red (Before Fix)
```
Buggy payload: { CONTENT_EXTRACTION_SUPPORTED_MEDIA_MIME_TYPES: undefined }
Result after save with buggy payload: {
  CONTENT_EXTRACTION_SUPPORTED_MEDIA_MIME_TYPES: [ 'image/*', 'audio/*' ]
}
```

#### Test Green (After Fix)
```
PS C:\Users\erijo\Downloads\claude> node --test test_reproduce_issue_28747.mjs
Fixed payload: { CONTENT_EXTRACTION_SUPPORTED_MEDIA_MIME_TYPES: [] }
Result after save with fixed payload: { CONTENT_EXTRACTION_SUPPORTED_MEDIA_MIME_TYPES: [] }
▶ Open WebUI Issue #28747: Clearing Supported Media MIME Types
  ✔ reproduces bug: saving empty string with buggy serialization does not clear MIME types (2.267ms)
  ✔ verified fix: saving empty string with fixed serialization successfully clears MIME types to [] (0.4978ms)
  ✔ verified fix: saving non-empty comma-separated list works as expected (0.225ms)
✔ Open WebUI Issue #28747: Clearing Supported Media MIME Types (4.1461ms)
ℹ tests 3
ℹ suites 1
ℹ pass 3
ℹ fail 0
```

### Reference
Fixes #28747

### Disclosure
This fix was written with AI assistance.
