### PR TITLE
fix: stale checkbox state when deselecting items in the model editor selectors

### DIFF
--- a/src/lib/components/workspace/Models/ActionsSelector.svelte
+++ b/src/lib/components/workspace/Models/ActionsSelector.svelte
@@ -61,7 +61,7 @@
 
 		<div class="flex flex-col">
 			<div class=" flex items-center flex-wrap mt-1">
-				{#each selectedActions as action, actionIdx}
+				{#each selectedActions as action, actionIdx (action.id)}
 					<div class=" flex items-center gap-2 mr-3">
 						<div class="self-center flex items-center">
 							<Checkbox

--- a/src/lib/components/workspace/Models/DefaultFiltersSelector.svelte
+++ b/src/lib/components/workspace/Models/DefaultFiltersSelector.svelte
@@ -57,7 +57,7 @@
 	<div class="flex flex-col">
 		{#if filters.length > 0}
 			<div class=" flex items-center flex-wrap mt-1">
-				{#each selectedFilters as filter}
+				{#each selectedFilters as filter (filter.id)}
 					{@const isSelected = selectedFilterIds.includes(filter.id)}
 					<div class=" flex items-center gap-2 mr-3">
 						<div class="self-center flex items-center">

--- a/src/lib/components/workspace/Models/FiltersSelector.svelte
+++ b/src/lib/components/workspace/Models/FiltersSelector.svelte
@@ -62,7 +62,7 @@
 		<!-- TODO: Filter order matters -->
 		<div class="flex flex-col">
 			<div class=" flex items-center flex-wrap mt-1">
-				{#each selectedFilters as filter}
+				{#each selectedFilters as filter (filter.id)}
 					{@const isSelected = filter.is_global || selectedFilterIds.includes(filter.id)}
 					<div class=" flex items-center gap-2 mr-3">
 						<div class="self-center flex items-center">

--- a/src/lib/components/workspace/Models/SkillsSelector.svelte
+++ b/src/lib/components/workspace/Models/SkillsSelector.svelte
@@ -54,7 +54,7 @@
 	<div class="flex flex-col mb-1">
 		{#if activeSkills.length > 0}
 			<div class=" flex items-center flex-wrap mt-1">
-				{#each selectedSkills as skill, skillIdx}
+				{#each selectedSkills as skill, skillIdx (skill.id)}
 					<div class=" flex items-center gap-2 mr-3">
 						<div class="self-center flex items-center">
 							<Checkbox

--- a/src/lib/components/workspace/Models/ToolsSelector.svelte
+++ b/src/lib/components/workspace/Models/ToolsSelector.svelte
@@ -52,7 +52,7 @@
 	<div class="flex flex-col mb-1">
 		{#if tools.length > 0}
 			<div class=" flex items-center flex-wrap mt-1">
-				{#each selectedTools as tool, toolIdx}
+				{#each selectedTools as tool, toolIdx (tool.id)}
 					<div class=" flex items-center gap-2 mr-3">
 						<div class="self-center flex items-center">
 							<Checkbox


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. First-time contributors should not open pull requests directly unless the pull request contains only i18n/localization updates.
   Do not open a PR as the first step.
   For real, reproducible bugs, start with a well-described Issue that explains the problem, why it matters, and what outcome you are looking for.
   For feature requests, enhancements, behavior changes, UI/UX changes, architecture changes, suspected fixes, or unconfirmed approaches, start with an active Discussion.
   If you want to propose an implementation, include it only as a reference in the Issue or Discussion, such as a local diff, patch, or branch.
   Opening an Issue or Discussion does not mean a PR is the right next step. Maintainers will confirm when a PR would be useful.
   We ask for this because PRs, especially from first-time contributors, often need broader maintainer context on product direction, scope, architecture, UX, edge cases, compatibility, documentation, and long-term maintenance before implementation.
   We may close unsolicited PRs without review.
   Contributors with a history of successful merged PRs may be given more latitude.
3. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

**Before submitting, make sure you've checked and filled out the following:**

- [x] **Linked Issue/Discussion:** Closes #28832
- [x] **First-time contributor policy:** not my first contribution.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** **Manual** end-to-end tests have been performed to verify the fix/feature works correctly and does not introduce regressions.
- [x] **User-facing changes:** I have confirmed whether this PR changes the UI. It restores the intended checkbox behavior; no layout or styling changes.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

In the model editor, deselecting a tool removes it from the list but makes the next tool's checkbox render as deselected while the tool is still selected. That checkbox then needs two clicks to actually remove its tool, and the stale state cascades to the following tool on every removal.

**Root cause.** The selected tool list is rendered by an unkeyed `{#each selectedTools as tool}`. `Checkbox` keeps its own internal `_state`, which only re-syncs from the `state` prop when the prop value changes. Unchecking a tool removes it from `selectedTools`; without a key, Svelte reuses component instances by index, so the clicked `Checkbox` instance (internally `unchecked`) is rebound to the next tool. Its `state` prop is the literal `"checked"` before and after the rebind, so the sync never fires and the next tool renders unchecked while still selected. Clicking it once flips the internal state back to `checked` and dispatches `checked`, which the deselect handler ignores; only the second click removes the tool, at which point the same stale instance shifts onto the tool after that.

**Fix.** Key the each block by item id, so removing an item destroys its component instance instead of shifting instances across items:

```diff
-				{#each selectedTools as tool, toolIdx}
+				{#each selectedTools as tool, toolIdx (tool.id)}
```

The sibling selectors on the same editor (`ActionsSelector`, `SkillsSelector`, `FiltersSelector`, `DefaultFiltersSelector`) render their selected lists with the identical unkeyed pattern and the same reuse defect, so they get the identical one line change. Keyed each blocks are already the convention for these removable selected item lists elsewhere, for example `MessageInput.svelte` (`{#each selectedFilterIds as filterId (filterId)}`) and `MessageInput/InputMenu/Knowledge.svelte` (`(file.id)`).

### Fixed

- Fixed the model editor's Tools, Skills, Actions, Filters, and Default Filters selectors showing the next item as deselected (and requiring two clicks to remove it) after deselecting an item, caused by unkeyed list rendering reusing checkbox state across items.

---

### Additional Information

Verified manually on top of `8a42aa53e`:

1. Before the change, with three tools selected, unchecking the first makes the second render unchecked (`aria-checked="false"`, no checkmark) while still listed and still in `selectedToolIds`; the first click on it is swallowed and the second click removes it, after which the third tool inherits the stale unchecked rendering. This matches the video in #28832 exactly.
2. After the change, each single click removes exactly the clicked tool and every remaining checkbox stays checked. Repeated removals produce no cascade.
3. Spot checked the Actions selector after the change with three actions: unchecking the first removes only it, and the remaining checkboxes stay checked.

This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Screenshots or Videos

No layout or styling changes; the difference is checkbox state correctness after deselecting an item.
### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
