### PR TITLE
refactor: drop the unused synchronous batch embedding helpers

### DIFF
--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -5,7 +5,6 @@ import hashlib
 import logging
 import os
 import re
-import time
 from typing import Awaitable, Optional, Union
 from urllib.parse import quote
 
@@ -856,39 +855,6 @@ async def query_collection_with_hybrid_search(
     return merge_and_sort_query_results(results, k=k)
 
 
-def generate_openai_batch_embeddings(
-    model: str,
-    texts: list[str],
-    url: str = 'https://api.openai.com/v1',
-    key: str = '',
-    prefix: str = None,
-    user: UserModel = None,
-) -> list[list[float]]:
-    log.debug('generate_openai_batch_embeddings:model %s batch size: %s', model, len(texts))
-    json_data = {'input': texts, 'model': model}
-    if isinstance(RAG_EMBEDDING_PREFIX_FIELD_NAME, str) and isinstance(prefix, str):
-        json_data[RAG_EMBEDDING_PREFIX_FIELD_NAME] = prefix
-
-    headers = {
-        'Content-Type': 'application/json',
-        'Authorization': f'Bearer {key}',
-    }
-    if ENABLE_FORWARD_USER_INFO_HEADERS and user:
-        headers = include_user_info_headers(headers, user)
-
-    r = requests.post(
-        f'{url}/embeddings',
-        headers=headers,
-        json=json_data,
-    )
-    r.raise_for_status()
-    data = r.json()
-    if 'data' in data:
-        return [elem['embedding'] for elem in data['data']]
-    else:
-        raise ValueError("Unexpected OpenAI embeddings response: missing 'data' key")
-
-
 async def agenerate_openai_batch_embeddings(
     model: str,
     texts: list[str],
@@ -924,48 +890,6 @@ async def agenerate_openai_batch_embeddings(
                 return [item['embedding'] for item in data['data']]
             else:
                 raise ValueError("Unexpected OpenAI embeddings response: missing 'data' key")
-
-
-def generate_azure_openai_batch_embeddings(
-    model: str,
-    texts: list[str],
-    url: str,
-    key: str = '',
-    version: str = '',
-    prefix: str = None,
-    user: UserModel = None,
-) -> list[list[float]]:
-    log.debug('generate_azure_openai_batch_embeddings:deployment %s batch size: %s', model, len(texts))
-    json_data = {'input': texts}
-    if isinstance(RAG_EMBEDDING_PREFIX_FIELD_NAME, str) and isinstance(prefix, str):
-        json_data[RAG_EMBEDDING_PREFIX_FIELD_NAME] = prefix
-
-    url = f'{url}/openai/deployments/{model}/embeddings?api-version={version}'
-
-    for _ in range(5):
-        headers = {
-            'Content-Type': 'application/json',
-            'api-key': key,
-        }
-        if ENABLE_FORWARD_USER_INFO_HEADERS and user:
-            headers = include_user_info_headers(headers, user)
-
-        r = requests.post(
-            url,
-            headers=headers,
-            json=json_data,
-        )
-        if r.status_code == 429:
-            retry = float(r.headers.get('Retry-After', '1'))
-            time.sleep(retry)
-            continue
-        r.raise_for_status()
-        data = r.json()
-        if 'data' in data:
-            return [elem['embedding'] for elem in data['data']]
-        else:
-            raise ValueError("Unexpected Azure OpenAI embeddings response: missing 'data' key")
-    raise Exception('Azure OpenAI embedding request failed: max retries (429) exceeded')
 
 
 async def agenerate_azure_openai_batch_embeddings(
@@ -1006,42 +930,6 @@ async def agenerate_azure_openai_batch_embeddings(
                 return [item['embedding'] for item in data['data']]
             else:
                 raise ValueError("Unexpected Azure OpenAI embeddings response: missing 'data' key")
-
-
-def generate_ollama_batch_embeddings(
-    model: str,
-    texts: list[str],
-    url: str,
-    key: str = '',
-    prefix: str = None,
-    user: UserModel = None,
-) -> list[list[float]]:
-    log.debug('generate_ollama_batch_embeddings:model %s batch size: %s', model, len(texts))
-    json_data = {'input': texts, 'model': model, 'truncate': True}
-    if isinstance(RAG_EMBEDDING_PREFIX_FIELD_NAME, str) and isinstance(prefix, str):
-        json_data[RAG_EMBEDDING_PREFIX_FIELD_NAME] = prefix
-
-    headers = {
-        'Content-Type': 'application/json',
-        'Authorization': f'Bearer {key}',
-    }
-    if ENABLE_FORWARD_USER_INFO_HEADERS and user:
-        headers = include_user_info_headers(headers, user)
-
-    r = requests.post(
-        f'{url}/api/embed',
-        headers=headers,
-        json=json_data,
-    )
-    if r.status_code != 200:
-        error_detail = r.json().get('error', r.text)
-        raise Exception(f'Ollama embed error ({r.status_code}): {error_detail}')
-    data = r.json()
-
-    if 'embeddings' in data:
-        return data['embeddings']
-    else:
-        raise ValueError("Unexpected Ollama embeddings response: missing 'embeddings' key")
 
 
 async def agenerate_ollama_batch_embeddings(

--- a/backend/open_webui/routers/ollama.py
+++ b/backend/open_webui/routers/ollama.py
@@ -881,7 +881,7 @@ async def embed(
     if not await Config.get('ollama.enable'):
         raise HTTPException(status_code=503, detail=ERROR_MESSAGES.OLLAMA_API_DISABLED)
 
-    log.info('generate_ollama_batch_embeddings %s', form_data)
+    log.info('embed %s', form_data)
     await check_model_access(user, await Models.get_model_by_id(form_data.model), BYPASS_MODEL_ACCESS_CONTROL)
     await validate_ollama_backend_idx(request, form_data.model, url_idx, user)
 
@@ -932,7 +932,7 @@ async def embeddings(
     if not await Config.get('ollama.enable'):
         raise HTTPException(status_code=503, detail=ERROR_MESSAGES.OLLAMA_API_DISABLED)
 
-    log.info('generate_ollama_embeddings %s', form_data)
+    log.info('embeddings %s', form_data)
     await check_model_access(user, await Models.get_model_by_id(form_data.model), BYPASS_MODEL_ACCESS_CONTROL)
     await validate_ollama_backend_idx(request, form_data.model, url_idx, user)
 


### PR DESCRIPTION
Every batch embedding provider in the retrieval layer exists twice, once synchronous and once asynchronous. Only the asynchronous versions are reachable: the single entry point that all embedding paths go through awaits those. The synchronous copies have no caller anywhere in the tree and were kept looking alive only by their own log lines.

This removes around 110 lines of duplicated request handling for OpenAI, Azure OpenAI and Ollama, so there is one implementation per provider instead of two that can silently drift apart. Nothing called the removed code, so behaviour is unchanged. Two log lines in the Ollama router named functions that no longer exist and now name the endpoints they sit in.

One thing worth knowing before this lands: the removed Azure helper was the only code in the tree that backed off on a 429 with Retry-After. The live asynchronous path raises instead. That gap is not new, but the deletion takes away the last worked example of it.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
