### PR TITLE
fix(#28767):fetching tags for a chat the user can read but does not own returns 401

### DIFF
--- a/backend/open_webui/routers/chats.py
+++ b/backend/open_webui/routers/chats.py
@@ -1302,8 +1302,14 @@ async def compact_chat_by_id(
 ############################
 
 
-@router.get('/{id}', response_model=ChatResponse | None)
-async def get_chat_by_id(id: str, user=Depends(get_verified_user), db: AsyncSession = Depends(get_async_session)):
+async def get_readable_chat(user, id: str, db: AsyncSession):
+    """Resolve a chat the given user has read access to, or None.
+
+    Read access is granted by any of: ownership, an admin override under
+    ENABLE_ADMIN_CHAT_ACCESS, an explicit shared_chat read grant, or access
+    to the folder the chat sits in. Kept as a single helper so every route
+    that needs to check "can this user read this chat" stays in step.
+    """
     chat = await Chats.get_chat_by_id_and_user_id(id, user.id, db=db)
 
     if not chat and user.role == 'admin':
@@ -1331,6 +1337,13 @@ async def get_chat_by_id(id: str, user=Depends(get_verified_user), db: AsyncSess
                 folder = await Folders.get_folder_by_id(candidate.folder_id, db=db)
                 if folder and await has_folder_access(user.id, folder, 'read', db):
                     chat = candidate
+
+    return chat
+
+
+@router.get('/{id}', response_model=ChatResponse | None)
+async def get_chat_by_id(id: str, user=Depends(get_verified_user), db: AsyncSession = Depends(get_async_session)):
+    chat = await get_readable_chat(user, id, db)
 
     if chat:
         data = ChatResponse.model_validate(chat, from_attributes=True).model_dump()
@@ -2153,9 +2166,12 @@ async def update_chat_folder_id_by_id(
 
 @router.get('/{id}/tags', response_model=list[TagModel])
 async def get_chat_tags_by_id(id: str, user=Depends(get_verified_user), db: AsyncSession = Depends(get_async_session)):
-    chat = await Chats.get_chat_by_id_and_user_id(id, user.id, db=db)
+    chat = await get_readable_chat(user, id, db)
     if chat:
         tags = chat.meta.get('tags', [])
+        # Tags are resolved against the requesting user's own tag rows, so a
+        # viewer who does not own the chat simply gets an empty list rather
+        # than another user's tags leaking through.
         return await Tags.get_tags_by_ids_and_user_id(tags, user.id, db=db)
     else:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=ERROR_MESSAGES.NOT_FOUND)


### PR DESCRIPTION
## What changed?

* Fixed `GET /api/v1/chats/{id}/tags` returning `401 Unauthorized` for chats the user is allowed to read but does not own.
* Extracted the shared chat access logic into a reusable `get_readable_chat(user, id, db)` helper.
* Updated both `GET /api/v1/chats/{id}` and `GET /api/v1/chats/{id}/tags` to use the same access checks.
* Preserved tag ownership boundaries by continuing to resolve tags through the requesting user's tag records.

## Why?

The chat endpoint supports multiple valid read-access paths:

* Chat ownership
* Admin chat access
* Explicit `shared_chat` read grants
* Read access through a shared folder

However, the tags endpoint previously checked only direct chat ownership. As a result, a chat could successfully load with `GET /api/v1/chats/{id}` while the subsequent `GET /api/v1/chats/{id}/tags` request returned `401 Unauthorized`.

The frontend requests chat tags when loading a chat, so this produced unnecessary 401 errors and caused tags to be missing for otherwise readable chats.

## How?

Added a shared `get_readable_chat(user, id, db)` helper containing the same four-way access checks used by the chat endpoint.

Both endpoints now use this helper to determine whether the requesting user can read the chat.

After access is granted, tags are still retrieved with:

```python
Tags.get_tags_by_ids_and_user_id(tags, user.id, db=db)
```

This ensures that a user who can read another user's chat does not gain access to that user's tag records.

## Result

A chat accessible through admin access, a `shared_chat` grant, or folder access can now retrieve its tags without receiving a false `401 Unauthorized`.

Non-owners continue to receive only tags belonging to the requesting user, preventing other users' tags from being exposed.

## Related Issue

Fixes #28767
