### PR TITLE
fix: bound nested metadata values so an unknown oversized field cannot scale with chunk count

### DIFF
--- a/backend/open_webui/retrieval/vector/utils.py
+++ b/backend/open_webui/retrieval/vector/utils.py
@@ -6,11 +6,21 @@ from open_webui.utils.misc import sanitize_text_for_db
 
 KEYS_TO_EXCLUDE = ['content', 'pages', 'tables', 'paragraphs', 'sections', 'figures']
 
+# A nested metadata value is deep-copied onto every chunk by the text splitter and then
+# stringified by process_metadata before storage, so a single unbounded one costs memory
+# proportional to the chunk count. KEYS_TO_EXCLUDE only catches the field names we know
+# about; this bounds the ones we do not.
+MAX_NESTED_METADATA_ITEMS = 64
+
+
+def _is_unbounded(value: Any) -> bool:
+    # len() is O(1) for list and dict - never serialize a value just to measure it.
+    return isinstance(value, (list, dict)) and len(value) > MAX_NESTED_METADATA_ITEMS
+
 
 def filter_metadata(metadata: dict[str, any]) -> dict[str, any]:
     # Removes large/redundant fields from metadata dict.
-    metadata = {key: value for key, value in metadata.items() if key not in KEYS_TO_EXCLUDE}
-    return metadata
+    return {key: value for key, value in metadata.items() if key not in KEYS_TO_EXCLUDE and not _is_unbounded(value)}
 
 
 def process_metadata(
@@ -21,7 +31,7 @@ def process_metadata(
     result = {}
     for key, value in metadata.items():
         # Skip large fields
-        if key in KEYS_TO_EXCLUDE:
+        if key in KEYS_TO_EXCLUDE or _is_unbounded(value):
             continue
         if value is None:
             continue


### PR DESCRIPTION
> **Draft.** Opened alongside #28771 so the code is visible next to the discussion. Two
> boxes below are deliberately left unchecked until the author has completed a manual
> end-to-end test and signed the CLA. Please treat the discussion as the place to say
> whether this approach is wanted at all — happy to close this if you would rather solve
> it differently.

# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Relates to #28771. Related: #14670 (closed).
- [x] **Target branch:** targets `dev`.
- [x] **Description:** below.
- [x] **Changelog:** below.
- [ ] **Documentation:** no user-facing behaviour or setting changes, so no docs update. Say the word if a note is wanted anyway.
- [x] **Dependencies:** none added or changed.
- [ ] **Testing:** logic-level assertions only so far (see below). **Manual end-to-end test on a running instance still pending.**
- [ ] **No Unchecked AI Code:** **pending author review and manual testing.**
- [x] **Self-Review:** performed; `ruff format --check` and `ruff check` clean on the changed file.
- [x] **Architecture:** a module constant, not a new setting.
- [x] **Git Hygiene:** one atomic commit, branched from current `dev`, nothing unrelated.
- [x] **Title Prefix:** `fix`.

# Changelog Entry

### Description

`filter_metadata` removes the six analyze-result fields that caused #14670, but it matches
on field *name*. Any other nested value passes through, is deep-copied onto every chunk by
the text splitter, and is then stringified by `process_metadata`, so one unknown oversized
field costs memory proportional to chunk count.

Concretely, Azure Document Intelligence metadata arrives via `langchain_community`'s
`AzureAIDocumentIntelligenceLoader`, which sets `metadata=result.as_dict()`.
`AnalyzeResult` has 15 fields; `KEYS_TO_EXCLUDE` covers six. `keyValuePairs`, `documents`,
`styles` and `languages` are not covered. With the default `prebuilt-layout` those stay
small, but `DOCUMENT_INTELLIGENCE_MODEL` is operator-settable and a non-layout model
populates `documents` and `keyValuePairs` with `boundingRegions` — the same per-word
polygon data #14670 was about, under names the blacklist does not match.

This bounds nested values by item count in addition to the name list. `len()` is O(1) on
`list` and `dict`, so nothing is serialized just to be measured. A nested value that
survives `filter_metadata` is stringified by `process_metadata` before storage anyway, so
it was never queryable structured data downstream — dropping an oversized one loses
nothing usable.

The guard is applied in `process_metadata` as well, so it holds for all twelve vector
store clients that call it rather than only the loader path.

Full reasoning, including the order-of-operations detail about why filtering cannot
prevent the single-document allocation, is in #28771.

### Added

- `MAX_NESTED_METADATA_ITEMS` (64) and a private `_is_unbounded()` helper in `backend/open_webui/retrieval/vector/utils.py`.

### Changed

- `filter_metadata()` and `process_metadata()` now drop `list`/`dict` values holding more than `MAX_NESTED_METADATA_ITEMS` items, in addition to the existing `KEYS_TO_EXCLUDE` name check.

### Fixed

- An analyze-result field not named in `KEYS_TO_EXCLUDE` no longer reaches per-chunk metadata, where its cost multiplies by chunk count.

---

### Additional Information

**Known limit, stated plainly:** this bounds by item count, so a short list of
individually huge items still passes. Bounding by serialized size would catch that but
costs a full serialization of every nested value on every document, which seemed the wrong
trade. The threshold of 64 is a judgement call — happy to change it, or to key it off
something better.

**What has been verified:** assertions over the changed functions confirming that the
existing `KEYS_TO_EXCLUDE` behaviour is unchanged; that `styles`, `documents` and
`keyValuePairs` shaped like a real `AnalyzeResult` are now dropped; that ordinary loader
metadata (`source`, `page`, small tag lists) passes through untouched; that
`process_metadata` drops the same values rather than stringifying them; and the 64/65
boundary. `ruff format --check` and `ruff check` pass.

**What has not:** a controlled measurement of peak memory on a large document, and a manual
end-to-end upload against a running instance. Both are noted as unchecked above.

Read against the versions `backend/requirements.txt` pins for v0.10.2:
`langchain-community==0.4.2`, `langchain-text-splitters==1.1.2`,
`azure-ai-documentintelligence==1.0.2`. `dev` and v0.10.2 are identical for
`vector/utils.py` as of today.

### Screenshots or Videos

- Not applicable; no user-facing change.

### Contributor License Agreement

- [ ] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
