### PR TITLE
fix: let the composer's model selector shrink so narrow containers keep every control visible

### DIFF
--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -2141,7 +2141,7 @@
 							</div>
 
 							<div class=" flex justify-between mt-0.5 mb-2 mx-0.5 max-w-full" dir="ltr">
-								<div class="ml-1 self-end flex items-center flex-1 min-w-0">
+								<div class="ml-1 self-end flex items-center shrink-0">
 									<InputMenu
 										bind:files
 										selectedModels={selectedModelIds}
@@ -2476,7 +2476,7 @@
 									</div>
 								</div>
 
-								<div class="self-end flex space-x-1 mr-1 shrink-0 gap-[0.03125rem]">
+								<div class="self-end flex space-x-1 mr-1 min-w-0 gap-[0.03125rem]">
 									<div class="flex min-w-0 max-w-[10rem] items-center sm:max-w-[13rem]">
 										<ModelSelector
 											bind:this={modelSelector}


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. First-time contributors should not open pull requests directly unless the pull request contains only i18n/localization updates.
   Do not open a PR as the first step.
   For real, reproducible bugs, start with a well-described Issue that explains the problem, why it matters, and what outcome you are looking for.
   For feature requests, enhancements, behavior changes, UI/UX changes, architecture changes, suspected fixes, or unconfirmed approaches, start with an active Discussion.
   If you want to propose an implementation, include it only as a reference in the Issue or Discussion, such as a local diff, patch, or branch.
   Opening an Issue or Discussion does not mean a PR is the right next step. Maintainers will confirm when a PR would be useful.
   We ask for this because PRs, especially from first-time contributors, often need broader maintainer context on product direction, scope, architecture, UX, edge cases, compatibility, documentation, and long-term maintenance before implementation.
   We may close unsolicited PRs without review.
   Contributors with a history of successful merged PRs may be given more latitude.
3. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

**Before submitting, make sure you've checked and filled out the following:**

- [x] **Linked Issue/Discussion:** Closes #28911
- [x] **First-time contributor policy:** not my first contribution.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** **Manual** end-to-end tests have been performed to verify the fix/feature works correctly and does not introduce regressions.
- [x] **User-facing changes:** I have confirmed whether this PR changes the UI. It restores the intended composer layout in narrow containers; wide and mobile layouts are unchanged.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

When a note's `Chat` panel is resized toward its 350px minimum, the composer's bottom row breaks: the model selector renders on top of the `+` and `Integrations` buttons, hiding them, and the send button is pushed outside the rounded input container. The same happens anywhere the composer gets a narrow container while the viewport stays wide, such as the main chat squeezed by a wide `Controls` panel.

**Root cause.** The bottom row is `flex justify-between` with mismatched sides: the left button group is `flex-1 min-w-0`, so under pressure it collapses toward zero while its buttons overflow it, and the right group (model selector, voice, send) is `shrink-0`, so it never shrinks below the selector's width cap plus the two buttons. In a container narrower than the right group, the right group overlays the collapsed left buttons (it paints on top as the later sibling) and overflows the container on the right. The selector's `sm:max-w-[13rem]` cap keys on the viewport, so a 350px panel inside a desktop window still gets the wide cap, and the rem based cap grows further with `UI Scale`.

**Fix.** Swap which side gives way: the left group keeps its intrinsic width (`flex-1 min-w-0` to `shrink-0`) and the right group becomes shrinkable (`shrink-0` to `min-w-0`), which the model selector already supports since its wrapper carries `min-w-0` and its label truncates. `justify-between` still spreads the two groups at full width.

### Fixed

- Fixed the chat composer's bottom row in narrow containers, such as a note's resized chat panel, where the model selector covered the `+` and `Integrations` buttons and the send button overflowed the input container.

---

### Additional Information

Verified manually on top of `7229fac0c`, measuring element bounding boxes rather than eyeballing:

1. Before, at the note chat panel's 350px minimum: the model selector (250px at 1.25x `UI Scale`) started at the same x coordinate as the `+` button, fully covering both left buttons, and the send button's right edge sat 15px past the container's right edge.
2. After, same panel width: zero overlapping controls, all five laid out left to right, the selector's label truncated (111px), and the send button inside the container.
3. Wide desktop chat after the change: unchanged, with the left buttons at the left edge, the selector at its full width cap, and no overlaps.
4. 375px mobile viewport after the change: clean, with the selector truncated to fit and the send button inside the container.

This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Screenshots or Videos

Before is current `dev`, after is this branch, both with a note's chat panel at its minimum width.

| Surface | Before | After |
|---|---|---|
| Note chat panel composer at minimum panel width | <img width="631" height="1280" alt="image" src="https://github.com/user-attachments/assets/91d78dd3-bc50-48c7-a235-014f2897d470" /> | <img width="631" height="1280" alt="image" src="https://github.com/user-attachments/assets/2be9b568-7566-4d72-9bb3-b0139d4c3c16" /> |

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
