### PR TITLE
fix(chat): dispatch all completed sentences sequentially in call overlay mode

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -1922,23 +1922,21 @@
 			messageContentParts.pop();
 		}
 
-		const nextContentPart = messageContentParts.at(-1) ?? '';
-		if (!nextContentPart || (!final && nextContentPart === message.lastSentence)) {
-			return;
+		let n = message.ttsSent ?? 0;
+		for (; n < messageContentParts.length; n++) {
+			const part = messageContentParts[n];
+			if (!part) continue;
+			if (!final && (part.split(/\s+/).length < 4 || part.length < 50)) break;
+			eventTarget.dispatchEvent(
+				new CustomEvent('chat', {
+					detail: {
+						id: message.id,
+						content: part
+					}
+				})
+			);
 		}
-
-		if (!final) {
-			message.lastSentence = nextContentPart;
-		}
-
-		eventTarget.dispatchEvent(
-			new CustomEvent('chat', {
-				detail: {
-					id: message.id,
-					content: nextContentPart
-				}
-			})
-		);
+		message.ttsSent = n;
 	};
 
 	const getContents = () => {


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Closes #28730
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [x] **Documentation:** Relevant documentation has been added or updated.
- [x] **Dependencies:** No new dependencies added.
- [x] **Testing:** Manual tests and isolated unit tests have been performed.
- [x] **No Unchecked AI Code:** This PR has undergone thorough human review AND manual testing.
- [x] **Self-Review:** A self-review of the code has been performed.
- [x] **Architecture:** Smart defaults are preferred over new settings.
- [x] **Git Hygiene:** The PR is atomic, rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description
Ensures all completed sentences in streamed chunks are sequentially dispatched to the audio overlay during call mode, preventing dropped sentences when multiple sentences arrive in a single chunk.

### Fixed
- Fixed call overlay mode dropping earlier sentences when multiple sentences arrive within a single streamed response chunk (#28730).

---

### Additional Information
In `src/lib/components/chat/Chat.svelte`, `dispatchCallOverlayAudio` previously only dispatched `messageContentParts.at(-1)`. It now tracks `message.ttsSent` index to iterate and dispatch all newly completed parts in order.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
