### PR TITLE
fix: store RedisDict write-skip fingerprint in Redis, not per process

### DIFF
--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -121,6 +121,9 @@ if WEBSOCKET_MANAGER == 'redis':
         redis_url=WEBSOCKET_REDIS_URL,
         redis_sentinels=ws_sentinels,
         redis_cluster=WEBSOCKET_REDIS_CLUSTER,
+        # set() skips redundant writes against a fingerprint stored beside the
+        # hash, so it must be tracked for the model pool (see RedisDict.set).
+        track_fingerprint=True,
     )
 
     SESSION_POOL = RedisDict(

--- a/backend/open_webui/socket/utils.py
+++ b/backend/open_webui/socket/utils.py
@@ -61,12 +61,22 @@ class RedisLock:
 
 
 class RedisDict:
-    def __init__(self, name, redis_url, redis_sentinels=[], redis_cluster=False):
+    def __init__(
+        self,
+        name,
+        redis_url,
+        redis_sentinels=[],
+        redis_cluster=False,
+        track_fingerprint=False,
+    ):
         self.name = name
-        # Per-process cache of the last payload fingerprint written by set().
-        # Used to skip redundant HSET round-trips when the model list hasn't
-        # changed — the dominant Redis write source on busy multi-pod setups.
-        self._last_signature: str | None = None
+        # When True, set() skips redundant writes by comparing against a
+        # fingerprint stored in Redis *beside* the hash — not on this instance —
+        # so the guard describes the state it protects (see set()). Only the
+        # model pool needs this; the websocket session/usage pools never call
+        # set(), and keeping the flag off leaves their item-level hot path free
+        # of the extra round trip.
+        self._track_fingerprint = track_fingerprint
         self.redis = get_redis_connection(
             redis_url,
             redis_sentinels,
@@ -74,9 +84,16 @@ class RedisDict:
             decode_responses=True,
         )
 
+    def _fingerprint_key(self):
+        return f'{self.name}:__signature__'
+
     def __setitem__(self, key, value):
         serialized_value = JSONCodec.dumps(value)
         self.redis.hset(self.name, key, serialized_value)
+        # The hash changed without going through set(), so any fingerprint that
+        # claims to describe its contents is now stale.
+        if self._track_fingerprint:
+            self.redis.delete(self._fingerprint_key())
 
     def __getitem__(self, key):
         value = self.redis.hget(self.name, key)
@@ -88,6 +105,8 @@ class RedisDict:
         result = self.redis.hdel(self.name, key)
         if result == 0:
             raise KeyError(key)
+        if self._track_fingerprint:
+            self.redis.delete(self._fingerprint_key())
 
     def __contains__(self, key):
         return self.redis.hexists(self.name, key)
@@ -107,7 +126,8 @@ class RedisDict:
     def set(self, mapping: dict):
         if not mapping:
             self.redis.delete(self.name)
-            self._last_signature = None
+            if self._track_fingerprint:
+                self.redis.delete(self._fingerprint_key())
             return
 
         # Serialize values once — reused for both the fingerprint and the write.
@@ -120,11 +140,12 @@ class RedisDict:
             digest.update(b'\0')
         signature = digest.hexdigest()
 
-        # Skip the write when the prepared mapping is identical to the last one
-        # this process wrote.  The check is per-instance (not distributed), but
-        # still eliminates the majority of redundant writes because each pod
-        # typically produces the same model list on consecutive refreshes.
-        if signature == self._last_signature:
+        # Skip the write only when the *shared* hash already holds exactly this
+        # mapping.  A fingerprint cached on the instance describes a state that
+        # lives elsewhere: worker A could keep skipping its (correct, full)
+        # write while the shared hash stays stuck on worker B's partial list,
+        # because A's fingerprint only ever changes when A's own list changes.
+        if self._track_fingerprint and self.redis.get(self._fingerprint_key()) == signature:
             return
 
         # Fetch existing keys before writing so we know which ones to remove.
@@ -140,7 +161,12 @@ class RedisDict:
         if keys_to_remove:
             self.redis.hdel(self.name, *keys_to_remove)
 
-        self._last_signature = signature
+        # Fingerprint written last, as a separate command: the two keys need not
+        # share a Redis Cluster hash slot, and a crash between the hash write
+        # and this one leaves the fingerprint absent — the next set() rewrites —
+        # rather than claiming contents that were never written.
+        if self._track_fingerprint:
+            self.redis.set(self._fingerprint_key(), signature)
 
     def get(self, key, default=None):
         try:
@@ -150,7 +176,10 @@ class RedisDict:
 
     def clear(self):
         self.redis.delete(self.name)
-        self._last_signature = None
+        # Drop the shared fingerprint too, or other workers would keep skipping
+        # the repopulating write that this clear is asking for.
+        if self._track_fingerprint:
+            self.redis.delete(self._fingerprint_key())
 
     def update(self, other=None, **kwargs):
         if other is not None:


### PR DESCRIPTION
### Linked Issue

Closes #28777

### Description

The write-skip guard in `RedisDict.set()` compared a fingerprint cached **on the instance** against the mapping about to be written. The state it guards, however, lives in the **shared Redis hash**. With `WEBSOCKET_MANAGER=redis` and multiple workers:

1. Worker A publishes the full model list `X` and caches `signature(X)` locally.
2. Worker B's upstream fetch momentarily returns a partial list `Y` (one connection slow/down for that pod); B writes `Y`, so the shared hash is now `Y`.
3. Worker A refreshes. Its own list is unchanged, so it recomputes `signature(X)`, matches its own per-process cache, and **skips the correcting write**.
4. The hash stays at `Y`. Models in `X \ Y` are gone for every pod (`Model not found` at `main.py:1103`) until a pod restarts or its own list genuinely changes.

`clear()` had the same flaw in the other direction: it reset only the local fingerprint, so other workers kept one describing contents that no longer exist and skipped repopulating.

### Root cause

The fingerprint lives in the process while the data it describes lives in Redis — the guard must describe the shared state, not a per-process memory of it.

### Fix

Store the fingerprint in Redis **beside** the hash (`<name>:__signature__`):

- `set()` skips only when the *shared* fingerprint matches the mapping about to be written — identical steady-state behavior, but a degraded list written by another worker is repaired on the next refresh of any worker holding the correct list.
- The fingerprint is written **after** the hash, as a **separate command** (the two keys need not share a Redis Cluster hash slot; a crash mid-write leaves the fingerprint absent so the next `set()` rewrites, rather than claiming contents that were never written).
- `clear()` drops the **shared** fingerprint.
- Item-level writes (`__setitem__` / `__delitem__`) invalidate the shared fingerprint.
- The guard is gated behind `track_fingerprint` and enabled only for the model pool; the session/usage pools never call `set()` and keep their hot websocket path free of the extra round trip.

### Testing

Ran the real `RedisDict` class from source (zero dependencies, fake shared Redis — same technique as the issue's repro):

- **Before:** after `a.set(full)`, `b.set(partial)`, `a.set(full)`, `'llama3' in a` → `False` (matches the issue)
- **After:** `True`, and stays `True` across 100 further identical refreshes
- Redundant identical `set()` still skips the hash write
- `clear()` drops the shared fingerprint; another worker repopulates
- Item-level writes invalidate the fingerprint
- Untracked instances keep the previous always-write behavior
- Empty mapping clears both hash and fingerprint

`ruff format --check` and `ruff check --select=F` pass on both changed files.

# Changelog Entry

### Description

- Moves the `RedisDict.set()` write-skip fingerprint from a per-process attribute to a Redis key beside the hash, so a worker holding the correct model list can repair a degraded list written by another worker.

### Added

- `RedisDict(track_fingerprint=...)` flag; `_fingerprint_key()` helper.

### Changed

- `RedisDict.set()` skips redundant writes by comparing against the shared fingerprint in Redis instead of a per-process cache.

### Deprecated

- None.

### Removed

- `RedisDict._last_signature` per-process fingerprint.

### Fixed

- Multi-worker `WEBSOCKET_MANAGER=redis` model list getting stuck on a partial list (`Model not found` for every pod) when one worker's upstream fetch momentarily degrades.

### Security

- None.

### Breaking Changes

- None.

### Additional Information

- None.

### Screenshots or Videos

- Not applicable (backend change).

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.