### PR TITLE
fix: give docx and pptx previews in the file modal a definite frame height

### DIFF
--- a/src/lib/components/common/FileItemModal.svelte
+++ b/src/lib/components/common/FileItemModal.svelte
@@ -569,7 +569,7 @@
 						{#if docxError}
 							<div class="text-red-500 text-sm p-4">{docxError}</div>
 						{:else if docxData}
-							<DocxPreview data={docxData} className="max-h-[60vh]" />
+							<DocxPreview data={docxData} className="h-[60vh]" />
 						{:else}
 							<div class="text-gray-500 text-sm p-4">No content available</div>
 						{/if}

--- a/src/lib/components/common/PptxPreview.svelte
+++ b/src/lib/components/common/PptxPreview.svelte
@@ -215,7 +215,7 @@
 	bind:this={rootEl}
 	class="relative grid {hideThumbs
 		? 'grid-cols-[minmax(0,1fr)]'
-		: 'grid-cols-[144px_minmax(0,1fr)]'} h-full min-h-0 bg-transparent text-gray-900 dark:text-gray-100 {className}"
+		: 'grid-cols-[144px_minmax(0,1fr)]'} min-h-0 bg-transparent text-gray-900 dark:text-gray-100 {className}"
 >
 	<aside
 		class={hideThumbs


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. First-time contributors should not open pull requests directly unless the pull request contains only i18n/localization updates.
   Do not open a PR as the first step.
   For real, reproducible bugs, start with a well-described Issue that explains the problem, why it matters, and what outcome you are looking for.
   For feature requests, enhancements, behavior changes, UI/UX changes, architecture changes, suspected fixes, or unconfirmed approaches, start with an active Discussion.
   If you want to propose an implementation, include it only as a reference in the Issue or Discussion, such as a local diff, patch, or branch.
   Opening an Issue or Discussion does not mean a PR is the right next step. Maintainers will confirm when a PR would be useful.
   We ask for this because PRs, especially from first-time contributors, often need broader maintainer context on product direction, scope, architecture, UX, edge cases, compatibility, documentation, and long-term maintenance before implementation.
   We may close unsolicited PRs without review.
   Contributors with a history of successful merged PRs may be given more latitude.
3. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

**Before submitting, make sure you've checked and filled out the following:**

- [x] **Linked Issue/Discussion:** Closes #28877
- [x] **First-time contributor policy:** not my first contribution.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** **Manual** end-to-end tests have been performed to verify the fix/feature works correctly and does not introduce regressions.
- [x] **User-facing changes:** I have confirmed whether this PR changes the UI. It restores the intended preview layout in the file modal; no styling changes beyond the frame height resolving.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

On the file modal's `Preview` tab, the DOCX and PPTX previews are built as a fixed frame with internal scrolling and `absolute bottom-3` overlay controls, but the frame never gets a definite height. Nothing inside it can scroll, the modal body scrolls the whole preview instead, and three symptoms follow: the DOCX zoom pill scrolls away with the content, the PPTX slide opens below the fold, and the PPTX controls sit at the very bottom of an overgrown preview while the thumbnail rail cannot scroll.

**Root cause.** Two height resolution failures, one per component. `DocxPreview` receives `className="max-h-[60vh]"`, which caps but never sets the height, so the root's `min-h-full` and the scroll container's `h-full` resolve against an indefinite parent and the content grows past the capped frame. `PptxPreview` receives the definite `className="h-[60vh]"`, but its root hardcodes `h-full` in its own class list, which wins over the passed class and resolves to auto, growing the root to the thumbnail rail's full height.

**Fix.** Give the DOCX frame the definite height its PPTX sibling call site already intends (`max-h-[60vh]` to `h-[60vh]`), and remove the hardcoded `h-full` from the `PptxPreview` root so the height passed by the consumer applies. The other consumer of both components, the chat file panel (`FileNav/FilePreview.svelte`), passes `className="w-full h-full"`, so it keeps the identical computed style: the same `h-full` still arrives via `className` for `PptxPreview`, and its `DocxPreview` call site is untouched.

### Fixed

- Fixed the DOCX and PPTX previews in the file modal overflowing it: the zoom and slide controls now stay anchored to the preview frame, the current slide is visible when the preview opens, and the document and thumbnail rail scroll inside the frame.

---

### Additional Information

Verified manually on top of `7229fac0c` with a multi page DOCX and a 24 slide PPTX, measured on a 612px viewport:

1. Before: the DOCX preview root held 4642px of visibly overflowing content behind a 367px cap, its scroll container never scrolled (scrollHeight equal to clientHeight), and the zoom pill moved 1:1 with the modal scroll (800px of scrolling moved it 800px off screen). The PPTX root computed to 1708px, the slide's top edge sat at 761px (past the 612px viewport), and the controls sat at 1813px.
2. After: both roots compute to exactly 60vh (367px). The DOCX container scrolls internally (359px client, 5796px scroll) and the pill stays at the same viewport position through 1000px of scrolling; zoom in still works. The PPTX slide is fully visible on open (top edge 212px), the thumbnail rail scrolls internally (367px client, 1506px scroll), the controls stay in view, and thumbnail clicks still switch slides.
3. The chat file panel previews are unaffected by construction (see Description); the `PptxPreview` root's computed classes there are identical before and after.

The three symptoms were found by the issue reporter with real documents on the latest `dev` Docker image; the measurements and fix verification above are from driving the file modal directly against a `dev` checkout.

This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Screenshots or Videos

Before is current `dev`, after is this branch.

| Surface | Before | After |
|---|---|---|
| DOCX preview after scrolling down in the document | <img width="1096" height="939" alt="image" src="https://github.com/user-attachments/assets/548bc3eb-c38c-4562-9250-ea85a08ed180" /> | <img width="1096" height="939" alt="image" src="https://github.com/user-attachments/assets/c9b60188-75dd-4ac7-9969-b4078ac95825" /> |
| PPTX preview immediately after opening the Preview tab | <img width="1099" height="1082" alt="image" src="https://github.com/user-attachments/assets/5428d36a-cbaf-41d2-8b3e-28a4ba84c0cf" /> | <img width="1102" height="956" alt="image" src="https://github.com/user-attachments/assets/706f64c0-8a82-4a67-b388-0e379443992b" /> |

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
