### PR TITLE
refac: remove unused knowledge base accessors

### DIFF
--- a/backend/open_webui/models/knowledge.py
+++ b/backend/open_webui/models/knowledge.py
@@ -484,24 +484,6 @@ class KnowledgeTable:
             db=db,
         )
 
-    async def get_knowledge_bases_by_user_id(
-        self, user_id: str, permission: str = 'write', db: Optional[AsyncSession] = None
-    ) -> list[KnowledgeUserModel]:
-        knowledge_bases = await self.get_knowledge_bases(db=db)
-        user_groups = await Groups.get_groups_by_member_id(user_id, db=db)
-        user_group_ids = {group.id for group in user_groups}
-
-        # One grants query for all non-owned knowledge bases instead of one each
-        accessible_ids = await AccessGrants.get_accessible_resource_ids(
-            user_id=user_id,
-            resource_type='knowledge',
-            resource_ids=[kb.id for kb in knowledge_bases if kb.user_id != user_id],
-            permission=permission,
-            user_group_ids=user_group_ids,
-            db=db,
-        )
-        return [kb for kb in knowledge_bases if kb.user_id == user_id or kb.id in accessible_ids]
-
     async def get_knowledge_by_id(self, id: str, db: Optional[AsyncSession] = None) -> Optional[KnowledgeModel]:
         try:
             async with get_async_db_context(db) as db:
@@ -510,29 +492,6 @@ class KnowledgeTable:
                 return await self._to_knowledge_model(knowledge, db=db) if knowledge else None
         except Exception:
             return None
-
-    async def get_knowledge_by_id_and_user_id(
-        self, id: str, user_id: str, db: Optional[AsyncSession] = None
-    ) -> Optional[KnowledgeModel]:
-        knowledge = await self.get_knowledge_by_id(id, db=db)
-        if not knowledge:
-            return None
-
-        if knowledge.user_id == user_id:
-            return knowledge
-
-        user_groups = await Groups.get_groups_by_member_id(user_id, db=db)
-        user_group_ids = {group.id for group in user_groups}
-        if await AccessGrants.has_access(
-            user_id=user_id,
-            resource_type='knowledge',
-            resource_id=knowledge.id,
-            permission='write',
-            user_group_ids=user_group_ids,
-            db=db,
-        ):
-            return knowledge
-        return None
 
     async def get_knowledges_by_file_id(self, file_id: str, db: Optional[AsyncSession] = None) -> list[KnowledgeModel]:
         try:
@@ -803,25 +762,6 @@ class KnowledgeTable:
                 await db.commit()
                 if form_data.access_grants is not None:
                     await AccessGrants.set_access_grants('knowledge', id, form_data.access_grants, db=db)
-                return await self.get_knowledge_by_id(id=id, db=db)
-        except Exception as e:
-            log.exception(e)
-            return None
-
-    async def update_knowledge_data_by_id(
-        self, id: str, data: dict, db: Optional[AsyncSession] = None
-    ) -> Optional[KnowledgeModel]:
-        try:
-            async with get_async_db_context(db) as db:
-                await db.execute(
-                    update(Knowledge)
-                    .filter_by(id=id)
-                    .values(
-                        data=data,
-                        updated_at=int(time.time()),
-                    )
-                )
-                await db.commit()
                 return await self.get_knowledge_by_id(id=id, db=db)
         except Exception as e:
             log.exception(e)


### PR DESCRIPTION
Three methods on KnowledgeTable have no callers anywhere in the repository. get_knowledge_bases_by_user_id loaded every knowledge base and filtered them in Python, which search_knowledge_bases already does in SQL with pagination. get_knowledge_by_id_and_user_id duplicates check_access_by_user_id with the permission hardcoded to write. update_knowledge_data_by_id writes a data column that a migration dropped, so it could only ever raise and return None through its own except block.

What remains is one per-entry access helper and one SQL-filtered list path, so nobody reaches for the slower or the broken variant by accident.

No behaviour change.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
