### PR TITLE
fix: expire abandoned response stream entries in Redis

### DIFF
--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -377,6 +377,13 @@ REDIS_CLUSTER = os.getenv('REDIS_CLUSTER', 'False').lower() == 'true'
 
 REDIS_KEY_PREFIX = os.getenv('REDIS_KEY_PREFIX', 'open-webui')
 
+# TTL in seconds for in-flight response-stream state; values <= 0 disable expiry
+REDIS_RESPONSE_STREAM_TTL = os.getenv('REDIS_RESPONSE_STREAM_TTL', '3600')
+try:
+    REDIS_RESPONSE_STREAM_TTL = int(REDIS_RESPONSE_STREAM_TTL)
+except ValueError:
+    REDIS_RESPONSE_STREAM_TTL = 3600
+
 REDIS_SENTINEL_HOSTS = os.getenv('REDIS_SENTINEL_HOSTS', '')
 REDIS_SENTINEL_PORT = os.getenv('REDIS_SENTINEL_PORT', '26379')
 

--- a/backend/open_webui/tasks.py
+++ b/backend/open_webui/tasks.py
@@ -4,8 +4,9 @@ import logging
 from uuid import uuid4
 
 from redis.asyncio import Redis
+from redis.exceptions import NoPermissionError
 
-from open_webui.env import REDIS_KEY_PREFIX
+from open_webui.env import REDIS_KEY_PREFIX, REDIS_RESPONSE_STREAM_TTL
 from open_webui.utils.json_codec import JSONCodec, dumps_bytes
 
 log = logging.getLogger(__name__)
@@ -20,6 +21,8 @@ REDIS_TASKS_KEY = f'{REDIS_KEY_PREFIX}:tasks'
 REDIS_ITEM_TASKS_KEY = f'{REDIS_KEY_PREFIX}:tasks:item'
 REDIS_RESPONSE_STREAMS_KEY = f'{REDIS_KEY_PREFIX}:tasks:response_streams'
 REDIS_PUBSUB_CHANNEL = f'{REDIS_KEY_PREFIX}:tasks:commands'
+
+_hexpire_unavailable = False
 
 
 async def redis_task_command_listener(app):
@@ -152,6 +155,8 @@ async def save_response_stream(
     content: str,
     output: list,
 ):
+    global _hexpire_unavailable
+
     if not task_id or not chat_id or not message_id:
         return
 
@@ -164,6 +169,25 @@ async def save_response_stream(
 
     if redis:
         await redis.hset(REDIS_RESPONSE_STREAMS_KEY, task_id, dumps_bytes(data))
+
+        if REDIS_RESPONSE_STREAM_TTL > 0 and not _hexpire_unavailable:
+            # HSET clears a hash field's TTL, so it must be re-armed after every write
+            try:
+                await redis.hexpire(REDIS_RESPONSE_STREAMS_KEY, REDIS_RESPONSE_STREAM_TTL, task_id)
+            except Exception as e:
+                # cluster clients raise a bare RedisError for commands the server
+                # does not know, so this must catch more than ResponseError
+                message = str(e).lower()
+                if (
+                    isinstance(e, NoPermissionError)
+                    or 'unknown command' in message
+                    or "doesn't exist in redis commands" in message
+                ):
+                    _hexpire_unavailable = True
+                    log.warning(
+                        f'Response-stream snapshots will not expire, HEXPIRE unusable (needs Redis 7.4+ and ACL access): {e}'
+                    )
+                # anything else (OOM, failover, connection loss) is transient and retried on the next write
     else:
         response_streams[task_id] = data
 


### PR DESCRIPTION
In-flight response streams are persisted into one global Redis hash so reconnecting clients can restore streaming messages. The fields are only deleted when a task ends cleanly: a SIGKILLed or OOM-killed container leaks its multi-MB field forever and the hash grows without bound across restarts.

This adds REDIS_RESPONSE_STREAM_TTL (seconds, default 3600, values <= 0 disable) and re-arms a per-field TTL with HEXPIRE after every write, since HSET clears a field's TTL. Abandoned fields now expire on their own once a stream stops being written. HEXPIRE needs Redis 7.4+ and ACL access; if the first call reports the command unavailable the writer logs one warning and stops trying, leaving older Redis versions behaving exactly as before.

Fields leaked before this change carry no TTL and can be cleared once with redis-cli DEL open-webui:tasks:response_streams (adjust for REDIS_KEY_PREFIX).

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
