### PR TITLE
refactor: remove unused request and response models

### DIFF
--- a/backend/open_webui/models/access_grants.py
+++ b/backend/open_webui/models/access_grants.py
@@ -57,24 +57,6 @@ class AccessGrantModel(BaseModel):
     created_at: int
 
 
-class AccessGrantResponse(BaseModel):
-    """Slim grant model for API responses — resource context is implicit from the parent."""
-
-    id: str
-    principal_type: str
-    principal_id: str
-    permission: str
-
-    @classmethod
-    def from_grant(cls, grant: 'AccessGrantModel') -> 'AccessGrantResponse':
-        return cls(
-            id=grant.id,
-            principal_type=grant.principal_type,
-            principal_id=grant.principal_id,
-            permission=grant.permission,
-        )
-
-
 ####################
 # Conversion utilities
 ####################
@@ -275,7 +257,7 @@ def strip_anyone_access_grants(access_grants: Optional[list]) -> list:
 
 def grants_to_access_control(grants: list) -> Optional[dict]:
     """
-    Convert a list of grant objects (AccessGrantModel or AccessGrantResponse)
+    Convert a list of AccessGrantModel objects
     back to the old-style access_control JSON dict for backward compatibility.
 
     Semantics:

--- a/backend/open_webui/models/auths.py
+++ b/backend/open_webui/models/auths.py
@@ -34,15 +34,6 @@ class Auth(Base):  # credential ↔ user linkage
     active = Column(Boolean)  # account soft-disable toggle
 
 
-class AuthModel(BaseModel):
-    """Pydantic mirror of the ``auth`` table row."""
-
-    id: str
-    email: str
-    password: str
-    active: bool = True
-
-
 class Token(BaseModel):
     """JWT bearer-token response wrapper."""
 
@@ -66,10 +57,6 @@ class SigninForm(BaseModel):
 class LdapForm(BaseModel):
     user: str
     password: str
-
-
-class ProfileImageUrlForm(BaseModel):
-    profile_image_url: str
 
 
 class UpdatePasswordForm(BaseModel):

--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -250,10 +250,6 @@ class ChatTitleMessagesForm(BaseModel):
     messages: list[dict]
 
 
-class ChatTitleForm(BaseModel):
-    title: str
-
-
 class ChatResponse(BaseModel):
     id: str
     user_id: str

--- a/backend/open_webui/models/folders.py
+++ b/backend/open_webui/models/folders.py
@@ -63,20 +63,6 @@ class FolderNameIdResponse(BaseModel):
     updated_at: int
 
 
-class SharedFolderResponse(BaseModel):
-    id: str
-    name: str
-    parent_id: Optional[str] = None
-    user_id: str
-    owner_name: Optional[str] = None
-    permission: str = 'read'
-    access_grants: list = []
-    is_expanded: bool = False
-    meta: Optional[dict] = None
-    created_at: int
-    updated_at: int
-
-
 ####################
 # Forms
 ####################

--- a/backend/open_webui/models/groups.py
+++ b/backend/open_webui/models/groups.py
@@ -86,14 +86,6 @@ class GroupMember(Base):
     updated_at = Column(BigInteger, nullable=True)
 
 
-class GroupMemberModel(BaseModel):
-    id: str
-    group_id: str
-    user_id: str
-    created_at: Optional[int] = None  # timestamp in epoch
-    updated_at: Optional[int] = None  # timestamp in epoch
-
-
 ####################
 # Forms
 ####################

--- a/backend/open_webui/models/oauth_sessions.py
+++ b/backend/open_webui/models/oauth_sessions.py
@@ -51,18 +51,6 @@ class OAuthSessionModel(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
 
-####################
-# Forms
-####################
-
-
-class OAuthSessionResponse(BaseModel):
-    id: str
-    user_id: str
-    provider: str
-    expires_at: int
-
-
 class OAuthSessionTable:
     def __init__(self):
         self.encryption_key = OAUTH_SESSION_TOKEN_ENCRYPTION_KEY

--- a/backend/open_webui/models/tags.py
+++ b/backend/open_webui/models/tags.py
@@ -39,16 +39,6 @@ class TagModel(BaseModel):
     model_config = ConfigDict(from_attributes=True)  # allows ORM model binding
 
 
-# --- tag schema forms ---
-# Forms
-####################
-
-
-class TagChatIdForm(BaseModel):
-    name: str
-    chat_id: str
-
-
 class TagTable:
     async def insert_new_tag(
         self,

--- a/backend/open_webui/models/users.py
+++ b/backend/open_webui/models/users.py
@@ -152,19 +152,6 @@ class ApiKey(Base):
     updated_at = Column(BigInteger, nullable=False)
 
 
-class ApiKeyModel(BaseModel):
-    id: str
-    user_id: str
-    key: str
-    data: dict | None = None
-    expires_at: int | None = None
-    last_used_at: int | None = None
-    created_at: int  # timestamp in epoch
-    updated_at: int  # timestamp in epoch
-
-    model_config = ConfigDict(from_attributes=True)
-
-
 ####################
 # Forms
 ####################
@@ -185,15 +172,6 @@ class UpdateProfileForm(BaseModel):
 
 class UserGroupIdsModel(UserModel):
     group_ids: list[str] = []
-
-
-class UserModelResponse(UserModel):
-    model_config = ConfigDict(extra='allow')
-
-
-class UserListResponse(BaseModel):
-    users: list[UserModelResponse]
-    total: int
 
 
 class UserGroupIdsListResponse(BaseModel):
@@ -230,11 +208,6 @@ class UserIdNameStatusResponse(UserStatus):
 
 class UserInfoListResponse(BaseModel):
     users: list[UserInfoResponse]
-    total: int
-
-
-class UserIdNameListResponse(BaseModel):
-    users: list[UserIdNameResponse]
     total: int
 
 

--- a/backend/open_webui/routers/ollama.py
+++ b/backend/open_webui/routers/ollama.py
@@ -1516,12 +1516,6 @@ class UrlForm(BaseModel):
     url: str
 
 
-class UploadBlobForm(BaseModel):
-    """Form carrying a filename for blob uploads."""
-
-    filename: str
-
-
 def parse_huggingface_url(hf_url: str) -> str | None:
     """Extract the filename from a HuggingFace download URL."""
     try:

--- a/backend/open_webui/routers/scim.py
+++ b/backend/open_webui/routers/scim.py
@@ -65,15 +65,6 @@ def scim_error(status_code: int, detail: str, scim_type: Optional[str] = None):
     return JSONResponse(status_code=status_code, content=error_body)
 
 
-class SCIMError(BaseModel):
-    """SCIM Error Response"""
-
-    schemas: List[str] = [SCIM_ERROR_SCHEMA]
-    status: str
-    scimType: Optional[str] = None
-    detail: Optional[str] = None
-
-
 class SCIMMeta(BaseModel):
     """SCIM Resource Metadata"""
 


### PR DESCRIPTION
Fourteen request and response models across the model and router layers have no reference anywhere: no endpoint takes them as a body, no handler returns them and no other model builds on them. Several sit directly beside the model that is actually used for the same data, which makes it easy to reach for the wrong one when editing those files.

This removes around 115 lines and leaves one model per shape. No route signature changes, so the API surface is untouched. Two section banners that introduced nothing but a removed model go with them, and one docstring stops naming a model that no longer exists.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
