### PR TITLE
perf: skip the outlet filter pass when the model has no filters

### DIFF
--- a/backend/open_webui/routers/pipelines.py
+++ b/backend/open_webui/routers/pipelines.py
@@ -54,6 +54,12 @@ def get_sorted_filters(model_id, models):
     return sorted_filters
 
 
+def has_pipeline_outlet_filters(model, models):
+    # process_pipeline_outlet_filter also runs the model itself when it is a pipeline
+    model_id = model.get('id') if isinstance(model, dict) else model
+    return (isinstance(model, dict) and 'pipeline' in model) or bool(get_sorted_filters(model_id, models))
+
+
 async def get_openai_connection(url_idx: int) -> tuple[str, str]:
     base_urls = await Config.get('openai.api_base_urls', [])
     api_keys = await Config.get('openai.api_keys', [])

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -57,7 +57,7 @@ from open_webui.routers.images import (
     image_generations,
 )
 from open_webui.routers.pipelines import (
-    get_sorted_filters,
+    has_pipeline_outlet_filters,
     process_pipeline_inlet_filter,
     process_pipeline_outlet_filter,
 )
@@ -3701,7 +3701,8 @@ async def outlet_filter_handler(ctx):
 
     Replaces the separate POST /api/chat/completed round-trip.
     Persists outlet-modified content to DB and emits a chat:outlet event
-    so the frontend can sync its in-memory state.
+    so the frontend can sync its in-memory state. Returns immediately when
+    the model has no filters.
 
     For temp/API chats, messages are built from form_data plus ctx['assistant_message'].
     """
@@ -3723,6 +3724,13 @@ async def outlet_filter_handler(ctx):
 
     is_unsaved_chat = not is_saved_chat_id(chat_id)
     try:
+        filter_functions = (
+            await get_filter_functions(request, model, metadata.get('filter_ids', [])) if ENABLE_PLUGINS else []
+        )
+        # Nothing can modify the messages: skip the pass
+        if not filter_functions and not has_pipeline_outlet_filters(model, request.app.state.MODELS):
+            return
+
         messages_map = None
 
         if is_unsaved_chat:
@@ -3798,9 +3806,7 @@ async def outlet_filter_handler(ctx):
             '__model__': model,
         }
 
-        if ENABLE_PLUGINS:
-            filter_functions = await get_filter_functions(request, model, metadata.get('filter_ids', []))
-
+        if filter_functions:
             outlet_result, _ = await process_filter_functions(
                 request=request,
                 filter_context=None,
@@ -6071,11 +6077,7 @@ async def streaming_chat_response_handler(response, ctx):
             has_api_outlet_filters = ENABLE_API_OUTLET_FILTERS and bool(filter_functions)
             if ENABLE_API_OUTLET_FILTERS and not has_api_outlet_filters:
                 try:
-                    model_id = model.get('id') if isinstance(model, dict) else model
-                    has_api_outlet_filters = bool(
-                        (isinstance(model, dict) and 'pipeline' in model)
-                        or get_sorted_filters(model_id, request.app.state.MODELS)
-                    )
+                    has_api_outlet_filters = has_pipeline_outlet_filters(model, request.app.state.MODELS)
                 except Exception:
                     has_api_outlet_filters = True
 


### PR DESCRIPTION
On installs without any filter functions or pipeline filters, which is the default, every completed chat message still paid the full outlet pass: the whole messages map was fetched from the database, every message on the branch was rebuilt with a deepcopy of its output, and the resulting list was emitted to the client as a chat:outlet event even though nothing could have changed. On long chats that event alone ships hundreds of kilobytes per completed message (measured with typical reasoning outputs: 86 KB at 10 turns, 429 KB at 50, 1.3 MB at 150) and the frontend handler drops it because no content differs.

The handler now resolves the model's filter functions and pipeline filters first and returns before any of that work when both are empty. On installs without filters that check is a single small query, and behavior with filters configured is unchanged. The API fallback stream path already had this gate; it now shares the same pipeline-filter predicate.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
