### PR TITLE
fix(documents): allow clearing supported media MIME types in settings

### DIFF
--- a/src/lib/components/admin/Settings/Documents.svelte
+++ b/src/lib/components/admin/Settings/Documents.svelte
@@ -282,7 +282,7 @@
 					: {},
 			CONTENT_EXTRACTION_SUPPORTED_MEDIA_MIME_TYPES:
 				RAGConfig.CONTENT_EXTRACTION_SUPPORTED_MEDIA_MIME_TYPES.trim() === ''
-					? undefined
+					? []
 					: RAGConfig.CONTENT_EXTRACTION_SUPPORTED_MEDIA_MIME_TYPES.split(',')
 							.map((mimeType: string) => mimeType.trim())
 							.filter((mimeType: string) => mimeType !== ''),


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Closes #28747
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [x] **Documentation:** Relevant documentation has been added or updated.
- [x] **Dependencies:** No new dependencies added.
- [x] **Testing:** Manual tests and isolated unit tests have been performed.
- [x] **No Unchecked AI Code:** This PR has undergone thorough human review AND manual testing.
- [x] **Self-Review:** A self-review of the code has been performed.
- [x] **Architecture:** Smart defaults are preferred over new settings.
- [x] **Git Hygiene:** The PR is atomic, rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description
Allows clearing the "Supported Media MIME Types" field in Admin Settings → Documents. When left empty, an empty array (`[]`) is submitted so the backend removes previously configured MIME types.

### Fixed
- Fixed an issue where clearing Supported Media MIME Types serialized to `undefined`, preventing the backend from clearing the stored list (#28747).

---

### Additional Information
In `src/lib/components/admin/Settings/Documents.svelte`, an empty field was serialized as `undefined` instead of `[]`. The backend API treats `None` as "keep existing value", so sending `[]` allows administrators to clear the list.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
