### PR TITLE
fix: tolerate reasoning items without started_at when closing them at stream end

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -5262,9 +5262,10 @@ async def streaming_chat_response_handler(response, ctx):
                             reasoning_item = output[-1]
                             if reasoning_item.get('ended_at') is None:
                                 reasoning_item['ended_at'] = time.time()
-                                reasoning_item['duration'] = int(
-                                    reasoning_item['ended_at'] - reasoning_item['started_at']
-                                )
+                                if reasoning_item.get('started_at') is not None:
+                                    reasoning_item['duration'] = int(
+                                        reasoning_item['ended_at'] - reasoning_item['started_at']
+                                    )
                                 reasoning_item['status'] = 'completed'
 
                     if response_tool_calls:


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. First-time contributors should not open pull requests directly unless the pull request contains only i18n/localization updates.
   Do not open a PR as the first step.
   For real, reproducible bugs, start with a well-described Issue that explains the problem, why it matters, and what outcome you are looking for.
   For feature requests, enhancements, behavior changes, UI/UX changes, architecture changes, suspected fixes, or unconfirmed approaches, start with an active Discussion.
   If you want to propose an implementation, include it only as a reference in the Issue or Discussion, such as a local diff, patch, or branch.
   Opening an Issue or Discussion does not mean a PR is the right next step. Maintainers will confirm when a PR would be useful.
   We ask for this because PRs, especially from first-time contributors, often need broader maintainer context on product direction, scope, architecture, UX, edge cases, compatibility, documentation, and long-term maintenance before implementation.
   We may close unsolicited PRs without review.
   Contributors with a history of successful merged PRs may be given more latitude.
3. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

**Before submitting, make sure you've checked and filled out the following:**

- [x] **Linked Issue/Discussion:** Closes #28871
- [x] **First-time contributor policy:** not my first contribution.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** **Manual** end-to-end tests have been performed to verify the fix/feature works correctly and does not introduce regressions.
- [x] **User-facing changes:** I have confirmed whether this PR changes the UI. It does not; the observable difference is that a previously dying chat turn now completes.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

When a connection streams Responses API events and the response ends while the last output item is a reasoning item (the model put its whole answer into the reasoning and produced no message text), the entire chat turn dies with `Error processing chat payload: 'started_at'` and the user sees the raw `'started_at'` string as the error. Observed in the wild on GroqCloud with `qwen/qwen3.6-27b`.

**Root cause.** Reasoning items created by Open WebUI's own stream handling always carry a local `started_at` timestamp, but items adopted from a Responses API stream are the server's items verbatim (`response.output_item.added` / `response.output_item.done` in `handle_responses_streaming_event`), and the OpenAI item schema has no `started_at`. The stream end cleanup that closes a trailing reasoning item reads `ended_at` defensively with `.get()` but dereferences `started_at` bare one line later, so an adopted reasoning item passes the `ended_at is None` guard and raises `KeyError`, killing the turn.

**Fix.** Compute the duration only when `started_at` is present, mirroring the `.get()` defensiveness the block already uses for `ended_at`. Locally created reasoning items keep their duration; adopted items close as `completed` with `ended_at` set and no fabricated duration. Stamping `started_at` at adoption was considered and rejected: `response.output_item.done` replaces adopted items wholesale, and stored reasoning items are replayed to the provider verbatim on later turns, so locally stamped fields would grow the replay payload.

### Fixed

- Fixed streaming chat turns dying with `KeyError: 'started_at'` when a Responses API stream ends on a reasoning item, such as a reasoning model on a Responses API connection ending its turn without message content.

---

### Additional Information

Verified manually on top of `7229fac0c` with the deterministic reproduction from #28871 (a stub OpenAI compatible endpoint replaying a Responses stream that adds a reasoning item, streams reasoning deltas, and completes without a message item):

1. Before the change, the turn dies exactly as in the issue: the message is saved with `error: {"content": "'started_at'"}`, empty content, and no output items.
2. After the change, the same stream completes: the reasoning item is saved as `completed` with `ended_at` set and no `duration` key, and the message carries no error.
3. Locally created reasoning items are unaffected: their creation sites always set `started_at`, so the new condition is true and the duration math is unchanged.

The bug was found by the issue reporter with a GroqCloud connection on the latest `dev` Docker image; the deterministic reproduction and the fix verification are from driving the chat completion API directly against a `dev` checkout.

This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Screenshots or Videos

No UI changes; the difference is the chat turn surviving. Before is current `dev`, after is this branch, both on the reproduction from #28871.

| Surface | Before | After |
|---|---|---|
| Chat turn after a reasoning only Responses API stream ends | <img width="2294" height="1274" alt="image" src="https://github.com/user-attachments/assets/baf50269-ace1-4342-9860-dab6d3ae1bb0" /> | <img width="2294" height="1274" alt="image" src="https://github.com/user-attachments/assets/54160beb-30e7-4863-9a7c-a507e1253f1e" /> |

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
