### PR TITLE
fix: bound nested metadata by stringified size, so a single-entry payload cannot scale with chunk count

### DIFF
--- a/backend/open_webui/retrieval/vector/utils.py
+++ b/backend/open_webui/retrieval/vector/utils.py
@@ -6,11 +6,52 @@ from open_webui.utils.misc import sanitize_text_for_db
 
 KEYS_TO_EXCLUDE = ['content', 'pages', 'tables', 'paragraphs', 'sections', 'figures']
 
+# A nested metadata value is deep-copied onto every chunk by the text splitter, so one
+# oversized value costs memory proportional to the chunk count. KEYS_TO_EXCLUDE catches the
+# field names we know about; this bounds the size of the nested values we do not.
+MAX_NESTED_METADATA_CHARS = 4096
+
+# Scalars are exempt on purpose: pinecone.py and s3vector.py put the chunk text itself into
+# metadata before calling process_metadata, and dropping that would lose the stored document.
+_CONTAINER_TYPES = (list, dict, tuple, set)
+
+# Floor charged per item visited, which is what bounds the walk by the ceiling rather than by
+# the size of the value.
+_ITEM_OVERHEAD = 2
+
+
+def _is_unbounded(value: Any) -> bool:
+    """True when str() of a container value would exceed MAX_NESTED_METADATA_CHARS characters.
+
+    Stops as soon as the ceiling is passed, so the work is bounded by the ceiling rather than
+    by the value, and nothing is serialized in order to measure it. Nesting is charged like any
+    other item, so depth cannot hide size and a cycle terminates. The charge under-estimates
+    what str() writes, so a value that would fit is never dropped.
+    """
+    if not isinstance(value, _CONTAINER_TYPES):
+        return False
+
+    budget = MAX_NESTED_METADATA_CHARS
+    stack: list[Any] = [value]
+    while stack:
+        current = stack.pop()
+        entries = current.items() if isinstance(current, dict) else enumerate(current)
+        for key, item in entries:
+            budget -= _ITEM_OVERHEAD + (len(key) if isinstance(key, str) else 0)
+            if isinstance(item, _CONTAINER_TYPES):
+                stack.append(item)
+            elif isinstance(item, (str, bytes, bytearray)):
+                # len() is O(1) here, and these are the only leaves that can be large. Never
+                # str() a leaf: that materializes what this guard exists to keep out.
+                budget -= len(item)
+            if budget < 0:
+                return True
+    return False
+
 
 def filter_metadata(metadata: dict[str, any]) -> dict[str, any]:
     # Removes large/redundant fields from metadata dict.
-    metadata = {key: value for key, value in metadata.items() if key not in KEYS_TO_EXCLUDE}
-    return metadata
+    return {key: value for key, value in metadata.items() if key not in KEYS_TO_EXCLUDE and not _is_unbounded(value)}
 
 
 def process_metadata(
@@ -21,7 +62,7 @@ def process_metadata(
     result = {}
     for key, value in metadata.items():
         # Skip large fields
-        if key in KEYS_TO_EXCLUDE:
+        if key in KEYS_TO_EXCLUDE or _is_unbounded(value):
             continue
         if value is None:
             continue


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Relates to #28771. Replaces #28773 (closed). Related: #14670 (closed).
- [x] **First-time contributor policy:** @Classic298 named this approach when closing #28773 — *"Bounding by nesting or serialized size is what would actually cover it, and #28771 stays open for that."* This PR is that bound. If that was not an invitation to open it, say so and I will close it.
- [x] **Target branch:** targets `dev`.
- [x] **Description:** below.
- [x] **Changelog:** below.
- [ ] **Documentation:** not applicable — no user-facing behaviour or setting changes.
- [ ] **Testing:** 20 assertions against the patched file from a clean checkout (script below). A container end-to-end run was **not** repeated for this revision; the change is two pure functions with no I/O. Say the word and I will run it and post the output.
- [x] **User-facing changes:** confirmed none. No UI change, so no screenshots.
- [x] **No Unchecked AI Code:** reviewed line by line by the author; every number below measured on this machine.
- [x] **Self-Review:** performed. `ruff format --check` and `ruff check` clean on the changed file.
- [x] **Architecture:** a module constant, not a new setting.
- [x] **Git Hygiene:** one atomic commit, branched from current `dev`, nothing unrelated.
- [x] **Title Prefix:** `fix`.

# Changelog Entry

### Description

**What #28773 got wrong.** It bounded the number of items at the top level. Your close said the
field the reasoning was aimed at holds a single entry with the region data nested inside it, so it
stays under the limit — exactly right. Measured against unpatched `dev` with a
`prebuilt-document`-shaped `AnalyzeResult`, all four fields `KEYS_TO_EXCLUDE` does not name hold
one top-level item:

| field | top-level items | reaches every chunk on `dev` |
|---|---|---|
| `documents` | 1 | 1,508,949 chars |
| `keyValuePairs` | 1 | leaks |
| `styles` | 1 | leaks |
| `languages` | 1 | leaks |

Raising 64 to 128 or 256 changes nothing, because 1 is under all of them.

**What this does instead.** Bounds what a value would cost once stringified:

```
if value is not (list|dict|tuple|set): keep            # scalars out of scope, deliberately
budget = MAX_NESTED_METADATA_CHARS
stack  = [value]
while stack:
    for key, item in (pop().items() if dict else enumerate(pop())):
        budget -= _ITEM_OVERHEAD + (len(key) if key is str else 0)
        if item is (list|dict|tuple|set): push it
        elif item is (str|bytes|bytearray): budget -= len(item)     # len() is O(1)
        if budget < 0: return DROP
return keep
```

Three properties the earlier version lacked:

1. **Nesting cannot hide size** — a nested container is charged like any other item, top level or five levels down.
2. **Work is bounded by the ceiling, not the value** — every visited item spends at least `_ITEM_OVERHEAD`, so at most 2,049 items are visited, and no leaf is stringified (`len()` is O(1) on `str`/`bytes`; `str()` of a big enough `int` raises past Python's digit limit, in a function called once per chunk).
3. **It cannot over-filter** — the charge strictly under-estimates what `str()` writes, so `charge ≤ len(str(value))` always. 30,000 randomized nested values: zero dropped that `str()` would have fit.

A surviving nested value is stringified by `process_metadata` before storage anyway, so it was never
queryable structured data — dropping an oversized one loses nothing usable. The guard is applied in
`process_metadata` too, so it holds for all twelve vector-store clients, not only the loader path.

### Added

- `MAX_NESTED_METADATA_CHARS` (4096), `_CONTAINER_TYPES`, `_ITEM_OVERHEAD` and a private `_is_unbounded()` in `backend/open_webui/retrieval/vector/utils.py`.

### Changed

- `filter_metadata()` and `process_metadata()` also drop container values whose stringified size would exceed the ceiling. `KEYS_TO_EXCLUDE` short-circuits first in both, so its behaviour is byte-for-byte unchanged and the new output is always a subset of the old.

### Fixed

- A nested analyze-result field not named in `KEYS_TO_EXCLUDE` no longer reaches per-chunk metadata, **including when the outer list holds a single entry** — the case #28773 missed.

---

### Additional Information

**Oversized scalars are out of scope, deliberately.** `pinecone.py:176` and `s3vector.py:182` copy the
chunk text into metadata before calling `process_metadata`, so bounding scalars would drop the stored
document there whenever `CHUNK_SIZE` exceeded the ceiling.

**Why 4096:** a judgement call — largest nested value any in-tree loader builds is a two-key dict
(~62 chars); Pinecone's 40 KB per-record limit is the tightest of the twelve. Happy to change it.

<details>
<summary>Measurements — all on this machine, patched file loaded from a clean <code>dev</code> checkout</summary>

| | |
|---|---|
| Reviewer's shape — 1 outer item, 50,000 nested regions, 3.6 MB stringified | rejected in **0.156 ms**; `str()` of it takes 33 ms |
| 30.7 MB value | rejected in **0.15 ms** vs **225 ms** to serialize |
| 200,000-level nesting chain | 0.22 ms, iterative, no `RecursionError` |
| Self-referential dict | terminates in <1 ms — budget strictly decreases per visit, so no visited-set is needed |
| 4M-item tuple / 20 MB bytes / 4M bytearray leaf | under 2 ms each. `len(str(b))` on that bytes leaf alone is 31 ms and 83,886,083 chars |
| 5,000-digit `int` leaf | kept, does not raise |
| Ordinary loader metadata | unchanged, both functions |
| Largest kept value, real size | 1.86–2.00× the ceiling in characters (under-count is by design) |

</details>

<details>
<summary>Other known limits, stated plainly</summary>

- **The ceiling is per value, not aggregate.** Per-chunk worst case is *(surviving nested fields) × ceiling*: measured at **30,495 characters** for an `AnalyzeResult`'s four unnamed nested fields at maximum survival — inside Pinecone's 40,960. Bounded, where today it is not. No aggregate budget on purpose: sharing one budget across a dict makes *which* fields survive depend on insertion order, so a benign field could evict `source`. Glad to add it if you want the tighter total.
- **A field a loader already serialized to a JSON string** — `datalab_marker.py:237`, `metadata['images'] = JSONCodec.dumps(...)` — stays unbounded, since it is a scalar. Same amplification, different type. Worth a separate change; I did not want to smuggle it in here.
- **Filtering still cannot prevent the single-document allocation.** `filter_metadata` runs on `doc.metadata`, i.e. after the loader has already built it — the order-of-operations point in #28771. This bounds the per-chunk multiplication only.

</details>

<details>
<summary>Self-contained repro script (no dependencies, ~5 seconds)</summary>

```python
"""python3 check.py backend/open_webui/retrieval/vector/utils.py"""
import pathlib, sys, time

path = pathlib.Path(sys.argv[1])
src = '\n'.join(l for l in path.read_text().splitlines() if not l.startswith('from open_webui'))
ns = {'sanitize_text_for_db': lambda v: v, 'SearchResult': object}
exec(compile(src, str(path), 'exec'), ns)
filter_metadata, guard = ns['filter_metadata'], ns.get('_is_unbounded')

regions = lambda n: [{'pageNumber': 1, 'polygon': [1.0 + i, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]} for i in range(n)]
metadata = {
    'documents': [{'docType': 'prebuilt-document', 'boundingRegions': regions(20_000)}],  # ONE item
    'keyValuePairs': [{'key': {'content': 'Invoice', 'boundingRegions': regions(20_000)}}],
    'styles': [{'isHandwritten': False, 'spans': [{'offset': i, 'length': 2} for i in range(20_000)]}],
    'languages': [{'locale': 'en', 'spans': [{'offset': i, 'length': 3} for i in range(20_000)]}],
    'modelId': 'prebuilt-document', 'source': 'invoice.pdf', 'page': 3,
}
kept = filter_metadata(metadata)
leaked = [k for k in ('documents', 'keyValuePairs', 'styles', 'languages') if k in kept]
print('top-level items per field:', {k: len(metadata[k]) for k in ('documents', 'keyValuePairs', 'styles', 'languages')})
print('kept:', sorted(kept))
print('leaked:', leaked or 'none', f'({max((len(str(kept[k])) for k in leaked), default=0):,} chars)')

ordinary = {'source': 'notes.txt', 'page': 1, 'name': 'notes.txt', 'hash': 'deadbeef' * 8,
            'embedding_config': {'engine': 'openai', 'model': 'text-embedding-3-small'}, 'tags': ['a', 'b']}
print('ordinary metadata intact:', filter_metadata(ordinary) == ordinary)

if guard:
    huge = {'documents': [{'boundingRegions': regions(400_000)}]}          # one outer item, ~31 MB
    t = time.perf_counter(); assert guard(huge); g = time.perf_counter() - t
    t = time.perf_counter(); size = len(str(huge)); s = time.perf_counter() - t
    print(f'{size/1e6:.1f} MB value: rejected in {g*1000:.2f} ms; str() takes {s*1000:.0f} ms')

    cyclic = {'name': 'x'}; cyclic['self'] = cyclic
    t = time.perf_counter(); assert guard(cyclic); print(f'cycle terminates in {(time.perf_counter()-t)*1000:.2f} ms')

    deep = cur = {}
    for _ in range(200_000): cur['n'] = {}; cur = cur['n']
    t = time.perf_counter(); assert guard(deep); print(f'200k-deep value: {(time.perf_counter()-t)*1000:.2f} ms')

    t = time.perf_counter(); guard({'f': [bytes(20 * 1024 * 1024)]})
    print(f'20 MB bytes leaf: {(time.perf_counter()-t)*1000:.2f} ms (never stringified)')
    assert not guard({'f': [10**5000]}), 'a huge int leaf must not raise'
```

On unpatched `dev` this prints four leaked fields and 1,508,949 characters; with the patch,
`leaked: none`, ordinary metadata intact, every timing sub-millisecond.

</details>

Read against `dev` at 7229fac.

### Screenshots or Videos

- Not applicable; no user-facing change.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
