### PR TITLE
fix: stop failed uploads from wedging the chat message queue

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -2461,9 +2461,7 @@
 		const lastMessage = history.currentId ? history.messages[history.currentId] : null;
 		if (
 			(lastMessage && lastMessage.role === 'assistant' && !lastMessage.done) ||
-			queue.some((m) =>
-				(m.files ?? []).some((file) => ['uploading', 'error'].includes(file.status))
-			)
+			queue.some((m) => (m.files ?? []).some((file) => file.status === 'uploading'))
 		) {
 			return;
 		}
@@ -2495,7 +2493,7 @@
 	const sendQueuedMessageNow = async (id) => {
 		const queue = $chatRequestQueues[$chatId] ?? [];
 		const item = queue.find((m) => m.id === id);
-		if (!item || (item.files ?? []).some((file) => ['uploading', 'error'].includes(file.status))) {
+		if (!item || (item.files ?? []).some((file) => file.status === 'uploading')) {
 			return;
 		}
 
@@ -2527,6 +2525,9 @@
 			...q,
 			[$chatId]: queue.filter((m) => m.id !== id)
 		}));
+		// Restart queue processing: removing a stuck message (e.g. one with a failed
+		// upload) must let the remaining queued messages through.
+		processNextInQueue($chatId);
 	};
 
 	const chatCompletedHandler = async (_chatId, modelId, responseMessageId, messages) => {
@@ -3132,11 +3133,13 @@
 			return;
 		}
 
+		// Only queue behind genuinely in-flight uploads. A file stuck in 'error'
+		// will never finish uploading, so it must not hold new messages hostage.
 		if (
 			($chatRequestQueues[$chatId] ?? []).some((m) =>
-				(m.files ?? []).some((file) => ['uploading', 'error'].includes(file.status))
+				(m.files ?? []).some((file) => file.status === 'uploading')
 			) ||
-			(files.length > 0 && files.some((file) => ['uploading', 'error'].includes(file.status)))
+			(files.length > 0 && files.some((file) => file.status === 'uploading'))
 		) {
 			chatRequestQueues.update((q) => ({
 				...q,

--- a/src/lib/components/chat/MessageInput/QueuedMessageItem.svelte
+++ b/src/lib/components/chat/MessageInput/QueuedMessageItem.svelte
@@ -79,28 +79,33 @@
 
 	<!-- Actions -->
 	<div class="flex items-center gap-1 shrink-0">
-		<!-- Send immediately -->
+		<!-- Send immediately (allowed once uploads have settled; a failed upload is not
+			coming back, so the message can still be sent without it) -->
 		<Tooltip
-			content={files.some((file) => ['uploading', 'error'].includes(file.status))
+			content={files.some((file) => file.status === 'uploading')
 				? $i18n.t('Waiting for upload')
-				: $i18n.t('Send now')}
+				: files.some((file) => file.status === 'error')
+					? $i18n.t('Upload failed')
+					: $i18n.t('Send now')}
 		>
 			<button
 				type="button"
-				class="p-1 text-gray-400 transition-colors {files.some((file) =>
-					['uploading', 'error'].includes(file.status)
+				class="p-1 text-gray-400 transition-colors {files.some(
+					(file) => file.status === 'uploading'
 				)
 					? 'opacity-40 cursor-not-allowed'
 					: 'hover:text-gray-700 dark:text-gray-500 dark:hover:text-gray-300'}"
-				disabled={files.some((file) => ['uploading', 'error'].includes(file.status))}
+				disabled={files.some((file) => file.status === 'uploading')}
 				on:click={() => {
-					if (!files.some((file) => ['uploading', 'error'].includes(file.status))) {
+					if (!files.some((file) => file.status === 'uploading')) {
 						onSendNow(id);
 					}
 				}}
-				aria-label={files.some((file) => ['uploading', 'error'].includes(file.status))
+				aria-label={files.some((file) => file.status === 'uploading')
 					? $i18n.t('Waiting for upload')
-					: $i18n.t('Send now')}
+					: files.some((file) => file.status === 'error')
+						? $i18n.t('Upload failed')
+						: $i18n.t('Send now')}
 			>
 				<svg
 					xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. First-time contributors should not open pull requests directly unless the pull request contains only i18n/localization updates.
   Do not open a PR as the first step.
   For real, reproducible bugs, start with a well-described Issue that explains the problem, why it matters, and what outcome you are looking for.
   For feature requests, enhancements, behavior changes, UI/UX changes, architecture changes, suspected fixes, or unconfirmed approaches, start with an active Discussion.
   If you want to propose an implementation, include it only as a reference in the Issue or Discussion, such as a local diff, patch, or branch.
   Opening an Issue or Discussion does not mean a PR is the right next step. Maintainers will confirm when a PR would be useful.
   We ask for this because PRs, especially from first-time contributors, often need broader maintainer context on product direction, scope, architecture, UX, edge cases, compatibility, documentation, and long-term maintenance before implementation.
   We may close unsolicited PRs without review.
   Contributors with a history of successful merged PRs may be given more latitude.
3. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

### Do not open a pull request as the first step.

For real, reproducible bugs, start with a well-described [Issue](https://github.com/open-webui/open-webui/issues) that explains the problem, why it matters, and what outcome you are looking for.

For feature requests, enhancements, behavior changes, UI/UX changes, architecture changes, suspected fixes, or unconfirmed approaches, start with an active [Discussion](https://github.com/open-webui/open-webui/discussions). Merely opening a discussion is not enough; it needs to be actively discussed.

If you want to propose an implementation, include it only as a reference in the Issue or Discussion, such as a local diff, patch, or branch.

Opening an Issue or Discussion does not mean a PR is the right next step. Maintainers will confirm when a PR would be useful.

We ask for this because PRs, especially from first-time contributors, often need broader maintainer context on product direction, scope, architecture, UX, edge cases, compatibility, documentation, and long-term maintenance before implementation.

Unsolicited PRs may be closed without review. Contributors with a history of successful merged PRs may be given more latitude.

<!--
### ⚠️ Important: Your PR is a contribution, not a guarantee of merge.

We appreciate thoughtful contributions. Pull requests are for implementation-ready changes that have already been requested, confirmed, or actively discussed in a linked Issue or Discussion. Feature ideas, behavior changes, UI/UX changes, architecture changes, suspected fixes, and unconfirmed approaches should start as an Issue or Discussion instead.

Before opening a PR, make sure the change has a clear linked problem, follows nearby patterns, has been manually tested, and accounts for related or downstream behavior. PRs that are ideas, prototypes, unresolved design questions, unchecked AI-generated code, symptom-only patches, one-off patches, or changes where affected paths have not been checked will usually be closed.

The most impactful way to contribute to Open WebUI is through well-written bug reports, detailed feature discussions, and thoughtful ideas. These directly shape the project. If you do open a pull request, please know that Open WebUI is held to the highest standard of code quality, consistency, and architectural coherence, and every line merged becomes something the core team must own, maintain, and support indefinitely. Submitted code may be refactored, rewritten, or used as inspiration for a different implementation. This is not a reflection of your work's quality. It is how we ensure that a small team can deeply understand and evolve every part of the codebase.
-->

**Before submitting, make sure you've checked and filled out the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing, well-described [Issue](https://github.com/open-webui/open-webui/issues) for a real bug or an active, substantive [Discussion](https://github.com/open-webui/open-webui/discussions) for a feature request or enhancement — `Closes #28880`.
- [x] **First-time contributor policy:** This is not my first contribution to Open WebUI, this PR contains only i18n/localization updates, or a maintainer explicitly asked me to open this PR after reviewing the linked Issue or Discussion. (Previously merged PRs: #27319, #27320, #27321, #27335.)
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented. (No new or updated dependencies.)
- [x] **Testing:** **Manual** end-to-end tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **User-facing changes:** I have confirmed whether this PR changes the UI. If it does, screenshots are required, and a video recording is recommended.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **BREAKING CHANGE**: Changes affecting backward compatibility
  - **build**: Build system or dependency changes
  - **ci**: CI/CD workflow changes
  - **chore**: Refactoring, cleanup, or non-functional changes
  - **docs**: Documentation additions or updates
  - **feat**: New features or enhancements
  - **fix**: Bug fixes or corrections
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvements
  - **refactor**: Code restructuring

# Changelog Entry

### Description

- A single failed attachment upload used to wedge the chat's entire message queue: the failed message could never send, every later message was force-queued behind it, and even deleting the stuck message did not restart the queue. Queue gating now distinguishes in-flight uploads from settled failures so a failed upload can no longer hold messages hostage.

### Added

- None.

### Changed

- "Send now" on a queued message is enabled once uploads have settled; if a file failed, its tooltip reads "Upload failed" instead of "Waiting for upload".
- Deleting a queued message now restarts queue processing so remaining messages flush immediately.

### Deprecated

- None.

### Removed

- None.

### Fixed

- Failed attachment uploads no longer wedge the chat message queue (#28880): queue processing, force-queuing, and "Send now" hold only while uploads are genuinely in flight; deleting a queued message flushes the rest of the queue.

### Security

- None.

### Breaking Changes

- **BREAKING CHANGE**: None.

---

### Additional Information

- Reproduction and diagnosis follow issue #28880; all four cited code sites still matched `dev` head when I verified before changing anything.
- Frontend-only change (queue gating in `Chat.svelte`, send-now affordance in `QueuedMessageItem.svelte`); no backend, API, or dependency changes.
- Manually walked the issue's reproduction steps end to end against the fix: queued message with failing URL attachment, subsequent plain-text send while wedged, send-now after failure, delete-flush path, and the normal uploading flow to confirm unchanged behavior.

### Screenshots or Videos

- Screenshots attached below (before/after states from the reproduction in the issue).

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
