### PR TITLE
feat: extract text from OpenDocument files (.odt/.ods/.odp) in temporary chats

### DIFF
--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -1881,6 +1881,63 @@ export const extractContentFromFile = async (file: File) => {
 		});
 	}
 
+	// Uses jszip to pull the text out of an OpenDocument file (.odt/.ods/.odp)
+	async function extractOdfText(file: File) {
+		const [arrayBuffer, { default: JSZip }] = await Promise.all([
+			file.arrayBuffer(),
+			import('jszip')
+		]);
+
+		const content = await JSZip.loadAsync(arrayBuffer).then((zip) =>
+			zip.file('content.xml')?.async('string')
+		);
+		if (!content) {
+			throw new Error('content.xml not found');
+		}
+
+		const doc = new DOMParser().parseFromString(content, 'application/xml');
+		if (doc.getElementsByTagName('parsererror').length > 0) {
+			throw new Error('content.xml is not well-formed');
+		}
+
+		const TEXT_NS = 'urn:oasis:names:tc:opendocument:xmlns:text:1.0';
+		const TABLE_NS = 'urn:oasis:names:tc:opendocument:xmlns:table:1.0';
+
+		const textOf = (node: Element) => (node.textContent ?? '').trim();
+
+		// Spreadsheets read as rows of tab-separated cells, everything else as
+		// paragraphs and headings in document order.
+		const rows = Array.from(doc.getElementsByTagNameNS(TABLE_NS, 'table-row'));
+		if (rows.length > 0) {
+			return rows
+				.map((row) =>
+					Array.from(row.getElementsByTagNameNS(TABLE_NS, 'table-cell'))
+						.map(textOf)
+						.join('\t')
+						.trimEnd()
+				)
+				.filter((row) => row.length > 0)
+				.join('\n');
+		}
+
+		const blocks: string[] = [];
+		const walk = (node: Element) => {
+			for (const child of Array.from(node.children)) {
+				if (
+					child.namespaceURI === TEXT_NS &&
+					(child.localName === 'p' || child.localName === 'h')
+				) {
+					blocks.push(textOf(child));
+					continue;
+				}
+				walk(child);
+			}
+		};
+		walk(doc.documentElement);
+
+		return blocks.filter((block) => block.length > 0).join('\n');
+	}
+
 	async function extractDocxText(file: File) {
 		const [arrayBuffer, { default: mammoth }] = await Promise.all([
 			file.arrayBuffer(),
@@ -1904,6 +1961,14 @@ export const extractContentFromFile = async (file: File) => {
 		ext === '.docx'
 	) {
 		return await extractDocxText(file);
+	}
+
+	// OpenDocument check (LibreOffice: text, spreadsheet, presentation)
+	if (
+		type.startsWith('application/vnd.oasis.opendocument.') ||
+		['.odt', '.ods', '.odp'].includes(ext)
+	) {
+		return await extractOdfText(file);
 	}
 
 	// Text check (plain or common text-based)


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Relates to #28906 (the issue I opened was moved to Discussions by a maintainer as a missing feature rather than a bug)
- [x] **Target branch:** targets `dev`
- [x] **Description:** provided below
- [x] **Changelog:** included at the bottom
- [ ] **Documentation:** no docs change needed — this restores the behaviour the docs already imply for attachments
- [x] **Dependencies:** none added; `jszip` is already a dependency
- [x] **Testing:** manual tests described below
- [x] **No Unchecked AI Code:** human-reviewed and manually tested
- [x] **Self-Review:** done
- [x] **Architecture:** no new settings, no new state — one branch next to the existing DOCX branch

---

### Description

In a temporary chat the file is deliberately never uploaded, so the text has to
be extracted in the browser. `extractContentFromFile` covers PDF (pdf.js) and
DOCX (mammoth), then falls back to reading the raw bytes as text.

A ZIP container is "decodable as text", so that fallback silently turns an
OpenDocument file into mojibake, and the model is handed ZIP headers and the
names of the archive parts instead of the document. It answers, reasonably, that
it cannot read the file.

`.docx` has first-class support today. This adds the same for the formats the
free office suite produces — `.odt`, `.ods`, `.odp` — which is a large share of
documents for anyone working in LibreOffice.

The text of an OpenDocument file lives in `content.xml` inside the archive, and
`jszip` is already a dependency, so nothing new is pulled in:

- spreadsheets are read as rows of tab-separated cells;
- text documents and presentations as paragraphs and headings in document order.

Nothing changes on the server: in a normal chat the same file already goes
through Tika, and that path is untouched.

### Testing

Built `.odt`, `.ods` and `.odp` fixtures and ran the extraction over them:

| file | result |
|---|---|
| `.odt` | heading and both paragraphs, in document order |
| `.ods` | rows as tab-separated cells: `Item<TAB>Value`, `Example<TAB>42` |
| `.odp` | text of both slides |

Before the change all three returned ZIP headers and part names. `svelte-check`
reports no new errors in the touched file, and `prettier --check` passes.

### Changelog Entry

### Added

- **📄 OpenDocument attachments in temporary chats**: `.odt`, `.ods` and `.odp`
  files attached to a temporary chat now have their text extracted in the
  browser, the way `.docx` and `.pdf` already are, instead of reaching the model
  as raw ZIP bytes.

---

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
