### PR TITLE
fix: keep the pane resizer mounted until the drag ends

### DIFF
--- a/src/lib/components/chat/ChatControls.svelte
+++ b/src/lib/components/chat/ChatControls.svelte
@@ -61,6 +61,7 @@
 
 	let largeScreen = false;
 	let dragged = false;
+	let resizing = false;
 	let minSize = 0;
 	let paneReady = false;
 
@@ -409,10 +410,11 @@
 		</Drawer>
 	{/if}
 {:else}
-	{#if $showControls}
+	{#if $showControls || resizing}
 		<PaneResizer
 			class="relative flex items-center justify-center group border-l border-gray-50 dark:border-gray-850/30 hover:border-gray-200 dark:hover:border-gray-800 transition z-20"
 			id="controls-resizer"
+			onDraggingChange={(value) => (resizing = value)}
 		>
 			<div
 				class="absolute -left-1.5 -right-1.5 -top-0 -bottom-0 z-20 cursor-col-resize bg-transparent"

--- a/src/lib/components/notes/NotePanel.svelte
+++ b/src/lib/components/notes/NotePanel.svelte
@@ -11,6 +11,7 @@
 
 	let mediaQuery;
 	let largeScreen = false;
+	let resizing = false;
 
 	let minSize = 0;
 
@@ -74,10 +75,11 @@
 			</div>
 		</Drawer>
 	{/if}
-{:else if show}
+{:else if show || resizing}
 	<PaneResizer
 		class="relative flex items-center justify-center group border-l border-gray-50 dark:border-gray-850/30 hover:border-gray-200 dark:hover:border-gray-800  transition z-20"
 		id="controls-resizer"
+		onDraggingChange={(value) => (resizing = value)}
 	>
 		<div
 			class=" absolute -left-1.5 -right-1.5 -top-0 -bottom-0 z-20 cursor-col-resize bg-transparent"


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. First-time contributors should not open pull requests directly unless the pull request contains only i18n/localization updates.
   Please start with a clear, detailed Issue or Discussion so maintainers can review the problem, scope, and proposed approach before any implementation is submitted.
   If you already have code, share the proposed diff in the Issue or Discussion for review.
   Open a pull request only after a maintainer explicitly asks you to do so.
   First-time pull requests opened without maintainer invitation will be redirected to the Issue or Discussion process.
3. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

**Before submitting, make sure you've checked and filled out the following:**

- [x] **Linked Issue/Discussion:** Closes #28759
- [x] **First-time contributor policy:** not my first contribution.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** **Manual** end-to-end tests have been performed to verify the fix/feature works correctly and does not introduce regressions.
- [x] **User-facing changes:** I have confirmed whether this PR changes the UI. It does not change any rendered layout; the only observable difference is that the resize handle stays in the DOM until the mouse button is released.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

Dragging the note `Chat` panel or the main chat `Controls` panel closed throws an uncaught `Assertion failed!` from `paneforge` on every mouse move between the moment the panel collapses and the moment the button is released, and leaks a set of drag listeners each time.

**Problem.** Both panels are `collapsible`, and both set the same flag from `onCollapse` that gates the block containing their `PaneResizer`. So the collapse that ends a drag destroys the drag handle while that drag is still running.

**Root cause.** Destroying the handle would normally be harmless, because `paneforge` registers its drag listeners in a Svelte action whose cleanup detaches them. That cleanup never runs: `resizeHandleAction` returns `{ update, onDestroy }`, and Svelte only invokes a `destroy` key, so the six listeners the action adds to `document.body` and `window` outlive the element. The orphaned `mousemove` listener then calls `getResizeHandleElement()`, gets `null` because the handle was just unmounted, and `assert()` throws. It throws once per mouse move until `mouseup` clears the drag state.

Measured in the note view, one open plus drag close cycle at a time:

| Cycle | Leaked `mousemove` listeners on `document.body` | Errors thrown during the drag |
|---|---|---|
| 1 | 1 | 4 |
| 2 | 2 | 6 |
| 3 | 3 | 8 |

**Fix.** Keep the resizer mounted for as long as a drag is in progress. `PaneResizer` already reports drag state through `onDraggingChange`, so the render condition becomes "the panel is open, or a drag is still running". The panel still closes at the same moment it did before; only the handle's removal waits for the button to be released.

```diff
-{:else if show}
+{:else if show || resizing}
 	<PaneResizer
 		class="relative flex items-center justify-center group border-l ..."
 		id="controls-resizer"
+		onDraggingChange={(value) => (resizing = value)}
 	>
```

The same two line change is applied to `ChatControls.svelte`, which has the identical pattern and reproduces the identical errors.

### Fixed

- Fixed uncaught `Assertion failed!` errors thrown on every mouse move when the note `Chat` panel or the chat `Controls` panel is dragged closed.

---

### Additional Information

The layer that actually owns the broken invariant is `paneforge` 0.0.6, which never detaches its drag listeners because it returns the wrong cleanup key for a Svelte action. That is not fixable from this repository without either patching the dependency or migrating to `paneforge` 1.x, which is a different API. This change fixes the layer Open WebUI does own: it stops destroying a resize handle in the middle of that handle's own drag, which is the precondition the library assumes.

One residual, deliberately left alone: with this change the handle unmounts at `mouseup` instead of at collapse, so one set of drag listeners is still leaked per drag close. Deferring the unmount by a single `tick()` clears that too, verified locally at zero leaked listeners across three cycles, but it only works because the action's reactive update happens to run before the destroy. That is a flush ordering race, and encoding it here felt worse than leaving a bounded leak that belongs to the dependency. Happy to add it if preferred.

Verified against commit `21e390561`, in both the note `Chat` panel and the chat `Controls` panel:

1. Errors during a drag close: 4, 6, 8 across three cycles before the change; 0, 0, 0 after.
2. The handle stays in the DOM for every mouse move of the drag, and is gone once the button is released.
3. Reopening the panel after a drag close works, and a resize drag that does not collapse still tracks the cursor exactly (a 180px drag moves the handle 180px).
4. Closing the panel with its own button still works and leaks nothing, unchanged from before.

### Screenshots or Videos

Before is current `dev`.

#### Before

<img width="2559" height="1276" alt="image" src="https://github.com/user-attachments/assets/88d64dde-5c9f-4615-96a5-90ff4ab2ef98" />

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
