### PR TITLE
fix: download nltk data somewhere a non-root UID can read

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -149,7 +149,7 @@ RUN set -e; \
     python -c "import os; from sentence_transformers import SentenceTransformer; SentenceTransformer(os.environ.get('AUXILIARY_EMBEDDING_MODEL', 'TaylorAI/bge-micro-v2'), device='cpu')"; \
     python -c "import os; from faster_whisper import WhisperModel; WhisperModel(os.environ['WHISPER_MODEL'], device='cpu', compute_type='int8', download_root=os.environ['WHISPER_MODEL_DIR'])"; \
     python -c "import os; import tiktoken; tiktoken.get_encoding(os.environ['TIKTOKEN_ENCODING_NAME'])"; \
-    python -c "import nltk; nltk.download('punkt_tab')"; \
+    python -c "import nltk; nltk.download('punkt_tab', download_dir='/usr/local/share/nltk_data')"; \
     else \
     pip3 install 'torch<=2.9.1' torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu --no-cache-dir; \
     uv pip install --system -r requirements.txt --no-cache-dir; \
@@ -158,7 +158,7 @@ RUN set -e; \
     python -c "import os; from sentence_transformers import SentenceTransformer; SentenceTransformer(os.environ.get('AUXILIARY_EMBEDDING_MODEL', 'TaylorAI/bge-micro-v2'), device='cpu')"; \
     python -c "import os; from faster_whisper import WhisperModel; WhisperModel(os.environ['WHISPER_MODEL'], device='cpu', compute_type='int8', download_root=os.environ['WHISPER_MODEL_DIR'])"; \
     python -c "import os; import tiktoken; tiktoken.get_encoding(os.environ['TIKTOKEN_ENCODING_NAME'])"; \
-    python -c "import nltk; nltk.download('punkt_tab')"; \
+    python -c "import nltk; nltk.download('punkt_tab', download_dir='/usr/local/share/nltk_data')"; \
     fi; \
     fi; \
     mkdir -p /app/backend/data; chown -R $UID:$GID /app/backend/data/; \


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked and filled out the following:**

- [x] **Linked Issue/Discussion:** Relates to #16592 (closed) — the arbitrary-UID umbrella issue. This is a two-line follow-up in the same area as #26664. Happy to move it to a Discussion or drop it if you would rather not carry it.
- [x] **First-time contributor policy:** Not my first contribution — #26664.
- [x] **Target branch:** targets `dev`.
- [x] **Description:** below.
- [x] **Changelog:** below.
- [x] **Documentation:** no configuration surface change.
- [x] **Dependencies:** none added or updated; same corpus, different directory.
- [x] **Testing:** manual, in-container, logs below.
- [x] **User-facing changes:** no UI change.
- [x] **No Unchecked AI Code:** written with AI assistance, then reviewed and manually tested by me — the logs below are from my own runs.
- [x] **Self-Review:** performed.
- [x] **Architecture:** no new setting; two-line change to an existing build step.
- [x] **Git Hygiene:** one commit, one logical change, based on current `dev`.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

`nltk.download` targets the first entry of `nltk.data.path` that already exists and is writable. None of the system-wide candidates exist in this image, so `punkt_tab` is written to `$HOME/nltk_data` — `/root/nltk_data`, inside a directory that is mode 0700. The corpus itself is world-readable; the parent is what blocks it, so the 15 MB shipped in every non-slim image is unreachable for any run that is not root.

### Fixed

- The bundled `punkt_tab` corpus is readable when the container does not run as root.

---

### Additional Information

**Before**, stock `v0.11.0`:

```
$ docker run --rm --user 1002720000:0 ghcr.io/open-webui/open-webui:v0.11.0 \
    python -c "import nltk; nltk.data.find('tokenizers/punkt_tab')"
LookupError:
  Resource punkt_tab not found.
  Searched in:
    - '/root/nltk_data'
    - '/usr/local/nltk_data'
    - '/usr/local/share/nltk_data'
    ...

$ docker run --rm --user 0:0 ghcr.io/open-webui/open-webui:v0.11.0 sh -c 'ls -ld /root /root/nltk_data'
drwx------ 1 root root   /root
drwxr-xr-x 3 root root   /root/nltk_data
```

**After**, the built image:

```
$ docker run --rm --user 1002720000:0 <built> \
    python -c "import nltk; nltk.data.find('tokenizers/punkt_tab')"
/usr/local/share/nltk_data/tokenizers/punkt_tab
```

`/usr/local/share/nltk_data` is already on `nltk.data.path` (twice — `sys.prefix` is `/usr/local`), so nothing changes at the read side and no `NLTK_DATA` is needed. Size is unchanged: `du -sb` reports 15,294,518 B in either location.

**Scope, honestly:** I could not find anything in the current tree that loads this corpus. `unstructured==0.22.31` moved to spaCy, and `retrieval.py` instantiates only `MarkdownHeaderTextSplitter`, `RecursiveCharacterTextSplitter` and `TokenTextSplitter`. So this makes a shipped asset usable rather than fixing a reported failure. **If you would rather drop the `punkt_tab` download altogether, that is a smaller image and I am glad to send that patch instead** — just say which you prefer.

### Screenshots or Videos

- Not applicable — no UI change.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
