### PR TITLE
fix: preserve underline formatting when serializing rich-text to markdown

### DIFF
--- a/src/lib/components/common/RichTextInput.svelte
+++ b/src/lib/components/common/RichTextInput.svelte
@@ -118,6 +118,16 @@
 		}
 	});
 
+	// Underline has no CommonMark/GFM syntax, so without a rule Turndown's
+	// default behavior for an inline element it doesn't recognize is to drop
+	// the tag and keep only its text, silently discarding the formatting.
+	turndownService.addRule('underline', {
+		filter: 'u',
+		replacement: function (content) {
+			return `<u>${content}</u>`;
+		}
+	});
+
 	import { onMount, onDestroy, tick, getContext } from 'svelte';
 	import { createEventDispatcher } from 'svelte';
 


### PR DESCRIPTION
### Description

The Underline toolbar button (available in the chat input and Channels) lets users mark text underlined, and TipTap renders it as `<u>...</u>` while composing. On send, `RichTextInput.svelte` serializes the editor's HTML to Markdown via Turndown (`turndownService.turndown(editor.getHTML())`). Turndown has custom rules for paragraphs, GFM tables, task-list items, and mentions, but no rule for the `<u>` tag. Turndown's default behavior for an inline element without a matching rule is to drop the tag and keep only its text — so underline formatting is silently discarded on send, while bold, italic, and strikethrough (mapped via `@joplin/turndown-plugin-gfm`) survive.

Closes #26904

### Fixed

- Added a Turndown rule for `<u>` that preserves it as raw `<u>...</u>` HTML in the serialized Markdown — the standard fallback for underline, since it has no CommonMark/GFM syntax of its own. This mirrors the existing `mentions` rule a few lines below, which also emits a literal tag rather than a Markdown construct.

### Additional Information

`<u>` is a standard tag not stripped by DOMPurify's default allowlist, and `marked` (configured with `gfm: true`) passes raw inline HTML through, so the round-tripped Markdown renders underlined again on display — matching how bold/italic/strikethrough already round-trip.

Reproduced against the actual `turndown` package (not a reimplementation):

```js
const html = '<p>This is <u>underlined</u> and <strong>bold</strong> and <em>italic</em>.</p>';

// before fix
'This is underlined and **bold** and _italic_.'

// after fix
'This is <u>underlined</u> and **bold** and _italic_.'
```

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
