### PR TITLE
fix: clear the integrations search when leaving a section

### DIFF
--- a/src/lib/components/chat/MessageInput/IntegrationsMenu.svelte
+++ b/src/lib/components/chat/MessageInput/IntegrationsMenu.svelte
@@ -260,6 +260,8 @@
 	{closeOnOutsideClick}
 	onOpenChange={(state) => {
 		if (state === false) {
+			toolQuery = '';
+			skillQuery = '';
 			onClose();
 		}
 	}}
@@ -474,6 +476,7 @@
 					<button
 						class="flex w-full justify-between gap-2 items-center h-[1.6875rem] px-2 text-[0.8125rem] font-normal cursor-pointer rounded-xl hover:bg-gray-50/40 dark:hover:bg-gray-800/40"
 						on:click={() => {
+							toolQuery = '';
 							tab = '';
 						}}
 					>
@@ -589,6 +592,7 @@
 					<button
 						class="flex w-full justify-between gap-2 items-center h-[1.6875rem] px-2 text-[0.8125rem] font-normal cursor-pointer rounded-xl hover:bg-gray-50/40 dark:hover:bg-gray-800/40"
 						on:click={() => {
+							skillQuery = '';
 							tab = '';
 						}}
 					>


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. First-time contributors should not open pull requests directly unless the pull request contains only i18n/localization updates.
   Do not open a PR as the first step.
   For real, reproducible bugs, start with a well-described Issue that explains the problem, why it matters, and what outcome you are looking for.
   For feature requests, enhancements, behavior changes, UI/UX changes, architecture changes, suspected fixes, or unconfirmed approaches, start with an active Discussion.
   If you want to propose an implementation, include it only as a reference in the Issue or Discussion, such as a local diff, patch, or branch.
   Opening an Issue or Discussion does not mean a PR is the right next step. Maintainers will confirm when a PR would be useful.
   We ask for this because PRs, especially from first-time contributors, often need broader maintainer context on product direction, scope, architecture, UX, edge cases, compatibility, documentation, and long-term maintenance before implementation.
   We may close unsolicited PRs without review.
   Contributors with a history of successful merged PRs may be given more latitude.
3. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

**Before submitting, make sure you've checked and filled out the following:**

- [x] **Linked Issue/Discussion:** Closes #28811
- [x] **First-time contributor policy:** not my first contribution.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** **Manual** end-to-end tests have been performed to verify the fix/feature works correctly and does not introduce regressions.
- [x] **User-facing changes:** I have confirmed whether this PR changes the UI. The section rows stay in the menu, and the search box is empty on the next visit to a section. No markup or styling changes.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

A search in the `Tools` or `Skills` submenu that matches nothing removes that section from the Integrations menu once you go back, so it cannot be opened again. Closing and reopening the menu does not recover it; only a page reload does.

**Problem.** The menu decides whether to render a section from the same record the search filters, `Object.keys(tools).length > 0`. A search that matches nothing leaves that record empty, so the section row stops rendering. Going back only changes the tab and leaves the query set, and reopening the menu runs `init` which reloads using that same query, so the empty result is rebuilt. The query lives in component state, which is why a reload is the only way out.

**Fix.** Clear the section's search when leaving it, where leaving means both going back and closing the menu.

```diff
 					<button
 						class="flex w-full justify-between gap-2 items-center h-[1.6875rem] px-2 text-[0.8125rem] font-normal cursor-pointer rounded-xl hover:bg-gray-50/40 dark:hover:bg-gray-800/40"
 						on:click={() => {
+							toolQuery = '';
 							tab = '';
 						}}
 					>
```

with the same for `skillQuery` on the skills back button, and both cleared in the close branch that `onOpenChange` already has:

```diff
 	onOpenChange={(state) => {
 		if (state === false) {
+			toolQuery = '';
+			skillQuery = '';
 			onClose();
 		}
 	}}
```

### Fixed

- Fixed the `Tools` and `Skills` sections disappearing from the Integrations menu after a search that returned no results.

---

### Additional Information

No new state, helper, or lifecycle hook is introduced. `$: if (show && toolQuery !== searchedToolQuery)` already schedules the reload, so clearing the query is enough to rebuild the unfiltered record through the path the component already uses, and it resets the search box for the next visit at the same time. The close branch of `onOpenChange` was already there and already called `onClose()`.

This brings the menu in line with the `+` menu, which does not have this problem. There each section is a separate component holding its own `let query = ''`, and `Dropdown` renders its content under `{#if show}`, so leaving a section or closing the menu destroys that component and discards its search. The Integrations menu keeps its sections inline, so the query lives in the parent and survives both, which is why it needs to be cleared explicitly at the same two moments.

Verified manually on top of `7cf6051a7`:

1. Before the change, searching `egegre` in `Tools` and going back left the menu showing `Skills 19` only, and reopening the menu did not restore `Tools`. After the change, going back restores `Tools 39` and `Skills 19`.
2. The same holds for the `Skills` section.
3. Sampling the menu after going back, the section row is present again within 120ms, which is inside the menu's own 150ms entrance animation.
4. Searching with results, selecting a tool while the list is filtered, then going back keeps that tool selected, and the next visit to the section shows the full list of 39 with an empty search box.
5. Going back without having searched behaves as before.

The close path is verified by reading the code rather than by an automated click: `closeDropdown` sets `show` to false and calls `onOpenChange(false)` on every close, which is the branch this change extends. A dropdown close cannot be synthesised from script here because it is driven by trusted pointer events, so that path was checked by hand.

This is not caused by #28807. The behavior reproduces on `dev` both before and after that commit.

This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Screenshots or Videos

Before is current `dev`. After is this branch.

| Surface | Before | After |
|---|---|---|
| Integrations menu after a no-result search in `Tools`, then back | <img width="483" height="268" alt="image" src="https://github.com/user-attachments/assets/4e4a7399-5ece-440a-88db-d9663ab040e4" /> | <img width="483" height="268" alt="image" src="https://github.com/user-attachments/assets/3ad39188-e2ce-40b3-85cc-68d4d21e9719" /> |
| Integrations menu after a no-result search in `Skills`, then back | <img width="483" height="268" alt="image" src="https://github.com/user-attachments/assets/8910c8bd-8f1f-4844-b7e7-c1f537438fc3" /> | <img width="483" height="268" alt="image" src="https://github.com/user-attachments/assets/5c0d4530-2641-4853-9a20-a01ca8e3aa17" /> |

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
