### PR TITLE
perf: stop resending the full accumulated output at every tool-call boundary

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -83,7 +83,7 @@ from open_webui.utils.access_control.files import get_owner_accessible_folder_fi
 from open_webui.utils.access_control.folders import has_folder_access
 from open_webui.utils.ask_user import stage_ask_user_tool_call
 from open_webui.utils.chat import generate_chat_completion
-from open_webui.utils.chat_id import is_saved_chat_id
+from open_webui.utils.chat_id import CHANNEL_CHAT_ID_PREFIX, is_saved_chat_id
 from open_webui.utils.code_interpreter import execute_code_jupyter
 from open_webui.utils.context_compaction import compact_messages_for_request
 from open_webui.utils.files import (
@@ -579,18 +579,30 @@ def deep_merge(target, source):
 RESPONSE_COMPLETION_RESPONSE_FIELDS = ('error', 'id', 'output', 'usage')
 
 
-def get_response_completion_event_data(event: dict) -> dict:
+def get_response_completion_event_data(event: dict, include_response_output: bool) -> dict:
     """Build the data payload for response:completion events."""
     response = event.get('response')
     if not isinstance(response, dict):
         return event
 
     response_data = {key: response[key] for key in RESPONSE_COMPLETION_RESPONSE_FIELDS if key in response}
+    if not include_response_output:
+        response_data.pop('output', None)
 
     return {
         **event,
         'response': response_data,
     }
+
+
+def strip_input_image_parts(item: dict) -> dict:
+    """input_image parts are LLM-only; keep base64 images out of frontend events."""
+    if item.get('type') != 'function_call_output':
+        return item
+    parts = item.get('output', [])
+    if not any(part.get('type') == 'input_image' for part in parts):
+        return item
+    return {**item, 'output': [part for part in parts if part.get('type') != 'input_image']}
 
 
 def handle_responses_streaming_event(
@@ -4161,6 +4173,7 @@ async def streaming_chat_response_handler(response, ctx):
     event_caller = ctx['event_caller']
     chat_id = metadata.get('chat_id') or ''
     save_to_chat = is_saved_chat_id(chat_id)
+    is_channel_chat = chat_id.startswith(CHANNEL_CHAT_ID_PREFIX)
 
     extra_params = {
         '__event_emitter__': event_emitter,
@@ -4526,6 +4539,22 @@ async def streaming_chat_response_handler(response, ctx):
             def full_output():
                 return prior_output + output if prior_output else output
 
+            async def emit_output_item_event(event_type, item, output_index):
+                # No-op for channel chats; they receive full chat:completion snapshots instead.
+                if is_channel_chat:
+                    return
+                await event_emitter(
+                    {
+                        'type': 'response:completion',
+                        'data': {
+                            'type': event_type,
+                            'output_index': len(prior_output) + output_index,
+                            # The item may be mutated after this emit.
+                            'item': strip_input_image_parts(item).copy(),
+                        },
+                    }
+                )
+
             def get_message_error_content(error):
                 if isinstance(error, HTTPException):
                     error = error.detail
@@ -4716,7 +4745,11 @@ async def streaming_chat_response_handler(response, ctx):
                         await event_emitter(
                             {
                                 'type': 'response:completion',
-                                'data': get_response_completion_event_data(response_data),
+                                'data': get_response_completion_event_data(
+                                    response_data,
+                                    # A continuation's response.completed output would drop prior tool history.
+                                    include_response_output=not prior_output or is_channel_chat,
+                                ),
                             }
                         )
                         await save_current_response_stream(stream_output)
@@ -5501,7 +5534,13 @@ async def streaming_chat_response_handler(response, ctx):
                     ask_user_stage = stage_ask_user_tool_call(response_tool_calls, output, output_id)
                     if ask_user_stage:
                         if ask_user_stage['error']:
-                            await event_emitter({'type': 'chat:completion', 'data': {'output': full_output()}})
+                            if is_channel_chat:
+                                await event_emitter({'type': 'chat:completion', 'data': {'output': full_output()}})
+                            else:
+                                # The staged call and its error output share the call_id.
+                                for index, item in enumerate(output):
+                                    if item.get('call_id') == ask_user_stage['call_id']:
+                                        await emit_output_item_event('response.output_item.done', item, index)
                             continue
 
                         if is_saved_chat_id(metadata.get('chat_id')) and metadata.get('message_id'):
@@ -5522,16 +5561,16 @@ async def streaming_chat_response_handler(response, ctx):
                         call_id = tc.get('id', '')
                         if call_id not in existing_call_ids:
                             func = tc.get('function', {})
-                            output.append(
-                                {
-                                    'type': 'function_call',
-                                    'id': call_id or output_id('fc'),
-                                    'call_id': call_id,
-                                    'name': func.get('name', ''),
-                                    'arguments': func.get('arguments', '{}'),
-                                    'status': 'in_progress',
-                                }
-                            )
+                            call_item = {
+                                'type': 'function_call',
+                                'id': call_id or output_id('fc'),
+                                'call_id': call_id,
+                                'name': func.get('name', ''),
+                                'arguments': func.get('arguments', '{}'),
+                                'status': 'in_progress',
+                            }
+                            output.append(call_item)
+                            await emit_output_item_event('response.output_item.added', call_item, len(output) - 1)
 
                     tool_approval_mode = metadata.get('params', {}).get('tool_approval_mode', 'full')
                     if (
@@ -5556,14 +5595,16 @@ async def streaming_chat_response_handler(response, ctx):
                         )
                         return
 
-                    await event_emitter(
-                        {
-                            'type': 'chat:completion',
-                            'data': {
-                                'output': full_output(),
-                            },
-                        }
-                    )
+                    if is_channel_chat:
+                        # The channel emitter rebuilds the stored message from each snapshot.
+                        await event_emitter(
+                            {
+                                'type': 'chat:completion',
+                                'data': {
+                                    'output': full_output(),
+                                },
+                            }
+                        )
 
                     tools = metadata.get('tools', {})
 
@@ -5736,25 +5777,26 @@ async def streaming_chat_response_handler(response, ctx):
                                 # Frontend display (MCP images, audio, etc.)
                                 display_files.append(file_item)
 
-                        output.append(
-                            {
-                                'type': 'function_call_output',
-                                'id': output_id('fco'),
-                                'call_id': result.get('tool_call_id', ''),
-                                'output': output_parts,
-                                'status': local_output_status,
-                                **({'files': display_files} if display_files else {}),
-                                **({'embeds': result.get('embeds')} if result.get('embeds') else {}),
-                            }
-                        )
+                        result_item = {
+                            'type': 'function_call_output',
+                            'id': output_id('fco'),
+                            'call_id': result.get('tool_call_id', ''),
+                            'output': output_parts,
+                            'status': local_output_status,
+                            **({'files': display_files} if display_files else {}),
+                            **({'embeds': result.get('embeds')} if result.get('embeds') else {}),
+                        }
+                        output.append(result_item)
+                        await emit_output_item_event('response.output_item.done', result_item, len(output) - 1)
 
                     # Update function_call statuses and parsed/sanitized arguments.
                     for tc in response_tool_calls:
                         call_id = tc.get('id', '')
-                        for item in output:
+                        for item_index, item in enumerate(output):
                             if item.get('type') == 'function_call' and item.get('call_id') == call_id:
                                 item['status'] = result_status_by_call_id.get(call_id, 'completed')
                                 item['arguments'] = tc.get('function', {}).get('arguments', '{}')
+                                await emit_output_item_event('response.output_item.done', item, item_index)
                                 break
 
                     # Append a new empty message item for the next response
@@ -5830,25 +5872,15 @@ async def streaming_chat_response_handler(response, ctx):
                                     )
                         tool_call_sources.clear()
 
-                    # Strip input_image parts (large base64 data URIs) from the
-                    # output sent to the frontend — they're only for LLM consumption
-                    # via convert_output_to_messages.
-                    frontend_output = []
-                    for item in full_output():
-                        if item.get('type') == 'function_call_output':
-                            parts = item.get('output', [])
-                            if any(p.get('type') == 'input_image' for p in parts):
-                                item = {**item, 'output': [p for p in parts if p.get('type') != 'input_image']}
-                        frontend_output.append(item)
-
-                    await event_emitter(
-                        {
-                            'type': 'chat:completion',
-                            'data': {
-                                'output': frontend_output,
-                            },
-                        }
-                    )
+                    if is_channel_chat:
+                        await event_emitter(
+                            {
+                                'type': 'chat:completion',
+                                'data': {
+                                    'output': [strip_input_image_parts(item) for item in full_output()],
+                                },
+                            }
+                        )
 
                     try:
                         new_form_data = {

--- a/src/lib/components/chat/Messages/structuredOutput.ts
+++ b/src/lib/components/chat/Messages/structuredOutput.ts
@@ -458,15 +458,21 @@ function appendDelta(current: unknown, delta: unknown): unknown {
 	return delta ?? current ?? '';
 }
 
-function ensureOutputItem(
-	output: OutputItem[],
-	outputIndex: number,
-	fallback?: OutputItem
-): OutputItem {
-	while (output.length <= outputIndex) {
-		output.push(
-			fallback ?? { type: 'message', status: 'in_progress', role: 'assistant', content: [] }
-		);
+function placeholderItem(): OutputItem {
+	return { type: 'message', status: 'in_progress', role: 'assistant', content: [] };
+}
+
+// Pad any gap so a client that missed events never holds a sparse array.
+function padOutput(output: OutputItem[], index: number) {
+	while (output.length < index) {
+		output.push(placeholderItem());
+	}
+}
+
+function ensureItem(output: OutputItem[], outputIndex: number, fallback?: OutputItem): OutputItem {
+	padOutput(output, outputIndex);
+	if (output.length === outputIndex) {
+		output.push(fallback ?? placeholderItem());
 	}
 	output[outputIndex] = { ...output[outputIndex] };
 	return output[outputIndex];
@@ -481,10 +487,13 @@ function ensurePart(parts: OutputContentPart[], index: number, fallback?: Output
 }
 
 function findOutputItemIndex(output: OutputItem[], item: OutputItem): number {
+	// Type must match: a function_call_output shares its call_id with the
+	// function_call it answers and must not replace it.
 	return output.findIndex(
 		(existing) =>
-			(!!item.id && existing?.id === item.id) ||
-			(!!item.call_id && existing?.call_id === item.call_id)
+			existing?.type === item.type &&
+			((!!item.id && existing?.id === item.id) ||
+				(!!item.call_id && existing?.call_id === item.call_id))
 	);
 }
 
@@ -528,6 +537,7 @@ export function applyResponseStreamEvent(
 		} else if (outputIndex < nextOutput.length) {
 			nextOutput.splice(outputIndex, 0, item);
 		} else {
+			padOutput(nextOutput, outputIndex);
 			nextOutput[outputIndex] = item;
 		}
 		return nextOutput;
@@ -539,7 +549,9 @@ export function applyResponseStreamEvent(
 		}
 		const item = { ...event.item };
 		const existingIndex = findOutputItemIndex(nextOutput, item);
-		nextOutput[existingIndex >= 0 ? existingIndex : outputIndex] = item;
+		const targetIndex = existingIndex >= 0 ? existingIndex : outputIndex;
+		padOutput(nextOutput, targetIndex);
+		nextOutput[targetIndex] = item;
 		return nextOutput;
 	}
 
@@ -547,7 +559,7 @@ export function applyResponseStreamEvent(
 		return output;
 	}
 
-	const item = ensureOutputItem(nextOutput, outputIndex, {
+	const item = ensureItem(nextOutput, outputIndex, {
 		id: event.item_id,
 		type: eventType.includes('reasoning')
 			? 'reasoning'


### PR DESCRIPTION
On tool-heavy chats the streaming path emitted the entire accumulated output twice per tool-call iteration, so a turn with dozens of tool calls pushed the same multi-megabyte payload dozens of times through the websocket layer, multiplied by the Redis fanout in multi-container deployments.

Tool calls already stream as incremental response:completion events. This change extends that vocabulary to the tool boundary: each tool result is emitted once as an output item event, the completed call follows with its sanitized arguments, and the per-iteration full snapshots are dropped for regular chats. Channel chats keep the snapshots because the channel message store is rebuilt from each one. A continuation no longer re-sends its own output list on completion, which previously reset the client's accumulated state at every boundary until the next snapshot repaired it. The frontend now matches items by type as well as call id so a result can never replace the call it answers, and pads missed indices so a client that reconnected mid-run never holds a sparse array. Code-interpreter retries keep their bounded snapshots.

Measured with a socket capture against a live instance and a mocked tool-calling upstream: pre-completion full snapshots per iteration go from two to zero, final client and database state is identical, and on a single-iteration turn snapshot payload bytes drop from 1672 to 678. The saving scales with iteration count times accumulated output size. During a rolling deploy a stale frontend can hide a tool block mid-stream until the final completion event restores it, so backend and frontend ship together.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
