### PR TITLE
refactor: remove the dead signature check, the token header helper and an unused environment variable

### DIFF
--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -914,7 +914,6 @@ if WEBUI_NAME != 'Open WebUI':
 # https://docs.openwebui.com/license.
 WEBUI_FAVICON_URL = 'https://openwebui.com/favicon.png'
 WEBUI_BUILD_HASH = os.getenv('WEBUI_BUILD_HASH', 'dev-build')
-TRUSTED_SIGNATURE_KEY = os.getenv('TRUSTED_SIGNATURE_KEY', '')
 
 ####################################
 # Feature flags

--- a/backend/open_webui/utils/auth.py
+++ b/backend/open_webui/utils/auth.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import base64
 import hashlib
-import hmac
 import logging
 import os
 import uuid
@@ -30,7 +29,6 @@ from open_webui.env import (
     PASSWORD_VALIDATION_REGEX_PATTERN,
     REDIS_KEY_PREFIX,
     STATIC_DIR,
-    TRUSTED_SIGNATURE_KEY,
     WEBUI_AUTH_TRUSTED_EMAIL_HEADER,
     WEBUI_SECRET_KEY,
     pk,
@@ -52,22 +50,6 @@ PASSWORD_BCRYPT_MAX_BYTES = 72
 ##############
 # Auth Utils
 ##############
-
-
-def verify_signature(payload: str, signature: str) -> bool:
-    """
-    Verifies the HMAC signature of the received payload.
-    """
-    try:
-        expected_signature = base64.b64encode(
-            hmac.new(TRUSTED_SIGNATURE_KEY, payload.encode(), hashlib.sha256).digest()
-        ).decode()
-
-        # Compare securely to prevent timing attacks
-        return hmac.compare_digest(expected_signature, signature)
-
-    except Exception:
-        return False
 
 
 def override_static(path: str, content: str):
@@ -323,10 +305,6 @@ async def revoke_user_tokens(request, user_id: str):
         str(int(datetime.now(UTC).timestamp())),
         ex=int(expires_delta.total_seconds()) if expires_delta else None,
     )
-
-
-def extract_token_from_auth_header(auth_header: str):
-    return auth_header[len('Bearer ') :]
 
 
 def create_api_key():


### PR DESCRIPTION
The backend carries an HMAC signature verifier that nothing calls. It could not have worked in any case: it feeds the key straight from the environment into the HMAC constructor as text where bytes are required, so every call raised, got swallowed by the surrounding catch-all and returned false for correct and incorrect signatures alike. It failed closed, so there was never a window where a bad signature was accepted. A helper that pulls a token out of an authorization header sits in the same module with no caller since token checks moved to dependencies.

Removing the verifier leaves TRUSTED_SIGNATURE_KEY with no reader, so it goes too. The variable is not referenced in the documentation and setting it never had an effect, so no deployment changes.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
