### PR TITLE
fix: skip the autocompletion debounce when the document shrank past the captured position

### DIFF
--- a/src/lib/components/common/RichTextInput/AutoCompletion.js
+++ b/src/lib/components/common/RichTextInput/AutoCompletion.js
@@ -86,6 +86,7 @@ export const AIAutocompletion = Extension.create({
 
 						const newState = view.state;
 						const newSelection = newState.selection;
+						if (currentPos >= newState.doc.content.size) return false;
 						const newNode = newState.doc.nodeAt(currentPos);
 
 						// Check if the node still exists and is still a paragraph


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. First-time contributors should not open pull requests directly unless the pull request contains only i18n/localization updates.
   Do not open a PR as the first step.
   For real, reproducible bugs, start with a well-described Issue that explains the problem, why it matters, and what outcome you are looking for.
   For feature requests, enhancements, behavior changes, UI/UX changes, architecture changes, suspected fixes, or unconfirmed approaches, start with an active Discussion.
   If you want to propose an implementation, include it only as a reference in the Issue or Discussion, such as a local diff, patch, or branch.
   Opening an Issue or Discussion does not mean a PR is the right next step. Maintainers will confirm when a PR would be useful.
   We ask for this because PRs, especially from first-time contributors, often need broader maintainer context on product direction, scope, architecture, UX, edge cases, compatibility, documentation, and long-term maintenance before implementation.
   We may close unsolicited PRs without review.
   Contributors with a history of successful merged PRs may be given more latitude.
3. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

**Before submitting, make sure you've checked and filled out the following:**

- [x] **Linked Issue/Discussion:** Closes #28823
- [x] **First-time contributor policy:** not my first contribution.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** **Manual** end-to-end tests have been performed to verify the fix/feature works correctly and does not introduce regressions.
- [x] **User-facing changes:** I have confirmed whether this PR changes the UI. It does not; the only observable difference is the absence of the console error.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

With `Prompt Autocompletion` enabled, finishing a multi paragraph message and then sending or clearing it within a second of the last keystroke throws an uncaught `RangeError: Position N outside of fragment (<paragraph>)` from the autocompletion plugin.

**Root cause.** On every keydown the plugin captures `currentPos = $head.before()`, an absolute document position, and dereferences it one second later with `newState.doc.nodeAt(currentPos)`. ProseMirror positions do not survive document changes unmapped: when the document shrinks below the captured position during the debounce window, `Fragment.findIndex` throws instead of returning null. The guard on the next line ("Check if the node still exists") is meant for exactly this case but sits after the call that throws, so it never runs. The position can only be out of range when the cursor's paragraph was not the document's first block, which is why the error needs multi paragraph content in the input.

**Fix.** Take the early return the code already intends, one line before the dereference:

```diff
 					debounceTimer = setTimeout(() => {
 						if (isComposing) return false;
 
 						const newState = view.state;
 						const newSelection = newState.selection;
+						if (currentPos >= newState.doc.content.size) return false;
 						const newNode = newState.doc.nodeAt(currentPos);
```

### Fixed

- Fixed an uncaught `RangeError` thrown by the autocompletion plugin when the chat input shrinks or is cleared during the suggestion debounce window.

---

### Additional Information

Verified manually on top of `8a42aa53e`:

1. The deterministic reproduction from #28823 (two paragraph document, cursor at the end, keydown to arm the debounce, document cleared within the second) throws `RangeError: Position 62 outside of fragment` before the change and nothing after it, across repeated runs.
2. Autocompletion itself is unaffected: with the document left alone at timer fire, the completion request still goes out and the suggestion renders (`data-suggestion` present on the paragraph, Tab accept unchanged).
3. The suggestion dispatch later in the same callback is already protected by the `view.state === newState` reference check, so this was the only line dereferencing the stale position unguarded.

The bug was found and independently reproduced by the issue reporter on Firefox against latest `dev` (positions 7 and 77 observed); the deterministic reproduction and fix verification above are from driving the editor directly.

This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Screenshots or Videos

No visual changes; the difference is the browser console after the reproduction steps.

#### Before

<img width="2553" height="644" alt="image" src="https://github.com/user-attachments/assets/ba48621e-8cb9-433d-b40c-84dafd138a50" />

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
