### PR TITLE
docs: document OpenAI-compatible base URL in Docker quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,8 +167,16 @@ This will start the Open WebUI server, which you can access at [http://localhost
 - **If you're only using OpenAI API**, use this command:
 
   ```bash
-  docker run -d -p 3000:8080 -e OPENAI_API_KEY=your_secret_key -v open-webui:/app/backend/data --name open-webui --restart always ghcr.io/open-webui/open-webui:main
+  docker run -d -p 3000:8080 \
+    -e OPENAI_API_BASE_URL=https://api.example.com/v1 \
+    -e OPENAI_API_KEY=your_secret_key \
+    -v open-webui:/app/backend/data \
+    --name open-webui \
+    --restart always \
+    ghcr.io/open-webui/open-webui:main
   ```
+
+  If you are using an OpenAI-compatible gateway or local server, set `OPENAI_API_BASE_URL` to its API endpoint. You can also configure connections later in **Admin Settings -> Connections**. Make sure the endpoint exposes the model ID you want to use.
 
 ### Installing Open WebUI with Bundled Ollama Support
 


### PR DESCRIPTION
## Summary

- Document `OPENAI_API_BASE_URL` in the OpenAI-only Docker quick start.
- Clarify configuration for OpenAI-compatible gateways and local servers.
- Mention Admin Settings -> Connections and model IDs.

Related to open-webui/docs#1348

## Testing

- Reviewed the README Markdown rendering and Docker command formatting.
- Documentation-only change; no runtime code or dependencies changed.

## Checklist

- [x] Linked issue: Related to open-webui/docs#1348
- [x] Target branch: `dev`
- [x] Documentation updated.
- [x] Manual self-review completed.
- [x] The change is limited to one documentation file.

### Changelog Entry

#### Description

- Documented the base URL needed for OpenAI-compatible API gateways in the OpenAI-only Docker quick start.

#### Changed

- Expanded the Docker command with `OPENAI_API_BASE_URL` and connection guidance.

#### Fixed

- Addressed the documentation gap tracked in open-webui/docs#1348.

#### Additional Information

- Documentation-only change; no runtime code or dependencies changed.

### Contributor License Agreement

<!--
DO NOT DELETE THE TEXT BELOW
Keep the Contributor License Agreement confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [ ] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.