### PR TITLE
refactor: remove unreachable vector database client methods

### DIFF
--- a/backend/open_webui/retrieval/vector/dbs/elasticsearch.py
+++ b/backend/open_webui/retrieval/vector/dbs/elasticsearch.py
@@ -210,10 +210,6 @@ class ElasticsearchClient(VectorDBBase):
     def _has_index(self, dimension: int):
         return self.client.indices.exists(index=self._get_index_name(dimension=dimension))
 
-    def get_or_create_index(self, dimension: int):
-        if not self._has_index(dimension=dimension):
-            self._create_index(dimension=dimension)
-
     # Status: works
     def get(self, collection_name: str) -> Optional[GetResult]:
         # Get all the items in the collection.

--- a/backend/open_webui/retrieval/vector/dbs/oracle23ai.py
+++ b/backend/open_webui/retrieval/vector/dbs/oracle23ai.py
@@ -32,7 +32,6 @@ import array
 import json
 import logging
 import os
-import threading
 import time
 from decimal import Decimal
 from typing import Any, Dict, List, Optional, Union
@@ -163,65 +162,6 @@ class Oracle23aiClient(VectorDBBase):
                     time.sleep(wait_time)
                 else:
                     raise
-
-    def start_health_monitor(self, interval_seconds: int = 60):
-        """
-        Start a background thread to periodically check the health of the connection pool.
-
-        Args:
-            interval_seconds (int): Number of seconds between health checks
-        """
-
-        def _monitor():
-            while True:
-                try:
-                    log.info('[HealthCheck] Running periodic DB health check...')
-                    self.ensure_connection()
-                    log.info('[HealthCheck] Connection is healthy.')
-                except Exception as e:
-                    log.exception(f'[HealthCheck] Connection health check failed: {e}')
-                time.sleep(interval_seconds)
-
-        thread = threading.Thread(target=_monitor, daemon=True)
-        thread.start()
-        log.info('Started DB health monitor every %s seconds.', interval_seconds)
-
-    def _reconnect_pool(self):
-        """
-        Attempt to reinitialize the connection pool if it's been closed or broken.
-        """
-        try:
-            log.info('Attempting to reinitialize the Oracle connection pool...')
-
-            # Close existing pool if it exists
-            if self.pool:
-                try:
-                    self.pool.close()
-                except Exception as close_error:
-                    log.warning(f'Error closing existing pool: {close_error}')
-
-            # Re-create the appropriate connection pool based on DB type
-            if ORACLE_DB_USE_WALLET:
-                self._create_adb_pool()
-            else:  # DBCS
-                self._create_dbcs_pool()
-
-            log.info('Connection pool reinitialized.')
-        except Exception as e:
-            log.exception(f'Failed to reinitialize the connection pool: {e}')
-            raise
-
-    def ensure_connection(self):
-        """
-        Ensure the database connection is alive, reconnecting pool if needed.
-        """
-        try:
-            with self.get_connection() as connection:
-                with connection.cursor() as cursor:
-                    cursor.execute('SELECT 1 FROM dual')
-        except Exception as e:
-            log.exception(f'Connection check failed: {e}, attempting to reconnect pool...')
-            self._reconnect_pool()
 
     def _output_type_handler(self, cursor, metadata):
         """

--- a/backend/open_webui/retrieval/vector/dbs/pinecone.py
+++ b/backend/open_webui/retrieval/vector/dbs/pinecone.py
@@ -16,10 +16,7 @@ try:
 except ImportError:
     GRPC_AVAILABLE = False
 
-import asyncio  # for async upserts
 import concurrent.futures  # for parallel batch upserts
-import functools  # for partial binding in async tasks
-import random  # for jitter in retry backoff
 
 from open_webui.config import (
     PINECONE_API_KEY,
@@ -126,43 +123,6 @@ class PineconeClient(VectorDBBase):
         except Exception as e:
             log.error(f'Failed to initialize Pinecone index: {e}')
             raise RuntimeError(f'Failed to initialize Pinecone index: {e}')
-
-    def _retry_pinecone_operation(self, operation_func, max_retries=3):
-        """Retry Pinecone operations with exponential backoff for rate limits and network issues."""
-        for attempt in range(max_retries):
-            try:
-                return operation_func()
-            except Exception as e:
-                error_str = str(e).lower()
-                # Check if it's a retryable error (rate limits, network issues, timeouts)
-                is_retryable = any(
-                    keyword in error_str
-                    for keyword in [
-                        'rate limit',
-                        'quota',
-                        'timeout',
-                        'network',
-                        'connection',
-                        'unavailable',
-                        'internal error',
-                        '429',
-                        '500',
-                        '502',
-                        '503',
-                        '504',
-                    ]
-                )
-
-                if not is_retryable or attempt == max_retries - 1:
-                    # Don't retry for non-retryable errors or on final attempt
-                    raise
-
-                # Exponential backoff with jitter
-                delay = (2**attempt) + random.uniform(0, 1)
-                log.warning(
-                    f'Pinecone operation failed (attempt {attempt + 1}/{max_retries}), retrying in {delay:.2f}s: {e}'
-                )
-                time.sleep(delay)
 
     def _create_points(self, items: List[VectorItem], collection_name_with_prefix: str) -> List[Dict[str, Any]]:
         """Convert VectorItem objects to Pinecone point format."""
@@ -306,50 +266,6 @@ class PineconeClient(VectorDBBase):
         log.debug('Upsert of %s vectors took %.2f seconds', len(points), elapsed)
         log.info(
             "Successfully upserted %s vectors in parallel batches into '%s'", len(points), collection_name_with_prefix
-        )
-
-    async def insert_async(self, collection_name: str, items: List[VectorItem]) -> None:
-        """Async version of insert using asyncio and run_in_executor for improved performance."""
-        if not items:
-            log.warning('No items to insert')
-            return
-
-        collection_name_with_prefix = self._get_collection_name_with_prefix(collection_name)
-        points = self._create_points(items, collection_name_with_prefix)
-
-        # Create batches
-        batches = [points[i : i + BATCH_SIZE] for i in range(0, len(points), BATCH_SIZE)]
-        loop = asyncio.get_event_loop()
-        tasks = [loop.run_in_executor(None, functools.partial(self.index.upsert, vectors=batch)) for batch in batches]
-        results = await asyncio.gather(*tasks, return_exceptions=True)
-        for result in results:
-            if isinstance(result, Exception):
-                log.error(f'Error in async insert batch: {result}')
-                raise result
-        log.info(
-            "Successfully async inserted %s vectors in batches into '%s'", len(points), collection_name_with_prefix
-        )
-
-    async def upsert_async(self, collection_name: str, items: List[VectorItem]) -> None:
-        """Async version of upsert using asyncio and run_in_executor for improved performance."""
-        if not items:
-            log.warning('No items to upsert')
-            return
-
-        collection_name_with_prefix = self._get_collection_name_with_prefix(collection_name)
-        points = self._create_points(items, collection_name_with_prefix)
-
-        # Create batches
-        batches = [points[i : i + BATCH_SIZE] for i in range(0, len(points), BATCH_SIZE)]
-        loop = asyncio.get_event_loop()
-        tasks = [loop.run_in_executor(None, functools.partial(self.index.upsert, vectors=batch)) for batch in batches]
-        results = await asyncio.gather(*tasks, return_exceptions=True)
-        for result in results:
-            if isinstance(result, Exception):
-                log.error(f'Error in async upsert batch: {result}')
-                raise result
-        log.info(
-            "Successfully async upserted %s vectors in batches into '%s'", len(points), collection_name_with_prefix
         )
 
     def search(


### PR DESCRIPTION
Three of the bundled vector database backends carry methods that nothing calls: an async insert and upsert pair plus a retry wrapper on Pinecone, an index bootstrap on Elasticsearch and a background health monitor on Oracle. None of them are part of the vector client interface, and the async facade in front of every backend already runs the synchronous methods in worker threads, so the async variants on Pinecone were never wired up.

The Oracle health monitor was the only entry into a connection self-healing chain, so the reconnect helpers underneath it go as well rather than being left standing with no way in.

This removes around 150 lines of code that no path can reach, plus the imports that only existed to serve it. Worth knowing before it lands: the Pinecone retry wrapper and the Oracle pool rebuild were written but never connected to anything, so neither backend loses behaviour, but the tree no longer carries a worked example of either idea.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
