### PR TITLE
fix: normalize tags stored as plain strings instead of crashing the connection editor

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -244,7 +244,7 @@ from open_webui.utils.middleware import (
     process_chat_payload,
     process_chat_response,
 )
-from open_webui.utils.misc import merge_model_params
+from open_webui.utils.misc import merge_model_params, normalize_tags
 from open_webui.utils.model_ids import strip_provider_model_prefix
 from open_webui.utils.models import (
     check_model_access,
@@ -888,19 +888,16 @@ async def get_models(request: Request, refresh: bool = False, user=Depends(get_v
     models = await get_filtered_models(models, user)
 
     for model in models:
+        meta = model.get('info', {}).get('meta', {})
+
         # Remove profile image URL to reduce payload size
-        if model.get('info', {}).get('meta', {}).get('profile_image_url'):
-            model['info']['meta'].pop('profile_image_url', None)
+        meta.pop('profile_image_url', None)
 
-        try:
-            model_tags = [tag.get('name') for tag in model.get('info', {}).get('meta', {}).get('tags', [])]
-            tags = [tag.get('name') for tag in model.get('tags', [])]
+        if 'tags' in meta:
+            meta['tags'] = normalize_tags(meta['tags'])
 
-            tags = list(set(model_tags + tags))
-            model['tags'] = [{'name': tag} for tag in tags]
-        except Exception as e:
-            log.debug('Error processing model tags: %s', e)
-            model['tags'] = []
+        tags = meta.get('tags', []) + normalize_tags(model.get('tags'))
+        model['tags'] = list({tag['name']: tag for tag in tags}.values())
 
     model_order_list = await Config.get('ui.model_order_list')
     if model_order_list:

--- a/backend/open_webui/models/models.py
+++ b/backend/open_webui/models/models.py
@@ -9,7 +9,7 @@ from open_webui.internal.db import Base, JSONField, get_async_db_context
 from open_webui.models.access_grants import AccessGrantModel, AccessGrants
 from open_webui.models.groups import Groups
 from open_webui.models.users import User, UserModel, UserResponse, Users
-from open_webui.utils.misc import json_text_variants
+from open_webui.utils.misc import json_text_variants, normalize_tags
 from open_webui.utils.validate import validate_profile_image_url
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 from sqlalchemy import BigInteger, Boolean, Column, String, Text, cast, delete, func, or_, select, update
@@ -97,17 +97,9 @@ class ModelMeta(BaseModel):
 
     @model_validator(mode='before')
     @classmethod
-    def normalize_tags(cls, data):
+    def normalize_meta_tags(cls, data):
         if isinstance(data, dict) and 'tags' in data:
-            raw_tags = data['tags']
-            if isinstance(raw_tags, list):
-                normalized = []
-                for tag in raw_tags:
-                    if isinstance(tag, str):
-                        normalized.append({'name': tag})
-                    elif isinstance(tag, dict) and 'name' in tag:
-                        normalized.append(tag)
-                data['tags'] = normalized
+            data['tags'] = normalize_tags(data['tags'])
         return data
 
 

--- a/backend/open_webui/utils/misc.py
+++ b/backend/open_webui/utils/misc.py
@@ -38,6 +38,19 @@ def merge_model_params(base: dict, override: dict) -> dict:
     return params
 
 
+def normalize_tags(tags) -> list[dict]:
+    # Unvalidated config and API payloads hold tags as plain strings or malformed dicts
+    if not isinstance(tags, list):
+        return []
+
+    normalized = []
+    for tag in tags:
+        name = tag.get('name') if isinstance(tag, dict) else tag
+        if isinstance(name, str) and name.strip():
+            normalized.append({'name': name.strip()})
+    return normalized
+
+
 def _strip_filter_entry(entry):
     # Compose list-form env syntax passes surrounding quotes through verbatim
     return (entry or '').strip().strip('"\'').strip()

--- a/src/lib/apis/index.ts
+++ b/src/lib/apis/index.ts
@@ -1,5 +1,5 @@
 import { WEBUI_BASE_URL } from '$lib/constants';
-import { convertOpenApiToToolPayload } from '$lib/utils';
+import { convertOpenApiToToolPayload, normalizeTags } from '$lib/utils';
 import { getOpenAIModelsDirect } from './openai';
 
 const TOOL_SERVER_FETCH_TIMEOUT = 10000;
@@ -141,8 +141,8 @@ export const getModels = async (
 					}
 				}
 
-				const tags = apiConfig.tags;
-				if (tags) {
+				const tags = normalizeTags(apiConfig.tags);
+				if (tags.length > 0) {
 					for (const model of models) {
 						model.tags = tags;
 					}

--- a/src/lib/components/AddConnectionModal.svelte
+++ b/src/lib/components/AddConnectionModal.svelte
@@ -18,6 +18,7 @@
 	import Spinner from '$lib/components/common/Spinner.svelte';
 	import XMark from '$lib/components/icons/XMark.svelte';
 	import Textarea from './common/Textarea.svelte';
+	import { normalizeTags } from '$lib/utils';
 
 	export let onSubmit: Function = () => {};
 	export let onDelete: Function = () => {};
@@ -249,7 +250,7 @@
 				: '';
 
 			enable = connection.config?.enable ?? true;
-			tags = connection.config?.tags ?? [];
+			tags = normalizeTags(connection.config?.tags);
 			prefixId = connection.config?.prefix_id ?? '';
 			passthroughParams = Array.isArray(connection.config?.passthrough_params)
 				? connection.config.passthrough_params.join(', ')

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -33,6 +33,13 @@ import { decode } from 'html-entities';
 
 export const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
+// Unvalidated config and API payloads hold tags as plain strings or malformed dicts
+export const normalizeTags = (tags: unknown): { name: string }[] =>
+	(Array.isArray(tags) ? tags : [])
+		.map((tag) => (typeof tag === 'string' ? tag : tag?.name))
+		.filter((name): name is string => typeof name === 'string' && name.trim() !== '')
+		.map((name) => ({ name: name.trim() }));
+
 export const formatNumber = (num: number): string => {
 	return new Intl.NumberFormat('en-US', { notation: 'compact', maximumFractionDigits: 1 })
 		.format(num)


### PR DESCRIPTION
Opening Advanced on a connection whose tags are stored as plain strings throws in the browser and the panel never opens, so the connection cannot be edited any more. The editor has always written tags as objects with a name, but OPENAI_API_CONFIGS and OLLAMA_API_CONFIGS accept raw JSON and the docs list tags as a supported key without saying it must be objects, so a list of strings is accepted and stored.

The same shape does two more things today. One string tag made the models endpoint throw while merging tags, which was caught and blanked, so every tag on every model from that connection silently disappeared, including the model's own workspace tags. A tag object with a null name passed validation and reached the frontend, where it breaks the model picker.

Tags are now normalized to a canonical trimmed name object where unvalidated config first meets model data: the models endpoint, the model metadata validator, the direct connection path and the connection editor. Downstream renderers keep assuming a name is present, which they always did, and saving a connection through the editor migrates its stored tags. Verified by diffing old against new endpoint behaviour across 15 model shapes: every difference is a tag that used to vanish or crash and now renders, valid data is untouched, and the only two shapes that still raise raise identically on an unchanged line above.

Fixes #28749

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
