### PR TITLE
feat: add role filter to the {{MESSAGES}} template variable

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -2320,7 +2320,7 @@ Strictly return in JSON format:
 
 ### Chat History:
 <chat_history>
-{{MESSAGES:END:6}}
+{{MESSAGES:END:6|ROLES:user,assistant}}
 </chat_history>
 """
 

--- a/backend/open_webui/utils/task.py
+++ b/backend/open_webui/utils/task.py
@@ -156,6 +156,21 @@ def truncate_content(content: str, max_chars: int, mode: str = 'middletruncate')
         return f'{content[:half]}...{content[-(max_chars - half) :]}'
 
 
+def apply_role_filter(messages: list[dict], roles_str: str) -> list[dict]:
+    """Keep only the messages whose role is listed in roles_str.
+
+    roles_str is a comma separated list of roles, like 'user,assistant'.
+    Roles are matched case-insensitively and may also be separated by spaces.
+    An empty list leaves the messages untouched, so a typo degrades to the
+    previous behaviour instead of silently emptying the chat history.
+    """
+    roles = {role.lower() for role in re.split(r'[,\s]+', roles_str) if role}
+    if not roles:
+        return messages
+
+    return [message for message in messages if (message.get('role') or '').lower() in roles]
+
+
 def apply_content_filter(messages: list[dict], filter_str: str) -> list[dict]:
     """Apply a content filter to each message's content.
 
@@ -197,59 +212,75 @@ def apply_content_filter(messages: list[dict], filter_str: str) -> list[dict]:
 def replace_messages_variable(
     template: str, messages: Optional[list[dict]] = None, variable_name: str = 'MESSAGES'
 ) -> str:
+    """Expand a {{MESSAGES}} variable into a rendered chat history.
+
+    Supported forms, where each may carry zero or more `|filter` suffixes:
+
+        {{MESSAGES}}                    every message
+        {{MESSAGES:START:4}}            the first 4 messages
+        {{MESSAGES:END:6}}              the last 6 messages
+        {{MESSAGES:MIDDLETRUNCATE:6}}   the first and last 3 messages
+
+    Two kinds of filter may be chained in any order:
+
+        |ROLES:user,assistant           keep only these roles
+        |middletruncate:500             truncate each message's content
+        |start:200  |end:200
+
+    Role filters select *which* messages are rendered and are applied before
+    the positional selector, so `{{MESSAGES:END:6|ROLES:user}}` renders the
+    last 6 user messages rather than whatever user messages happen to sit in
+    the last 6 of the whole history.  Content filters shorten each surviving
+    message and are applied last.
+    """
+
     def replacement_function(match):
-        # Groups: (1) filter for bare MESSAGES
-        #         (2) START count, (3) filter for START
-        #         (4) END count,   (5) filter for END
-        #         (6) MIDDLE count,(7) filter for MIDDLE
-        bare_filter = match.group(1)
-        start_length = match.group(2)
-        start_filter = match.group(3)
-        end_length = match.group(4)
-        end_filter = match.group(5)
-        middle_length = match.group(6)
-        middle_filter = match.group(7)
+        selector = match.group('selector')
+        length = match.group('length')
+        filters_str = match.group('filters') or ''
 
         # If messages is None, handle it as an empty list
         if messages is None:
             return ''
 
-        # Select messages based on the variant
-        if start_length is not None:
-            selected = messages[: int(start_length)]
-            content_filter = start_filter
-        elif end_length is not None:
-            selected = messages[-int(end_length) :]
-            content_filter = end_filter
-        elif middle_length is not None:
-            mid = int(middle_length)
-            if len(messages) <= mid:
-                selected = messages
-            else:
-                half = mid // 2
-                start_msgs = messages[:half]
-                end_msgs = messages[-half:] if mid % 2 == 0 else messages[-(half + 1) :]
-                selected = start_msgs + end_msgs
-            content_filter = middle_filter
-        else:
-            # Bare {{MESSAGES}} or {{MESSAGES|filter}}
-            selected = messages
-            content_filter = bare_filter
+        filters = [f for f in filters_str.split('|') if f]
+        role_filters = [f for f in filters if f.split(':', 1)[0].lower() == 'roles']
+        content_filters = [f for f in filters if f not in role_filters]
 
-        # Apply content filter if present
-        if content_filter:
+        # Role filtering runs first so the positional selector below counts
+        # only the messages that are actually rendered.
+        selected = messages
+        for role_filter in role_filters:
+            _, _, roles_str = role_filter.partition(':')
+            selected = apply_role_filter(selected, roles_str)
+
+        selector = (selector or '').upper()
+        if selector == 'START':
+            selected = selected[: int(length)]
+        elif selector == 'END':
+            selected = selected[-int(length) :]
+        elif selector == 'MIDDLETRUNCATE':
+            mid = int(length)
+            if len(selected) > mid:
+                half = mid // 2
+                start_msgs = selected[:half]
+                end_msgs = selected[-half:] if mid % 2 == 0 else selected[-(half + 1) :]
+                selected = start_msgs + end_msgs
+
+        for content_filter in content_filters:
             selected = apply_content_filter(selected, content_filter)
 
         return get_messages_content(selected)
 
     variable_pattern = re.escape(variable_name)
+    # A filter is either ROLES:<comma separated roles> or <mode>:<int>;
+    # any number of them may be chained with '|'.
+    filter_pattern = r'(?:(?i:ROLES):[\w,\s]+|\w+:\d+)'
     template = re.sub(
-        r'(?:'
-        rf'\{{\{{{variable_pattern}(?:\|(\w+:\d+))?\}}\}}'
-        rf'|\{{\{{{variable_pattern}:START:(\d+)(?:\|(\w+:\d+))?\}}\}}'
-        rf'|\{{\{{{variable_pattern}:END:(\d+)(?:\|(\w+:\d+))?\}}\}}'
-        rf'|\{{\{{{variable_pattern}:MIDDLETRUNCATE:(\d+)(?:\|(\w+:\d+))?\}}\}}'
-        r')',
+        rf'\{{\{{{variable_pattern}'
+        rf'(?::(?P<selector>START|END|MIDDLETRUNCATE):(?P<length>\d+))?'
+        rf'(?P<filters>(?:\|{filter_pattern})*)'
+        r'\}\}',
         replacement_function,
         template,
     )


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Discussion [#28893](https://github.com/open-webui/open-webui/discussions/28893)
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** Manual tests have been performed to verify the feature works correctly and does not introduce regressions.
- [x] **No Unchecked AI Code:** This PR has undergone thorough human review AND manual testing.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new setting is introduced — the capability is added to the existing template syntax and applied to the default template.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `feat`

# Changelog Entry

### Description

The `{{MESSAGES}}` template variable can select messages **by position** (`:START:n`, `:END:n`, `:MIDDLETRUNCATE:n`) and truncate their **content** (`|middletruncate:n`, `|start:n`, `|end:n`), but it cannot select them **by role** — every selected message is rendered, `system` message included.

This PR adds an optional `|ROLES:` filter and uses it in the default query-generation template.

**Why it matters for query generation.** `generate_queries()` renders the chat history into the query-generation prompt for both retrieval (`chat_completion_files_handler`) and web search (`chat_web_search_handler`). With the default `{{MESSAGES:END:6}}`, the system prompt is included, so it is sent to the task model — potentially a different, external provider (`TASK_MODEL_EXTERNAL`) — and it steers the queries that then go to the vector store or to an external search engine.

In #25223, a similar report was answered with "you can edit the query generation prompt in the admin panel". The current syntax cannot express this particular need, though: there is no way to keep several conversation turns while excluding the system message. `{{MESSAGES:END:1}}` and `{{prompt}}` both exclude it but discard multi-turn context, which is what makes query generation useful in the first place.

**Before** — the `### Chat History:` block rendered into the query-generation prompt, for an HR assistant answering a follow-up question:

```
SYSTEM: You are ACME Corp's internal HR assistant. Always answer in a warm, informal tone
        and address the employee by their first name. Never mention or compare against
        competitors such as Globex or Initech. If a question touches on salary bands,
        redirect the employee to their manager instead of answering directly. Internal
        policy reference: HR-2024-REV3. Escalation contact: hr-escalation@acme.example.
USER: Hi! I'm planning some time off next spring.
ASSISTANT: Happy to help with that. Are you looking at the annual leave policy,
           or something more specific like parental or unpaid leave?
USER: Annual leave. How many days do I get?
ASSISTANT: That depends on your contract type and seniority. Let me check the policy.
USER: And what about part-timers?
```

**After:**

```
USER: Hi! I'm planning some time off next spring.
ASSISTANT: Happy to help with that. Are you looking at the annual leave policy,
           or something more specific like parental or unpaid leave?
USER: Annual leave. How many days do I get?
ASSISTANT: That depends on your contract type and seniority. Let me check the policy.
USER: And what about part-timers?
```

The conversation context that makes `And what about part-timers?` resolvable is kept; the persona, the internal policy reference and the escalation address are not sent to the task model.

### Added

- Optional `|ROLES:<roles>` filter for the `{{MESSAGES}}` template variable:

  ```
  {{MESSAGES:END:6|ROLES:user,assistant}}
  {{MESSAGES|ROLES:user|middletruncate:500}}
  ```

  - Roles are comma- or space-separated and matched case-insensitively; the `ROLES` keyword itself is case-insensitive.
  - Role filters chain with the existing content filters, in any order.
  - Role filtering is applied **before** the positional selector, so `{{MESSAGES:END:6|ROLES:user}}` renders the last 6 *user* messages rather than whichever user messages happen to fall inside the last 6 of the whole history.
  - An empty or unparsable role list leaves the messages untouched, so a typo degrades to the previous behaviour instead of silently emptying the chat history.

- `apply_role_filter()` in `backend/open_webui/utils/task.py`, alongside the existing `apply_content_filter()`.

The filter is available to every template that renders `{{MESSAGES}}` (title, tags, follow-up, autocomplete, and the `COMPACTED_MESSAGES` / `RECENT_MESSAGES` variables used by context compaction).

### Changed

- `DEFAULT_QUERY_GENERATION_PROMPT_TEMPLATE` now uses `{{MESSAGES:END:6|ROLES:user,assistant}}`, so retrieval and web search query generation no longer receives the system prompt out of the box. Only this default template is changed; the other defaults are untouched.
- `replace_messages_variable()` was refactored from four alternated regex branches with seven positional groups to a single pattern with named groups and a repeatable filter suffix, so that chained filters stay readable.

### Breaking Changes

None.

Templates without `|ROLES` behave exactly as before — verified byte-for-byte against the previous implementation (see Testing).

Admin-customised templates (`QUERY_GENERATION_PROMPT_TEMPLATE` / `task.query.prompt_template`) keep taking precedence and are unaffected; their authors can opt in by adding `|ROLES:user,assistant` to their `{{MESSAGES}}` variable.

---

### Additional Information

Relates to discussion [#28893](https://github.com/open-webui/open-webui/discussions/28893) (this request was opened as an issue and converted to Discussions by a maintainer).

**Note on the default template change**

On installations using the default template, the system prompt is no longer part of the context the task model reads when generating queries. That is the intent of the change, but it is worth stating explicitly for anyone who was relying on it indirectly.

The clearest example is language. The task asks for queries "in the given language", and the language is inferred from the rendered context. Today a system prompt such as *"You are a French-speaking assistant, always answer in French"* is part of that context; after this change the language is inferred from the user and assistant turns alone. In most conversations that is the same signal or a better one, since the user writes in their own language — but it can differ on a short or ambiguous opening turn.

Setups that prefer the previous behaviour can restore it by setting a custom query-generation template with a plain `{{MESSAGES:END:6}}`.

Related (all closed): #25223, #22329, #10996.

**Testing**

The repository has no Python test suite covering these helpers, so verification was done with standalone scripts exercising the extracted functions:

- **Backward compatibility (18/18):** every pre-existing form — `{{MESSAGES}}`, `:START:n`, `:END:n`, `:MIDDLETRUNCATE:n`, content filters, malformed variants left as literals, `None` messages — produces byte-identical output between the implementation on `dev` and this one.
- **New syntax (18/18 + 7/7):** role filtering alone and combined with selectors and content filters; ordering of chained filters; case-insensitivity of both the keyword and the role names; comma and space separators; empty and unknown role lists; multimodal (list) message content; messages without a `role` key.
- **Custom variable names:** `COMPACTED_MESSAGES` and `RECENT_MESSAGES` (used by `utils/context_compaction.py`) still expand correctly and remain isolated from `MESSAGES`.
- **End-to-end:** rendering the actual `DEFAULT_QUERY_GENERATION_PROMPT_TEMPLATE` from `config.py` against a conversation containing a system prompt confirms the system message is no longer rendered.
- `ruff format` reports no changes. `ruff check` reports no new findings on the touched files (13 pre-existing findings, down from 15 — the refactor removed two now-unused locals).

### Screenshots or Videos

Not applicable — backend-only change with no UI surface.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
