### PR TITLE
fix: bound nested metadata values so an unknown oversized field cannot scale with chunk count

### DIFF
--- a/backend/open_webui/retrieval/vector/utils.py
+++ b/backend/open_webui/retrieval/vector/utils.py
@@ -6,11 +6,21 @@ from open_webui.utils.misc import sanitize_text_for_db
 
 KEYS_TO_EXCLUDE = ['content', 'pages', 'tables', 'paragraphs', 'sections', 'figures']
 
+# A nested metadata value is deep-copied onto every chunk by the text splitter and then
+# stringified by process_metadata before storage, so a single unbounded one costs memory
+# proportional to the chunk count. KEYS_TO_EXCLUDE only catches the field names we know
+# about; this bounds the ones we do not.
+MAX_NESTED_METADATA_ITEMS = 64
+
+
+def _is_unbounded(value: Any) -> bool:
+    # len() is O(1) for list and dict - never serialize a value just to measure it.
+    return isinstance(value, (list, dict)) and len(value) > MAX_NESTED_METADATA_ITEMS
+
 
 def filter_metadata(metadata: dict[str, any]) -> dict[str, any]:
     # Removes large/redundant fields from metadata dict.
-    metadata = {key: value for key, value in metadata.items() if key not in KEYS_TO_EXCLUDE}
-    return metadata
+    return {key: value for key, value in metadata.items() if key not in KEYS_TO_EXCLUDE and not _is_unbounded(value)}
 
 
 def process_metadata(
@@ -21,7 +31,7 @@ def process_metadata(
     result = {}
     for key, value in metadata.items():
         # Skip large fields
-        if key in KEYS_TO_EXCLUDE:
+        if key in KEYS_TO_EXCLUDE or _is_unbounded(value):
             continue
         if value is None:
             continue


### PR DESCRIPTION
> Replaces #28772, which the CLA bot closed for an unchecked CLA box — that is now
> accepted. Opened alongside #28771, which carries the full reasoning.

# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Relates to #28771. Related: #14670 (closed).
- [x] **Target branch:** targets `dev`.
- [x] **Description:** below.
- [x] **Changelog:** below.
- [ ] **Documentation:** no user-facing behaviour or setting changes, so no docs update. Say the word if a note is wanted anyway.
- [x] **Dependencies:** none added or changed.
- [x] **Testing:** manual end-to-end test performed against a real `ghcr.io/open-webui/open-webui:v0.10.2` container, before and after. Results below.
- [x] **No Unchecked AI Code:** reviewed line by line by the author and manually tested as described below.
- [x] **Self-Review:** performed; `ruff format --check` and `ruff check` clean on the changed file.
- [x] **Architecture:** a module constant, not a new setting.
- [x] **Git Hygiene:** one atomic commit, branched from current `dev`, nothing unrelated.
- [x] **Title Prefix:** `fix`.

# Changelog Entry

### Description

`filter_metadata` removes the six analyze-result fields that caused #14670, but it matches
on field *name*. Any other nested value passes through, is deep-copied onto every chunk by
the text splitter, and is then stringified by `process_metadata`, so one unknown oversized
field costs memory proportional to chunk count.

Concretely, Azure Document Intelligence metadata arrives via `langchain_community`'s
`AzureAIDocumentIntelligenceLoader`, which sets `metadata=result.as_dict()`.
`AnalyzeResult` has 15 fields; `KEYS_TO_EXCLUDE` covers six. `keyValuePairs`, `documents`,
`styles` and `languages` are not covered. With the default `prebuilt-layout` those stay
small, but `DOCUMENT_INTELLIGENCE_MODEL` is operator-settable and a non-layout model
populates `documents` and `keyValuePairs` with `boundingRegions` — the same per-word
polygon data #14670 was about, under names the blacklist does not match.

This bounds nested values by item count in addition to the name list. `len()` is O(1) on
`list` and `dict`, so nothing is serialized just to be measured. A nested value that
survives `filter_metadata` is stringified by `process_metadata` before storage anyway, so
it was never queryable structured data downstream — dropping an oversized one loses
nothing usable.

The guard is applied in `process_metadata` as well, so it holds for all twelve vector
store clients that call it rather than only the loader path.

Full reasoning, including the order-of-operations detail about why filtering cannot
prevent the single-document allocation, is in #28771.

### Added

- `MAX_NESTED_METADATA_ITEMS` (64) and a private `_is_unbounded()` helper in `backend/open_webui/retrieval/vector/utils.py`.

### Changed

- `filter_metadata()` and `process_metadata()` now drop `list`/`dict` values holding more than `MAX_NESTED_METADATA_ITEMS` items, in addition to the existing `KEYS_TO_EXCLUDE` name check.

### Fixed

- An analyze-result field not named in `KEYS_TO_EXCLUDE` no longer reaches per-chunk metadata, where its cost multiplies by chunk count.

---

### Additional Information

**Known limit, stated plainly:** this bounds by item count, so a short list of
individually huge items still passes. Bounding by serialized size would catch that but
costs a full serialization of every nested value on every document, which seemed the wrong
trade. The threshold of 64 is a judgement call — happy to change it, or to key it off
something better.

**Manual test, on `ghcr.io/open-webui/open-webui:v0.10.2`** (a throwaway container, default
extraction engine, no Azure calls — the patched functions are on the path for every
engine):

*The gap is real in the running image.* Feeding `filter_metadata` / `process_metadata` a
metadata dict shaped like `AnalyzeResult.as_dict()` from a `prebuilt-document` model:

| | before | after |
|---|---|---|
| fields leaking past `KEYS_TO_EXCLUDE` | `styles`, `languages`, `documents`, `keyValuePairs` | none |
| largest value handed to the vector store | `documents` — 23,400 chars | `modelId` — 17 chars |
| ordinary loader metadata (`source`, `page`, `name`, small tag list) | intact | intact |

Each of those leaked values is stringified by `process_metadata` and then stored once per
chunk, so the 23,400 characters above are paid per chunk, not per document.

*No regression on the normal path.* A 72 KB text file uploaded through `POST
/api/v1/files/`, then queried through `POST /api/v1/retrieval/query/doc`, on the same
container before and after the change:

| | before | after |
|---|---|---|
| upload | `status: True` | `status: True` |
| retrieval hits (`k=3`) | 3 | 3 |
| top chunk | `Section 26. The quick brown fox…` | identical |
| chunk metadata keys | `created_by, embedding_config, file_id, hash, name, source, start_index` | identical |
| new errors in container logs | — | none |

*Over-filtering check.* Every `metadata={...}` construction in
`backend/open_webui/retrieval/loaders/main.py` builds a flat dict of scalars (`source`,
`page`, `row`, `file_name`), so nothing in-tree currently passes a nested value large
enough for the new bound to touch.

**Logic-level assertions** also cover the `KEYS_TO_EXCLUDE` behaviour being unchanged and
the 64/65 boundary. `ruff format --check` and `ruff check` pass on the changed file.

**What has not:** a controlled measurement of peak memory on a large document, and a manual
end-to-end upload against a running instance. Both are noted as unchecked above.

Read against the versions `backend/requirements.txt` pins for v0.10.2:
`langchain-community==0.4.2`, `langchain-text-splitters==1.1.2`,
`azure-ai-documentintelligence==1.0.2`. `dev` and v0.10.2 are identical for
`vector/utils.py` as of today.

### Screenshots or Videos

- Not applicable; no user-facing change.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
