### PR TITLE
fix: discard stale mention search responses when the query has changed

### DIFF
--- a/src/lib/components/channel/MessageInput/MentionList.svelte
+++ b/src/lib/components/channel/MessageInput/MentionList.svelte
@@ -41,6 +41,7 @@
 			.sort((a, b) => a.label.localeCompare(b.label));
 
 	const getUserList = async () => {
+		const requestQuery = query;
 		const [channelMembers, searchResults] = await Promise.all([
 			channelId
 				? getChannelMembersById(localStorage.token, channelId, query, 'name', 'asc').catch(
@@ -55,6 +56,8 @@
 				return null;
 			})
 		]);
+
+		if (requestQuery !== query) return;
 
 		const memberUsers = (channelMembers?.users ?? []) as UserSuggestion[];
 		const searchedUsers = (searchResults?.users ?? []) as UserSuggestion[];


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. First-time contributors should not open pull requests directly unless the pull request contains only i18n/localization updates.
   Do not open a PR as the first step.
   For real, reproducible bugs, start with a well-described Issue that explains the problem, why it matters, and what outcome you are looking for.
   For feature requests, enhancements, behavior changes, UI/UX changes, architecture changes, suspected fixes, or unconfirmed approaches, start with an active Discussion.
   If you want to propose an implementation, include it only as a reference in the Issue or Discussion, such as a local diff, patch, or branch.
   Opening an Issue or Discussion does not mean a PR is the right next step. Maintainers will confirm when a PR would be useful.
   We ask for this because PRs, especially from first-time contributors, often need broader maintainer context on product direction, scope, architecture, UX, edge cases, compatibility, documentation, and long-term maintenance before implementation.
   We may close unsolicited PRs without review.
   Contributors with a history of successful merged PRs may be given more latitude.
3. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

**Before submitting, make sure you've checked and filled out the following:**

- [x] **Linked Issue/Discussion:** Closes #28883
- [x] **First-time contributor policy:** not my first contribution.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** **Manual** end-to-end tests have been performed to verify the fix/feature works correctly and does not introduce regressions.
- [x] **User-facing changes:** I have confirmed whether this PR changes the UI. It does not; the mention list simply stops losing entries.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

The channel mention popup can drop users that match the current query. `getUserList` in `MentionList.svelte` fires on every query change and assigns `_users` unconditionally when its responses arrive, so when the query changes while a previous search is still in flight (typing fast, or backspacing right after typing), the older query's response can land last and overwrite the list. The client side filter re-filters by the live query, which hides stale supersets, but it cannot restore users that a stale narrower response removed: type `@li`, backspace to `@l`, and if the `li` response arrives after the `l` response, a user matching `@l` silently vanishes from the popup.

**Fix.** Capture the query when the request starts and discard the response if the query has changed by the time it resolves. Three added lines, no behavior change for in-order responses.

### Fixed

- Fixed the channel mention list dropping users that match the current query when a search response for a previously typed query arrives late.

---

### Additional Information

Verified manually on top of `7229fac0c` with the deterministic reproduction from #28883 (responses for the older query delayed via a fetch wrapper so they always arrive after the newer query's responses, with the component itself unmodified apart from this fix):

1. Before the change: typing `@li` then backspacing to `@l` first shows both matching users (`Light`, `Ollama`), then collapses to `Light` only when the stale `li` response lands, while the input still reads `@l`.
2. After the change, under the same enforced response ordering: the popup keeps both users; the stale response is discarded.
3. Normal searching is unchanged: with responses arriving in order, the guard's comparison always passes and the list updates exactly as before. The `_models` and `_channels` suggestion lists are populated once from stores in `onMount` and were never part of the race.

This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
