### PR TITLE
feat: register CyberArk Identity app_id JWS header for joserfc

### DIFF
--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -199,6 +199,12 @@ JWSRegistry.default_header_registry.setdefault(
     'client_id',
     HeaderParameter('OAuth client identifier', 'str'),
 )
+# CyberArk Identity (Idaptive) includes a private app_id in ID token JWS headers;
+# register it so joserfc does not reject the token with UnsupportedHeaderError.
+JWSRegistry.default_header_registry.setdefault(
+    'app_id',
+    HeaderParameter('CyberArk Identity application identifier', 'str'),
+)
 
 
 def _normalize_token_expiry(token: dict) -> dict:


### PR DESCRIPTION
## Problem
Since the `authlib.jose` → `joserfc` migration (#27310), OpenWebUI rejects OIDC id_tokens whose JWS **header** carries provider-specific params, raising:

```
joserfc.errors.UnsupportedHeaderError: unsupported_header: Unsupported {'app_id'} in header
```

**CyberArk Identity (Idaptive)** adds a private `app_id` claim to the id_token JWS header. The token exchange succeeds (200), but id_token parsing fails at the header check, so every OIDC login fails — surfaced to users as a misleading "email or password incorrect."

This is the same class of issue already handled for Apereo CAS's `client_id` header, right above this change.

## Fix
Register `app_id` as a known header parameter, mirroring the existing `client_id` registration:

```python
JWSRegistry.default_header_registry.setdefault(
    'app_id',
    HeaderParameter('CyberArk Identity application identifier', 'str'),
)
```

No behavior change for other providers; it only stops joserfc from rejecting CyberArk tokens.

## Testing
Verified against a live CyberArk Identity (`*.idaptive.app`) OIDC app on OpenWebUI 0.11.0: before, login 500s with `UnsupportedHeaderError: {'app_id'}`; after registering the header, the id_token parses and OIDC login completes.