### PR TITLE
refactor: remove unused helpers across constants, routers and utils

### DIFF
--- a/backend/open_webui/constants.py
+++ b/backend/open_webui/constants.py
@@ -24,17 +24,6 @@ def _error_message(err='', fallback='') -> str:
     return f'[ERROR: {err}]'
 
 
-class MESSAGES(str, Enum):
-    DEFAULT = lambda msg='': f'{msg if msg else ""}'
-    MODEL_ADDED = lambda model='': f"The model '{model}' has been added successfully."
-    MODEL_DELETED = lambda model='': f"The model '{model}' has been deleted successfully."
-
-
-class WEBHOOK_MESSAGES(str, Enum):
-    DEFAULT = lambda msg='': f'{msg if msg else ""}'
-    USER_SIGNUP = lambda username='': f'New user signed up: {username}' if username else 'New user signed up'
-
-
 class ERROR_MESSAGES(str, Enum):
     def __str__(self) -> str:
         return super().__str__()

--- a/backend/open_webui/migrations/util.py
+++ b/backend/open_webui/migrations/util.py
@@ -11,10 +11,3 @@ def get_existing_tables() -> set[str]:
     """Return table names already present in the database."""
     conn = op.get_bind()
     return set(inspect(conn).get_table_names())
-
-
-def get_revision_id() -> str:
-    """Generate a short random revision identifier."""
-    import uuid
-
-    return uuid.uuid4().hex[:12]

--- a/backend/open_webui/retrieval/vector/dbs/pgvector.py
+++ b/backend/open_webui/retrieval/vector/dbs/pgvector.py
@@ -60,10 +60,6 @@ Base = declarative_base()
 log = logging.getLogger(__name__)
 
 
-def pgcrypto_encrypt(val, key):
-    return func.pgp_sym_encrypt(val, literal(key))
-
-
 def pgcrypto_decrypt(col, key, outtype='text'):
     return func.cast(func.pgp_sym_decrypt(col, literal(key)), outtype)
 

--- a/backend/open_webui/routers/ollama.py
+++ b/backend/open_webui/routers/ollama.py
@@ -220,21 +220,6 @@ async def get_ollama_config_values() -> dict:
     return {field: values[storage_key] for field, storage_key in OLLAMA_CONFIG_KEYS.items() if storage_key in values}
 
 
-async def get_ollama_runtime_config() -> tuple[bool, list[str], dict]:
-    values = await Config.get_many('ollama.enable', 'ollama.base_urls', 'ollama.api_configs')
-    return (
-        values.get('ollama.enable'),
-        values.get('ollama.base_urls') or [],
-        values.get('ollama.api_configs') or {},
-    )
-
-
-async def get_ollama_connection(idx: int) -> tuple[str, dict, str | None]:
-    _, base_urls, api_configs = await get_ollama_runtime_config()
-    url = base_urls[idx]
-    return url, resolve_api_config(api_configs, idx, url), get_api_key(idx, url, api_configs)
-
-
 @router.head('/')
 @router.get('/')
 async def get_status() -> dict:

--- a/backend/open_webui/routers/tools.py
+++ b/backend/open_webui/routers/tools.py
@@ -48,14 +48,6 @@ log = logging.getLogger(__name__)
 router = APIRouter()
 
 
-async def get_tool_module(request, tool_id, load_from_db=True):
-    """
-    Get the tool module by its ID.
-    """
-    tool_module, _ = await get_tool_module_from_cache(request, tool_id, load_from_db)
-    return tool_module
-
-
 ############################
 # GetTools
 # The danger is not in having tools, but in reaching

--- a/backend/open_webui/tools/knowledge_fs.py
+++ b/backend/open_webui/tools/knowledge_fs.py
@@ -274,20 +274,6 @@ def _get_subdirs(tree: dict, parent_id: str | None) -> list[dict]:
     return sorted([d for d in tree['dirs'].values() if d['parent_id'] == parent_id], key=lambda d: d['name'])
 
 
-def _get_files_under_dir(tree: dict, dir_id: str) -> list[dict]:
-    """Get all files recursively under a directory."""
-    # Collect this dir + all descendant dir IDs
-    target_ids = {dir_id}
-    changed = True
-    while changed:
-        changed = False
-        for d in tree['dirs'].values():
-            if d['parent_id'] in target_ids and d['id'] not in target_ids:
-                target_ids.add(d['id'])
-                changed = True
-    return [f for f in tree['files'] if f['directory_id'] in target_ids]
-
-
 # =============================================================================
 # FILE RESOLUTION & ACCESS CONTROL
 # =============================================================================
@@ -504,16 +490,6 @@ async def _resolve_file(ref: str, user: dict, model_knowledge: list[dict] | None
             + '\n'.join(f'  {m["id"]}  {m["filename"]}  ({m.get("knowledge_name", "direct")})' for m in matches)
         }
 
-    return None
-
-
-async def _get_file_content(file_id: str) -> str | None:
-    """Get file content by ID."""
-    from open_webui.models.files import Files
-
-    f = await Files.get_file_by_id(file_id)
-    if f and f.data:
-        return f.data.get('content', '')
     return None
 
 

--- a/backend/open_webui/utils/calendar.py
+++ b/backend/open_webui/utils/calendar.py
@@ -6,7 +6,6 @@ RRULE expansion reusing the automation infra.
 
 import datetime as dt
 import logging
-from zoneinfo import ZoneInfo
 
 from open_webui.utils.automations import _resolve_tz
 
@@ -76,12 +75,3 @@ def expand_recurring_event(
         occurrence_start = rule.after(occurrence_start)
 
     return instances
-
-
-def ns_from_date(year: int, month: int, day: int, tz: str | None = None) -> int:
-    """Create epoch nanoseconds from a date."""
-    if tz:
-        date_time = dt.datetime(year, month, day, tzinfo=ZoneInfo(tz))
-    else:
-        date_time = dt.datetime(year, month, day)
-    return int(date_time.timestamp() * 1_000_000_000)

--- a/backend/open_webui/utils/filter.py
+++ b/backend/open_webui/utils/filter.py
@@ -94,12 +94,6 @@ async def resolve_filter_pipeline(request, model: dict, enabled_filter_ids: list
     return filter_ids, filter_functions
 
 
-async def get_sorted_filter_ids(request, model: dict, enabled_filter_ids: list = None):
-    filter_ids, _ = await resolve_filter_pipeline(request, model, enabled_filter_ids)
-
-    return filter_ids
-
-
 async def get_filter_functions(request, model: dict, enabled_filter_ids: list = None):
     _, filter_functions = await resolve_filter_pipeline(request, model, enabled_filter_ids)
     return filter_functions

--- a/backend/open_webui/utils/images/comfyui.py
+++ b/backend/open_webui/utils/images/comfyui.py
@@ -33,22 +33,8 @@ async def queue_prompt(prompt, client_id, base_url, api_key):
         raise
 
 
-async def get_image(filename, subfolder, folder_type, base_url, api_key):
-    log.info('get_image')
-    data = {'filename': filename, 'subfolder': subfolder, 'type': folder_type}
-    url_values = urllib.parse.urlencode(data)
-    session = await get_session()
-    async with session.get(
-        f'{base_url}/view?{url_values}',
-        headers={**default_headers, 'Authorization': f'Bearer {api_key}'},
-        ssl=AIOHTTP_CLIENT_SESSION_SSL,
-    ) as r:
-        r.raise_for_status()
-        return await r.read()
-
-
 def get_image_url(filename, subfolder, folder_type, base_url):
-    log.info('get_image')
+    log.info('get_image_url')
     data = {'filename': filename, 'subfolder': subfolder, 'type': folder_type}
     url_values = urllib.parse.urlencode(data)
     return f'{base_url}/view?{url_values}'

--- a/backend/open_webui/utils/mcp/client.py
+++ b/backend/open_webui/utils/mcp/client.py
@@ -122,30 +122,6 @@ class MCPClient:
         else:
             return result_content
 
-    async def list_resources(self, cursor: Optional[str] = None) -> Optional[dict]:
-        if not self.session:
-            raise RuntimeError('MCP client is not connected.')
-
-        result = await self.session.list_resources(cursor=cursor)
-        if not result:
-            raise Exception('No result returned from MCP list_resources call.')
-
-        result_dict = result.model_dump()
-        resources = result_dict.get('resources', [])
-
-        return resources
-
-    async def read_resource(self, uri: str) -> Optional[dict]:
-        if not self.session:
-            raise RuntimeError('MCP client is not connected.')
-
-        result = await self.session.read_resource(uri)
-        if not result:
-            raise Exception('No result returned from MCP read_resource call.')
-        result_dict = result.model_dump()
-
-        return result_dict
-
     async def disconnect(self):
         """Clean up and close the session.
 


### PR DESCRIPTION
Two message enums and twelve helpers spread across the constants module, the migration utilities, two routers, the knowledge filesystem tools, an MCP client and the shared utils have no reference anywhere in the tree. They are unrelated to each other, and the only thing they share is that nothing reaches them. One of them was the sole caller of an Ollama runtime config reader, so that goes as well rather than being left behind for the next sweep.

Neither enum ever held a member. Both class bodies contain only lambdas, which the enum machinery treats as methods, so there was nothing to look up by name or iterate over. The signup webhook text they were meant to supply comes from the events module today.

This removes around 125 lines. Each deletion stands on its own and none of them changes behaviour, because none of the code ran. One log line in the ComfyUI helpers named a removed function and now names the function it sits in.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
