### PR TITLE
perf: stop scanning every tool on each tool listing

### DIFF
--- a/backend/open_webui/models/tools.py
+++ b/backend/open_webui/models/tools.py
@@ -169,20 +169,35 @@ class ToolsTable:
                 for tool in tools
             }
 
-    async def get_tools(self, defer_content: bool = False, db: AsyncSession | None = None) -> list[ToolUserModel]:
+    async def get_tools(
+        self,
+        defer_content: bool = False,
+        db: AsyncSession | None = None,
+        user_id: str | None = None,
+        user_group_ids: set[str] | None = None,
+    ) -> list[ToolUserModel]:
+        """List tools, scoped to what user_id may read when given."""
         async with get_async_db_context(db) as db:
-            if defer_content:
-                # Skip Tool.content (plugin source, potentially large) via a
-                # column select; Row attributes satisfy from_attributes.
-                result = await db.execute(
-                    select(
-                        Tool.id, Tool.user_id, Tool.name, Tool.specs, Tool.meta, Tool.updated_at, Tool.created_at
-                    ).order_by(Tool.updated_at.desc())
+            stmt = (
+                select(Tool.id, Tool.user_id, Tool.name, Tool.specs, Tool.meta, Tool.updated_at, Tool.created_at)
+                if defer_content
+                else select(Tool)
+            ).order_by(Tool.updated_at.desc())
+
+            if user_id is not None:
+                if user_group_ids is None:
+                    user_group_ids = {group.id for group in await Groups.get_groups_by_member_id(user_id, db=db)}
+                stmt = AccessGrants.has_permission_filter(
+                    db=db,
+                    query=stmt,
+                    DocumentModel=Tool,
+                    filter={'user_id': user_id, 'group_ids': user_group_ids},
+                    resource_type='tool',
+                    permission='read',
                 )
-                all_tools = result.all()
-            else:
-                result = await db.execute(select(Tool).order_by(Tool.updated_at.desc()))
-                all_tools = result.scalars().all()
+
+            result = await db.execute(stmt)
+            all_tools = result.all() if defer_content else result.scalars().all()
 
             user_ids = list(set(tool.user_id for tool in all_tools))
             tool_ids = [tool.id for tool in all_tools]
@@ -209,28 +224,6 @@ class ToolsTable:
                     )
                 )
             return tools
-
-    async def get_tools_by_user_id(
-        self,
-        user_id: str,
-        permission: str = 'write',
-        defer_content: bool = False,
-        db: AsyncSession | None = None,
-    ) -> list[ToolUserModel]:
-        tools = await self.get_tools(defer_content=defer_content, db=db)
-        user_groups = await Groups.get_groups_by_member_id(user_id, db=db)
-        user_group_ids = {group.id for group in user_groups}
-
-        # One grants query for all non-owned tools instead of one per tool
-        accessible_ids = await AccessGrants.get_accessible_resource_ids(
-            user_id=user_id,
-            resource_type='tool',
-            resource_ids=[tool.id for tool in tools if tool.user_id != user_id],
-            permission=permission,
-            user_group_ids=user_group_ids,
-            db=db,
-        )
-        return [tool for tool in tools if tool.user_id == user_id or tool.id in accessible_ids]
 
     async def get_tool_valves_by_id(self, id: str, db: AsyncSession | None = None) -> dict | None:
         try:

--- a/backend/open_webui/routers/tools.py
+++ b/backend/open_webui/routers/tools.py
@@ -71,11 +71,18 @@ async def get_tools(
     db: AsyncSession = Depends(get_async_session),
 ):
     tools = []
+    is_bypass_admin = user.role == 'admin' and BYPASS_ADMIN_ACCESS_CONTROL
+    user_group_ids = {group.id for group in await Groups.get_groups_by_member_id(user.id, db=db)}
 
     # Local Tools
     if ENABLE_PLUGINS:
         tools_cache = get_tools_cache(request)
-        for tool in await Tools.get_tools(defer_content=True, db=db):
+        for tool in await Tools.get_tools(
+            defer_content=True,
+            db=db,
+            user_id=None if is_bypass_admin else user.id,
+            user_group_ids=user_group_ids,
+        ):
             tool_module = tools_cache.get(tool.id)
             has_user_valves = (
                 hasattr(tool_module, 'UserValves')
@@ -166,31 +173,14 @@ async def get_tools(
                 )
             )
 
-    if not (user.role == 'admin' and BYPASS_ADMIN_ACCESS_CONTROL):
-        user_group_ids = {group.id for group in await Groups.get_groups_by_member_id(user.id, db=db)}
-        filtered_tools = []
-        for tool in tools:
-            if tool.user_id == user.id:
-                filtered_tools.append(tool)
-            elif str(tool.id).startswith('server:'):
-                if await has_access(
-                    user.id,
-                    'read',
-                    server_access_grants.get(str(tool.id), []),
-                    user_group_ids,
-                    db=db,
-                ):
-                    filtered_tools.append(tool)
-            elif await AccessGrants.has_access(
-                user_id=user.id,
-                resource_type='tool',
-                resource_id=tool.id,
-                permission='read',
-                user_group_ids=user_group_ids,
-                db=db,
-            ):
-                filtered_tools.append(tool)
-        tools = filtered_tools
+    if not is_bypass_admin:
+        # Local tools arrive access-filtered from the query; server entries are config-driven.
+        tools = [
+            tool
+            for tool in tools
+            if not tool.id.startswith('server:')
+            or await has_access(user.id, 'read', server_access_grants.get(tool.id, []), user_group_ids, db=db)
+        ]
 
     if query:
         q = query.casefold()
@@ -209,17 +199,19 @@ async def get_tool_list(user=Depends(get_verified_user), db: AsyncSession = Depe
     if not ENABLE_PLUGINS:
         return []
 
-    if user.role == 'admin' and BYPASS_ADMIN_ACCESS_CONTROL:
-        tools = await Tools.get_tools(defer_content=True, db=db)
-    else:
-        tools = await Tools.get_tools_by_user_id(user.id, 'read', defer_content=True, db=db)
-
+    is_bypass_admin = user.role == 'admin' and BYPASS_ADMIN_ACCESS_CONTROL
     user_group_ids = {group.id for group in await Groups.get_groups_by_member_id(user.id, db=db)}
+    tools = await Tools.get_tools(
+        defer_content=True,
+        db=db,
+        user_id=None if is_bypass_admin else user.id,
+        user_group_ids=user_group_ids,
+    )
 
     result = []
     for tool in tools:
         has_write = (
-            (user.role == 'admin' and BYPASS_ADMIN_ACCESS_CONTROL)
+            is_bypass_admin
             or user.id == tool.user_id
             or any(
                 g.permission == 'write'
@@ -334,10 +326,10 @@ async def export_tools(
             detail=ERROR_MESSAGES.UNAUTHORIZED,
         )
 
-    if user.role == 'admin' and BYPASS_ADMIN_ACCESS_CONTROL:
-        return await Tools.get_tools(db=db)
-    else:
-        return await Tools.get_tools_by_user_id(user.id, 'read', db=db)
+    return await Tools.get_tools(
+        db=db,
+        user_id=None if (user.role == 'admin' and BYPASS_ADMIN_ACCESS_CONTROL) else user.id,
+    )
 
 
 ############################


### PR DESCRIPTION
Listing tools loaded every tool in the instance and then ran one database query per tool to work out what the caller may see. On a workspace with 500 tools the main listing endpoint issued over 500 queries per request, and the paginated list resolved the caller's group membership twice on top of that.

Tools now arrive already filtered: the owner-or-grant check runs in the query as an EXISTS subquery, the same way prompts and the search endpoints already do it, and listings keep skipping the tool source column as before. Tool-server entries are config-driven rather than database rows, so they are still matched against their own grants in Python.

Measured with 500 tools of which 3 are visible to the caller: 504 queries and ~290 ms before, 4 queries and ~2.7 ms after. The resulting set is unchanged for owner, public, direct-user, group and multi-grant entries.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
