### PR TITLE
fix: bake in the spaCy model unstructured installs at runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -150,6 +150,8 @@ RUN set -e; \
     python -c "import os; from faster_whisper import WhisperModel; WhisperModel(os.environ['WHISPER_MODEL'], device='cpu', compute_type='int8', download_root=os.environ['WHISPER_MODEL_DIR'])"; \
     python -c "import os; import tiktoken; tiktoken.get_encoding(os.environ['TIKTOKEN_ENCODING_NAME'])"; \
     python -c "import nltk; nltk.download('punkt_tab')"; \
+    # unstructured installs this into root-owned site-packages on first use
+    python -m spacy download en_core_web_sm --no-cache-dir; \
     else \
     pip3 install 'torch<=2.9.1' torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu --no-cache-dir; \
     uv pip install --system -r requirements.txt --no-cache-dir; \
@@ -159,16 +161,13 @@ RUN set -e; \
     python -c "import os; from faster_whisper import WhisperModel; WhisperModel(os.environ['WHISPER_MODEL'], device='cpu', compute_type='int8', download_root=os.environ['WHISPER_MODEL_DIR'])"; \
     python -c "import os; import tiktoken; tiktoken.get_encoding(os.environ['TIKTOKEN_ENCODING_NAME'])"; \
     python -c "import nltk; nltk.download('punkt_tab')"; \
+    # unstructured installs this into root-owned site-packages on first use
+    python -m spacy download en_core_web_sm --no-cache-dir; \
     fi; \
     fi; \
     mkdir -p /app/backend/data; chown -R $UID:$GID /app/backend/data/; \
     if [ -d /app/backend/data/cache ]; then chmod -R a+rX /app/backend/data/cache; fi; \
     rm -rf /var/lib/apt/lists/*;
-
-# Optional: PPTX parsing through unstructured may need spaCy's English model.
-# Keep this out of the default image to avoid the extra image bloat; deployments
-# with read-only site-packages can uncomment it and bake the model in.
-# RUN python -m spacy download en_core_web_sm
 
 # Install Ollama if requested
 RUN if [ "$USE_OLLAMA" = "true" ]; then \


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked and filled out the following:**

- [x] **Linked Issue/Discussion:** Relates to #17594 and #24393 — both closed, both the same root cause, neither fixed in the image. Happy to move this to a Discussion if you would rather have that conversation first.
- [x] **First-time contributor policy:** Not my first contribution — #26664.
- [x] **Target branch:** targets `dev`.
- [x] **Description:** below.
- [x] **Changelog:** below.
- [x] **Documentation:** no configuration surface change.
- [x] **Dependencies:** no Python dependency added. `en_core_web_sm` is the model `unstructured==0.22.31` already pins and installs itself at runtime; this moves that install to build time. 15 MB.
- [x] **Testing:** manual, in-container, logs below.
- [x] **User-facing changes:** no UI change.
- [x] **No Unchecked AI Code:** written with AI assistance, then reviewed and manually tested by me — the logs below are from my own runs.
- [x] **Self-Review:** performed.
- [x] **Architecture:** no new setting; `USE_SLIM=true` still skips it.
- [x] **Git Hygiene:** one commit, one logical change, based on current `dev`.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

`unstructured` classifies narrative text with `sent_tokenize`/`pos_tag`, and those install `en_core_web_sm` into site-packages the first time a document is parsed. site-packages is root-owned, so under any non-root UID the install fails and the upload fails with it.

This also removes a runtime fetch from github.com, which no air-gapped deployment can satisfy however it is run — root included.

### Fixed

- Uploading `.xls`/`.xlsx`, `.pptx`, `.epub`, `.msg`, `.rst` or `.xml` no longer fails under a non-root UID with `Failed to install en_core_web_sm … Permission denied`, and no longer needs network access to github.com at runtime.

### Changed

- `en_core_web_sm` is installed at build time. `main`, `cuda`, `cuda126` and `ollama` grow by 22.6 MB against a 7.16 GB image; `slim` is unchanged.

---

### Additional Information

**Before**, stock `v0.11.0` as a non-root UID:

```
$ docker run --rm --user 1002720000:0 ghcr.io/open-webui/open-webui:v0.11.0 \
    python -c "import unstructured.nlp.tokenize as t; print(t.sent_tokenize('Hi. There.'))"
RuntimeError: Failed to install en_core_web_sm to /usr/local/lib/python3.11/site-packages:
[Errno 13] Permission denied: '/usr/local/lib/python3.11/site-packages/en_core_web_sm'.
Ensure the site-packages directory is writable, or pre-install the model with:
python -m spacy download en_core_web_sm
```

The error text is unstructured's own, and it prescribes exactly this command.

Through the UI the same thing surfaces as a failed upload:

```
ERROR ... open_webui.routers.retrieval:process_file - Failed to install en_core_web_sm ...
ERROR ... open_webui.routers.files:_process_handler - Error processing file: d0ab4795-...
GET /api/v1/files/d0ab4795-...  ->  {"status": "failed"}
```

**After**, same command against the built image:

```
$ docker run --rm --user 1002720000:0 <built> \
    python -c "import unstructured.nlp.tokenize as t; print(t.sent_tokenize('Hi. There.'))"
['Hi.', 'There.']
```

Which formats are affected — running the real loaders from `retrieval/loaders/main.py` against real files with `_get_nlp` stubbed to raise:

```
xlsx (title row above table)  spaCy reached: True
xlsx (clean table only)       spaCy reached: False
pptx                          spaCy reached: True
epub                          spaCy reached: True
rst, xml                      spaCy reached: True
docx, html                    spaCy reached: False   (Docx2txtLoader / BSHTMLLoader)
doc, odt                      ModuleNotFoundError: No module named 'docx'
ppt                           FileNotFoundError: soffice command was not found
```

So `doc`, `odt` and `ppt` are broken earlier for unrelated reasons and this does not fix them. The `.xlsx` case needs no exotic input: a title row above the table leaves a cell outside the detected subtable, and that cell goes through `_create_element` → `is_possible_narrative_text` → spaCy.

Cost, measured on an isolated layer:

```
model on disk                      15,291,492 B
layer growth                       22.6 MB   (the extra ~7 MB is .pyc the CLI writes
                                              across spacy/thinc/click)
pip cache avoided by --no-cache-dir     13 MB
base image                         7.16 GB uncompressed, 1.83 GB compressed
```

This revisits 5b8975b7d, which left the line commented out over image size and suggested downstreams uncomment it. The reason I think it is worth another look: uncommenting requires building your own image, so it is not available to anyone on a published tag, and the "read-only site-packages" case that note names is any container that does not run as root. **Glad to put it behind an `ARG` instead of moving the default — say the word and I will push that.**

### Screenshots or Videos

- Not applicable — no UI change.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
