### PR TITLE
fix: send the model id when ejecting from the model selector

### DIFF
--- a/src/lib/components/chat/ModelSelector/ModelItem.svelte
+++ b/src/lib/components/chat/ModelSelector/ModelItem.svelte
@@ -275,7 +275,7 @@
 					on:click={(e) => {
 						e.preventDefault();
 						e.stopPropagation();
-						unloadModelHandler(item.model);
+						unloadModelHandler(item.value);
 					}}
 				>
 					<ArrowUpTray className="size-3" />


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. First-time contributors should not open pull requests directly unless the pull request contains only i18n/localization updates.
   Do not open a PR as the first step.
   For real, reproducible bugs, start with a well-described Issue that explains the problem, why it matters, and what outcome you are looking for.
   For feature requests, enhancements, behavior changes, UI/UX changes, architecture changes, suspected fixes, or unconfirmed approaches, start with an active Discussion.
   If you want to propose an implementation, include it only as a reference in the Issue or Discussion, such as a local diff, patch, or branch.
   Opening an Issue or Discussion does not mean a PR is the right next step. Maintainers will confirm when a PR would be useful.
   We ask for this because PRs, especially from first-time contributors, often need broader maintainer context on product direction, scope, architecture, UX, edge cases, compatibility, documentation, and long-term maintenance before implementation.
   We may close unsolicited PRs without review.
   Contributors with a history of successful merged PRs may be given more latitude.
3. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

**Before submitting, make sure you've checked and filled out the following:**

- [x] **Linked Issue/Discussion:** Closes #28764
- [x] **First-time contributor policy:** not my first contribution.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** **Manual** end-to-end tests have been performed to verify the fix/feature works correctly and does not introduce regressions.
- [x] **User-facing changes:** I have confirmed whether this PR changes the UI. No layout or markup changes; the eject button now succeeds instead of raising an error toast.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

Ejecting a loaded model from the chat input's model selector fails with `422 Unprocessable Entity`, and the user sees `Error unloading model: [object Object]`. The model stays resident.

**Problem.** The click handler passes the whole model object where the rest of the chain expects a model id, so the request body is `{"model": {...the entire serialized model...}}`. `ModelUnloadForm` declares `model: str`, so validation rejects the request before any provider logic runs.

**Root cause.** Commit `25802c048` changed the argument from the item's id to the item's model object, and widened the prop type in the same change, which removed the type error that would otherwise have caught it:

```diff
-	export let unloadModelHandler: (modelValue: string) => void = () => {};
+	export let unloadModelHandler: (model: any) => void = () => {};

-						unloadModelHandler(item.value);
+						unloadModelHandler(item.model);
```

Items are built as `{ value: model.id, label: model.name, model: model }`, so `item.value` is the id string and `item.model` is the object. The receiving handler in `Selector.svelte` and the `unloadModel` helper both still declare and expect a string, and neither was changed.

**Fix.** Pass the id again.

```diff
--- a/src/lib/components/chat/ModelSelector/ModelItem.svelte
+++ b/src/lib/components/chat/ModelSelector/ModelItem.svelte
@@ -275,7 +275,7 @@
 					on:click={(e) => {
 						e.preventDefault();
 						e.stopPropagation();
-						unloadModelHandler(item.model);
+						unloadModelHandler(item.value);
 					}}
 				>
```

### Fixed

- Fixed ejecting a model from the chat model selector failing with a 422 error because the whole model object was sent instead of the model id.

---

### Additional Information

The endpoint was never at fault. Posting an id string to it works on unpatched `dev`:

| Request body | Status | Response |
|---|---|---|
| `{"model": <full model object>}` | 422 | `{"detail":[{"type":"string_type","loc":["body","model"], ...}]}` |
| `{"model": "qwen3:0.6b"}` | 200 | `{"status": true}` |

Verified end to end against `5ea9ff3ed` with a local Ollama connection:

1. Before the change, clicking eject sends the full model object (several kilobytes, since it carries every attached action and filter including their base64 icon data URIs), the endpoint returns 422, and the toast reads `Error unloading model: [object Object]`.
2. After the change, the same click sends `{"model":"qwen2.5:3b-instruct-q8_0"}`, the endpoint returns `200 {"status": true}`, the toast reads `Model unloaded successfully`, and the model is gone from `ollama ps`.
3. Workspace preset models eject correctly too, because the endpoint already resolves `base_model_id` to the base model.
4. The eject control in Admin Settings > Models was unaffected either way; it calls a different endpoint and extracts the id first.

Two related points deliberately left out of this diff, noted in #28764 so they can be judged separately. Restoring the prop type to `(modelValue: string)` would let the compiler catch a recurrence, and the error toast interpolates the raw error, so any validation failure renders as `[object Object]` rather than something actionable.

This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Screenshots or Videos

Before is current `dev`. After is this branch. No layout changes; the visible difference is the toast and the network response.

| Surface | Before | After |
|---|---|---|
| Chat model selector, clicking eject on a loaded model | <img width="532" height="888" alt="image" src="https://github.com/user-attachments/assets/a34c52c6-12cd-4759-b97e-464c7ef216e0" /> | <img width="513" height="888" alt="image" src="https://github.com/user-attachments/assets/d0ede6a4-ceeb-445a-b1d0-1f5dca282744" /> |
| Network panel, `POST /api/models/unload` | <img width="2560" height="388" alt="image" src="https://github.com/user-attachments/assets/69a46b27-a806-4021-a6aa-6c96830523c6" /> | <img width="2555" height="388" alt="image" src="https://github.com/user-attachments/assets/eaa84386-ba82-40eb-9e94-c71c23b631cb" /> |

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
