### PR TITLE
refactor: remove the deprecated automation worker alias and unused terminal helper

### DIFF
--- a/backend/open_webui/utils/automations.py
+++ b/backend/open_webui/utils/automations.py
@@ -41,7 +41,6 @@ from open_webui.models.users import Users
 from open_webui.utils.auth import create_token
 from open_webui.utils.misc import parse_duration
 from open_webui.utils.task import prompt_template
-from open_webui.utils.terminals import get_terminal_server_url
 from starlette.datastructures import Headers
 
 log = logging.getLogger(__name__)
@@ -198,12 +197,6 @@ def rrule_interval_seconds(s: str) -> Optional[int]:
 ############################
 
 
-# Keep the old name as an alias so any stale imports still work.
-async def automation_worker_loop(app) -> None:
-    """Deprecated alias — use scheduler_worker_loop."""
-    await scheduler_worker_loop(app)
-
-
 async def scheduler_worker_loop(app) -> None:
     """Unified background scheduler for all time-based work.
 
@@ -330,54 +323,6 @@ async def _resolve_model_defaults(app, model_id: str) -> tuple[list[str], dict, 
                 features[feature_id] = True
 
     return tool_ids, features, filter_ids, terminal_id
-
-
-async def _set_terminal_cwd(app, server_id: str, user, cwd: str, chat_id: str) -> None:
-    """Set the working directory on a terminal server via the proxy.
-
-    Routes through the open-webui terminal proxy endpoint so that
-    auth headers, orchestrator policy routing, and X-User-Id are
-    handled correctly — same path the frontend uses.
-    """
-    import aiohttp
-    from open_webui.env import AIOHTTP_CLIENT_SESSION_SSL
-
-    connections = getattr(getattr(app, 'state', None), 'config', None)
-    if connections is None:
-        return
-    connections = getattr(connections, 'TERMINAL_SERVER_CONNECTIONS', None) or []
-    connection = next((c for c in connections if c.get('id') == server_id), None)
-    if connection is None:
-        log.warning(f'Terminal server {server_id} not found for CWD set')
-        return
-
-    base_url = get_terminal_server_url(connection)
-    if not base_url:
-        return
-
-    target_url = f'{base_url}/files/cwd'
-
-    headers = {'Content-Type': 'application/json', 'X-User-Id': user.id}
-    if chat_id:
-        headers['X-Session-Id'] = chat_id
-
-    auth_type = connection.get('auth_type', 'bearer')
-    if auth_type == 'bearer':
-        headers['Authorization'] = f'Bearer {connection.get("key", "")}'
-
-    try:
-        async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=10)) as session:
-            async with session.post(
-                target_url,
-                json={'path': cwd},
-                headers=headers,
-                ssl=AIOHTTP_CLIENT_SESSION_SSL,
-            ) as resp:
-                if resp.status != 200:
-                    body = await resp.text()
-                    log.warning(f'Failed to set terminal CWD to {cwd}: HTTP {resp.status} — {body[:200]}')
-    except Exception as e:
-        log.warning(f'Failed to set terminal CWD: {e}')
 
 
 async def _execute_channel_automation(


### PR DESCRIPTION
The automation module wraps the scheduler loop under its old name, with a comment saying it is kept so stale imports still work. Startup imports the real name directly and nothing anywhere in the tree reaches the alias, so it only provides a second name for the same loop. A helper that pushes a working directory to a terminal server sits beside it with no caller either.

That helper was the only reader of the terminal block in the automation payload. The block still validates and persists, so this change leaves it in place, but nothing consumes it any more.

This removes around 55 lines and leaves one entry point for the scheduler.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
