### PR TITLE
fix: derive integrations toggle state from the selected ids

### DIFF
--- a/src/lib/components/chat/MessageInput/IntegrationsMenu.svelte
+++ b/src/lib/components/chat/MessageInput/IntegrationsMenu.svelte
@@ -34,7 +34,6 @@
 		id: string;
 		name: string;
 		description?: string;
-		enabled: boolean;
 		meta?: { description?: string };
 		is_active?: boolean;
 		authenticated?: boolean;
@@ -113,8 +112,7 @@
 			a[tool.id] = {
 				...tool,
 				name: tool.name,
-				description: tool.meta?.description,
-				enabled: selectedToolIds.includes(tool.id)
+				description: tool.meta?.description
 			};
 			return a;
 		}, {});
@@ -130,8 +128,7 @@
 				items[`direct_server:${serverIdx}`] = {
 					id: `direct_server:${serverIdx}`,
 					name,
-					description: server.info.description ?? '',
-					enabled: selectedToolIds.includes(`direct_server:${serverIdx}`)
+					description: server.info.description ?? ''
 				};
 			}
 		}
@@ -150,8 +147,7 @@
 				a[skill.id] = {
 					...skill,
 					name: skill.name,
-					description: skill.description,
-					enabled: selectedSkillIds.includes(skill.id)
+					description: skill.description
 				};
 				return a;
 			}, {});
@@ -229,9 +225,7 @@
 			return;
 		}
 
-		tool.enabled = !tool.enabled;
-
-		const state = tool.enabled;
+		const state = !selectedToolIds.includes(toolId);
 		await tick();
 
 		if (state) {
@@ -245,9 +239,7 @@
 		const skill = skills?.[skillId];
 		if (!skill) return;
 
-		skill.enabled = !skill.enabled;
-
-		const state = skill.enabled;
+		const state = !selectedSkillIds.includes(skillId);
 		await tick();
 
 		if (state) {
@@ -506,7 +498,7 @@
 									<button
 										class="relative flex w-full justify-between gap-2 items-center h-[1.6875rem] px-2 text-[0.8125rem] font-normal cursor-pointer rounded-xl hover:bg-gray-50/40 dark:hover:bg-gray-800/40"
 										aria-pressed={(tools?.[toolId]?.authenticated ?? true)
-											? tools?.[toolId]?.enabled
+											? selectedToolIds.includes(toolId)
 											: undefined}
 										on:click={async (e) => {
 											await toggleTool(toolId, e);
@@ -584,7 +576,7 @@
 										{/if}
 
 										<div class=" shrink-0" inert>
-											<Switch state={tools?.[toolId]?.enabled} />
+											<Switch state={selectedToolIds.includes(toolId)} />
 										</div>
 									</button>
 								{/each}
@@ -620,7 +612,7 @@
 								{#each skillIds as skillId}
 									<button
 										class="relative flex w-full justify-between gap-2 items-center h-[1.6875rem] px-2 text-[0.8125rem] font-normal cursor-pointer rounded-xl hover:bg-gray-50/40 dark:hover:bg-gray-800/40"
-										aria-pressed={skills?.[skillId]?.enabled}
+										aria-pressed={selectedSkillIds.includes(skillId)}
 										on:click={async () => {
 											await toggleSkill(skillId);
 										}}
@@ -642,7 +634,7 @@
 										</div>
 
 										<div class=" shrink-0" inert>
-											<Switch state={skills?.[skillId]?.enabled} />
+											<Switch state={selectedSkillIds.includes(skillId)} />
 										</div>
 									</button>
 								{/each}


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. First-time contributors should not open pull requests directly unless the pull request contains only i18n/localization updates.
   Do not open a PR as the first step.
   For real, reproducible bugs, start with a well-described Issue that explains the problem, why it matters, and what outcome you are looking for.
   For feature requests, enhancements, behavior changes, UI/UX changes, architecture changes, suspected fixes, or unconfirmed approaches, start with an active Discussion.
   If you want to propose an implementation, include it only as a reference in the Issue or Discussion, such as a local diff, patch, or branch.
   Opening an Issue or Discussion does not mean a PR is the right next step. Maintainers will confirm when a PR would be useful.
   We ask for this because PRs, especially from first-time contributors, often need broader maintainer context on product direction, scope, architecture, UX, edge cases, compatibility, documentation, and long-term maintenance before implementation.
   We may close unsolicited PRs without review.
   Contributors with a history of successful merged PRs may be given more latitude.
3. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

**Before submitting, make sure you've checked and filled out the following:**

- [x] **Linked Issue/Discussion:** Closes #28803
- [x] **First-time contributor policy:** not my first contribution.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** **Manual** end-to-end tests have been performed to verify the fix/feature works correctly and does not introduce regressions.
- [x] **User-facing changes:** I have confirmed whether this PR changes the UI. The toggle now moves when clicked; no markup or styling changes.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

Toggling a tool or a skill in the Integrations menu does not move that row's switch. The row keeps rendering its old state until the submenu is left and reopened. The selection itself works, so the icon appears in the chat input immediately and the menu ends up contradicting the input bar. `aria-pressed` carries the same stale value, so assistive technology is told the control is off while it is on.

**Root cause.** The two handlers copied the record entry into a local variable and mutated a property on it:

```js
const skill = skills?.[skillId];
skill.enabled = !skill.enabled;
```

`skills` and `tools` are the reactive variables, but the root of that assignment is `skill`, a local `const`. Svelte only instruments assignments rooted at the reactive variable, so the object changed while `skills` was never invalidated, and the switch and `aria-pressed` that read through it never re-rendered.

This came in with `954613944`, which moved the toggle logic out of the template into the two handlers. The inline version wrote `tools[toolId].enabled = !tools[toolId].enabled`, whose root is `tools`, so the row re-rendered. Extracting the logic changed the root to the alias and silently dropped the invalidation.

**Fix.** `enabled` was only ever a mirror of the selection arrays: it was initialised as `selectedToolIds.includes(tool.id)` and flipped alongside them. Rather than restore the invalidation, this removes the duplicate and derives the rendered state from the same arrays the selection writes, matching what the filter rows and the built-in toggles in this file already do.

```diff
-											<Switch state={skills?.[skillId]?.enabled} />
+											<Switch state={selectedSkillIds.includes(skillId)} />
```

```diff
-		skill.enabled = !skill.enabled;
-
-		const state = skill.enabled;
+		const state = !selectedSkillIds.includes(skillId);
```

with the same for tools, plus `aria-pressed` on both rows and the removal of the now unused `enabled` field from the local type and the three places that initialised it.

### Fixed

- Fixed tool and skill toggles in the Integrations menu not updating until the submenu was reopened.

---

### Additional Information

The substitution is exact rather than approximate. The record key is the same string used in the selection array on both paths, real tools keyed by `tool.id` against `selectedToolIds.includes(tool.id)`, and direct server entries keyed by `direct_server:${serverIdx}` against the identical literal, so `selectedToolIds.includes(toolId)` evaluates to precisely what `enabled` was initialised to. `enabled` had no other readers: three initialisers, two handler mutations, and the four render sites this PR changes.

`await tick()` in both handlers is left as it was, so the ordering of the selection update is unchanged.

Verified manually on `dev` @ `5ea9ff3ed`, measuring `aria-pressed` and the switch's `data-state` in the DOM:

1. Before the change, clicking a skill row left both at `false` and `unchecked`, and the row's HTML was byte identical across the click. After the change they go to `true` and `checked` on the first click, and back on the second.
2. The same holds for tool rows.
3. The selection still reaches the chat input, and the state still survives leaving and reopening the submenu, and a full close and reopen of the menu.
4. Toggling while a search filter is active still works, and the filtered list renders the correct state.
5. `Web Search`, `Image` and `Code Interpreter` in the same menu are untouched and still flip immediately, confirming the `Switch` component and the dropdown were never involved.

This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
