### PR TITLE
fix: make the container usable under an arbitrary UID (secret key location, baked spaCy/nltk models)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -18,3 +18,6 @@ uploads
 **/*.db
 _test
 backend/data/*
+# a dev key from `bash backend/start.sh` would otherwise be COPYd into the
+# image and then outrank the deployment's own persisted key
+backend/.webui_secret_key

--- a/Dockerfile
+++ b/Dockerfile
@@ -152,6 +152,9 @@ RUN set -e; \
     # Without an explicit dir this lands in /root/nltk_data, which is mode 0700
     # and so unreadable when the container does not run as root.
     python -c "import nltk; nltk.download('punkt_tab', download_dir='/usr/local/share/nltk_data')"; \
+    # unstructured installs this into site-packages on first use, which fails
+    # when the container is not root. See the note below this RUN.
+    python -m spacy download en_core_web_sm --no-cache-dir; \
     else \
     pip3 install 'torch<=2.9.1' torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu --no-cache-dir; \
     uv pip install --system -r requirements.txt --no-cache-dir; \
@@ -163,16 +166,18 @@ RUN set -e; \
     # Without an explicit dir this lands in /root/nltk_data, which is mode 0700
     # and so unreadable when the container does not run as root.
     python -c "import nltk; nltk.download('punkt_tab', download_dir='/usr/local/share/nltk_data')"; \
+    # unstructured installs this into site-packages on first use, which fails
+    # when the container is not root. See the note below this RUN.
+    python -m spacy download en_core_web_sm --no-cache-dir; \
     fi; \
     fi; \
     mkdir -p /app/backend/data; chown -R $UID:$GID /app/backend/data/; \
     if [ -d /app/backend/data/cache ]; then chmod -R a+rX /app/backend/data/cache; fi; \
     rm -rf /var/lib/apt/lists/*;
 
-# Optional: PPTX parsing through unstructured may need spaCy's English model.
-# Keep this out of the default image to avoid the extra image bloat; deployments
-# with read-only site-packages can uncomment it and bake the model in.
-# RUN python -m spacy download en_core_web_sm
+# The spaCy model above is installed by default rather than left for downstreams
+# to uncomment here (5b8975b7d): uncommenting requires building your own image,
+# so it is not available on a published tag. The slim tag still skips it.
 
 # Install Ollama if requested
 RUN if [ "$USE_OLLAMA" = "true" ]; then \

--- a/Dockerfile
+++ b/Dockerfile
@@ -149,7 +149,9 @@ RUN set -e; \
     python -c "import os; from sentence_transformers import SentenceTransformer; SentenceTransformer(os.environ.get('AUXILIARY_EMBEDDING_MODEL', 'TaylorAI/bge-micro-v2'), device='cpu')"; \
     python -c "import os; from faster_whisper import WhisperModel; WhisperModel(os.environ['WHISPER_MODEL'], device='cpu', compute_type='int8', download_root=os.environ['WHISPER_MODEL_DIR'])"; \
     python -c "import os; import tiktoken; tiktoken.get_encoding(os.environ['TIKTOKEN_ENCODING_NAME'])"; \
-    python -c "import nltk; nltk.download('punkt_tab')"; \
+    # Without an explicit dir this lands in /root/nltk_data, which is mode 0700
+    # and so unreadable when the container does not run as root.
+    python -c "import nltk; nltk.download('punkt_tab', download_dir='/usr/local/share/nltk_data')"; \
     else \
     pip3 install 'torch<=2.9.1' torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu --no-cache-dir; \
     uv pip install --system -r requirements.txt --no-cache-dir; \
@@ -158,7 +160,9 @@ RUN set -e; \
     python -c "import os; from sentence_transformers import SentenceTransformer; SentenceTransformer(os.environ.get('AUXILIARY_EMBEDDING_MODEL', 'TaylorAI/bge-micro-v2'), device='cpu')"; \
     python -c "import os; from faster_whisper import WhisperModel; WhisperModel(os.environ['WHISPER_MODEL'], device='cpu', compute_type='int8', download_root=os.environ['WHISPER_MODEL_DIR'])"; \
     python -c "import os; import tiktoken; tiktoken.get_encoding(os.environ['TIKTOKEN_ENCODING_NAME'])"; \
-    python -c "import nltk; nltk.download('punkt_tab')"; \
+    # Without an explicit dir this lands in /root/nltk_data, which is mode 0700
+    # and so unreadable when the container does not run as root.
+    python -c "import nltk; nltk.download('punkt_tab', download_dir='/usr/local/share/nltk_data')"; \
     fi; \
     fi; \
     mkdir -p /app/backend/data; chown -R $UID:$GID /app/backend/data/; \

--- a/backend/start.sh
+++ b/backend/start.sh
@@ -29,7 +29,28 @@ fi
 
 # ── Secret key setup ─────────────────────────────────────────────────────────
 
-KEY_FILE="${WEBUI_SECRET_KEY_FILE:-.webui_secret_key}"
+# Where the generated key lives, in order of preference:
+#   1. WEBUI_SECRET_KEY_FILE, if the operator set one
+#   2. an existing, non-empty ./.webui_secret_key, so installs that already have
+#      one keep it -- tested with -e, not -r, so that a key we cannot read is
+#      still selected and fails loudly below rather than being quietly bypassed
+#      in favour of a freshly generated one
+#   3. DATA_DIR, which is the mounted volume
+# This script cd's to its own directory, so for a container (2) resolves inside
+# the image rather than on the volume: the key is lost whenever the container is
+# recreated, which silently invalidates every session. That directory is also
+# not writable when the container runs as a non-root or arbitrary UID
+# (OpenShift's restricted SCC), and `set -e` then aborts the boot outright.
+# DATA_DIR is read from the environment only. A value set solely in
+# backend/.env is not visible here, and those deployments keep the old
+# behaviour; this does not make them worse, it just does not fix them.
+if [[ -n "${WEBUI_SECRET_KEY_FILE:-}" ]]; then
+  KEY_FILE="$WEBUI_SECRET_KEY_FILE"
+elif [[ -e .webui_secret_key && -s .webui_secret_key ]]; then
+  KEY_FILE=".webui_secret_key"
+else
+  KEY_FILE="${DATA_DIR:-./data}/.webui_secret_key"
+fi
 WEBUI_SECRET_KEY_LENGTH="${WEBUI_SECRET_KEY_LENGTH:-24}"
 PORT="${PORT:-8080}"
 HOST="${HOST:-0.0.0.0}"
@@ -37,13 +58,45 @@ HOST="${HOST:-0.0.0.0}"
 if [[ -z "${WEBUI_SECRET_KEY:-}" && -z "${WEBUI_JWT_SECRET_KEY:-}" ]]; then
   echo "No WEBUI_SECRET_KEY environment variable set, loading from file."
 
-  if [[ ! -f "$KEY_FILE" ]]; then
+  # Regenerate when the key is missing or empty, but deliberately NOT when it is
+  # merely unreadable. An empty key is a reachable state -- an interrupted write
+  # leaves one -- and on a volume it persists, so it would otherwise be loaded
+  # as "" on every later boot and fail with a misleading "WEBUI_SECRET_KEY is
+  # not set". A key we cannot read, on the other hand, may well be a perfectly
+  # good one belonging to another UID or group, and it is also the default
+  # encryption key for OAuth client info, OAuth session tokens and valves, so
+  # replacing it would destroy data at rest rather than merely sign people out.
+  # `-s` needs no read permission, so that case falls through to the `cat` below
+  # and fails loudly, which is what stock does today.
+  if [[ ! -s "$KEY_FILE" ]]; then
     echo "Generating new WEBUI_SECRET_KEY..."
     if ! [[ "$WEBUI_SECRET_KEY_LENGTH" =~ ^[1-9][0-9]*$ ]]; then
       echo "WEBUI_SECRET_KEY_LENGTH must be a positive integer." >&2
       exit 1
     fi
-    head -c "$WEBUI_SECRET_KEY_LENGTH" /dev/random | base64 > "$KEY_FILE"
+    # Resolve a symlink first so we replace its target, as the plain redirect
+    # used to, rather than swapping out the operator's link for a regular file.
+    if [[ -L "$KEY_FILE" ]]; then
+      # readlink -f exits non-zero and silent when a parent component is missing
+      # or the link is circular; say so rather than dying with no output.
+      key_link="$KEY_FILE"
+      KEY_FILE=$(readlink -f -- "$key_link") || {
+        echo "Cannot resolve the symlink at $key_link." >&2
+        exit 1
+      }
+    fi
+    mkdir -p -- "$(dirname -- "$KEY_FILE")"
+    # Write to a temporary file and rename so an interrupted write cannot leave
+    # a half-written key behind. Only reached when the target is missing or
+    # empty, so the rename never lands on a key worth keeping.
+    # 0640, not 0600: the key lives on a volume that may be remounted under a
+    # different arbitrary UID, and group 0 is the part OpenShift keeps stable.
+    key_tmp=$(mktemp -- "$KEY_FILE.XXXXXX")
+    trap 'rm -f -- "${key_tmp:-}"' EXIT
+    head -c "$WEBUI_SECRET_KEY_LENGTH" /dev/random | base64 > "$key_tmp"
+    chmod 640 -- "$key_tmp"
+    mv -f -- "$key_tmp" "$KEY_FILE"
+    trap - EXIT
   fi
 
   echo "Loading WEBUI_SECRET_KEY from ${KEY_FILE}"


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. First-time contributors should not open pull requests directly unless the pull request contains only i18n/localization updates.
3. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

**Before submitting, make sure you've checked and filled out the following:**

- [x] **Linked Issue/Discussion:** Closes #26662. Please read the caveat under *Git Hygiene* below — that issue covers the secret-key commit; the two `build:` commits are not covered by it.
- [x] **First-time contributor policy:** Not my first contribution — most recently #26664, on the same arbitrary-UID theme.
- [x] **Target branch:** targets `dev`.
- [x] **Description:** below.
- [x] **Changelog:** below.
- [ ] **Documentation:** not yet. The `DATA_DIR` requirement and the key location are user-visible; I'll open a PR against open-webui/docs if you want it published.
- [x] **Dependencies:** no Python dependency added. The build now installs the `en_core_web_sm` spaCy model, which `unstructured==0.22.31` already pins and installs itself at runtime — see the cost table below.
- [x] **Testing:** manual end-to-end, in-container, stock v0.11.0 as the control. Matrices below. No UI change, so no screenshots.
- [x] **User-facing changes:** confirmed — no UI change.
- [x] **No Unchecked AI Code:** written with AI assistance (`Co-Authored-By` trailer on each commit), then reviewed line by line and manually tested by me. Every number and quoted output below was measured in a container, not inferred — several earlier drafts of this PR were wrong precisely because I reasoned instead of running, so I stopped doing that.
- [x] **Self-Review:** done.
- [ ] **Architecture:** honest answer — no. Commit 2 changes what ships in the default image and revisits a call you made in 5b8975b7d, and I have not opened a Discussion for it. If you'd rather have that conversation first, see *Git Hygiene*.
- [ ] **Git Hygiene:** rebased on `dev`, no unrelated commits — but **not atomic**. This is two logical changes: a boot-blocking fix (#26662) and a change to default image contents. I've pushed the secret-key commit alone as `sebdanielsson:fix/openshift-secret-key` — say the word and I'll repoint this PR at that branch and take the model baking to a Discussion.
- [x] **Title Prefix:** `fix`.

---

## Description

Three things that stop the image working when it doesn't run as root — OpenShift's restricted SCC assigns an arbitrary UID, but the same applies to `docker run --user`, `runAsNonRoot` and a read-only rootfs. This follows #26664, which fixed the static-asset half.

### 1. The generated secret key is written where it cannot be written, and does not survive (#26662)

`start.sh` cd's to its own directory, so `.webui_secret_key` lands in `/app/backend` — an image layer — not on the volume at `/app/backend/data`.

```
No WEBUI_SECRET_KEY environment variable set, loading from file.
Generating new WEBUI_SECRET_KEY...
start.sh: line 46: .webui_secret_key: Permission denied
```

`set -euo pipefail` turns that failed redirect into an aborted boot. Even as root it's a bug: three container recreates against a named volume produce three different keys, so every JWT stops validating and everyone is silently signed out.

Resolution order is now `WEBUI_SECRET_KEY_FILE` → an existing non-empty `./.webui_secret_key` (so installs that have one keep it) → `DATA_DIR`. The write goes through a temp file and a rename, at mode 0640 so a PVC remounted under a different arbitrary UID in GID 0 still works.

Regeneration triggers on missing-or-empty, **not** on unreadable. A key we can't read may be a good one owned by another UID, and `WEBUI_SECRET_KEY` is the default for `OAUTH_CLIENT_INFO_ENCRYPTION_KEY`, `OAUTH_SESSION_TOKEN_ENCRYPTION_KEY` and valve encryption — replacing it would make data already at rest undecryptable rather than merely signing people out. `-s` needs no read permission, so that case falls through to the `cat` and aborts loudly, as it does today.

### 2. `unstructured` installs its spaCy model into site-packages at runtime

`sent_tokenize`/`pos_tag` install `en_core_web_sm` into site-packages on first use. site-packages is root-owned, so under a non-root UID the install fails and the upload fails with it:

```
Failed to install en_core_web_sm to /usr/local/lib/python3.11/site-packages:
[Errno 13] Permission denied: '.../site-packages/en_core_web_sm'.
Ensure the site-packages directory is writable, or pre-install the model
with: python -m spacy download en_core_web_sm
```

unstructured's own error prescribes that command, so the build runs it. It also removes a runtime fetch from github.com, which no air-gapped deployment can satisfy however it's run — root included.

I know 5b8975b7d deliberately left this out over image size. What I think is worth revisiting: uncommenting requires building your own image, so it isn't available to anyone on a published tag, and the "read-only site-packages" case that note names is any container not running as root. Line 22 says non-root is untested, which is fair — this is one of the things that doesn't survive contact with it, and it fails as a hard error on upload rather than as a degradation. **Glad to put it behind an `ARG` instead of moving the default — say the word.**

### 3. The baked nltk corpus lands somewhere non-root cannot read

`nltk.download` targets the first entry of `nltk.data.path` that already exists and is writable. None of the system-wide candidates exist in the image, so `punkt_tab` goes to `/root/nltk_data`, inside a directory that is mode 0700.

Being straight about scope: I could not find anything that currently loads this corpus — `unstructured` 0.22.31 uses spaCy, and `retrieval.py` instantiates only the Markdown, RecursiveCharacter and Token splitters. So this makes 15 MB that ships either way usable, rather than fixing a reported failure. **Deleting the download outright may be the better patch and a smaller image; happy to send that instead.**

## Testing

Run as `--user 1002720000:0` with a writable volume, stock v0.11.0 as the control.

**Secret key**

| case | this PR | stock |
|---|---|---|
| fresh | `data/.webui_secret_key` 0640, boots | aborts on the redirect (#26662) |
| container recreated 3× | same key, nobody signed out | 3 different keys |
| 0-byte key on the volume | regenerated, boots | n/a — stock never reads the volume |
| volume reused under another UID, GID 0 | same key loaded | n/a |
| key unreadable (foreign GID) | untouched, exit 1, `cat: Permission denied`, no temp files left | same |
| existing legacy `./.webui_secret_key` | loaded, no second key written | loaded |
| legacy key empty | falls through to `DATA_DIR`, regenerates | loaded as `""` → `SystemExit` |
| legacy key unreadable | selected, aborts loudly | same |
| `WEBUI_SECRET_KEY_FILE=…/nested/key` | creates the tree | `No such file or directory` |
| `DATA_DIR` containing spaces | correct path, no word-splitting | same |
| key file is a symlink | link preserved, target written through | target written |
| dangling symlink | `Cannot resolve the symlink at …`, exit 1 | dies with no output |

**Models** — as `--user 1002720000:0`: `nltk.data.find('tokenizers/punkt_tab')` resolves (stock: `LookupError`), and `unstructured.nlp.tokenize.sent_tokenize('Hej. Detta ar en mening.')` returns `['Hej.', 'Detta ar en mening.']` (stock: the `Permission denied` above).

**Affected formats** — running the real loaders from `retrieval/loaders/main.py` against real files with `_get_nlp` stubbed to raise: **xls/xlsx, pptx, epub, msg, rst, xml** reach spaCy. `doc`, `odt` and `ppt` reach unstructured but die earlier on a missing python-docx or libreoffice, so this doesn't fix them. `docx` and `html` use `Docx2txtLoader`/`BSHTMLLoader` and never reach spaCy.

The `.xlsx` case needs no exotic input: any sheet with a title row above the table has a cell outside the detected subtable, and that cell goes through `_create_element` → `is_possible_narrative_text` → spaCy. A clean rectangular table doesn't trigger it.

**Cost**

| | |
|---|---|
| model on disk | 15 MB |
| layer growth | 22.6 MB — the extra ~7 MB is `.pyc` the CLI writes across spacy/thinc/click |
| base image | 7.16 GB uncompressed, 1.83 GB compressed |
| pip cache avoided by `--no-cache-dir` | 13 MB, which would be the image's first pip cache |
| tags affected | main, cuda, cuda126, ollama grow; **slim unchanged** |

## Known limits

- `DATA_DIR` set only in `backend/.env` is invisible to `start.sh`, which reads the environment. Those deployments keep the current behaviour — not made worse, not fixed.
- Two replicas racing on a shared volume at first boot can still settle on different keys. The rename makes each write atomic but elects no winner.
- `start.sh` still calls `nltk.download('punkt_tab')` without a `download_dir` on the Playwright path. Same root cause, left alone to keep the diff focused.

---

# Changelog Entry

### Description

- Makes the container work when it does not run as root: the auto-generated `WEBUI_SECRET_KEY` is written to `DATA_DIR` instead of the read-only working directory, and the spaCy model and nltk corpus that document parsing needs are baked into the image instead of being fetched into root-owned site-packages at runtime.

### Changed

- Secret key path resolution: `WEBUI_SECRET_KEY_FILE` → existing `./.webui_secret_key` → `DATA_DIR`.
- The key is written atomically (temp file + rename) with mode 0640 instead of a plain redirect.
- `WEBUI_SECRET_KEY_FILE` may now point at a nested path; parent directories are created.
- `DATA_DIR` must be writable at boot unless `WEBUI_SECRET_KEY` / `WEBUI_SECRET_KEY_FILE` is set.
- `en_core_web_sm` is installed at build time. `main`, `cuda`, `cuda126` and `ollama` grow by 22.6 MB; `slim` is unchanged.
- The nltk `punkt_tab` corpus is downloaded to `/usr/local/share/nltk_data` instead of `/root/nltk_data`.

### Fixed

- Container no longer aborts at startup under a non-root or arbitrary UID with `start.sh: line 46: .webui_secret_key: Permission denied` (#26662).
- Users are no longer signed out on every `docker compose down && up`.
- A 0-byte key file is regenerated instead of being loaded as `""` and failing with a misleading "WEBUI_SECRET_KEY is not set".
- Uploading `.xls`/`.xlsx`, `.pptx`, `.epub`, `.msg`, `.rst` and `.xml` no longer fails under a non-root UID with `Failed to install en_core_web_sm … Permission denied`, and no longer requires network access to github.com at runtime.

### Security

- Generated key files are created 0640 (owner + GID 0) instead of inheriting the process umask.
- An existing secret key that the process cannot read is never overwritten, so data encrypted with it stays decryptable.

---

### Additional Information

- Follows #26664, which fixed the static-asset half of the same problem. Related: #16592.
- `.dockerignore` now excludes `backend/.webui_secret_key`, so a dev key left by a source-tree `bash backend/start.sh` is not `COPY`d into an image, where it would outrank that deployment's own persisted key. Custom images that had baked one in will generate a fresh key once and sign their users out.
- If you'd prefer this split, `sebdanielsson:fix/openshift-secret-key` has the #26662 fix alone.

### Screenshots or Videos

- Not applicable — no user-facing UI change.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
