### PR TITLE
refactor: remove unused frontend constants, stores and helpers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,6 @@
 				"i18next-browser-languagedetector": "^7.2.0",
 				"i18next-resources-to-backend": "^1.2.0",
 				"idb": "^7.1.1",
-				"js-sha256": "^0.10.1",
 				"jspdf": "^4.0.0",
 				"jszip": "^3.10.1",
 				"katex": "^0.16.22",
@@ -9894,12 +9893,6 @@
 			"bin": {
 				"jiti": "lib/jiti-cli.mjs"
 			}
-		},
-		"node_modules/js-sha256": {
-			"version": "0.10.1",
-			"resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.10.1.tgz",
-			"integrity": "sha512-5obBtsz9301ULlsgggLg542s/jqtddfOpV5KJc4hajc9JV8GeY2gZHSVpYBn4nWqAUTJ9v+xwtbJ1mIBgIH5Vw==",
-			"license": "MIT"
 		},
 		"node_modules/js-tokens": {
 			"version": "9.0.1",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,6 @@
 		"i18next-browser-languagedetector": "^7.2.0",
 		"i18next-resources-to-backend": "^1.2.0",
 		"idb": "^7.1.1",
-		"js-sha256": "^0.10.1",
 		"jspdf": "^4.0.0",
 		"jszip": "^3.10.1",
 		"katex": "^0.16.22",

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -6,7 +6,6 @@
 // https://docs.openwebui.com/license.
 export const APP_NAME = 'Open WebUI';
 
-export const WEBUI_HOSTNAME = '';
 export const WEBUI_BASE_URL = '';
 export const WEBUI_API_BASE_URL = `${WEBUI_BASE_URL}/api/v1`;
 
@@ -20,86 +19,6 @@ export const RETRIEVAL_API_BASE_URL = `${WEBUI_BASE_URL}/api/v1/retrieval`;
 // was built here keep its word across every release.
 export const WEBUI_VERSION = APP_VERSION;
 export const WEBUI_BUILD_HASH = APP_BUILD_HASH;
-export const REQUIRED_OLLAMA_VERSION = '0.1.16';
-
-export const SUPPORTED_FILE_TYPE = [
-	'application/epub+zip',
-	'application/pdf',
-	'text/plain',
-	'text/csv',
-	'text/xml',
-	'text/html',
-	'text/x-python',
-	'text/css',
-	'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-	'application/octet-stream',
-	'application/x-javascript',
-	'text/markdown',
-	'audio/mpeg',
-	'audio/wav',
-	'audio/ogg',
-	'audio/x-m4a'
-];
-
-export const SUPPORTED_FILE_EXTENSIONS = [
-	'md',
-	'rst',
-	'go',
-	'py',
-	'java',
-	'sh',
-	'bat',
-	'ps1',
-	'cmd',
-	'js',
-	'ts',
-	'css',
-	'cpp',
-	'hpp',
-	'h',
-	'c',
-	'cs',
-	'htm',
-	'html',
-	'sql',
-	'log',
-	'ini',
-	'pl',
-	'pm',
-	'r',
-	'dart',
-	'dockerfile',
-	'env',
-	'php',
-	'hs',
-	'hsc',
-	'lua',
-	'nginxconf',
-	'conf',
-	'm',
-	'mm',
-	'plsql',
-	'perl',
-	'rb',
-	'rs',
-	'db2',
-	'scala',
-	'bash',
-	'swift',
-	'vue',
-	'svelte',
-	'doc',
-	'docx',
-	'pdf',
-	'csv',
-	'txt',
-	'xls',
-	'xlsx',
-	'pptx',
-	'ppt',
-	'msg'
-];
-
 export const DEFAULT_CAPABILITIES = {
 	file_context: true,
 	vision: true,

--- a/src/lib/stores/chatList.ts
+++ b/src/lib/stores/chatList.ts
@@ -144,13 +144,3 @@ export const setAllChatsRead = () => {
 	chatsStore.update((items) => (items ? items.map(updateChat) : items));
 	pinnedChatsStore.update((items) => items.map(updateChat));
 };
-
-export const resetChatListState = () => {
-	requestGeneration += 1;
-	currentPage = 1;
-	paginationReady = false;
-	allLoaded = false;
-	loadingNextPage = false;
-	chatsStore.set(null);
-	pinnedChatsStore.set([]);
-};

--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -30,9 +30,6 @@ export const mobile = writable(false);
 
 export const socket: Writable<null | Socket> = writable(null);
 export const socketConnected: Writable<boolean> = writable(true);
-export const activeUserIds: Writable<null | string[]> = writable(null);
-export const USAGE_POOL: Writable<null | string[]> = writable(null);
-
 export const theme = writable('system');
 
 export const shortCodesToEmojis = writable(
@@ -136,10 +133,8 @@ export const showChangelog = writable(false);
 
 export const showControls = writable(false);
 export const showEmbeds = writable(false);
-export const showOverview = writable(false);
 export const showArtifacts = writable(false);
 export const showCallOverlay = writable(false);
-export const showFileNav = writable(false);
 export const showFileNavPath: Writable<string | null> = writable(null);
 export const showFileNavDir: Writable<string | null> = writable(null);
 export const selectedTerminalId: Writable<string | null> = writable(null);
@@ -153,7 +148,6 @@ export const temporaryChatEnabled = writable(false);
 
 // Transient one-shot event from the desktop shell (Spotlight, drag-and-drop, etc.).
 // Set by +layout.svelte, consumed and cleared by Chat.svelte.
-export type DesktopEventFile = { name: string; mimeType: string; dataUrl: string };
 export type DesktopEvent = {
 	type: string;
 	data?: any;

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -1,6 +1,5 @@
 import type { Writable } from 'svelte/store';
 import { v4 as uuidv4 } from 'uuid';
-import sha256 from 'js-sha256';
 import DOMPurify from 'dompurify';
 import { WEBUI_BASE_URL } from '$lib/constants';
 
@@ -300,19 +299,6 @@ export const sanitizeHistory = (history) => {
 	for (const message of Object.values(history.messages)) {
 		message.childrenIds = message.childrenIds.filter((childId) => history.messages[childId]);
 	}
-};
-
-export const getGravatarURL = (email) => {
-	// Trim leading and trailing whitespace from
-	// an email address and force all characters
-	// to lower case
-	const address = String(email).trim().toLowerCase();
-
-	// Create a SHA256 hash of the final string
-	const hash = sha256(address);
-
-	// Grab the actual image URL
-	return `https://www.gravatar.com/avatar/${hash}`;
 };
 
 export const canvasPixelTest = () => {
@@ -712,37 +698,6 @@ export const removeLastWordFromString = (inputString, wordString) => {
 	console.log('resultString', resultString);
 
 	return resultString;
-};
-
-export const removeFirstHashWord = (inputString) => {
-	// Split the string into an array of words
-	const words = inputString.split(' ');
-
-	// Find the index of the first word that starts with #
-	const index = words.findIndex((word) => word.startsWith('#'));
-
-	// Remove the first word with #
-	if (index !== -1) {
-		words.splice(index, 1);
-	}
-
-	// Join the remaining words back into a string
-	const resultString = words.join(' ');
-
-	return resultString;
-};
-
-export const transformFileName = (fileName) => {
-	// Convert to lowercase
-	const lowerCaseFileName = fileName.toLowerCase();
-
-	// Remove special characters using regular expression
-	const sanitizedFileName = lowerCaseFileName.replace(/[^\w\s]/g, '');
-
-	// Replace spaces with dashes
-	const finalFileName = sanitizedFileName.replace(/\s+/g, '-');
-
-	return finalFileName;
 };
 
 export const calculateSHA256 = async (file) => {


### PR DESCRIPTION
Thirteen exports across the constants module, the stores and the shared utils have no reader: four constants including two long file type lists, five stores and types, and four helpers. Some describe behaviour the app no longer has, such as a required Ollama version constant still pinned to 0.1.16.

Removing the gravatar helper leaves the js-sha256 package with no importer, so it comes out of the dependencies as well. The live gravatar path goes through the backend and is untouched. This removes around 150 lines and one direct dependency.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
