### PR TITLE
fix: reset workspace page when changing the view filter

### DIFF
--- a/src/lib/components/workspace/Knowledge.svelte
+++ b/src/lib/components/workspace/Knowledge.svelte
@@ -351,7 +351,7 @@
 						align="end"
 						onChange={async (value) => {
 							localStorage.workspaceViewOption = value;
-
+							page = 1;
 							await tick();
 						}}
 					/>

--- a/src/lib/components/workspace/Models.svelte
+++ b/src/lib/components/workspace/Models.svelte
@@ -564,6 +564,7 @@
 						align="end"
 						onChange={async (value) => {
 							localStorage.workspaceViewOption = value;
+							page = 1;
 							await tick();
 						}}
 					/>


### PR DESCRIPTION
# Pull Request Checklist

- [x] Closes #28734
- [x] Targets `dev`
- [x] No dependency or documentation changes
- [x] Atomic change and self-review completed

# Changelog Entry

### Description

- Reset the workspace list page to 1 when changing the ViewSelector filter on Models and Knowledge, matching Prompts and Skills.

### Fixed

- Switching to "Created by You" (or another view filter) while on page 2+ no longer leaves an empty page with the pager gone.

---

### Additional Information

- Validation: source comparison against Prompts/Skills `page = 1` on ViewSelector change; Models and Knowledge previously omitted the reset.
- No API, persistence, or UI contract changes beyond filter/page interaction.

### Screenshots or Videos

- Not applicable; focused page-reset alignment with existing workspace lists.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
