### PR TITLE
fix: show error icon when a tool call result contains an error

### DIFF
--- a/src/lib/components/chat/Messages/Markdown/ConsecutiveDetailsGroup.svelte
+++ b/src/lib/components/chat/Messages/Markdown/ConsecutiveDetailsGroup.svelte
@@ -12,7 +12,9 @@
 	import Sparkles from '$lib/components/icons/Sparkles.svelte';
 	import CheckCircle from '$lib/components/icons/CheckCircle.svelte';
 	import XMark from '$lib/components/icons/XMark.svelte';
+	import ErrorCircle from '$lib/components/icons/ErrorCircle.svelte';
 	import FullHeightIframe from '$lib/components/common/FullHeightIframe.svelte';
+	import { isToolResultError } from '$lib/components/common/toolCallUtils';
 
 	import { settings } from '$lib/stores';
 
@@ -21,6 +23,7 @@
 	export let id = '';
 	export let tokens: Array<{
 		summary?: string;
+		text?: string;
 		attributes?: {
 			type?: string;
 			name?: string;
@@ -68,6 +71,16 @@
 	);
 
 	$: codeInterpreterCount = tokens.filter((t) => t?.attributes?.type === 'code_interpreter').length;
+
+	// True when any completed tool call in the group returned an error payload
+	// (e.g. {"error": "403 Client Error: ..."}), so the group summary can show a
+	// warning icon instead of a success check.
+	$: hasError = tokens.some((t) => {
+		if (t?.attributes?.type !== 'tool_calls') return false;
+		if (t?.attributes?.done !== 'true') return false;
+		const text = decode(t?.text ?? '').replace(/<summary>.*?<\/summary>/gi, '').trim();
+		return isToolResultError(text);
+	});
 
 	// Collect all embeds from tool_calls tokens
 	$: allEmbeds = (() => {
@@ -156,6 +169,10 @@
 				{:else if hasRejected}
 					<div class="text-red-400 dark:text-red-500">
 						<XMark className="size-4" strokeWidth="2.5" />
+					</div>
+				{:else if toolCallCount > 0 && hasError}
+					<div class="text-red-500 dark:text-red-400">
+						<ErrorCircle className="size-4" strokeWidth="2" />
 					</div>
 				{:else if toolCallCount > 0}
 					<div class="text-emerald-500 dark:text-emerald-400">

--- a/src/lib/components/common/ToolCallDisplay.svelte
+++ b/src/lib/components/common/ToolCallDisplay.svelte
@@ -16,9 +16,11 @@
 	import WrenchSolid from '../icons/WrenchSolid.svelte';
 	import CheckCircle from '../icons/CheckCircle.svelte';
 	import XMark from '../icons/XMark.svelte';
+	import ErrorCircle from '../icons/ErrorCircle.svelte';
 	import Image from './Image.svelte';
 	import FullHeightIframe from './FullHeightIframe.svelte';
 	import { settings } from '$lib/stores';
+	import { isToolResultError } from './toolCallUtils';
 
 	export let id: string = '';
 	export let attributes: {
@@ -113,6 +115,7 @@
 
 	$: parsedArgs = parseArguments(args);
 	$: parsedResult = parseJSONString(result);
+	$: isError = isDone && isToolResultError(result);
 
 	const toggleOpen = () => {
 		open = !open;
@@ -170,6 +173,10 @@
 				{:else if isRejected}
 					<div class="text-red-400 dark:text-red-500">
 						<XMark className="size-4" strokeWidth="2.5" />
+					</div>
+				{:else if isDone && isError}
+					<div class="text-red-500 dark:text-red-400">
+						<ErrorCircle className="size-4" strokeWidth="2" />
 					</div>
 				{:else if isDone}
 					<div class="text-emerald-500 dark:text-emerald-400">

--- a/src/lib/components/common/toolCallUtils.ts
+++ b/src/lib/components/common/toolCallUtils.ts
@@ -1,0 +1,37 @@
+/**
+ * Iteratively unwrap nested JSON-encoded strings.
+ *
+ * The naive recursive form (`return parse(JSON.parse(str))`) recurses forever
+ * on scalar values such as `JSON.parse('5') -> 5`, because `JSON.parse(5)` is
+ * `JSON.parse('5')` again. Unwrapping in a `while` loop avoids that
+ * stack-overflow-and-recover path.
+ */
+export function parseToolResult(value: string | unknown): unknown {
+	let current: unknown = value;
+	while (typeof current === 'string') {
+		try {
+			current = JSON.parse(current);
+		} catch {
+			break;
+		}
+	}
+	return current;
+}
+
+/**
+ * A tool call result is considered an error when the (possibly JSON-encoded)
+ * payload is an object that carries a non-empty `error` string — the shape the
+ * Open WebUI backend uses for tool failures such as
+ * `{"error": "403 Client Error: Forbidden for url: ..."}`.
+ *
+ * Empty/null/non-string `error` fields are ignored so that normal results that
+ * happen to include an `error: null` or `error: 0` field are not misreported.
+ */
+export function isToolResultError(value: string | unknown): boolean {
+	const parsed = parseToolResult(value);
+	if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+		return false;
+	}
+	const error = (parsed as Record<string, unknown>).error;
+	return typeof error === 'string' && error.trim().length > 0;
+}

--- a/src/lib/components/icons/ErrorCircle.svelte
+++ b/src/lib/components/icons/ErrorCircle.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	export let className = 'size-4';
+	export let strokeWidth = '1.5';
+</script>
+
+<svg
+	aria-hidden="true"
+	xmlns="http://www.w3.org/2000/svg"
+	fill="none"
+	viewBox="0 0 24 24"
+	stroke-width={strokeWidth}
+	stroke="currentColor"
+	class={className}
+>
+	<path
+		stroke-linecap="round"
+		stroke-linejoin="round"
+		d="M12 9v4M12 16.992v.008M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
+	/>
+</svg>


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. First-time contributors should not open pull requests directly unless the pull request contains only i18n/localization updates.
   Do not open a PR as the first step.
   For real, reproducible bugs, start with a well-described Issue that explains the problem, why it matters, and what outcome you are looking for.
   For feature requests, enhancements, behavior changes, UI/UX changes, architecture changes, suspected fixes, or unconfirmed approaches, start with an active Discussion.
   If you want to propose an implementation, include it only as a reference in the Issue or Discussion, such as a local diff, patch, or branch.
   Opening an Issue or Discussion does not mean a PR is the right next step. Maintainers will confirm when a PR would be useful.
   We ask for this because PRs, especially from first-time contributors, often need broader maintainer context on product direction, scope, architecture, UX, edge cases, compatibility, documentation, and long-term maintenance before implementation.
   We may close unsolicited PRs without review.
   Contributors with a history of successful merged PRs may be given more latitude.
3. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Do not open a pull request as the first step.

For real, reproducible bugs, start with a well-described [Issue](https://github.com/open-webui/open-webui/issues) that explains the problem, why it matters, and what outcome you are looking for.

For feature requests, enhancements, behavior changes, UI/UX changes, architecture changes, suspected fixes, or unconfirmed approaches, start with an active [Discussion](https://github.com/open-webui/open-webui/discussions). Merely opening a discussion is not enough; it needs to be actively discussed.

If you want to propose an implementation, include it only as a reference in the Issue or Discussion, such as a local diff, patch, or branch.

Opening an Issue or Discussion does not mean a PR is the right next step. Maintainers will confirm when a PR would be useful.

We ask for this because PRs, especially from first-time contributors, often need broader maintainer context on product direction, scope, architecture, UX, edge cases, compatibility, documentation, and long-term maintenance before implementation.

Unsolicited PRs may be closed without review. Contributors with a history of successful merged PRs may be given more latitude.

**Before submitting, make sure you've checked and filled out the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing, well-described [Issue](https://github.com/open-webui/open-webui/issues) for a real bug or an active, substantive [Discussion](https://github.com/open-webui/open-webui/discussions) for a feature request or enhancement — `Closes #28016` (bug issue) · Discussion: https://github.com/open-webui/open-webui/discussions/28046
- [x] **First-time contributor policy:** This is not my first contribution to Open WebUI (#27319, #27320, #27321, #27335 merged previously), this PR contains only i18n/localization updates, or a maintainer explicitly asked me to open this PR after reviewing the linked Issue or Discussion.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs). *(No docs change needed for a UI status-icon fix.)*
- [x] **Testing:** **Manual** end-to-end tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **User-facing changes:** I have confirmed whether this PR changes the UI. If it does, screenshots are required, and a video recording is recommended. *(Screenshots attached below.)*
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes: `fix`

> Supersedes #28047 (closed by triage): the unit test file has been removed per the contribution checklist, and the branch is rebased onto current `dev` including the Aug 14–15 refactors of both touched components — no conflicts, error branch composes with the new `isRejected` XMark state (rejected > error > success precedence).

# Changelog Entry

### Description

- Tool call results that carry an error payload (e.g. `{"error": "403 Client Error: Forbidden for url: ..."}`) were always rendered with a green ✅ success check, hiding failures until the result was expanded. This renders a red error icon when a completed tool call's result is an error payload, in both the per-call row and the grouped summary.

### Added

- `ErrorCircle` icon component (mirrors the existing `CheckCircle` heroicons style).
- `toolCallUtils.ts` with `isToolResultError()` — a dependency-free helper that safely parses a (possibly JSON-encoded / double-encoded) tool result and reports an error only when it is an object with a **non-empty string** `error` field (the shape the backend uses for tool failures).

### Changed

- None outside the tool-call status icon rendering.

### Fixed

- Tool-call status icon now reflects errors: a completed call whose result is an error payload shows a red `ErrorCircle` instead of a green `CheckCircle`, both on the per-call "View Result from {name}" button (`ToolCallDisplay.svelte`) and the grouped "Explored {n} {name}" summary (`ConsecutiveDetailsGroup.svelte`). Fixes #28016.

---

### Additional Information

- Purely additive (0 deletions), 4 files / +81 lines, scoped strictly to the tool-call status icon.
- Edge case: some tools may include a string `error` field in a *successful* result. Detection is scoped to a **non-empty string** `error` to limit false positives; happy to switch to a more precise backend signal if one exists.
- No result-label text or i18n strings changed; only the icon + color reflect the error state.

### Screenshots or Videos

- Attached below: the tool-call row and grouped summary rendering before vs after for an error payload (`{"error": "403 ..."}`) and a success payload.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
