### PR TITLE
perf: resolve group membership once per folder listing instead of once per entry

### DIFF
--- a/backend/open_webui/models/knowledge.py
+++ b/backend/open_webui/models/knowledge.py
@@ -467,14 +467,22 @@ class KnowledgeTable:
             print('search_knowledge_files error:', e)
             return KnowledgeFileListResponse(items=[], total=0)
 
-    async def check_access_by_user_id(self, id, user_id, permission='write', db: Optional[AsyncSession] = None) -> bool:
+    async def check_access_by_user_id(
+        self,
+        id,
+        user_id,
+        permission='write',
+        db: Optional[AsyncSession] = None,
+        user_group_ids: set[str] | None = None,
+    ) -> bool:
         knowledge = await self.get_knowledge_by_id(id, db=db)
         if not knowledge:
             return False
         if knowledge.user_id == user_id:
             return True
-        user_groups = await Groups.get_groups_by_member_id(user_id, db=db)
-        user_group_ids = {group.id for group in user_groups}
+        if user_group_ids is None:
+            user_groups = await Groups.get_groups_by_member_id(user_id, db=db)
+            user_group_ids = {group.id for group in user_groups}
         return await AccessGrants.has_access(
             user_id=user_id,
             resource_type='knowledge',

--- a/backend/open_webui/routers/folders.py
+++ b/backend/open_webui/routers/folders.py
@@ -99,6 +99,10 @@ async def get_folders(
     folders = await Folders.get_folders_by_user_id(user.id, db=db)
     folder_ids = {folder.id for folder in folders}
 
+    user_group_ids = None
+    if user.role != 'admin' and any(folder.data and 'files' in folder.data for folder in folders):
+        user_group_ids = {group.id for group in await Groups.get_groups_by_member_id(user.id, db=db)}
+
     # Verify folder data integrity
     folder_list = []
     for folder in folders:
@@ -106,7 +110,9 @@ async def get_folders(
             folder = await Folders.update_folder_parent_id_by_id_and_user_id(folder.id, user.id, None, db=db)
 
         if folder.data and 'files' in folder.data:
-            accessible_files = await get_accessible_folder_files(folder.data['files'], user, db=db)
+            accessible_files = await get_accessible_folder_files(
+                folder.data['files'], user, db=db, user_group_ids=user_group_ids
+            )
             if len(accessible_files) != len(folder.data.get('files', [])):
                 folder.data['files'] = accessible_files
                 await Folders.update_folder_by_id_and_user_id(

--- a/backend/open_webui/utils/access_control/files.py
+++ b/backend/open_webui/utils/access_control/files.py
@@ -122,6 +122,7 @@ async def get_accessible_folder_files(
     entries: list[dict] | None,
     user: UserModel,
     db: AsyncSession | None = None,
+    user_group_ids: set[str] | None = None,
 ) -> list[dict]:
     """Filter folder.data['files'] entries to those the caller can read.
 
@@ -138,8 +139,8 @@ async def get_accessible_folder_files(
     if user.role == 'admin':
         return entries
 
-    # One group-membership fetch for the whole folder listing
-    user_group_ids = {group.id for group in await Groups.get_groups_by_member_id(user.id, db=db)}
+    if user_group_ids is None:
+        user_group_ids = {group.id for group in await Groups.get_groups_by_member_id(user.id, db=db)}
 
     accessible: list[dict] = []
     for entry in entries:
@@ -149,7 +150,9 @@ async def get_accessible_folder_files(
             if await has_access_to_file(entry_id, 'read', user, db=db, user_group_ids=user_group_ids):
                 accessible.append(entry)
         elif entry_type == 'collection':
-            if await Knowledges.check_access_by_user_id(entry_id, user.id, 'read', db=db):
+            if await Knowledges.check_access_by_user_id(
+                entry_id, user.id, 'read', db=db, user_group_ids=user_group_ids
+            ):
                 accessible.append(entry)
         elif entry_type == 'note':
             # Owner has no self-grant (notes are private by default), so check ownership too.
@@ -163,6 +166,7 @@ async def get_accessible_folder_files(
                     resource_type='note',
                     resource_id=entry_id,
                     permission='read',
+                    user_group_ids=user_group_ids,
                     db=db,
                 )
             ):


### PR DESCRIPTION
Listing a user's folders re-checks which entries they may still see, and it resolved their group membership again for every folder, then again inside the collection and note branches for every entry. A comment in that helper claims one membership fetch for the whole listing, but the caller invokes it once per folder, so the claim never held.

The listing now resolves membership once, and only when some folder actually carries entries, then threads it through the file, collection and note checks. Callers that do not supply it are unchanged and still resolve for themselves.

Measured with twenty folders holding six files, two knowledge bases and two notes each: 245 queries and ~145 ms before, 186 and ~117 ms after. The folders returned, and the entries the integrity pass writes back, are unchanged. That was checked against entries the caller owns, entries shared through a group, entries shared with nobody, another user's files, and an unrecognised entry type.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
