### PR TITLE
feat: preconfigure OpenAI-compatible providers from env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,10 @@ OLLAMA_BASE_URL='http://localhost:11434'
 OPENAI_API_BASE_URL=''
 OPENAI_API_KEY=''
 
+# Preconfigured OpenAI-compatible providers: setting the key seeds the connection on first start
+# MELIOUS_API_KEY=''
+# MELIOUS_API_BASE_URL='https://api.melious.ai/v1'
+
 # AUTOMATIC1111_BASE_URL="http://localhost:7860"
 
 # For production, you should only need one host as

--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -364,6 +364,58 @@ OPENAI_API_BASE_URL = 'https://api.openai.com/v1'
 
 
 ####################################
+# OPENAI_COMPATIBLE_PROVIDERS
+####################################
+
+# OpenAI-compatible providers Open WebUI ships the base URL for. Setting a provider's API key env
+# var seeds a working connection on first start, so admins don't have to look the endpoint up and
+# type it in. Each entry may be pointed elsewhere with its own base URL env var (self-hosted or
+# regional deployments). Adding another provider is one entry here.
+OPENAI_COMPATIBLE_PROVIDERS = {
+    'melious': {
+        'name': 'Melious',
+        'base_url': 'https://api.melious.ai/v1',
+        'key_env': 'MELIOUS_API_KEY',
+        'base_url_env': 'MELIOUS_API_BASE_URL',
+    },
+}
+
+
+def load_openai_compatible_providers(base_urls: list[str], keys: list[str], api_configs: dict) -> None:
+    """Seed an OpenAI connection for every preconfigured provider whose API key env var is set.
+
+    Mutates the three lists/dicts in place. `base_urls` and `keys` are index-aligned, and
+    `api_configs` is keyed by that index, so keys are first normalized to the URL count the same
+    way `normalize_openai_api_keys` does. A base URL already present is left untouched, so an
+    explicit OPENAI_API_BASE_URLS entry always wins over the preset.
+    """
+    if len(keys) > len(base_urls):
+        del keys[len(base_urls) :]
+    else:
+        keys.extend([''] * (len(base_urls) - len(keys)))
+
+    configured_urls = {url.rstrip('/') for url in base_urls}
+
+    for provider in OPENAI_COMPATIBLE_PROVIDERS.values():
+        key = os.getenv(provider['key_env'], '').strip()
+        if not key:
+            continue
+
+        base_url = (os.getenv(provider['base_url_env'], '').strip() or provider['base_url']).rstrip('/')
+        if base_url in configured_urls:
+            log.info('%s is already configured at %s, skipping preset', provider['name'], base_url)
+            continue
+
+        base_urls.append(base_url)
+        keys.append(key)
+        api_configs[str(len(base_urls) - 1)] = {'enable': True, 'connection_type': 'external'}
+        configured_urls.add(base_url)
+
+
+load_openai_compatible_providers(OPENAI_API_BASE_URLS, OPENAI_API_KEYS, OPENAI_API_CONFIGS)
+
+
+####################################
 # MODELS
 ####################################
 

--- a/src/lib/components/AddConnectionModal.svelte
+++ b/src/lib/components/AddConnectionModal.svelte
@@ -360,6 +360,7 @@
 											<option value="https://api.groq.com/openai/v1" />
 											<option value="https://openrouter.ai/api/v1" />
 											<option value="https://api.x.ai/v1" />
+											<option value="https://api.melious.ai/v1"></option>
 										</datalist>
 									{/if}
 								</div>


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Relates to #28792 
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [x] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Manual tests have been performed to verify the feature works correctly and does not introduce regressions.
- [x] **No Unchecked AI Code:** This PR has undergone thorough human review AND manual testing.
- [x] **Self-Review:** A self-review of the code has been performed.
- [x] **Architecture:** Smart defaults are preferred over new settings.
- [x] **Git Hygiene:** The PR is atomic, rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `feat`

# Changelog Entry

### Description

- Open WebUI works with any OpenAI-compatible endpoint, but there is currently no way to ship one preconfigured, and nothing in the UI suggests a given provider is reachable. An admin has to know the base URL and type it in.
- This adds a small registry of OpenAI-compatible providers whose base URL ships with Open WebUI. Setting a provider's API key environment variable seeds a working connection on first start. Adding a provider later is a single dict entry, so this is a mechanism rather than a one-off.
- Melious is the first entry. It serves an OpenAI-compatible API on European infrastructure, which is the reason a self-hosted deployment might want it preconfigured.

### Added

- `OPENAI_COMPATIBLE_PROVIDERS` in `backend/open_webui/config.py` — a provider registry (`name`, `base_url`, `key_env`, `base_url_env`), following the `load_oauth_providers()` idiom already in that file.
- `load_openai_compatible_providers()` — seeds an OpenAI connection for every registry entry whose API key env var is set, splicing into `OPENAI_API_BASE_URLS` / `OPENAI_API_KEYS` / `OPENAI_API_CONFIGS` before `DEFAULT_CONFIG` is built.
- `MELIOUS_API_KEY` and `MELIOUS_API_BASE_URL` (documented, commented out, in `.env.example`).
- `https://api.melious.ai/v1` in the Add Connection URL suggestion datalist.

### Changed

- Nothing. With no provider key set, the resulting config is byte-identical to today's default.

### Additional Information

**Semantics, deliberately conservative:**

- **Seeds on first start only.** The values land in `DEFAULT_CONFIG`, so `Config.seed_defaults()` persists them only when the key isn't already in the DB. Existing installs keep their configuration — matching how `OPENAI_API_BASE_URLS` itself already behaves.
- **Explicit config always wins.** A base URL already present in `OPENAI_API_BASE_URLS` is skipped with a log line rather than duplicated.
- **Index alignment preserved.** `OPENAI_API_KEYS` is normalized to the URL count using the same truncate/pad rule as `normalize_openai_api_keys()` (`routers/openai.py`) and the admin UI (`admin/Settings/Connections.svelte`) before anything is appended.
- **No new request handling.** No `provider` enum value is added — nothing about these endpoints needs different treatment, so this is configuration only.

**Testing.** Verified against a live API key, in a container built from this branch:

| Case | Result |
| --- | --- |
| `MELIOUS_API_KEY` set, fresh volume | Connection seeded at index 1, key aligned, config `{enable, connection_type}` written; 73 models listed; chat works |
| No provider key set | Config identical to upstream default — `['https://api.openai.com/v1']`, `['']`, `{}` |
| `OPENAI_API_BASE_URLS` already contains the URL | Not duplicated; the explicit key is kept |
| `MELIOUS_API_BASE_URL` override | Honored, trailing slash stripped |
| Key env var empty / whitespace | Treated as unset |
| Key added to an **existing** volume | Correctly absent (seed-once); appears with `RESET_CONFIG_ON_START=True` |
| `ENABLE_PERSISTENT_CONFIG=False` | Present, served from `DEFAULT_CONFIG` |
| Second registry entry added locally | Both seeded, indices correct; loader is idempotent |
| Datalist | Present in the built client bundle with the same footprint as the existing seven entries |

Checks run: `ruff format --check` (256 files clean), `ruff check --select=F` (clean, zero new findings in the added block), `npm run format` + `npm run i18n:parse` + `git diff` (no drift — no new translatable strings, all 63 locale files unchanged), `npm run build`, `vitest run`.

### Screenshots or Videos

- [Admin → Settings → Connections showing the seeded connection]

<img width="1917" height="872" alt="Screenshot 2026-08-19 202150" src="https://github.com/user-attachments/assets/6f311556-40f7-426f-bbf1-d0a0a928a76b" />

- [Add Connection modal showing the URL suggestion]

<img width="977" height="699" alt="Screenshot 2026-08-19 202444" src="https://github.com/user-attachments/assets/2144ebdd-b3d1-40ef-a9b0-555fcaa1047a" />


### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.