### PR TITLE
perf: serve single-key config reads from a cached snapshot

### DIFF
--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -984,6 +984,16 @@ _default_group_share = os.getenv('DEFAULT_GROUP_SHARE_PERMISSION', 'members').st
 DEFAULT_GROUP_SHARE_PERMISSION = 'members' if _default_group_share == 'members' else _default_group_share == 'true'
 
 ####################################
+# CONFIG
+####################################
+
+# Seconds to hold the config table in memory. Floored at 1 because ttl=0 in aiocache means never expire.
+try:
+    CONFIG_CACHE_TTL = max(int(os.getenv('CONFIG_CACHE_TTL', '1')), 1)
+except (ValueError, TypeError):
+    CONFIG_CACHE_TTL = 1
+
+####################################
 # MODELS
 ####################################
 

--- a/backend/open_webui/models/config.py
+++ b/backend/open_webui/models/config.py
@@ -4,17 +4,20 @@ Replaces the old single-row JSON blob machinery with a simple per-key model
 mirroring cptr's Config.
 
 Each config key is stored as its own row: key TEXT PK, value JSON.
-Reads are direct DB lookups. Writes are explicit awaited upserts that raise on
-failure (no more fire-and-forget create_task).
+Single-key reads are served from a short-lived snapshot of the whole table, which every write
+retires. Multi-key and whole-table reads go straight to the database. Writes are explicit awaited
+upserts that raise on failure (no more fire-and-forget create_task).
 """
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 from typing import Any, ClassVar
 
 from fastapi.encoders import jsonable_encoder
+from open_webui.env import CONFIG_CACHE_TTL
 from open_webui.internal.db import Base, get_async_db
 from sqlalchemy import JSON, BigInteger, Column, Text, delete, select
 
@@ -95,6 +98,56 @@ def _json_value(value: Any) -> Any:
     return jsonable_encoder(value)
 
 
+def _copied(value: Any) -> Any:
+    """Independent copy for callers that mutate what they read; snapshot values are JSON, so only dict and list nest."""
+    if isinstance(value, dict):
+        return {key: _copied(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_copied(item) for item in value]
+    return value
+
+
+# Bumped by every write, which is what retires a snapshot taken before it.
+_cache_generation = 0
+_snapshot: tuple[int, float, dict[str, Any]] | None = None
+_refill_lock = asyncio.Lock()
+
+
+def _live_snapshot() -> dict[str, Any] | None:
+    """The cached rows, or None once a write or the TTL has retired them."""
+    if _snapshot is None:
+        return None
+    generation, expires_at, values = _snapshot
+    if generation != _cache_generation or expires_at <= time.monotonic():
+        return None
+    return values
+
+
+async def _persisted_config() -> dict[str, Any]:
+    """Every persisted config row, in one query, shared by all readers until it is retired."""
+    global _snapshot
+    values = _live_snapshot()
+    if values is not None:
+        return values
+    # One reader refills while the rest wait, so a slow query cannot become many.
+    async with _refill_lock:
+        values = _live_snapshot()
+        if values is not None:
+            return values
+        generation = _cache_generation
+        async with get_async_db() as db:
+            result = await db.execute(select(Config))
+            values = {row.key: row.value for row in result.scalars().all()}
+        # A write during the query already moved the generation on, retiring this on arrival.
+        _snapshot = (generation, time.monotonic() + CONFIG_CACHE_TTL, values)
+        return values
+
+
+def _invalidate_cache() -> None:
+    global _cache_generation
+    _cache_generation += 1
+
+
 # ── Model ────────────────────────────────────────────────────────────────────
 
 
@@ -142,9 +195,18 @@ class Config(Base):
         """Get a config value by key. Returns default if not set."""
         if not Config.persistent_enabled_for(key):
             return Config.default_value(key, default)
-        async with get_async_db() as db:
-            row = await db.get(Config, key)
-            return row.value if row else Config.default_value(key, default)
+        # These keys get read, mutated, then written back whole, so a stale read drops another worker's change.
+        if key in {
+            'tool_server.connections',
+            'events.webhooks',
+            'external_knowledge.connections',
+            'evaluation.arena.models',
+        }:
+            async with get_async_db() as db:
+                row = await db.get(Config, key)
+                return row.value if row else Config.default_value(key, default)
+        values = await _persisted_config()
+        return _copied(values[key]) if key in values else Config.default_value(key, default)
 
     @staticmethod
     async def get_many(*keys: str) -> dict:
@@ -218,6 +280,7 @@ class Config(Base):
                 else:
                     db.add(Config(key=key, value=value, updated_at=now))
             await db.commit()
+            _invalidate_cache()
 
     @staticmethod
     async def delete(key: str) -> bool:
@@ -227,6 +290,7 @@ class Config(Base):
             if row:
                 await db.delete(row)
                 await db.commit()
+                _invalidate_cache()
                 return True
             return False
 
@@ -236,6 +300,7 @@ class Config(Base):
         async with get_async_db() as db:
             await db.execute(delete(Config))
             await db.commit()
+            _invalidate_cache()
 
     @staticmethod
     async def seed_defaults(defaults: dict) -> None:
@@ -263,6 +328,7 @@ class Config(Base):
 
             if new_count:
                 await db.commit()
+                _invalidate_cache()
                 log.info('Seeded %d new config defaults', new_count)
 
     @staticmethod
@@ -291,6 +357,7 @@ class Config(Base):
                 await db.delete(row)
 
             await db.commit()
+            _invalidate_cache()
             log.info(
                 'Renamed %d config keys from %s.* to %s.*; deleted %d old duplicates',
                 moved_count,
@@ -376,6 +443,7 @@ class Config(Base):
 
             if repaired_keys or orphan_keys or default_model_keys:
                 await db.commit()
+                _invalidate_cache()
                 if repaired_keys or orphan_keys:
                     log.info('Repaired flattened dict config rows for %s', ', '.join(repaired_keys))
                 if default_model_keys:


### PR DESCRIPTION
Every Config.get was its own SELECT, so a request that checks a dozen permissions and settings paid a dozen round trips to a table that is tiny, rarely written and read constantly.

Single-key reads now come from one in-memory snapshot, refreshed at most once a second and retired by any write. Multi-key and whole-table reads still query the database, because the flows using them read a block of config, edit it and write it back, where a stale read would drop a change another worker committed. Three keys read that way singly are excluded too.

The snapshot is one SELECT, so keys that must agree now come from a consistent read. With a writer committing at 200/s an openai url and its api key were mispaired on 714 of 714 reads before, 0 of 27497 after.

13 config reads in one request, SQLite:
  permission-heavy   13 queries / 5.7 ms -> 1 query / 0.6 ms
  ollama request     13 queries / 6.1 ms -> 1 query / 0.8 ms

CONFIG_CACHE_TTL bounds how long a worker can serve a value another worker changed.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
