### PR TITLE
feat: add Olostep as a web search provider

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -1271,6 +1271,8 @@ SOUGOU_API_SK = os.getenv('SOUGOU_API_SK', '')
 
 TAVILY_API_KEY = os.getenv('TAVILY_API_KEY', '')
 
+OLOSTEP_API_KEY = os.getenv('OLOSTEP_API_KEY', '')
+
 TAVILY_EXTRACT_DEPTH = os.getenv('TAVILY_EXTRACT_DEPTH', 'basic')
 
 PLAYWRIGHT_WS_URL = os.getenv('PLAYWRIGHT_WS_URL', '')
@@ -2989,6 +2991,7 @@ DEFAULT_CONFIG = {
     'web.search.sougou_api_sid': SOUGOU_API_SID,
     'web.search.sougou_api_sk': SOUGOU_API_SK,
     'web.search.tavily_api_key': TAVILY_API_KEY,
+    'web.search.olostep_api_key': OLOSTEP_API_KEY,
     'web.search.tavily_extract_depth': TAVILY_EXTRACT_DEPTH,
     'web.loader.playwright_ws_url': PLAYWRIGHT_WS_URL,
     'web.loader.playwright_timeout': PLAYWRIGHT_TIMEOUT,

--- a/backend/open_webui/retrieval/web/olostep.py
+++ b/backend/open_webui/retrieval/web/olostep.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import logging
+
+import requests
+from open_webui.retrieval.web.main import SearchResult, get_filtered_results
+
+log = logging.getLogger(__name__)
+
+OLOSTEP_SEARCH_URL = "https://api.olostep.com/v1/searches"
+
+
+def search_olostep(
+    api_key: str,
+    query: str,
+    count: int,
+    filter_list: list[str] | None = None,
+) -> list[SearchResult]:
+    """Search using Olostep's Search API and return the results as a list of
+    SearchResult objects.
+
+    Args:
+        api_key (str): An Olostep API key
+        query (str): The query to search for
+        count (int): The maximum number of results to return
+        filter_list (list[str] | None): Optional domain filter list
+
+    Returns:
+        A list of SearchResult objects.
+    """
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {api_key}",
+    }
+    data = {"query": query, "limit": count}
+
+    response = requests.post(
+        OLOSTEP_SEARCH_URL,
+        headers=headers,
+        json=data,
+        timeout=count * 3 + 10,
+    )
+    response.raise_for_status()
+
+    json_response = response.json()
+
+    results = (json_response.get("result") or {}).get("links") or []
+    if filter_list:
+        results = get_filtered_results(results, filter_list)
+
+    return [
+        SearchResult(
+            link=result["url"],
+            title=result.get("title", ""),
+            snippet=result.get("description"),
+        )
+        for result in results[:count]
+        if result.get("url")
+    ]

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -115,6 +115,7 @@ from open_webui.retrieval.web.serply import search_serply
 from open_webui.retrieval.web.serpstack import search_serpstack
 from open_webui.retrieval.web.sougou import search_sougou
 from open_webui.retrieval.web.tavily import search_tavily
+from open_webui.retrieval.web.olostep import search_olostep
 from open_webui.retrieval.web.utils import get_web_loader
 from open_webui.retrieval.web.yacy import search_yacy
 from open_webui.retrieval.web.yandex import search_yandex
@@ -384,6 +385,7 @@ RETRIEVAL_CONFIG_KEYS = {
     'SOUGOU_API_SID': 'web.search.sougou_api_sid',
     'SOUGOU_API_SK': 'web.search.sougou_api_sk',
     'TAVILY_API_KEY': 'web.search.tavily_api_key',
+    'OLOSTEP_API_KEY': 'web.search.olostep_api_key',
     'TAVILY_EXTRACT_DEPTH': 'web.search.tavily_extract_depth',
     'TEXT_SPLITTER': 'rag.text_splitter',
     'TIKA_SERVER_URL': 'rag.tika_server_url',
@@ -2628,6 +2630,17 @@ async def search_web(request: Request, engine: str, query: str, user=None) -> li
             )
         else:
             raise Exception('No TAVILY_API_KEY found in environment variables')
+    elif engine == "olostep":
+        if config.OLOSTEP_API_KEY:
+            return await asyncio.to_thread(
+                search_olostep,
+                config.OLOSTEP_API_KEY,
+                query,
+                config.WEB_SEARCH_RESULT_COUNT,
+                config.WEB_SEARCH_DOMAIN_FILTER_LIST,
+            )
+        else:
+            raise Exception("No OLOSTEP_API_KEY found in environment variables")
     elif engine == 'exa':
         if config.EXA_API_KEY:
             return await asyncio.to_thread(

--- a/src/lib/components/admin/Settings/WebSearch.svelte
+++ b/src/lib/components/admin/Settings/WebSearch.svelte
@@ -47,7 +47,8 @@
 		'yandex',
 		'youcom',
 		'linkup',
-        'openserp'
+        'openserp',
+		'olostep'
 	];
 	let webLoaderEngines = ['playwright', 'firecrawl', 'tavily', 'microsoft_web_iq', 'external'];
 
@@ -569,6 +570,20 @@
 									variant="settings"
 									placeholder={$i18n.t('Enter Tavily API Key')}
 									bind:value={webConfig.TAVILY_API_KEY}
+								/>
+							</div>
+						</div>
+					{:else if webConfig.WEB_SEARCH_ENGINE === 'olostep'}
+						<div class="mb-2.5 flex w-full flex-col">
+							<div>
+								<div class=" self-center text-xs text-gray-600 dark:text-gray-400 mb-1">
+									{$i18n.t('Olostep API Key')}
+								</div>
+
+								<SensitiveInput
+									variant="settings"
+									placeholder={$i18n.t('Enter Olostep API Key')}
+									bind:value={webConfig.OLOSTEP_API_KEY}
 								/>
 							</div>
 						</div>


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Relates to #28805
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** No new dependencies — uses `requests`, already a project dependency.
- [x] **Testing:** Manual tests have been performed to verify the feature works correctly and does not introduce regressions.
- [x] **No Unchecked AI Code:** This PR has undergone thorough human review AND manual testing.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Follows the existing provider pattern exactly; no architectural changes.
- [x] **Git Hygiene:** The PR is atomic, rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** **feat**

# Changelog Entry

### Description

- Adds Olostep (https://olostep.com) as a `WEB_SEARCH_ENGINE` option, alongside the existing Tavily, Exa, Firecrawl and SearXNG providers. Olostep is a web data API for AI applications that handles JS rendering and anti-bot measures and returns clean, structured results. This follows the existing `tavily` provider pattern with no architectural changes.

### Added

- `backend/open_webui/retrieval/web/olostep.py` — new search provider implementing `search_olostep`
- `OLOSTEP_API_KEY` environment variable and `web.search.olostep_api_key` config key
- Dispatch branch for the `olostep` engine in the retrieval router
- Olostep option and API key input in the admin Web Search settings panel

### Changed

- N/A

### Deprecated

- N/A

### Removed

- N/A

### Fixed

- N/A

### Security

- N/A

### Breaking Changes

- N/A

---

### Additional Information

Verified `search_olostep` in-runtime against the live API — returns correctly structured results with title, link and snippet populated on each: