### PR TITLE
feat: add custom roles and scoped group manager workspace

### DIFF
--- a/backend/open_webui/constants.py
+++ b/backend/open_webui/constants.py
@@ -131,6 +131,16 @@ class ERROR_MESSAGES(str, Enum):
     REQUIRED_FIELD_EMPTY = lambda name='': f'Required field {name} is empty'
     OAUTH_NOT_CONFIGURED = lambda name='': f"Provider '{name}' is not configured"
 
+    # Custom role errors
+    CUSTOM_ROLE_NAME_TAKEN = lambda name='': f"A custom role named '{name}' already exists."
+    CUSTOM_ROLE_NOT_FOUND = 'The requested custom role was not found.'
+    CUSTOM_ROLE_RESERVED_NAME = lambda name='': f"'{name}' is a reserved role name."
+    CUSTOM_ROLE_INACTIVE = 'The custom role is no longer active.'
+    CUSTOM_ROLE_ASSIGN_FAILED = 'Failed to assign the custom role to the user.'
+    CUSTOM_ROLE_UNASSIGN_FAILED = 'Failed to remove the custom role from the user.'
+    CUSTOM_ROLE_CANNOT_ASSIGN_RESERVED = 'Cannot assign a reserved role via the custom role API.'
+    CUSTOM_ROLE_INVALID_REFERENCE = 'The role reference is not a valid custom role.'
+
 
 class TASKS(str, Enum):
     def __str__(self) -> str:

--- a/backend/open_webui/events.py
+++ b/backend/open_webui/events.py
@@ -129,6 +129,22 @@ class EventDefinitions(BaseModel):
     USER_ROLE_UPDATED: EventDefinition = EventDefinition(
         name='user.role_updated', description='A user role was updated.', message='User role updated'
     )
+    CUSTOM_ROLE_CREATED: EventDefinition = EventDefinition(
+        name='custom_role.created', description='A custom role was created.', message='Custom role created'
+    )
+    CUSTOM_ROLE_UPDATED: EventDefinition = EventDefinition(
+        name='custom_role.updated', description='A custom role was updated.', message='Custom role updated'
+    )
+    CUSTOM_ROLE_DEACTIVATED: EventDefinition = EventDefinition(
+        name='custom_role.deactivated',
+        description='A custom role was deactivated.',
+        message='Custom role deactivated',
+    )
+    CUSTOM_ROLE_ASSIGNED: EventDefinition = EventDefinition(
+        name='custom_role.assigned',
+        description='A custom role was assigned to a user.',
+        message='Custom role assigned',
+    )
     USER_STATUS_UPDATED: EventDefinition = EventDefinition(
         name='user.status_updated', description='A user status was updated.', message='User status updated'
     )
@@ -530,6 +546,9 @@ class EventDefinitions(BaseModel):
     )
     SKILL_DISABLED: EventDefinition = EventDefinition(
         name='skill.disabled', description='A skill was disabled.', message='Skill disabled'
+    )
+    SKILL_ACCESS_UPDATED: EventDefinition = EventDefinition(
+        name='skill.access_updated', description='Skill access was updated.', message='Skill access updated'
     )
     PROMPT_CREATED: EventDefinition = EventDefinition(
         name='prompt.created', description='A prompt was created.', message='Prompt created'

--- a/backend/open_webui/events.py
+++ b/backend/open_webui/events.py
@@ -8,9 +8,10 @@ import uuid
 from types import SimpleNamespace
 from typing import Any
 
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
 from open_webui.env import ENABLE_PLUGINS, VERSION
 from open_webui.models.config import Config
-from pydantic import BaseModel, ConfigDict, Field, model_validator
 from open_webui.retrieval.web.utils import validate_url
 from open_webui.utils.webhook import post_webhook
 
@@ -30,7 +31,7 @@ class EventDefinition(BaseModel):
     message: str | None = None
 
     @model_validator(mode='after')
-    def defaults(self) -> 'EventDefinition':
+    def defaults(self) -> EventDefinition:
         title = self.name.replace('.', ' ').replace('_', ' ').title()
         if self.description is None:
             object.__setattr__(self, 'description', f'{title}.')
@@ -139,6 +140,11 @@ class EventDefinitions(BaseModel):
         name='custom_role.deactivated',
         description='A custom role was deactivated.',
         message='Custom role deactivated',
+    )
+    CUSTOM_ROLE_DELETED: EventDefinition = EventDefinition(
+        name='custom_role.deleted',
+        description='A custom role was deleted.',
+        message='Custom role deleted',
     )
     CUSTOM_ROLE_ASSIGNED: EventDefinition = EventDefinition(
         name='custom_role.assigned',
@@ -796,7 +802,7 @@ def event_filter_matches(webhook: dict[str, Any], event_name: str) -> bool:
     return False
 
 
-def event_user_ids(event: 'Event') -> set[str]:
+def event_user_ids(event: Event) -> set[str]:
     user_ids = set()
     actor = event.actor or {}
     subject = event.subject or {}
@@ -847,7 +853,7 @@ async def event_target_matches(
     return any(group_ids.intersection(target_group_ids) for group_ids in user_group_ids.values())
 
 
-async def event_webhook_matches(webhook: dict[str, Any], event: 'Event') -> bool:
+async def event_webhook_matches(webhook: dict[str, Any], event: Event) -> bool:
     if not event_filter_matches(webhook, event.event):
         return False
 

--- a/backend/open_webui/internal/db.py
+++ b/backend/open_webui/internal/db.py
@@ -313,6 +313,10 @@ elif 'sqlite' in SQLALCHEMY_DATABASE_URL:
         else:
             cursor.execute('PRAGMA journal_mode=DELETE')
 
+        # Enable foreign key enforcement — required for RESTRICT/CASCADE
+        # FK actions on group_owned_asset and group_member.
+        cursor.execute('PRAGMA foreign_keys=ON')
+
         # Each PRAGMA is skipped when its env var is empty, allowing opt-out.
         if DATABASE_SQLITE_PRAGMA_SYNCHRONOUS:
             cursor.execute(f'PRAGMA synchronous={DATABASE_SQLITE_PRAGMA_SYNCHRONOUS}')

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -149,10 +149,12 @@ from open_webui.routers import (
     channels,
     chats,
     configs,
+    custom_roles,
     evaluations,
     files,
     folders,
     functions,
+    group_manager,
     groups,
     images,
     knowledge,
@@ -830,6 +832,7 @@ app.include_router(configs.router, prefix='/api/v1/configs', tags=['configs'])
 
 app.include_router(auths.router, prefix='/api/v1/auths', tags=['auths'])
 app.include_router(users.router, prefix='/api/v1/users', tags=['users'])
+app.include_router(custom_roles.router, prefix='/api/v1/custom-roles', tags=['custom-roles'])
 
 
 app.include_router(channels.router, prefix='/api/v1/channels', tags=['channels'])
@@ -847,6 +850,7 @@ app.include_router(skills.router, prefix='/api/v1/skills', tags=['skills'])
 app.include_router(memories.router, prefix='/api/v1/memories', tags=['memories'])
 app.include_router(folders.router, prefix='/api/v1/folders', tags=['folders'])
 app.include_router(groups.router, prefix='/api/v1/groups', tags=['groups'])
+app.include_router(group_manager.router, prefix='/api/v1/group-manager', tags=['group-manager'])
 app.include_router(files.router, prefix='/api/v1/files', tags=['files'])
 app.include_router(functions.router, prefix='/api/v1/functions', tags=['functions'])
 app.include_router(evaluations.router, prefix='/api/v1/evaluations', tags=['evaluations'])

--- a/backend/open_webui/migrations/versions/a2b3c4d5e6f7_extend_owned_asset_type_for_skill.py
+++ b/backend/open_webui/migrations/versions/a2b3c4d5e6f7_extend_owned_asset_type_for_skill.py
@@ -1,0 +1,65 @@
+"""Extend group_owned_asset CheckConstraint to include 'skill'
+
+Revision ID: a2b3c4d5e6f7
+Revises: fdcb6cc75284
+Create Date: 2026-08-21 00:01:00.000000
+
+Phase 3 (skills-only slice): extends the portable type allowlist on
+``group_owned_asset`` so that ``resource_type='skill'`` is accepted.
+
+For SQLite this is implemented as batch table recreation (SQLite does not
+support ALTER CHECK CONSTRAINT).  For PostgreSQL the old constraint is
+dropped and a new one is created.
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = 'a2b3c4d5e6f7'
+down_revision: str | None = 'fdcb6cc75284'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_NEW_CHECK = "resource_type IN ('knowledge', 'prompt', 'skill')"
+_OLD_CHECK_NAME = 'ck_group_owned_asset_type'
+
+
+def upgrade() -> None:
+    dialect = op.get_bind().dialect.name
+    if dialect == 'sqlite':
+        # SQLite: batch-recreate the table with the new constraint.
+        with op.batch_alter_table('group_owned_asset') as batch_op:
+            batch_op.drop_constraint(_OLD_CHECK_NAME, type_='check')
+            batch_op.create_check_constraint(
+                _OLD_CHECK_NAME,
+                _NEW_CHECK,
+            )
+    else:
+        # PostgreSQL (and other dialects): drop + create.
+        op.drop_constraint(_OLD_CHECK_NAME, 'group_owned_asset', type_='check')
+        op.create_check_constraint(
+            _OLD_CHECK_NAME,
+            'group_owned_asset',
+            _NEW_CHECK,
+        )
+
+
+def downgrade() -> None:
+    dialect = op.get_bind().dialect.name
+    _OLD_CHECK = "resource_type IN ('knowledge', 'prompt')"
+    if dialect == 'sqlite':
+        with op.batch_alter_table('group_owned_asset') as batch_op:
+            batch_op.drop_constraint(_OLD_CHECK_NAME, type_='check')
+            batch_op.create_check_constraint(
+                _OLD_CHECK_NAME,
+                _OLD_CHECK,
+            )
+    else:
+        op.drop_constraint(_OLD_CHECK_NAME, 'group_owned_asset', type_='check')
+        op.create_check_constraint(
+            _OLD_CHECK_NAME,
+            'group_owned_asset',
+            _OLD_CHECK,
+        )

--- a/backend/open_webui/migrations/versions/c5a8d3e2f1b0_add_custom_role_table.py
+++ b/backend/open_webui/migrations/versions/c5a8d3e2f1b0_add_custom_role_table.py
@@ -1,0 +1,61 @@
+"""Add custom_role table
+
+Revision ID: c5a8d3e2f1b0
+Revises: 6d09d1bf1f23
+Create Date: 2026-08-21 00:00:00.000000
+
+Phase 1 of custom-role foundation: creates the registry table that backs
+opaque ``custom:<uuid>`` references stored in the existing ``User.role`` column.
+
+Invariants enforced at the application layer (not DB CHECK constraints):
+- Reserved role names (admin, user, pending) cannot be inserted.
+- Role names are stored normalized (lowercased, trimmed).
+- Role IDs are immutable UUID4 primary keys.
+- Permission documents are validated against a fixed server-owned catalog
+  and normalised to a canonical full boolean tree (omissions are False).
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from open_webui.migrations.util import get_existing_tables
+
+# revision identifiers, used by Alembic.
+revision: str = 'c5a8d3e2f1b0'
+down_revision: Union[str, None] = '6d09d1bf1f23'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    existing_tables = get_existing_tables()
+
+    if 'custom_role' not in existing_tables:
+        op.create_table(
+            'custom_role',
+            sa.Column('id', sa.Text(), nullable=False, primary_key=True),
+            sa.Column('name', sa.Text(), nullable=False, unique=True),
+            sa.Column('display_name', sa.Text(), nullable=False),
+            sa.Column('active', sa.Boolean(), nullable=False, server_default=sa.text('1')),
+            # permissions: JSON tree validated against the server-owned
+            # _PERMISSION_CATALOG.  Stored as TEXT via JSONField for
+            # SQLite/Postgres portability.  Application validation
+            # normalises omissions to False (fail-closed).
+            sa.Column('permissions', sa.Text(), nullable=False, server_default='{}'),
+            sa.Column('created_at', sa.BigInteger(), nullable=False),
+            sa.Column('updated_at', sa.BigInteger(), nullable=False),
+        )
+        op.create_index(
+            'ix_custom_role_name',
+            'custom_role',
+            ['name'],
+            unique=True,
+        )
+
+
+def downgrade() -> None:
+    existing_tables = get_existing_tables()
+    if 'custom_role' in existing_tables:
+        op.drop_index('ix_custom_role_name', table_name='custom_role')
+        op.drop_table('custom_role')

--- a/backend/open_webui/migrations/versions/fdcb6cc75284_add_group_owned_asset_and_group_member_uniqueness.py
+++ b/backend/open_webui/migrations/versions/fdcb6cc75284_add_group_owned_asset_and_group_member_uniqueness.py
@@ -1,0 +1,70 @@
+"""Add group_owned_asset table
+
+Revision ID: fdcb6cc75284
+Revises: c5a8d3e2f1b0
+Create Date: 2026-08-21 00:00:00.000000
+
+Phase 2 of custom-role foundation: adds the group-owned-asset table that
+tracks exactly one owning group per (resource_type, resource_id).
+
+The historical migration ``37f288994c47`` (add_group_member_table) already
+creates the ``group_member`` table with the ``uq_group_member_group_user``
+unique constraint.  This migration does NOT create, drop, or modify that
+constraint — it only introduces ``group_owned_asset``.
+
+Changes:
+1. group_owned_asset: new table with unique (resource_type, resource_id),
+   index on group_id, CheckConstraint for supported types, and
+   RESTRICT on group deletion (no cascade).
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = 'fdcb6cc75284'
+down_revision: str | None = 'c5a8d3e2f1b0'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # ── group_owned_asset: new table ────────────────────────────────────
+    op.create_table(
+        'group_owned_asset',
+        sa.Column('id', sa.Text(), nullable=False, primary_key=True),
+        sa.Column('resource_type', sa.Text(), nullable=False),
+        sa.Column('resource_id', sa.Text(), nullable=False),
+        sa.Column(
+            'group_id',
+            sa.Text(),
+            sa.ForeignKey('group.id', ondelete='RESTRICT'),
+            nullable=False,
+        ),
+        sa.Column('created_by', sa.Text(), nullable=False),
+        sa.Column('created_at', sa.BigInteger(), nullable=False),
+        sa.Column('updated_at', sa.BigInteger(), nullable=False),
+        # Exactly one owner per (resource_type, resource_id)
+        sa.UniqueConstraint(
+            'resource_type',
+            'resource_id',
+            name='uq_group_owned_asset_resource',
+        ),
+        # Portable type allowlist enforced at DB level
+        sa.CheckConstraint(
+            "resource_type IN ('knowledge', 'prompt')",
+            name='ck_group_owned_asset_type',
+        ),
+    )
+    op.create_index(
+        'ix_group_owned_asset_group_id',
+        'group_owned_asset',
+        ['group_id'],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index('ix_group_owned_asset_group_id', table_name='group_owned_asset')
+    op.drop_table('group_owned_asset')

--- a/backend/open_webui/models/custom_roles.py
+++ b/backend/open_webui/models/custom_roles.py
@@ -1,0 +1,600 @@
+"""Custom role registry model, schemas, and database access layer.
+
+Custom roles are stored as opaque ``custom:<uuid>`` references in the existing
+``User.role`` column.  The registry provides the backing definition that maps
+each opaque reference to a normalized name, display name, active flag, and
+explicit permission set.
+
+Invariants enforced here:
+- Reserved role strings ``admin``, ``user``, ``pending`` may never be used as
+  custom role names.
+- Role IDs are immutable UUIDs generated at creation time.
+- Role names are stored normalized (lowercased, stripped) and uniqueness is
+  enforced.
+- Permission documents are validated against a fixed server-owned catalog
+  and normalized to a canonical full boolean tree (omissions are False).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import time
+import uuid
+from typing import Any
+
+from open_webui.internal.db import Base, JSONField, get_async_db_context
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from sqlalchemy import BigInteger, Boolean, Column, Index, Text, func, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+RESERVED_ROLE_NAMES: frozenset[str] = frozenset({'admin', 'user', 'pending'})
+
+_CUSTOM_ROLE_PREFIX = 'custom:'
+_CUSTOM_UUID_LENGTH = 36  # standard UUID4 length
+
+
+# ---------------------------------------------------------------------------
+# Server-owned permission catalog
+# ---------------------------------------------------------------------------
+# This is the SINGLE source of truth for the shape of a custom-role
+# permission document.  All boolean leaves default to False (deny).
+# Input validation rejects unknown keys; normalisation fills omissions
+# with False.  This catalog does NOT derive from caller-supplied or
+# configured defaults — it is fixed at import time.
+# ---------------------------------------------------------------------------
+
+_PERMISSION_CATALOG: dict[str, Any] = {
+    'workspace': {
+        'models': False,
+        'knowledge': False,
+        'prompts': False,
+        'tools': False,
+        'skills': False,
+        'models_import': False,
+        'models_export': False,
+        'prompts_import': False,
+        'prompts_export': False,
+        'tools_import': False,
+        'tools_export': False,
+        'skills_import': False,
+        'skills_export': False,
+    },
+    'sharing': {
+        'models': False,
+        'public_models': False,
+        'knowledge': False,
+        'public_knowledge': False,
+        'prompts': False,
+        'public_prompts': False,
+        'tools': False,
+        'public_tools': False,
+        'skills': False,
+        'public_skills': False,
+        'notes': False,
+        'public_notes': False,
+        'folders': False,
+        'public_chats': False,
+        'open_chats': False,
+        'public_calendars': False,
+    },
+    'access_grants': {
+        'allow_users': False,
+        'allow_groups': False,
+    },
+    'chat': {
+        'controls': False,
+        'valves': False,
+        'system_prompt': False,
+        'params': False,
+        'file_upload': False,
+        'web_upload': False,
+        'delete': False,
+        'delete_message': False,
+        'continue_response': False,
+        'regenerate_response': False,
+        'rate_response': False,
+        'edit': False,
+        'share': False,
+        'export': False,
+        'import': False,
+        'stt': False,
+        'tts': False,
+        'call': False,
+        'multiple_models': False,
+        'temporary': False,
+        'temporary_enforced': False,
+    },
+    'features': {
+        'api_keys': False,
+        'notes': False,
+        'folders': False,
+        'channels': False,
+        'direct_tool_servers': False,
+        'web_search': False,
+        'image_generation': False,
+        'code_interpreter': False,
+        'memories': False,
+        'automations': False,
+        'calendar': False,
+        'webhooks': False,
+    },
+    'settings': {
+        'interface': False,
+    },
+    'groups': {
+        'manage_members': False,
+        'manage_assets': False,
+        'manage_skills': False,
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Permission validation & normalisation
+# ---------------------------------------------------------------------------
+
+
+def _deep_merge(target: dict, source: dict) -> dict:
+    """Recursively merge *source* into *target* (in-place) and return *target*.
+
+    Leaf values in *source* always override the corresponding leaf in
+    *target* so that an explicit ``True`` grant replaces the catalog
+    default of ``False``.
+    """
+    for key, src_val in source.items():
+        if key not in target:
+            target[key] = src_val
+        elif isinstance(src_val, dict) and isinstance(target[key], dict):
+            _deep_merge(target[key], src_val)
+        else:
+            target[key] = src_val
+    return target
+
+
+def validate_permissions(doc: Any) -> dict[str, Any]:
+    """Validate a raw permission document against the server-owned catalog.
+
+    Rules:
+    - *doc* must be a ``dict`` (not ``None``, not a list, not a scalar).
+    - Intermediate nodes must be dicts.
+    - All leaf values must be booleans (``True`` / ``False``).
+    - No unknown top-level or nested keys are permitted.
+
+    Raises ``ValueError`` on any violation.
+    """
+    if not isinstance(doc, dict):
+        raise ValueError('Permissions must be a dictionary, not None or another type.')
+
+    def _check(d: dict, catalog: dict, path: str = '') -> None:
+        for key, value in d.items():
+            full = f'{path}.{key}' if path else key
+            if key not in catalog:
+                raise ValueError(f'Unknown permission key: {full}')
+            cat_val = catalog[key]
+            if isinstance(cat_val, dict):
+                if not isinstance(value, dict):
+                    raise ValueError(
+                        f'Permission {full} must be a dict, got {type(value).__name__}.'
+                    )
+                _check(value, cat_val, full)
+            else:
+                if not isinstance(value, bool):
+                    raise ValueError(
+                        f'Permission {full} must be a boolean, got {type(value).__name__}.'
+                    )
+
+    _check(doc, _PERMISSION_CATALOG)
+    return doc
+
+
+def normalize_permissions(doc: dict[str, Any] | None) -> dict[str, Any]:
+    """Normalise a validated permission document to the full canonical tree.
+
+    Returns a deep copy of ``_PERMISSION_CATALOG`` with overridden leaves
+    from *doc*.  Missing leaves are ``False`` (fail-closed).  If *doc* is
+    ``None`` or ``{}``, returns a full-deny tree.
+
+    Uses ``copy.deepcopy`` so that the server-owned ``_PERMISSION_CATALOG``
+    is never mutated.
+    """
+    import copy as _copy
+
+    base = _copy.deepcopy(_PERMISSION_CATALOG)
+    if not doc:
+        return base
+
+    _deep_merge(base, doc)
+    return base
+
+
+def get_permission_catalog() -> dict[str, Any]:
+    """Return a deep copy of the server-owned permission catalog.
+
+    Used by callers that need the canonical shape (e.g. test assertions,
+    API responses showing available permissions).
+    """
+    import copy
+    return copy.deepcopy(_PERMISSION_CATALOG)
+
+
+# ---------------------------------------------------------------------------
+# Role name helpers
+# ---------------------------------------------------------------------------
+
+
+def is_custom_role_ref(role: str) -> bool:
+    """Return True if *role* is a well-formed ``custom:<uuid>`` reference."""
+    if not role.startswith(_CUSTOM_ROLE_PREFIX):
+        return False
+    role_id = role[len(_CUSTOM_ROLE_PREFIX):]
+    if len(role_id) != _CUSTOM_UUID_LENGTH:
+        return False
+    try:
+        uuid.UUID(role_id)
+        return True
+    except ValueError:
+        return False
+
+
+def extract_custom_role_id(role: str) -> str | None:
+    """Return the UUID portion of a ``custom:<uuid>`` reference, or None."""
+    if is_custom_role_ref(role):
+        return role[len(_CUSTOM_ROLE_PREFIX):]
+    return None
+
+
+def make_custom_role_ref(role_id: str) -> str:
+    """Build a ``custom:<uuid>`` string from a raw UUID."""
+    return f'{_CUSTOM_ROLE_PREFIX}{role_id}'
+
+
+def normalize_role_name(name: str) -> str:
+    """Lowercase, strip, and collapse whitespace for uniqueness checks."""
+    return re.sub(r'\s+', ' ', name.strip().lower())
+
+
+# ---------------------------------------------------------------------------
+# Validation helpers
+# ---------------------------------------------------------------------------
+
+_NAME_RE = re.compile(r'^[a-z0-9]([a-z0-9_ -]*[a-z0-9])?$', re.IGNORECASE)
+
+
+def validate_role_name(name: str) -> str:
+    normalized = normalize_role_name(name)
+    if not normalized:
+        raise ValueError('Role name must not be empty.')
+    if len(normalized) > 64:
+        raise ValueError('Role name must be 64 characters or fewer.')
+    if not _NAME_RE.match(normalized):
+        raise ValueError(
+            'Role name may only contain letters, digits, spaces, hyphens, '
+            'and underscores, and must start and end with a letter or digit.'
+        )
+    if normalized in RESERVED_ROLE_NAMES:
+        raise ValueError(
+            f"'{normalized}' is a reserved role name and cannot be used for custom roles."
+        )
+    return normalized
+
+
+# ---------------------------------------------------------------------------
+# DB Schema
+# ---------------------------------------------------------------------------
+
+
+class CustomRole(Base):
+    __tablename__ = 'custom_role'
+
+    id = Column(Text, primary_key=True, unique=True, nullable=False)
+    name = Column(Text, nullable=False, unique=True)
+    display_name = Column(Text, nullable=False)
+    active = Column(Boolean, nullable=False, default=True)
+    permissions = Column(JSONField(), nullable=False, default=dict)
+    created_at = Column(BigInteger, nullable=False)
+    updated_at = Column(BigInteger, nullable=False)
+
+    __table_args__ = (
+        Index('ix_custom_role_name', 'name', unique=True),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pydantic models
+# ---------------------------------------------------------------------------
+
+
+class CustomRoleModel(BaseModel):
+    """Pydantic schema for a custom role row."""
+
+    id: str
+    name: str
+    display_name: str
+    active: bool = True
+    permissions: dict[str, Any]
+    created_at: int
+    updated_at: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class CustomRoleCreateForm(BaseModel):
+    """Admin form for creating a new custom role."""
+
+    name: str
+    display_name: str
+    permissions: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator('name')
+    @classmethod
+    def validate_name(cls, v: str) -> str:
+        return validate_role_name(v)
+
+    @field_validator('display_name')
+    @classmethod
+    def validate_display_name(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            raise ValueError('Display name must not be empty.')
+        if len(v) > 128:
+            raise ValueError('Display name must be 128 characters or fewer.')
+        return v
+
+    @field_validator('permissions', mode='before')
+    @classmethod
+    def validate_permissions_field(cls, v: Any) -> dict[str, Any]:
+        if v is None:
+            raise ValueError(
+                'Permissions must not be null. '
+                'Provide a permission dictionary (can be empty {}).'
+            )
+        if not isinstance(v, dict):
+            raise ValueError('Permissions must be a dictionary.')
+        validate_permissions(v)
+        return v
+
+
+class CustomRoleUpdateForm(BaseModel):
+    """Admin form for updating an existing custom role.
+
+    Only ``display_name``, ``active``, and ``permissions`` are mutable.
+    Omitting ``permissions`` (not present in the request body) preserves
+    the existing value.  Explicitly sending ``null`` is rejected.
+    """
+
+    display_name: str | None = None
+    active: bool | None = None
+    permissions: dict[str, Any] | None = None
+
+    @model_validator(mode='before')
+    @classmethod
+    def reject_explicit_permissions_null(cls, data: Any) -> Any:
+        """Distinguish 'field omitted' from 'field explicitly null'.
+
+        If the raw input contains the key ``permissions`` with a ``None``
+        value we reject it.  When the key is absent Pydantic uses the
+        field default ``None`` which means 'omit / preserve existing'.
+        """
+        if isinstance(data, dict) and 'permissions' in data and data['permissions'] is None:
+            raise ValueError(
+                'Permissions must not be null. '
+                'Omit the field to preserve existing permissions, '
+                'or provide a permission dictionary.'
+            )
+        return data
+
+    @field_validator('display_name')
+    @classmethod
+    def validate_display_name(cls, v: str | None) -> str | None:
+        if v is None:
+            return v
+        v = v.strip()
+        if not v:
+            raise ValueError('Display name must not be empty.')
+        if len(v) > 128:
+            raise ValueError('Display name must be 128 characters or fewer.')
+        return v
+
+    @field_validator('permissions', mode='before')
+    @classmethod
+    def validate_permissions_field(cls, v: Any) -> dict[str, Any] | None:
+        if v is None:
+            return None
+        if not isinstance(v, dict):
+            raise ValueError('Permissions must be a dictionary.')
+        validate_permissions(v)
+        return v
+
+
+class CustomRoleResponse(BaseModel):
+    """API response for a single custom role."""
+
+    id: str
+    name: str
+    display_name: str
+    active: bool
+    permissions: dict[str, Any]
+    created_at: int
+    updated_at: int
+
+
+class CustomRoleListResponse(BaseModel):
+    items: list[CustomRoleResponse]
+    total: int
+
+
+class CustomRoleAssignForm(BaseModel):
+    """Admin form for assigning a custom role to a user."""
+
+    user_id: str
+    role_id: str  # the UUID of the custom role
+
+
+# ---------------------------------------------------------------------------
+# Table access class
+# ---------------------------------------------------------------------------
+
+
+class CustomRolesTable:
+    """Async database access methods for the ``custom_role`` table."""
+
+    async def create_role(
+        self,
+        form: CustomRoleCreateForm,
+        db: AsyncSession | None = None,
+    ) -> CustomRoleModel | None:
+        """Insert a new custom role.  Raises ValueError on name collision."""
+        normalized = normalize_role_name(form.name)
+
+        async with get_async_db_context(db) as session:
+            # Check uniqueness
+            existing = await session.execute(
+                select(CustomRole).where(CustomRole.name == normalized)
+            )
+            if existing.scalars().first():
+                raise ValueError(f"A custom role named '{normalized}' already exists.")
+
+            now = int(time.time())
+            role_id = str(uuid.uuid4())
+
+            row = CustomRole(
+                id=role_id,
+                name=normalized,
+                display_name=form.display_name.strip(),
+                active=True,
+                permissions=normalize_permissions(form.permissions),
+                created_at=now,
+                updated_at=now,
+            )
+            session.add(row)
+            await session.commit()
+            await session.refresh(row)
+            return CustomRoleModel.model_validate(row)
+
+    async def get_role_by_id(
+        self,
+        role_id: str,
+        db: AsyncSession | None = None,
+    ) -> CustomRoleModel | None:
+        async with get_async_db_context(db) as session:
+            row = await session.get(CustomRole, role_id)
+            return CustomRoleModel.model_validate(row) if row else None
+
+    async def get_role_by_name(
+        self,
+        name: str,
+        db: AsyncSession | None = None,
+    ) -> CustomRoleModel | None:
+        normalized = normalize_role_name(name)
+        async with get_async_db_context(db) as session:
+            result = await session.execute(
+                select(CustomRole).where(CustomRole.name == normalized)
+            )
+            row = result.scalars().first()
+            return CustomRoleModel.model_validate(row) if row else None
+
+    async def get_active_role_by_id(
+        self,
+        role_id: str,
+        db: AsyncSession | None = None,
+    ) -> CustomRoleModel | None:
+        """Return the role only if it exists AND is active (fail-closed)."""
+        role = await self.get_role_by_id(role_id, db=db)
+        if role and role.active:
+            return role
+        return None
+
+    async def list_roles(
+        self,
+        *,
+        include_inactive: bool = False,
+        skip: int = 0,
+        limit: int = 100,
+        db: AsyncSession | None = None,
+    ) -> dict[str, Any]:
+        async with get_async_db_context(db) as session:
+            stmt = select(CustomRole)
+            if not include_inactive:
+                stmt = stmt.where(CustomRole.active == True)  # noqa: E712
+
+            # Count before pagination
+            count_result = await session.execute(
+                select(func.count()).select_from(stmt.subquery())
+            )
+            total = count_result.scalar() or 0
+
+            stmt = stmt.order_by(CustomRole.name).offset(skip).limit(limit)
+            result = await session.execute(stmt)
+            roles = result.scalars().all()
+            return {
+                'items': [CustomRoleModel.model_validate(r) for r in roles],
+                'total': total,
+            }
+
+    async def update_role(
+        self,
+        role_id: str,
+        form: CustomRoleUpdateForm,
+        db: AsyncSession | None = None,
+    ) -> CustomRoleModel | None:
+        async with get_async_db_context(db) as session:
+            row = await session.get(CustomRole, role_id)
+            if not row:
+                return None
+
+            now = int(time.time())
+            updates: dict[str, Any] = {'updated_at': now}
+
+            if form.display_name is not None:
+                updates['display_name'] = form.display_name.strip()
+            if form.active is not None:
+                updates['active'] = form.active
+            if form.permissions is not None:
+                updates['permissions'] = normalize_permissions(form.permissions)
+
+            await session.execute(
+                update(CustomRole).where(CustomRole.id == role_id).values(**updates)
+            )
+            await session.commit()
+
+            # Re-fetch to return fresh state
+            row = await session.get(CustomRole, role_id)
+            return CustomRoleModel.model_validate(row) if row else None
+
+    async def deactivate_role(
+        self,
+        role_id: str,
+        db: AsyncSession | None = None,
+    ) -> CustomRoleModel | None:
+        """Soft-delete: set active=False.  Users keep the reference but lose access."""
+        return await self.update_role(
+            role_id,
+            CustomRoleUpdateForm(active=False),
+            db=db,
+        )
+
+    async def role_name_exists(
+        self,
+        name: str,
+        exclude_id: str | None = None,
+        db: AsyncSession | None = None,
+    ) -> bool:
+        normalized = normalize_role_name(name)
+        async with get_async_db_context(db) as session:
+            stmt = select(func.count()).select_from(CustomRole).where(
+                CustomRole.name == normalized
+            )
+            if exclude_id:
+                stmt = stmt.where(CustomRole.id != exclude_id)
+            result = await session.execute(stmt)
+            return (result.scalar() or 0) > 0
+
+
+CustomRoles = CustomRolesTable()

--- a/backend/open_webui/models/custom_roles.py
+++ b/backend/open_webui/models/custom_roles.py
@@ -482,9 +482,17 @@ class CustomRolesTable:
         self,
         role_id: str,
         db: AsyncSession | None = None,
+        *,
+        for_update: bool = False,
     ) -> CustomRoleModel | None:
         async with get_async_db_context(db) as session:
-            row = await session.get(CustomRole, role_id)
+            if for_update:
+                result = await session.execute(
+                    select(CustomRole).where(CustomRole.id == role_id).with_for_update()
+                )
+                row = result.scalars().first()
+            else:
+                row = await session.get(CustomRole, role_id)
             return CustomRoleModel.model_validate(row) if row else None
 
     async def get_role_by_name(
@@ -504,9 +512,11 @@ class CustomRolesTable:
         self,
         role_id: str,
         db: AsyncSession | None = None,
+        *,
+        for_update: bool = False,
     ) -> CustomRoleModel | None:
         """Return the role only if it exists AND is active (fail-closed)."""
-        role = await self.get_role_by_id(role_id, db=db)
+        role = await self.get_role_by_id(role_id, db=db, for_update=for_update)
         if role and role.active:
             return role
         return None
@@ -545,7 +555,10 @@ class CustomRolesTable:
         db: AsyncSession | None = None,
     ) -> CustomRoleModel | None:
         async with get_async_db_context(db) as session:
-            row = await session.get(CustomRole, role_id)
+            result = await session.execute(
+                select(CustomRole).where(CustomRole.id == role_id).with_for_update()
+            )
+            row = result.scalars().first()
             if not row:
                 return None
 
@@ -559,10 +572,17 @@ class CustomRolesTable:
             if form.permissions is not None:
                 updates['permissions'] = normalize_permissions(form.permissions)
 
-            await session.execute(
-                update(CustomRole).where(CustomRole.id == role_id).values(**updates)
-            )
-            await session.commit()
+            try:
+                await session.execute(
+                    update(CustomRole).where(CustomRole.id == role_id).values(**updates)
+                )
+                if form.active is False:
+                    await self._reset_assigned_users(session, role_id, now)
+                await session.commit()
+            except BaseException:
+                if session.in_transaction():
+                    await session.rollback()
+                raise
 
             # Re-fetch to return fresh state
             row = await session.get(CustomRole, role_id)
@@ -573,12 +593,68 @@ class CustomRolesTable:
         role_id: str,
         db: AsyncSession | None = None,
     ) -> CustomRoleModel | None:
-        """Soft-delete: set active=False.  Users keep the reference but lose access."""
+        """Deactivate and reset all assignments to the legacy ``user`` role."""
         return await self.update_role(
             role_id,
             CustomRoleUpdateForm(active=False),
             db=db,
         )
+
+    async def get_assigned_user_ids(
+        self,
+        role_id: str,
+        db: AsyncSession | None = None,
+    ) -> list[str]:
+        """Return users currently carrying the opaque reference for *role_id*."""
+        from open_webui.models.users import User
+
+        async with get_async_db_context(db) as session:
+            result = await session.execute(
+                select(User.id).where(User.role == make_custom_role_ref(role_id))
+            )
+            return list(result.scalars().all())
+
+    async def _reset_assigned_users(
+        self,
+        session: AsyncSession,
+        role_id: str,
+        now: int,
+    ) -> int:
+        """Reset exact custom-role references without touching other roles."""
+        from open_webui.models.users import User
+
+        result = await session.execute(
+            update(User)
+            .where(User.role == make_custom_role_ref(role_id))
+            .values(role='user', updated_at=now)
+        )
+        return int(getattr(result, 'rowcount', 0) or 0)
+
+    async def delete_role(
+        self,
+        role_id: str,
+        db: AsyncSession | None = None,
+    ) -> CustomRoleModel | None:
+        """Delete a role and atomically reset all of its assignments to ``user``."""
+        async with get_async_db_context(db) as session:
+            result = await session.execute(
+                select(CustomRole).where(CustomRole.id == role_id).with_for_update()
+            )
+            row = result.scalars().first()
+            if not row:
+                return None
+
+            role = CustomRoleModel.model_validate(row)
+            try:
+                await self._reset_assigned_users(session, role_id, int(time.time()))
+                await session.delete(row)
+                await session.commit()
+            except BaseException:
+                if session.in_transaction():
+                    await session.rollback()
+                raise
+
+            return role
 
     async def role_name_exists(
         self,

--- a/backend/open_webui/models/groups.py
+++ b/backend/open_webui/models/groups.py
@@ -10,11 +10,13 @@ from pydantic import BaseModel, ConfigDict
 from sqlalchemy import (
     JSON,
     BigInteger,
+    CheckConstraint,
     Column,
     ForeignKey,
     Index,
     String,
     Text,
+    UniqueConstraint,
     and_,
     cast,
     delete,
@@ -72,8 +74,10 @@ class GroupModel(BaseModel):
 
 class GroupMember(Base):
     __tablename__ = 'group_member'
-    # The table's (group_id, user_id) unique constraint cannot serve user_id lookups.
-    __table_args__ = (Index('ix_group_member_user_id_group_id', 'user_id', 'group_id'),)
+    __table_args__ = (
+        UniqueConstraint('group_id', 'user_id', name='uq_group_member_group_user'),
+        Index('ix_group_member_user_id_group_id', 'user_id', 'group_id'),
+    )
 
     id = Column(Text, unique=True, primary_key=True)
     group_id = Column(
@@ -81,7 +85,11 @@ class GroupMember(Base):
         ForeignKey('group.id', ondelete='CASCADE'),
         nullable=False,
     )
-    user_id = Column(Text, nullable=False)
+    user_id = Column(
+        Text,
+        ForeignKey('user.id', ondelete='CASCADE'),
+        nullable=False,
+    )
     created_at = Column(BigInteger, nullable=True)
     updated_at = Column(BigInteger, nullable=True)
 
@@ -646,3 +654,144 @@ class GroupTable:
 
 
 Groups = GroupTable()
+
+
+####################
+# GroupOwnedAsset DB Schema
+# Tracks exactly one owning group per (resource_type, resource_id).
+# This is distinct from access_grants which are read/write ACL rows.
+####################
+
+SUPPORTED_OWNED_ASSET_TYPES: frozenset[str] = frozenset({'knowledge', 'prompt', 'skill'})
+
+
+class GroupOwnedAsset(Base):
+    __tablename__ = 'group_owned_asset'
+
+    id = Column(Text, primary_key=True, nullable=False, unique=True)
+    resource_type = Column(Text, nullable=False)
+    resource_id = Column(Text, nullable=False)
+    group_id = Column(
+        Text,
+        ForeignKey('group.id', ondelete='RESTRICT'),
+        nullable=False,
+    )
+    created_by = Column(Text, nullable=False)
+    created_at = Column(BigInteger, nullable=False)
+    updated_at = Column(BigInteger, nullable=False)
+
+    __table_args__ = (
+        UniqueConstraint(
+            'resource_type',
+            'resource_id',
+            name='uq_group_owned_asset_resource',
+        ),
+        Index('ix_group_owned_asset_group_id', 'group_id'),
+        CheckConstraint(
+            "resource_type IN ('knowledge', 'prompt', 'skill')",
+            name='ck_group_owned_asset_type',
+        ),
+    )
+
+
+class GroupOwnedAssetModel(BaseModel):
+    """Pydantic schema for a group_owned_asset row."""
+
+    id: str
+    resource_type: str
+    resource_id: str
+    group_id: str
+    created_by: str
+    created_at: int
+    updated_at: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class GroupOwnedAssetsTable:
+    """Async database access methods for the ``group_owned_asset`` table."""
+
+    async def insert_asset(
+        self,
+        *,
+        resource_type: str,
+        resource_id: str,
+        group_id: str,
+        created_by: str,
+        db: AsyncSession | None = None,
+    ) -> GroupOwnedAssetModel:
+        """Insert a new ownership record.
+
+        Raises ``ValueError`` if the resource_type is not supported or if a
+        duplicate ``(resource_type, resource_id)`` already exists.
+        """
+        if resource_type not in SUPPORTED_OWNED_ASSET_TYPES:
+            raise ValueError(
+                f'Unsupported resource_type {resource_type!r}. '
+                f'Supported: {sorted(SUPPORTED_OWNED_ASSET_TYPES)}'
+            )
+
+        async with get_async_db_context(db) as session:
+            now = int(time.time())
+            asset_id = str(uuid.uuid4())
+
+            row = GroupOwnedAsset(
+                id=asset_id,
+                resource_type=resource_type,
+                resource_id=resource_id,
+                group_id=group_id,
+                created_by=created_by,
+                created_at=now,
+                updated_at=now,
+            )
+            session.add(row)
+            await session.flush()
+            return GroupOwnedAssetModel.model_validate(row)
+
+    async def get_asset_by_resource(
+        self,
+        resource_type: str,
+        resource_id: str,
+        db: AsyncSession | None = None,
+    ) -> GroupOwnedAssetModel | None:
+        async with get_async_db_context(db) as session:
+            result = await session.execute(
+                select(GroupOwnedAsset).where(
+                    GroupOwnedAsset.resource_type == resource_type,
+                    GroupOwnedAsset.resource_id == resource_id,
+                )
+            )
+            row = result.scalars().first()
+            return GroupOwnedAssetModel.model_validate(row) if row else None
+
+    async def get_assets_by_group_id(
+        self,
+        group_id: str,
+        *,
+        resource_type: str | None = None,
+        db: AsyncSession | None = None,
+    ) -> list[GroupOwnedAssetModel]:
+        async with get_async_db_context(db) as session:
+            stmt = select(GroupOwnedAsset).where(GroupOwnedAsset.group_id == group_id)
+            if resource_type is not None:
+                stmt = stmt.where(GroupOwnedAsset.resource_type == resource_type)
+            result = await session.execute(stmt.order_by(GroupOwnedAsset.created_at.desc()))
+            return [GroupOwnedAssetModel.model_validate(r) for r in result.scalars().all()]
+
+    async def delete_asset_by_resource(
+        self,
+        resource_type: str,
+        resource_id: str,
+        db: AsyncSession | None = None,
+    ) -> bool:
+        async with get_async_db_context(db) as session:
+            result = await session.execute(
+                delete(GroupOwnedAsset).where(
+                    GroupOwnedAsset.resource_type == resource_type,
+                    GroupOwnedAsset.resource_id == resource_id,
+                )
+            )
+            return result.rowcount > 0
+
+
+GroupOwnedAssets = GroupOwnedAssetsTable()

--- a/backend/open_webui/routers/auths.py
+++ b/backend/open_webui/routers/auths.py
@@ -1117,6 +1117,26 @@ async def add_user(
         except Exception as e:
             raise HTTPException(400, detail=str(e))
 
+        # Validate custom role references before insert
+        if form_data.role is not None:
+            from open_webui.models.custom_roles import is_custom_role_ref, extract_custom_role_id
+
+            if is_custom_role_ref(form_data.role):
+                from open_webui.models.custom_roles import CustomRoles
+
+                role_id = extract_custom_role_id(form_data.role)
+                active_role = await CustomRoles.get_active_role_by_id(role_id, db=db) if role_id else None
+                if not active_role:
+                    raise HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        detail=ERROR_MESSAGES.CUSTOM_ROLE_INACTIVE,
+                    )
+            elif form_data.role not in ('admin', 'user', 'pending'):
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=ERROR_MESSAGES.CUSTOM_ROLE_INVALID_REFERENCE,
+                )
+
         hashed = await get_password_hash(form_data.password)
         user = await Auths.insert_new_auth(
             form_data.email.lower(),

--- a/backend/open_webui/routers/chats.py
+++ b/backend/open_webui/routers/chats.py
@@ -36,7 +36,7 @@ from open_webui.socket.main import get_event_emitter
 from open_webui.tasks import get_response_streams_by_chat_id, has_active_tasks, stop_item_tasks
 from open_webui.utils.access_control import filter_allowed_access_grants, has_permission
 from open_webui.utils.access_control.folders import has_folder_write_access
-from open_webui.utils.auth import bearer_security, get_admin_user, get_current_user, get_verified_user
+from open_webui.utils.auth import bearer_security, get_admin_user, get_current_user, get_verified_user, is_verified_role
 from open_webui.utils.chat_fork import build_fork_history
 from open_webui.utils.context_compaction import compact_chat_branch, get_chat_context_usage
 from open_webui.utils.misc import get_message_list
@@ -96,7 +96,7 @@ async def get_optional_verified_user(
     except HTTPException:
         return None
 
-    if user.role not in {'user', 'admin'}:
+    if not await is_verified_role(user.role):
         return None
     return user
 
@@ -710,7 +710,7 @@ async def delete_all_user_chats(
     user=Depends(get_verified_user),
     db: AsyncSession = Depends(get_async_session),
 ):
-    if user.role == 'user' and not await has_permission(user.id, 'chat.delete', await Config.get('user.permissions')):
+    if user.role != 'admin' and not await has_permission(user.id, 'chat.delete', await Config.get('user.permissions')):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail=ERROR_MESSAGES.ACCESS_PROHIBITED,

--- a/backend/open_webui/routers/custom_roles.py
+++ b/backend/open_webui/routers/custom_roles.py
@@ -1,0 +1,347 @@
+"""Admin-only API for managing custom roles.
+
+All endpoints in this router require exact ``admin`` role (via ``get_admin_user``).
+Custom roles are stored as ``custom:<uuid>`` references in ``User.role``.
+
+Endpoints:
+- POST /create       — create a new custom role
+- GET /              — list all custom roles (paginated)
+- GET /{role_id}     — get a single custom role by ID
+- POST /{role_id}/update — update display_name, active, or permissions
+- POST /{role_id}/deactivate — soft-deactivate (set active=False)
+- POST /assign       — assign a custom role to a user
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from open_webui.constants import ERROR_MESSAGES
+from open_webui.events import EVENTS, publish_event
+from open_webui.internal.db import get_async_session
+from open_webui.models.custom_roles import (
+    CustomRoleAssignForm,
+    CustomRoleCreateForm,
+    CustomRoleListResponse,
+    CustomRoleResponse,
+    CustomRoles,
+    CustomRoleUpdateForm,
+    make_custom_role_ref,
+)
+from open_webui.models.users import Users
+from open_webui.utils.auth import get_admin_user
+from sqlalchemy.ext.asyncio import AsyncSession
+
+log = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _role_response(role) -> CustomRoleResponse:
+    """Build an API response from a CustomRoleModel."""
+    return CustomRoleResponse(
+        id=role.id,
+        name=role.name,
+        display_name=role.display_name,
+        active=role.active,
+        permissions=role.permissions,
+        created_at=role.created_at,
+        updated_at=role.updated_at,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Create
+# ---------------------------------------------------------------------------
+
+
+@router.post('/create', response_model=CustomRoleResponse)
+async def create_custom_role(
+    request: Request,
+    form_data: CustomRoleCreateForm,
+    user=Depends(get_admin_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Create a new custom role.
+
+    The role name must be unique, not reserved, and meet format constraints.
+    """
+    try:
+        role = await CustomRoles.create_role(form_data, db=db)
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        )
+
+    if role is None:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=ERROR_MESSAGES.DEFAULT(),
+        )
+
+    await publish_event(
+        request,
+        EVENTS.CUSTOM_ROLE_CREATED,
+        actor=user,
+        subject_id=role.id,
+        data={'name': role.name, 'display_name': role.display_name},
+    )
+
+    return _role_response(role)
+
+
+# ---------------------------------------------------------------------------
+# List
+# ---------------------------------------------------------------------------
+
+
+@router.get('/', response_model=CustomRoleListResponse)
+async def list_custom_roles(
+    include_inactive: bool = False,
+    page: int = 1,
+    user=Depends(get_admin_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """List custom roles with pagination."""
+    limit = 100
+    skip = max(0, (max(1, page) - 1) * limit)
+
+    result = await CustomRoles.list_roles(
+        include_inactive=include_inactive,
+        skip=skip,
+        limit=limit,
+        db=db,
+    )
+
+    return CustomRoleListResponse(
+        items=[_role_response(r) for r in result['items']],
+        total=result['total'],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Read
+# ---------------------------------------------------------------------------
+
+
+@router.get('/{role_id}', response_model=CustomRoleResponse)
+async def get_custom_role(
+    role_id: str,
+    user=Depends(get_admin_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Get a single custom role by ID."""
+    role = await CustomRoles.get_role_by_id(role_id, db=db)
+    if not role:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=ERROR_MESSAGES.CUSTOM_ROLE_NOT_FOUND,
+        )
+    return _role_response(role)
+
+
+# ---------------------------------------------------------------------------
+# Update
+# ---------------------------------------------------------------------------
+
+
+@router.post('/{role_id}/update', response_model=CustomRoleResponse)
+async def update_custom_role(
+    request: Request,
+    role_id: str,
+    form_data: CustomRoleUpdateForm,
+    user=Depends(get_admin_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Update display_name, active flag, or permissions of a custom role.
+
+    The role name and ID are immutable.
+    """
+    role = await CustomRoles.update_role(role_id, form_data, db=db)
+    if not role:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=ERROR_MESSAGES.CUSTOM_ROLE_NOT_FOUND,
+        )
+
+    await publish_event(
+        request,
+        EVENTS.CUSTOM_ROLE_UPDATED,
+        actor=user,
+        subject_id=role.id,
+        data={'name': role.name, 'display_name': role.display_name, 'active': role.active},
+    )
+
+    return _role_response(role)
+
+
+# ---------------------------------------------------------------------------
+# Deactivate (soft-delete)
+# ---------------------------------------------------------------------------
+
+
+@router.post('/{role_id}/deactivate', response_model=CustomRoleResponse)
+async def deactivate_custom_role(
+    request: Request,
+    role_id: str,
+    user=Depends(get_admin_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Soft-deactivate a custom role (set active=False).
+
+    Users currently assigned this role will fail-closed on the next request
+    because the role is no longer active.
+    """
+    role = await CustomRoles.deactivate_role(role_id, db=db)
+    if not role:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=ERROR_MESSAGES.CUSTOM_ROLE_NOT_FOUND,
+        )
+
+    await publish_event(
+        request,
+        EVENTS.CUSTOM_ROLE_DEACTIVATED,
+        actor=user,
+        subject_id=role.id,
+        data={'name': role.name},
+    )
+
+    return _role_response(role)
+
+
+# ---------------------------------------------------------------------------
+# Assign / Unassign
+# ---------------------------------------------------------------------------
+
+
+@router.post('/assign')
+async def assign_custom_role(
+    request: Request,
+    form_data: CustomRoleAssignForm,
+    user=Depends(get_admin_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Assign a custom role to a user.
+
+    Validates:
+    - The target role exists, is active, and is not a reserved role.
+    - The target user exists.
+    - The caller cannot assign roles to themselves via this endpoint.
+    """
+    # Validate that the role_id is a real, active custom role
+    role = await CustomRoles.get_active_role_by_id(form_data.role_id, db=db)
+    if not role:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=ERROR_MESSAGES.CUSTOM_ROLE_INACTIVE,
+        )
+
+    # Look up target user
+    target_user = await Users.get_user_by_id(form_data.user_id, db=db)
+    if not target_user:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=ERROR_MESSAGES.USER_NOT_FOUND,
+        )
+
+    # Cannot demote the first admin user
+    first_user = await Users.get_first_user(db=db)
+    if first_user and target_user.id == first_user.id and target_user.role == 'admin':
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=ERROR_MESSAGES.ACTION_PROHIBITED,
+        )
+
+    # Assign the role
+    role_ref = make_custom_role_ref(role.id)
+    updated = await Users.update_user_role_by_id(target_user.id, role_ref, db=db)
+    if not updated:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=ERROR_MESSAGES.CUSTOM_ROLE_ASSIGN_FAILED,
+        )
+
+    await publish_event(
+        request,
+        EVENTS.CUSTOM_ROLE_ASSIGNED,
+        actor=user,
+        subject_id=target_user.id,
+        data={
+            'role_id': role.id,
+            'role_name': role.name,
+            'old_role': target_user.role,
+            'new_role': role_ref,
+        },
+    )
+
+    await publish_event(
+        request,
+        EVENTS.USER_ROLE_UPDATED,
+        actor=user,
+        subject_id=target_user.id,
+        data={'role': role_ref},
+    )
+
+    return {'status': True, 'role': role_ref}
+
+
+@router.post('/{role_id}/unassign')
+async def unassign_custom_role(
+    request: Request,
+    role_id: str,
+    user_id: str,
+    user=Depends(get_admin_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Remove a custom role assignment, reverting the user to ``pending``.
+
+    Validates:
+    - The target user currently has ``custom:<role_id>`` as their role.
+    """
+    target_user = await Users.get_user_by_id(user_id, db=db)
+    if not target_user:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=ERROR_MESSAGES.USER_NOT_FOUND,
+        )
+
+    expected_ref = make_custom_role_ref(role_id)
+    if target_user.role != expected_ref:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=ERROR_MESSAGES.CUSTOM_ROLE_UNASSIGN_FAILED,
+        )
+
+    # Cannot demote the first admin
+    first_user = await Users.get_first_user(db=db)
+    if first_user and target_user.id == first_user.id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=ERROR_MESSAGES.ACTION_PROHIBITED,
+        )
+
+    # Revert to pending (legacy default)
+    updated = await Users.update_user_role_by_id(target_user.id, 'pending', db=db)
+    if not updated:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=ERROR_MESSAGES.CUSTOM_ROLE_UNASSIGN_FAILED,
+        )
+
+    await publish_event(
+        request,
+        EVENTS.USER_ROLE_UPDATED,
+        actor=user,
+        subject_id=user_id,
+        data={'role': 'pending'},
+    )
+
+    return {'status': True, 'role': 'pending'}

--- a/backend/open_webui/routers/custom_roles.py
+++ b/backend/open_webui/routers/custom_roles.py
@@ -6,15 +6,18 @@ Custom roles are stored as ``custom:<uuid>`` references in ``User.role``.
 Endpoints:
 - POST /create       — create a new custom role
 - GET /              — list all custom roles (paginated)
+- GET /permissions   — return the server-owned permission catalog
 - GET /{role_id}     — get a single custom role by ID
 - POST /{role_id}/update — update display_name, active, or permissions
 - POST /{role_id}/deactivate — soft-deactivate (set active=False)
+- DELETE /{role_id}  — delete a role and reset its assignments
 - POST /assign       — assign a custom role to a user
 """
 
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from open_webui.constants import ERROR_MESSAGES
@@ -27,6 +30,7 @@ from open_webui.models.custom_roles import (
     CustomRoleResponse,
     CustomRoles,
     CustomRoleUpdateForm,
+    get_permission_catalog,
     make_custom_role_ref,
 )
 from open_webui.models.users import Users
@@ -54,6 +58,23 @@ def _role_response(role) -> CustomRoleResponse:
         created_at=role.created_at,
         updated_at=role.updated_at,
     )
+
+
+async def _publish_role_reset_events(
+    request: Request,
+    actor,
+    user_ids: list[str],
+    reason: str,
+) -> None:
+    """Publish metadata-only role updates after a lifecycle transaction commits."""
+    for user_id in user_ids:
+        await publish_event(
+            request,
+            EVENTS.USER_ROLE_UPDATED,
+            actor=actor,
+            subject_id=user_id,
+            data={'role': 'user', 'reason': reason},
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -127,6 +148,17 @@ async def list_custom_roles(
 
 
 # ---------------------------------------------------------------------------
+# Permission catalog
+# ---------------------------------------------------------------------------
+
+
+@router.get('/permissions', response_model=dict[str, Any])
+async def get_custom_role_permission_catalog(user=Depends(get_admin_user)):
+    """Return the canonical server-owned permission catalog for role editors."""
+    return get_permission_catalog()
+
+
+# ---------------------------------------------------------------------------
 # Read
 # ---------------------------------------------------------------------------
 
@@ -164,6 +196,16 @@ async def update_custom_role(
 
     The role name and ID are immutable.
     """
+    if form_data.active is False:
+        role_for_update = await CustomRoles.get_role_by_id(role_id, db=db, for_update=True)
+        if not role_for_update:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=ERROR_MESSAGES.CUSTOM_ROLE_NOT_FOUND,
+            )
+        reset_user_ids = await CustomRoles.get_assigned_user_ids(role_id, db=db)
+    else:
+        reset_user_ids = []
     role = await CustomRoles.update_role(role_id, form_data, db=db)
     if not role:
         raise HTTPException(
@@ -171,13 +213,20 @@ async def update_custom_role(
             detail=ERROR_MESSAGES.CUSTOM_ROLE_NOT_FOUND,
         )
 
+    lifecycle_event = EVENTS.CUSTOM_ROLE_DEACTIVATED if form_data.active is False else EVENTS.CUSTOM_ROLE_UPDATED
+    lifecycle_data = {'name': role.name, 'display_name': role.display_name, 'active': role.active}
+    if form_data.active is False:
+        lifecycle_data.update({'reset_to': 'user', 'reset_user_count': len(reset_user_ids)})
+
     await publish_event(
         request,
-        EVENTS.CUSTOM_ROLE_UPDATED,
+        lifecycle_event,
         actor=user,
         subject_id=role.id,
-        data={'name': role.name, 'display_name': role.display_name, 'active': role.active},
+        data=lifecycle_data,
     )
+    if reset_user_ids:
+        await _publish_role_reset_events(request, user, reset_user_ids, 'custom_role_deactivated')
 
     return _role_response(role)
 
@@ -194,11 +243,14 @@ async def deactivate_custom_role(
     user=Depends(get_admin_user),
     db: AsyncSession = Depends(get_async_session),
 ):
-    """Soft-deactivate a custom role (set active=False).
-
-    Users currently assigned this role will fail-closed on the next request
-    because the role is no longer active.
-    """
+    """Deactivate a custom role and reset current assignments to ``user``."""
+    role_for_update = await CustomRoles.get_role_by_id(role_id, db=db, for_update=True)
+    if not role_for_update:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=ERROR_MESSAGES.CUSTOM_ROLE_NOT_FOUND,
+        )
+    reset_user_ids = await CustomRoles.get_assigned_user_ids(role_id, db=db)
     role = await CustomRoles.deactivate_role(role_id, db=db)
     if not role:
         raise HTTPException(
@@ -211,8 +263,58 @@ async def deactivate_custom_role(
         EVENTS.CUSTOM_ROLE_DEACTIVATED,
         actor=user,
         subject_id=role.id,
-        data={'name': role.name},
+        data={
+            'name': role.name,
+            'reset_to': 'user',
+            'reset_user_count': len(reset_user_ids),
+        },
     )
+    if reset_user_ids:
+        await _publish_role_reset_events(request, user, reset_user_ids, 'custom_role_deactivated')
+
+    return _role_response(role)
+
+
+# ---------------------------------------------------------------------------
+# Delete
+# ---------------------------------------------------------------------------
+
+
+@router.delete('/{role_id}', response_model=CustomRoleResponse)
+async def delete_custom_role(
+    request: Request,
+    role_id: str,
+    user=Depends(get_admin_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Delete a custom role and atomically reset current assignments to ``user``."""
+    role_for_update = await CustomRoles.get_role_by_id(role_id, db=db, for_update=True)
+    if not role_for_update:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=ERROR_MESSAGES.CUSTOM_ROLE_NOT_FOUND,
+        )
+    reset_user_ids = await CustomRoles.get_assigned_user_ids(role_id, db=db)
+    role = await CustomRoles.delete_role(role_id, db=db)
+    if not role:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=ERROR_MESSAGES.CUSTOM_ROLE_NOT_FOUND,
+        )
+
+    await publish_event(
+        request,
+        EVENTS.CUSTOM_ROLE_DELETED,
+        actor=user,
+        subject_id=role.id,
+        data={
+            'name': role.name,
+            'reset_to': 'user',
+            'reset_user_count': len(reset_user_ids),
+        },
+    )
+    if reset_user_ids:
+        await _publish_role_reset_events(request, user, reset_user_ids, 'custom_role_deleted')
 
     return _role_response(role)
 
@@ -237,7 +339,7 @@ async def assign_custom_role(
     - The caller cannot assign roles to themselves via this endpoint.
     """
     # Validate that the role_id is a real, active custom role
-    role = await CustomRoles.get_active_role_by_id(form_data.role_id, db=db)
+    role = await CustomRoles.get_active_role_by_id(form_data.role_id, db=db, for_update=True)
     if not role:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/backend/open_webui/routers/group_manager.py
+++ b/backend/open_webui/routers/group_manager.py
@@ -1,8 +1,9 @@
 """Scoped group-manager router.
 
-Additive endpoints under ``/api/v1/group-manager/groups/{group_id}/...``
-that allow group managers (custom-role holders with ``groups.manage_members``
-or ``groups.manage_assets``) to operate on a single group.
+Additive endpoints under ``/api/v1/group-manager/groups`` and
+``/api/v1/group-manager/groups/{group_id}/...`` that allow group managers
+(custom-role holders with ``groups.manage_members``, ``groups.manage_assets``,
+or ``groups.manage_skills``) to discover and operate on a single group.
 
 Security contract:
 - Every mutation uses ``group_manager_tx(db)`` then
@@ -36,6 +37,7 @@ from open_webui.models.access_grants import (
 )
 from open_webui.models.groups import (
     SUPPORTED_OWNED_ASSET_TYPES,
+    Group,
     GroupMember,
     GroupOwnedAsset,
     GroupOwnedAssets,
@@ -45,6 +47,7 @@ from open_webui.models.prompts import Prompt
 from open_webui.models.skills import Skill, SkillMeta
 from open_webui.models.users import User
 from open_webui.utils.access_control.group_manager import (
+    GroupManagerError,
     group_manager_tx,
     require_group_manager,
 )
@@ -139,6 +142,14 @@ class GroupManagerMemberInfo(BaseModel):
     id: str
     user_id: str
     created_at: int | None = None
+
+
+class GroupManagerGroupInfo(BaseModel):
+    """Minimal group discovery contract for the manager workspace."""
+
+    id: str
+    name: str
+    capabilities: list[str]
 
 
 # =====================================================================
@@ -296,6 +307,59 @@ async def _verify_ownership(
 # =====================================================================
 # Membership management (manage_members)
 # =====================================================================
+
+GROUP_MANAGER_CAPABILITIES: tuple[str, ...] = (
+    'groups.manage_members',
+    'groups.manage_assets',
+    'groups.manage_skills',
+)
+
+
+@router.get(
+    '/groups',
+    response_model=list[GroupManagerGroupInfo],
+)
+async def list_manageable_groups(
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """List groups for which the caller currently has a manager capability.
+
+    Membership is used only to enumerate candidates.  Each capability is
+    re-authorized through ``require_group_manager`` inside the same transaction
+    so custom-role activity, capability, and current membership remain the
+    source of truth.  Creator IDs and access grants are deliberately ignored.
+    """
+    response: list[GroupManagerGroupInfo] = []
+
+    async with group_manager_tx(db):
+        result = await db.execute(
+            select(Group)
+            .join(GroupMember, GroupMember.group_id == Group.id)
+            .where(GroupMember.user_id == user.id)
+            .order_by(Group.updated_at.desc(), Group.id.asc())
+        )
+        groups = result.scalars().all()
+
+        for group in groups:
+            capabilities: list[str] = []
+            for capability in GROUP_MANAGER_CAPABILITIES:
+                try:
+                    await require_group_manager(user.id, group.id, capability, db)
+                except GroupManagerError:
+                    continue
+                capabilities.append(capability)
+
+            if capabilities:
+                response.append(
+                    GroupManagerGroupInfo(
+                        id=group.id,
+                        name=group.name,
+                        capabilities=capabilities,
+                    )
+                )
+
+    return response
 
 
 @router.get(

--- a/backend/open_webui/routers/group_manager.py
+++ b/backend/open_webui/routers/group_manager.py
@@ -1,0 +1,1535 @@
+"""Scoped group-manager router.
+
+Additive endpoints under ``/api/v1/group-manager/groups/{group_id}/...``
+that allow group managers (custom-role holders with ``groups.manage_members``
+or ``groups.manage_assets``) to operate on a single group.
+
+Security contract:
+- Every mutation uses ``group_manager_tx(db)`` then
+  ``require_group_manager(user.id, group_id, capability, db)``.
+- Admin / legacy roles are **denied** on these scoped endpoints.
+- ``manage_members``: list / add / remove membership within the target group.
+- ``manage_assets``: create / update / delete ``knowledge`` and ``prompt``
+  rows with an authoritative ``group_owned_asset`` row.
+- Scoped creation atomically creates resource + ownership row + owning-group
+  read AccessGrant using flush-only primitives.
+- Scoped update / delete lock on exact ``(group_id, type, id)`` ownership.
+- ACL delta accepts only ``write: bool`` for the owning group.
+- Events are published only after successful commit and omit content.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import time
+import uuid
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from open_webui.constants import ERROR_MESSAGES
+from open_webui.events import EVENTS, publish_event
+from open_webui.internal.db import get_async_session
+from open_webui.models.access_grants import (
+    PRINCIPAL_TYPE_GROUP,
+    AccessGrant,
+)
+from open_webui.models.groups import (
+    SUPPORTED_OWNED_ASSET_TYPES,
+    GroupMember,
+    GroupOwnedAsset,
+    GroupOwnedAssets,
+)
+from open_webui.models.knowledge import Knowledge
+from open_webui.models.prompts import Prompt
+from open_webui.models.skills import Skill, SkillMeta
+from open_webui.models.users import User
+from open_webui.utils.access_control.group_manager import (
+    group_manager_tx,
+    require_group_manager,
+)
+from open_webui.utils.auth import get_verified_user
+from pydantic import BaseModel, ConfigDict, Field
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+log = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+# =====================================================================
+# Forms / response schemas
+# =====================================================================
+
+
+class GroupManagerMemberIdsForm(BaseModel):
+    user_ids: list[str]
+
+
+class GroupManagerKnowledgeCreateForm(BaseModel):
+    name: str
+    description: str = ''
+
+
+class GroupManagerPromptCreateForm(BaseModel):
+    command: str
+    name: str
+    content: str
+    data: dict | None = None
+    meta: dict | None = None
+    tags: list[str | None] = None
+
+
+class GroupManagerKnowledgeUpdateForm(BaseModel):
+    name: str | None = None
+    description: str | None = None
+
+
+class GroupManagerPromptUpdateForm(BaseModel):
+    name: str | None = None
+    content: str | None = None
+    data: dict | None = None
+    meta: dict | None = None
+    tags: list[str | None] = None
+
+
+class GroupManagerACLDeltaForm(BaseModel):
+    write: bool
+
+
+class GroupManagerAssetInfo(BaseModel):
+    """Slim metadata for an owned asset — never includes content."""
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    resource_type: str
+    resource_id: str
+    group_id: str
+    created_by: str
+    created_at: int
+    updated_at: int
+
+
+class GroupManagerKnowledgeResponse(BaseModel):
+    id: str
+    name: str
+    description: str
+    created_at: int
+    updated_at: int
+    write_access: bool = False
+
+
+class GroupManagerPromptResponse(BaseModel):
+    id: str
+    command: str
+    name: str
+    created_at: int
+    updated_at: int
+    write_access: bool = False
+
+
+class GroupManagerACLResponse(BaseModel):
+    resource_type: str
+    resource_id: str
+    write: bool
+
+
+class GroupManagerMemberInfo(BaseModel):
+    id: str
+    user_id: str
+    created_at: int | None = None
+
+
+# =====================================================================
+# Skill forms / response schemas (Phase 3: skills-only slice)
+# =====================================================================
+
+
+class GroupManagerSkillCreateForm(BaseModel):
+    """Payload allowlist for scoped skill creation.
+
+    Server controls id (group-namespaced slug), user_id, and access_grants.
+    """
+    model_config = ConfigDict(extra='forbid')
+
+    slug: str
+    name: str
+    description: str = ''
+    content: str = ''
+    tags: list[str] = Field(default_factory=list)
+    active: bool = True
+
+
+class GroupManagerSkillUpdateForm(BaseModel):
+    """Payload allowlist for scoped skill update.
+
+    All fields optional; omitted fields preserve existing values.
+    """
+    model_config = ConfigDict(extra='forbid')
+
+    name: str | None = None
+    description: str | None = None
+    content: str | None = None
+    tags: list[str] | None = None
+    active: bool | None = None
+
+
+class GroupManagerSkillResponse(BaseModel):
+    """Response for scoped skill operations — never includes access_grants."""
+    id: str
+    slug: str
+    name: str
+    description: str
+    content: str
+    is_active: bool
+    meta: SkillMeta
+    created_at: int
+    updated_at: int
+
+
+# =====================================================================
+# Flush-only primitives (non-committing)
+# =====================================================================
+
+
+async def _grant_access_flush(
+    resource_type: str,
+    resource_id: str,
+    principal_type: str,
+    principal_id: str,
+    permission: str,
+    db: AsyncSession,
+) -> None:
+    """Insert an AccessGrant row and flush — no commit.
+
+    Idempotent: skips if the grant already exists.
+    """
+    result = await db.execute(
+        select(AccessGrant).filter_by(
+            resource_type=resource_type,
+            resource_id=resource_id,
+            principal_type=principal_type,
+            principal_id=principal_id,
+            permission=permission,
+        )
+    )
+    if result.scalars().first() is not None:
+        return  # idempotent
+
+    grant = AccessGrant(
+        id=str(uuid.uuid4()),
+        resource_type=resource_type,
+        resource_id=resource_id,
+        principal_type=principal_type,
+        principal_id=principal_id,
+        permission=permission,
+        created_at=int(time.time()),
+    )
+    db.add(grant)
+    await db.flush()
+
+
+async def _revoke_access_flush(
+    resource_type: str,
+    resource_id: str,
+    principal_type: str,
+    principal_id: str,
+    permission: str,
+    db: AsyncSession,
+) -> None:
+    """Delete an AccessGrant row and flush — no commit."""
+    await db.execute(
+        delete(AccessGrant).filter_by(
+            resource_type=resource_type,
+            resource_id=resource_id,
+            principal_type=principal_type,
+            principal_id=principal_id,
+            permission=permission,
+        )
+    )
+    await db.flush()
+
+
+async def _revoke_all_access_flush(
+    resource_type: str,
+    resource_id: str,
+    db: AsyncSession,
+) -> None:
+    """Delete all AccessGrant rows for a resource and flush — no commit."""
+    await db.execute(
+        delete(AccessGrant).filter_by(
+            resource_type=resource_type,
+            resource_id=resource_id,
+        )
+    )
+    await db.flush()
+
+
+async def _verify_ownership(
+    group_id: str,
+    resource_type: str,
+    resource_id: str,
+    db: AsyncSession,
+) -> None:
+    """Verify that ``(group_id, resource_type, resource_id)`` exists in
+    ``group_owned_asset`` and lock the row.
+
+    Raises ``HTTPException(404)`` if not found.
+    """
+    result = await db.execute(
+        select(GroupOwnedAsset)
+        .where(
+            GroupOwnedAsset.group_id == group_id,
+            GroupOwnedAsset.resource_type == resource_type,
+            GroupOwnedAsset.resource_id == resource_id,
+        )
+        .with_for_update()
+    )
+    if result.scalars().first() is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=ERROR_MESSAGES.NOT_FOUND,
+        )
+
+
+# =====================================================================
+# Membership management (manage_members)
+# =====================================================================
+
+
+@router.get(
+    '/groups/{group_id}/members',
+    response_model=list[GroupManagerMemberInfo],
+)
+async def list_group_members(
+    group_id: str,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """List members of the target group."""
+    async with group_manager_tx(db):
+        await require_group_manager(
+            user.id, group_id, 'groups.manage_members', db,
+        )
+        result = await db.execute(
+            select(GroupMember)
+            .where(GroupMember.group_id == group_id)
+            .order_by(GroupMember.created_at.asc())
+        )
+        members = result.scalars().all()
+
+    return [
+        GroupManagerMemberInfo(
+            id=m.id,
+            user_id=m.user_id,
+            created_at=m.created_at,
+        )
+        for m in members
+    ]
+
+
+@router.post(
+    '/groups/{group_id}/members/add',
+    response_model=list[GroupManagerMemberInfo],
+)
+async def add_group_members(
+    request: Request,
+    group_id: str,
+    form_data: GroupManagerMemberIdsForm,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Add users to the target group. Only valid user IDs are accepted."""
+    pending_events: list[dict[str, Any]] = []
+
+    async with group_manager_tx(db):
+        await require_group_manager(
+            user.id, group_id, 'groups.manage_members', db,
+        )
+
+        now = int(time.time())
+        added_user_ids: list[str] = []
+
+        for uid in form_data.user_ids:
+            # Verify user exists
+            user_result = await db.execute(
+                select(User).where(User.id == uid),
+            )
+            if user_result.scalars().first() is None:
+                continue
+
+            # Check for existing membership
+            existing = await db.execute(
+                select(GroupMember).where(
+                    GroupMember.group_id == group_id,
+                    GroupMember.user_id == uid,
+                )
+            )
+            if existing.scalars().first() is not None:
+                continue  # already a member — skip
+
+            member = GroupMember(
+                id=str(uuid.uuid4()),
+                group_id=group_id,
+                user_id=uid,
+                created_at=now,
+                updated_at=now,
+            )
+            db.add(member)
+            await db.flush()
+            added_user_ids.append(uid)
+
+        if added_user_ids:
+            pending_events.append({
+                'event': EVENTS.GROUP_MEMBER_ADDED,
+                'subject_id': group_id,
+                'data': {'user_ids': added_user_ids},
+            })
+
+        # Return final member list
+        result = await db.execute(
+            select(GroupMember)
+            .where(GroupMember.group_id == group_id)
+            .order_by(GroupMember.created_at.asc())
+        )
+        members = result.scalars().all()
+
+    # Publish events after successful commit
+    for evt in pending_events:
+        await publish_event(
+            request,
+            evt['event'],
+            actor=user,
+            subject_id=evt['subject_id'],
+            data=evt.get('data'),
+        )
+
+    return [
+        GroupManagerMemberInfo(
+            id=m.id,
+            user_id=m.user_id,
+            created_at=m.created_at,
+        )
+        for m in members
+    ]
+
+
+@router.post(
+    '/groups/{group_id}/members/remove',
+    response_model=list[GroupManagerMemberInfo],
+)
+async def remove_group_members(
+    request: Request,
+    group_id: str,
+    form_data: GroupManagerMemberIdsForm,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Remove users from the target group."""
+    pending_events: list[dict[str, Any]] = []
+
+    async with group_manager_tx(db):
+        await require_group_manager(
+            user.id, group_id, 'groups.manage_members', db,
+        )
+
+        if form_data.user_ids:
+            await db.execute(
+                delete(GroupMember).where(
+                    GroupMember.group_id == group_id,
+                    GroupMember.user_id.in_(form_data.user_ids),
+                )
+            )
+            await db.flush()
+            pending_events.append({
+                'event': EVENTS.GROUP_MEMBER_REMOVED,
+                'subject_id': group_id,
+                'data': {'user_ids': form_data.user_ids},
+            })
+
+        # Return final member list
+        result = await db.execute(
+            select(GroupMember)
+            .where(GroupMember.group_id == group_id)
+            .order_by(GroupMember.created_at.asc())
+        )
+        members = result.scalars().all()
+
+    for evt in pending_events:
+        await publish_event(
+            request,
+            evt['event'],
+            actor=user,
+            subject_id=evt['subject_id'],
+            data=evt.get('data'),
+        )
+
+    return [
+        GroupManagerMemberInfo(
+            id=m.id,
+            user_id=m.user_id,
+            created_at=m.created_at,
+        )
+        for m in members
+    ]
+
+
+# =====================================================================
+# Asset management (manage_assets)
+# =====================================================================
+
+
+@router.get(
+    '/groups/{group_id}/assets',
+    response_model=list[GroupManagerAssetInfo],
+)
+async def list_group_assets(
+    group_id: str,
+    resource_type: str | None = None,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """List assets owned by the target group."""
+    async with group_manager_tx(db):
+        await require_group_manager(
+            user.id, group_id, 'groups.manage_assets', db,
+        )
+
+        stmt = select(GroupOwnedAsset).where(
+            GroupOwnedAsset.group_id == group_id,
+        )
+        if resource_type:
+            if resource_type not in SUPPORTED_OWNED_ASSET_TYPES:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=f'Unsupported resource_type: {resource_type}',
+                )
+            stmt = stmt.where(GroupOwnedAsset.resource_type == resource_type)
+        stmt = stmt.order_by(GroupOwnedAsset.created_at.desc())
+
+        result = await db.execute(stmt)
+        assets = result.scalars().all()
+
+    return [
+        GroupManagerAssetInfo.model_validate(a)
+        for a in assets
+    ]
+
+
+@router.post(
+    '/groups/{group_id}/assets/knowledge/create',
+    response_model=GroupManagerKnowledgeResponse,
+)
+async def create_group_knowledge(
+    request: Request,
+    group_id: str,
+    form_data: GroupManagerKnowledgeCreateForm,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Create a knowledge base owned by the group.
+
+    Atomically creates:
+    1. Knowledge row (flush only)
+    2. GroupOwnedAsset ownership row (flush only)
+    3. Owning-group read AccessGrant (flush only)
+    """
+    pending_events: list[dict[str, Any]] = []
+
+    async with group_manager_tx(db):
+        await require_group_manager(
+            user.id, group_id, 'groups.manage_assets', db,
+        )
+
+        now = int(time.time())
+        knowledge_id = str(uuid.uuid4())
+
+        # 1. Create Knowledge row
+        knowledge = Knowledge(
+            id=knowledge_id,
+            user_id=user.id,
+            name=form_data.name,
+            description=form_data.description,
+            meta=None,
+            created_at=now,
+            updated_at=now,
+        )
+        db.add(knowledge)
+        await db.flush()
+
+        # 2. Create ownership row
+        await GroupOwnedAssets.insert_asset(
+            resource_type='knowledge',
+            resource_id=knowledge_id,
+            group_id=group_id,
+            created_by=user.id,
+            db=db,
+        )
+
+        # 3. Owning-group read grant (baseline)
+        await _grant_access_flush(
+            'knowledge', knowledge_id,
+            PRINCIPAL_TYPE_GROUP, group_id, 'read',
+            db,
+        )
+
+        pending_events.append({
+            'event': EVENTS.KNOWLEDGE_CREATED,
+            'subject_id': knowledge_id,
+            'data': {'name': form_data.name},
+        })
+
+    for evt in pending_events:
+        await publish_event(
+            request,
+            evt['event'],
+            actor=user,
+            subject_id=evt['subject_id'],
+            data=evt.get('data'),
+        )
+
+    return GroupManagerKnowledgeResponse(
+        id=knowledge_id,
+        name=form_data.name,
+        description=form_data.description,
+        created_at=now,
+        updated_at=now,
+        write_access=True,
+    )
+
+
+@router.post(
+    '/groups/{group_id}/assets/prompts/create',
+    response_model=GroupManagerPromptResponse,
+)
+async def create_group_prompt(
+    request: Request,
+    group_id: str,
+    form_data: GroupManagerPromptCreateForm,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Create a prompt owned by the group.
+
+    Atomically creates:
+    1. Prompt row (flush only)
+    2. GroupOwnedAsset ownership row (flush only)
+    3. Owning-group read AccessGrant (flush only)
+
+    Rejects supplied ``access_grants`` — manager cannot set public /
+    user / other-group grants.
+    """
+    pending_events: list[dict[str, Any]] = []
+
+    async with group_manager_tx(db):
+        await require_group_manager(
+            user.id, group_id, 'groups.manage_assets', db,
+        )
+
+        # Check command uniqueness
+        existing = await db.execute(
+            select(Prompt).where(Prompt.command == form_data.command),
+        )
+        if existing.scalars().first() is not None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=ERROR_MESSAGES.COMMAND_TAKEN,
+            )
+
+        now = int(time.time())
+        prompt_id = str(uuid.uuid4())
+
+        # 1. Create Prompt row
+        prompt = Prompt(
+            id=prompt_id,
+            user_id=user.id,
+            command=form_data.command,
+            name=form_data.name,
+            content=form_data.content,
+            data=form_data.data or {},
+            meta=form_data.meta or {},
+            tags=form_data.tags or [],
+            is_active=True,
+            created_at=now,
+            updated_at=now,
+        )
+        db.add(prompt)
+        await db.flush()
+
+        # 2. Create ownership row
+        await GroupOwnedAssets.insert_asset(
+            resource_type='prompt',
+            resource_id=prompt_id,
+            group_id=group_id,
+            created_by=user.id,
+            db=db,
+        )
+
+        # 3. Owning-group read grant (baseline)
+        await _grant_access_flush(
+            'prompt', prompt_id,
+            PRINCIPAL_TYPE_GROUP, group_id, 'read',
+            db,
+        )
+
+        pending_events.append({
+            'event': EVENTS.PROMPT_CREATED,
+            'subject_id': prompt_id,
+            'data': {'name': form_data.name, 'command': form_data.command},
+        })
+
+    for evt in pending_events:
+        await publish_event(
+            request,
+            evt['event'],
+            actor=user,
+            subject_id=evt['subject_id'],
+            data=evt.get('data'),
+        )
+
+    return GroupManagerPromptResponse(
+        id=prompt_id,
+        command=form_data.command,
+        name=form_data.name,
+        created_at=now,
+        updated_at=now,
+        write_access=True,
+    )
+
+
+@router.post(
+    '/groups/{group_id}/assets/knowledge/{resource_id}/update',
+    response_model=GroupManagerKnowledgeResponse,
+)
+async def update_group_knowledge(
+    request: Request,
+    group_id: str,
+    resource_id: str,
+    form_data: GroupManagerKnowledgeUpdateForm,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Update a group-owned knowledge base.
+
+    First verifies ownership, then updates the knowledge row.
+    """
+    pending_events: list[dict[str, Any]] = []
+
+    async with group_manager_tx(db):
+        await require_group_manager(
+            user.id, group_id, 'groups.manage_assets', db,
+        )
+        await _verify_ownership(group_id, 'knowledge', resource_id, db)
+
+        # Lock and fetch the knowledge row
+        result = await db.execute(
+            select(Knowledge)
+            .where(Knowledge.id == resource_id)
+            .with_for_update()
+        )
+        knowledge = result.scalars().first()
+        if knowledge is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=ERROR_MESSAGES.NOT_FOUND,
+            )
+
+        now = int(time.time())
+        update_data: dict[str, Any] = {}
+        if form_data.name is not None:
+            update_data['name'] = form_data.name
+        if form_data.description is not None:
+            update_data['description'] = form_data.description
+        if update_data:
+            update_data['updated_at'] = now
+            await db.execute(
+                select(Knowledge)
+                .where(Knowledge.id == resource_id)
+                .with_for_update()
+            )
+            for key, value in update_data.items():
+                setattr(knowledge, key, value)
+            await db.flush()
+
+        updated_name = knowledge.name
+
+        pending_events.append({
+            'event': EVENTS.KNOWLEDGE_UPDATED,
+            'subject_id': resource_id,
+            'data': {'name': updated_name},
+        })
+
+    for evt in pending_events:
+        await publish_event(
+            request,
+            evt['event'],
+            actor=user,
+            subject_id=evt['subject_id'],
+            data=evt.get('data'),
+        )
+
+    return GroupManagerKnowledgeResponse(
+        id=knowledge.id,
+        name=knowledge.name,
+        description=knowledge.description,
+        created_at=knowledge.created_at,
+        updated_at=knowledge.updated_at,
+        write_access=True,
+    )
+
+
+@router.delete(
+    '/groups/{group_id}/assets/knowledge/{resource_id}/delete',
+    response_model=bool,
+)
+async def delete_group_knowledge(
+    request: Request,
+    group_id: str,
+    resource_id: str,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Delete a group-owned knowledge base.
+
+    In one transaction: delete ownership row, all grants, then the
+    knowledge row itself.
+    """
+    pending_events: list[dict[str, Any]] = []
+
+    async with group_manager_tx(db):
+        await require_group_manager(
+            user.id, group_id, 'groups.manage_assets', db,
+        )
+        await _verify_ownership(group_id, 'knowledge', resource_id, db)
+
+        # Fetch knowledge name for event
+        result = await db.execute(
+            select(Knowledge)
+            .where(Knowledge.id == resource_id)
+            .with_for_update()
+        )
+        knowledge = result.scalars().first()
+        knowledge_name = knowledge.name if knowledge else None
+
+        # 1. Delete ownership row
+        await GroupOwnedAssets.delete_asset_by_resource(
+            'knowledge', resource_id, db=db,
+        )
+
+        # 2. Delete all access grants
+        await _revoke_all_access_flush('knowledge', resource_id, db)
+
+        # 3. Delete the knowledge row
+        await db.execute(
+            delete(Knowledge).where(Knowledge.id == resource_id)
+        )
+        await db.flush()
+
+        pending_events.append({
+            'event': EVENTS.KNOWLEDGE_DELETED,
+            'subject_id': resource_id,
+            'data': {'name': knowledge_name},
+        })
+
+    for evt in pending_events:
+        await publish_event(
+            request,
+            evt['event'],
+            actor=user,
+            subject_id=evt['subject_id'],
+            data=evt.get('data'),
+        )
+
+    return True
+
+
+@router.post(
+    '/groups/{group_id}/assets/prompts/{resource_id}/update',
+    response_model=GroupManagerPromptResponse,
+)
+async def update_group_prompt(
+    request: Request,
+    group_id: str,
+    resource_id: str,
+    form_data: GroupManagerPromptUpdateForm,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Update a group-owned prompt.
+
+    First verifies ownership, then updates the prompt row.
+    Rejects supplied ``access_grants``.
+    """
+    pending_events: list[dict[str, Any]] = []
+
+    async with group_manager_tx(db):
+        await require_group_manager(
+            user.id, group_id, 'groups.manage_assets', db,
+        )
+        await _verify_ownership(group_id, 'prompt', resource_id, db)
+
+        # Lock and fetch the prompt row
+        result = await db.execute(
+            select(Prompt)
+            .where(Prompt.id == resource_id)
+            .with_for_update()
+        )
+        prompt = result.scalars().first()
+        if prompt is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=ERROR_MESSAGES.NOT_FOUND,
+            )
+
+        now = int(time.time())
+        update_data: dict[str, Any] = {}
+        if form_data.name is not None:
+            update_data['name'] = form_data.name
+        if form_data.content is not None:
+            update_data['content'] = form_data.content
+        if form_data.data is not None:
+            update_data['data'] = form_data.data
+        if form_data.meta is not None:
+            update_data['meta'] = form_data.meta
+        if form_data.tags is not None:
+            update_data['tags'] = form_data.tags
+        if update_data:
+            update_data['updated_at'] = now
+            for key, value in update_data.items():
+                setattr(prompt, key, value)
+            await db.flush()
+
+        pending_events.append({
+            'event': EVENTS.PROMPT_UPDATED,
+            'subject_id': resource_id,
+            'data': {'name': prompt.name, 'command': prompt.command},
+        })
+
+    for evt in pending_events:
+        await publish_event(
+            request,
+            evt['event'],
+            actor=user,
+            subject_id=evt['subject_id'],
+            data=evt.get('data'),
+        )
+
+    return GroupManagerPromptResponse(
+        id=prompt.id,
+        command=prompt.command,
+        name=prompt.name,
+        created_at=prompt.created_at,
+        updated_at=prompt.updated_at,
+        write_access=True,
+    )
+
+
+@router.delete(
+    '/groups/{group_id}/assets/prompts/{resource_id}/delete',
+    response_model=bool,
+)
+async def delete_group_prompt(
+    request: Request,
+    group_id: str,
+    resource_id: str,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Delete a group-owned prompt.
+
+    In one transaction: delete ownership row, all grants, then the
+    prompt row itself.
+    """
+    pending_events: list[dict[str, Any]] = []
+
+    async with group_manager_tx(db):
+        await require_group_manager(
+            user.id, group_id, 'groups.manage_assets', db,
+        )
+        await _verify_ownership(group_id, 'prompt', resource_id, db)
+
+        # Fetch prompt name/command for event
+        result = await db.execute(
+            select(Prompt)
+            .where(Prompt.id == resource_id)
+            .with_for_update()
+        )
+        prompt = result.scalars().first()
+        prompt_name = prompt.name if prompt else None
+        prompt_command = prompt.command if prompt else None
+
+        # 1. Delete ownership row
+        await GroupOwnedAssets.delete_asset_by_resource(
+            'prompt', resource_id, db=db,
+        )
+
+        # 2. Delete all access grants
+        await _revoke_all_access_flush('prompt', resource_id, db)
+
+        # 3. Delete the prompt row
+        await db.execute(
+            delete(Prompt).where(Prompt.id == resource_id)
+        )
+        await db.flush()
+
+        pending_events.append({
+            'event': EVENTS.PROMPT_DELETED,
+            'subject_id': resource_id,
+            'data': {'name': prompt_name, 'command': prompt_command},
+        })
+
+    for evt in pending_events:
+        await publish_event(
+            request,
+            evt['event'],
+            actor=user,
+            subject_id=evt['subject_id'],
+            data=evt.get('data'),
+        )
+
+    return True
+
+
+# =====================================================================
+# ACL delta
+# =====================================================================
+
+
+@router.post(
+    '/groups/{group_id}/assets/{resource_type}/{resource_id}/access/update',
+    response_model=GroupManagerACLResponse,
+)
+async def update_group_asset_acl(
+    request: Request,
+    group_id: str,
+    resource_type: str,
+    resource_id: str,
+    form_data: GroupManagerACLDeltaForm,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Adjust the owning-group write permission on a group-owned asset.
+
+    The read grant for the owning group is a permanent baseline and
+    cannot be removed through this endpoint.
+
+    Only ``write: bool`` is accepted — the endpoint rejects whole ACL
+    replacement or any other principal type.
+
+    Skills are excluded — they use ``groups.manage_skills`` and have
+    no ACL-delta endpoint; only baseline group ``read`` is allowed.
+    """
+    if resource_type not in SUPPORTED_OWNED_ASSET_TYPES:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f'Unsupported resource_type: {resource_type}',
+        )
+
+    if resource_type == 'skill':
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                'Skills do not support ACL delta. '
+                'Scoped skill endpoints grant baseline group read only.'
+            ),
+        )
+
+    pending_events: list[dict[str, Any]] = []
+    event_cls = (
+        EVENTS.KNOWLEDGE_ACCESS_UPDATED
+        if resource_type == 'knowledge'
+        else EVENTS.PROMPT_ACCESS_UPDATED
+    )
+
+    async with group_manager_tx(db):
+        await require_group_manager(
+            user.id, group_id, 'groups.manage_assets', db,
+        )
+        await _verify_ownership(group_id, resource_type, resource_id, db)
+
+        # Ensure the baseline read grant exists (idempotent)
+        await _grant_access_flush(
+            resource_type, resource_id,
+            PRINCIPAL_TYPE_GROUP, group_id, 'read',
+            db,
+        )
+
+        # Delta: add or remove the write grant
+        if form_data.write:
+            await _grant_access_flush(
+                resource_type, resource_id,
+                PRINCIPAL_TYPE_GROUP, group_id, 'write',
+                db,
+            )
+        else:
+            await _revoke_access_flush(
+                resource_type, resource_id,
+                PRINCIPAL_TYPE_GROUP, group_id, 'write',
+                db,
+            )
+
+        pending_events.append({
+            'event': event_cls,
+            'subject_id': resource_id,
+            'data': {},  # omit content
+        })
+
+    for evt in pending_events:
+        await publish_event(
+            request,
+            evt['event'],
+            actor=user,
+            subject_id=evt['subject_id'],
+            data=evt.get('data'),
+        )
+
+    return GroupManagerACLResponse(
+        resource_type=resource_type,
+        resource_id=resource_id,
+        write=form_data.write,
+    )
+
+
+# =====================================================================
+# Scoped skill management (manage_skills) — Phase 3 skills-only slice
+# =====================================================================
+
+_SLUG_RE = re.compile(r'^[a-z0-9][a-z0-9_-]{0,127}$')
+
+
+def _normalize_skill_meta(raw: Any) -> SkillMeta:
+    """Safely convert raw ``skill.meta`` (dict / None / SkillMeta) to SkillMeta.
+
+    SQLAlchemy returns a plain dict from JSON columns; SkillMeta is a
+    Pydantic model.  We must handle both forms (and None) to avoid
+    AttributeError on ``.tags`` access.
+    """
+    if raw is None:
+        return SkillMeta(tags=[])
+    if isinstance(raw, SkillMeta):
+        return raw
+    if isinstance(raw, dict):
+        return SkillMeta(tags=raw.get('tags', []))
+    # Unexpected type — degrade gracefully
+    return SkillMeta(tags=[])
+
+
+def _make_group_skill_id(group_id: str, slug: str) -> str:
+    """Build a collision-safe, group-namespaced skill ID.
+
+    Format: ``g-{group_id_short}--{slug}``  (≤ 255 chars total).
+    The prefix guarantees isolation across groups; the slug is
+    user-supplied but validated; and the composite is unique per-group
+    because ``(resource_type, resource_id)`` in ``group_owned_asset``
+    is globally unique.
+    """
+    short_gid = group_id[:12]
+    skill_id = f'g-{short_gid}--{slug}'
+    # Guard against overflow — the skill.id column is String (no length
+    # limit in practice, but keep IDs reasonable).
+    return skill_id[:255]
+
+
+def _validate_skill_slug(slug: str) -> str:
+    """Normalize and validate a skill slug.
+
+    Returns the normalized form or raises HTTPException 400.
+    """
+    normalized = slug.lower().strip().replace(' ', '-')
+    if not _SLUG_RE.match(normalized):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=ERROR_MESSAGES.DEFAULT(
+                'Invalid skill slug. Use lowercase letters, digits, '
+                'hyphens, and underscores (1-128 chars).'
+            ),
+        )
+    return normalized
+
+
+# --- Flush-only skill primitives (non-committing) ---------------------
+
+
+async def _skill_insert_flush(
+    skill_id: str,
+    group_id: str,
+    form: GroupManagerSkillCreateForm,
+    acting_user_id: str,
+    db: AsyncSession,
+) -> Skill:
+    """Insert a Skill row with ``user_id='group-asset:<group_id>'``.
+
+    The acting manager's ID is audit metadata only — stored in
+    ``created_by`` on the ownership row, NOT in ``skill.user_id``.
+    Flushed but not committed.
+    """
+    now = int(time.time())
+    meta_dict = {'tags': form.tags} if form.tags else {}
+    skill = Skill(
+        id=skill_id,
+        user_id=f'group-asset:{group_id}',
+        name=form.name,
+        description=form.description,
+        content=form.content,
+        meta=meta_dict,
+        is_active=form.active,
+        created_at=now,
+        updated_at=now,
+    )
+    db.add(skill)
+    await db.flush()
+    return skill
+
+
+async def _skill_update_flush(
+    skill: Skill,
+    form: GroupManagerSkillUpdateForm,
+    db: AsyncSession,
+) -> Skill:
+    """Update a locked Skill row with only allowed fields.
+
+    Flushed but not committed.
+    """
+    now = int(time.time())
+    if form.name is not None:
+        skill.name = form.name
+    if form.description is not None:
+        skill.description = form.description
+    if form.content is not None:
+        skill.content = form.content
+    if form.tags is not None:
+        skill.meta = {'tags': form.tags}
+    if form.active is not None:
+        skill.is_active = form.active
+    skill.updated_at = now
+    await db.flush()
+    return skill
+
+
+async def _skill_delete_flush(skill_id: str, db: AsyncSession) -> None:
+    """Delete a Skill row and flush — no commit."""
+    await db.execute(delete(Skill).where(Skill.id == skill_id))
+    await db.flush()
+
+
+# --- Scoped skill endpoints (manage_skills) ---------------------------
+
+
+@router.get(
+    '/groups/{group_id}/skills',
+    response_model=list[GroupManagerSkillResponse],
+)
+async def list_group_skills(
+    request: Request,
+    group_id: str,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """List skills owned by the target group.
+
+    Each mutation handler uses ``group_manager_tx(db)`` +
+    ``require_group_manager(..., 'groups.manage_skills', ...)``.
+    """
+    async with group_manager_tx(db):
+        await require_group_manager(
+            user.id, group_id, 'groups.manage_skills', db,
+        )
+
+        stmt = (
+            select(GroupOwnedAsset)
+            .where(
+                GroupOwnedAsset.group_id == group_id,
+                GroupOwnedAsset.resource_type == 'skill',
+            )
+            .order_by(GroupOwnedAsset.created_at.desc())
+        )
+        result = await db.execute(stmt)
+        ownership_rows = result.scalars().all()
+
+        if not ownership_rows:
+            return []
+
+        skill_ids = [o.resource_id for o in ownership_rows]
+        skill_result = await db.execute(
+            select(Skill).where(Skill.id.in_(skill_ids))
+        )
+        skills_by_id = {s.id: s for s in skill_result.scalars().all()}
+
+    response: list[GroupManagerSkillResponse] = []
+    for ownership in ownership_rows:
+        skill = skills_by_id.get(ownership.resource_id)
+        if skill is None:
+            continue
+        response.append(
+            GroupManagerSkillResponse(
+                id=skill.id,
+                slug=skill.id.split('--', 1)[1] if '--' in skill.id else skill.id,
+                name=skill.name,
+                description=skill.description or '',
+                content=skill.content,
+                is_active=skill.is_active,
+                meta=_normalize_skill_meta(skill.meta),
+                created_at=skill.created_at,
+                updated_at=skill.updated_at,
+            )
+        )
+    return response
+
+
+@router.post(
+    '/groups/{group_id}/skills/create',
+    response_model=GroupManagerSkillResponse,
+)
+async def create_group_skill(
+    request: Request,
+    group_id: str,
+    form_data: GroupManagerSkillCreateForm,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Create a skill owned by the group.
+
+    Atomically creates:
+    1. Skill row with ``user_id='group-asset:<group_id>'`` (flush only)
+    2. GroupOwnedAsset ownership row (flush only)
+    3. Owning-group ``read`` AccessGrant (flush only)
+
+    Server controls the skill ID (group-namespaced collision-safe slug).
+    The acting manager's user_id is audit metadata on the ownership row.
+    """
+    slug = _validate_skill_slug(form_data.slug)
+    skill_id = _make_group_skill_id(group_id, slug)
+    pending_events: list[dict[str, Any]] = []
+
+    async with group_manager_tx(db):
+        await require_group_manager(
+            user.id, group_id, 'groups.manage_skills', db,
+        )
+
+        # Check skill ID uniqueness
+        existing = await db.execute(
+            select(Skill).where(Skill.id == skill_id),
+        )
+        if existing.scalars().first() is not None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=ERROR_MESSAGES.DEFAULT('A skill with this slug already exists in this group.'),
+            )
+
+        # 1. Create Skill row
+        skill = await _skill_insert_flush(skill_id, group_id, form_data, user.id, db)
+
+        # 2. Create ownership row
+        await GroupOwnedAssets.insert_asset(
+            resource_type='skill',
+            resource_id=skill_id,
+            group_id=group_id,
+            created_by=user.id,
+            db=db,
+        )
+
+        # 3. Owning-group read grant (baseline — no write grant)
+        await _grant_access_flush(
+            'skill', skill_id,
+            PRINCIPAL_TYPE_GROUP, group_id, 'read',
+            db,
+        )
+
+        pending_events.append({
+            'event': EVENTS.SKILL_CREATED,
+            'subject_id': skill_id,
+            'data': {'name': form_data.name},
+        })
+
+    for evt in pending_events:
+        await publish_event(
+            request,
+            evt['event'],
+            actor=user,
+            subject_id=evt['subject_id'],
+            data=evt.get('data'),
+        )
+
+    return GroupManagerSkillResponse(
+        id=skill.id,
+        slug=slug,
+        name=skill.name,
+        description=skill.description or '',
+        content=skill.content,
+        is_active=skill.is_active,
+        meta=_normalize_skill_meta(skill.meta),
+        created_at=skill.created_at,
+        updated_at=skill.updated_at,
+    )
+
+
+@router.get(
+    '/groups/{group_id}/skills/{skill_id}',
+    response_model=GroupManagerSkillResponse,
+)
+async def get_group_skill(
+    request: Request,
+    group_id: str,
+    skill_id: str,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Read a single group-owned skill.
+
+    Verifies ownership before returning.
+    """
+    async with group_manager_tx(db):
+        await require_group_manager(
+            user.id, group_id, 'groups.manage_skills', db,
+        )
+        await _verify_ownership(group_id, 'skill', skill_id, db)
+
+        result = await db.execute(
+            select(Skill).where(Skill.id == skill_id),
+        )
+        skill = result.scalars().first()
+        if skill is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=ERROR_MESSAGES.NOT_FOUND,
+            )
+
+    return GroupManagerSkillResponse(
+        id=skill.id,
+        slug=skill_id.split('--', 1)[1] if '--' in skill_id else skill_id,
+        name=skill.name,
+        description=skill.description or '',
+        content=skill.content,
+        is_active=skill.is_active,
+        meta=_normalize_skill_meta(skill.meta),
+        created_at=skill.created_at,
+        updated_at=skill.updated_at,
+    )
+
+
+@router.post(
+    '/groups/{group_id}/skills/{skill_id}/update',
+    response_model=GroupManagerSkillResponse,
+)
+async def update_group_skill(
+    request: Request,
+    group_id: str,
+    skill_id: str,
+    form_data: GroupManagerSkillUpdateForm,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Update a group-owned skill.
+
+    First verifies ownership, then updates only allowed fields.
+    Rejects any attempt to change user_id, id, or access_grants.
+    """
+    pending_events: list[dict[str, Any]] = []
+
+    async with group_manager_tx(db):
+        await require_group_manager(
+            user.id, group_id, 'groups.manage_skills', db,
+        )
+        await _verify_ownership(group_id, 'skill', skill_id, db)
+
+        # Lock and fetch the skill row
+        result = await db.execute(
+            select(Skill).where(Skill.id == skill_id).with_for_update(),
+        )
+        skill = result.scalars().first()
+        if skill is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=ERROR_MESSAGES.NOT_FOUND,
+            )
+
+        # Update only allowed fields
+        await _skill_update_flush(skill, form_data, db)
+
+        pending_events.append({
+            'event': EVENTS.SKILL_UPDATED,
+            'subject_id': skill_id,
+            'data': {'name': skill.name},
+        })
+
+    for evt in pending_events:
+        await publish_event(
+            request,
+            evt['event'],
+            actor=user,
+            subject_id=evt['subject_id'],
+            data=evt.get('data'),
+        )
+
+    return GroupManagerSkillResponse(
+        id=skill.id,
+        slug=skill_id.split('--', 1)[1] if '--' in skill_id else skill_id,
+        name=skill.name,
+        description=skill.description or '',
+        content=skill.content,
+        is_active=skill.is_active,
+        meta=_normalize_skill_meta(skill.meta),
+        created_at=skill.created_at,
+        updated_at=skill.updated_at,
+    )
+
+
+@router.delete(
+    '/groups/{group_id}/skills/{skill_id}/delete',
+    response_model=bool,
+)
+async def delete_group_skill(
+    request: Request,
+    group_id: str,
+    skill_id: str,
+    user=Depends(get_verified_user),
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Delete a group-owned skill.
+
+    In one transaction: delete ownership row, all grants, then the
+    skill row itself.
+    """
+    pending_events: list[dict[str, Any]] = []
+
+    async with group_manager_tx(db):
+        await require_group_manager(
+            user.id, group_id, 'groups.manage_skills', db,
+        )
+        await _verify_ownership(group_id, 'skill', skill_id, db)
+
+        # Fetch skill name for event
+        result = await db.execute(
+            select(Skill).where(Skill.id == skill_id).with_for_update(),
+        )
+        skill = result.scalars().first()
+        skill_name = skill.name if skill else None
+
+        # 1. Delete ownership row
+        await GroupOwnedAssets.delete_asset_by_resource(
+            'skill', skill_id, db=db,
+        )
+
+        # 2. Delete all access grants
+        await _revoke_all_access_flush('skill', skill_id, db)
+
+        # 3. Delete the skill row
+        await _skill_delete_flush(skill_id, db)
+
+        pending_events.append({
+            'event': EVENTS.SKILL_DELETED,
+            'subject_id': skill_id,
+            'data': {'name': skill_name},
+        })
+
+    for evt in pending_events:
+        await publish_event(
+            request,
+            evt['event'],
+            actor=user,
+            subject_id=evt['subject_id'],
+            data=evt.get('data'),
+        )
+
+    return True

--- a/backend/open_webui/routers/ollama.py
+++ b/backend/open_webui/routers/ollama.py
@@ -488,7 +488,7 @@ async def get_ollama_tags(
         key = get_api_key(url_idx, url, (await Config.get('ollama.api_configs', {})))
         result = await send_request(f'{url}/api/tags', 'GET', key=key, user=user)
 
-    if user.role == 'user' and not BYPASS_MODEL_ACCESS_CONTROL:
+    if user.role != 'admin' and not BYPASS_MODEL_ACCESS_CONTROL:
         result['models'] = await get_filtered_models(result, user)
 
     return result
@@ -1491,7 +1491,7 @@ async def get_openai_models(
     now_ts = int(time.time())
     models = [{'id': m['model'], 'object': 'model', 'created': now_ts, 'owned_by': 'openai'} for m in raw_models]
 
-    if user.role == 'user' and not BYPASS_MODEL_ACCESS_CONTROL:
+    if user.role != 'admin' and not BYPASS_MODEL_ACCESS_CONTROL:
         model_ids = [m['id'] for m in models]
         model_infos = {mi.id: mi for mi in await Models.get_models_by_ids(model_ids, db=db)}
         user_group_ids = {g.id for g in await Groups.get_groups_by_member_id(user.id, db=db)}

--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -931,7 +931,7 @@ async def get_models(request: Request, url_idx: int | None = None, user=Depends(
                 error_detail = f'Unexpected error: {str(e)}'
                 raise HTTPException(status_code=500, detail=error_detail)
 
-    if user.role == 'user' and not BYPASS_MODEL_ACCESS_CONTROL:
+    if user.role != 'admin' and not BYPASS_MODEL_ACCESS_CONTROL:
         models['data'] = await get_filtered_models(models, user)
 
     return models

--- a/backend/open_webui/routers/users.py
+++ b/backend/open_webui/routers/users.py
@@ -971,6 +971,26 @@ async def update_user_by_id(
         # Build update dict from only the provided fields
         update_data = {}
         if form_data.role is not None:
+            # Validate custom role references
+            from open_webui.models.custom_roles import is_custom_role_ref, extract_custom_role_id
+
+            if is_custom_role_ref(form_data.role):
+                from open_webui.models.custom_roles import CustomRoles
+
+                role_id = extract_custom_role_id(form_data.role)
+                active_role = await CustomRoles.get_active_role_by_id(role_id, db=db) if role_id else None
+                if not active_role:
+                    raise HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        detail=ERROR_MESSAGES.CUSTOM_ROLE_INACTIVE,
+                    )
+            elif form_data.role not in ('admin', 'user', 'pending'):
+                # Reject unknown non-custom role strings
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=ERROR_MESSAGES.CUSTOM_ROLE_INVALID_REFERENCE,
+                )
+
             update_data['role'] = form_data.role
         if form_data.name is not None:
             update_data['name'] = form_data.name

--- a/backend/open_webui/utils/access_control/__init__.py
+++ b/backend/open_webui/utils/access_control/__init__.py
@@ -14,6 +14,33 @@ from open_webui.models.users import UserModel
 from open_webui.utils.json_codec import JSONCodec
 from sqlalchemy.ext.asyncio import AsyncSession
 
+# ---------------------------------------------------------------------------
+# Custom-role permission resolution
+# ---------------------------------------------------------------------------
+
+# Roles that use legacy permission evaluation (default_permissions + group OR-merging).
+# ``admin`` is always bypass-admin and never flows through the ordinary permissions path.
+LEGACY_PERMISSION_ROLES = {'user', 'pending'}
+
+
+async def _get_custom_role_permissions(role: str, db: AsyncSession | None = None) -> dict[str, Any] | None:
+    """Look up the explicit permission set for a custom role reference.
+
+    Returns the permissions dict if the role is a valid active custom role,
+    or ``None`` if it cannot be resolved (unknown, malformed, or disabled).
+    """
+    from open_webui.models.custom_roles import CustomRoles, extract_custom_role_id
+
+    role_id = extract_custom_role_id(role)
+    if role_id is None:
+        return None
+
+    active_role = await CustomRoles.get_active_role_by_id(role_id, db=db)
+    if active_role is None:
+        return None
+
+    return active_role.permissions
+
 
 def fill_missing_permissions(permissions: dict[str, Any], default_permissions: dict[str, Any]) -> dict[str, Any]:
     """
@@ -33,27 +60,81 @@ async def get_permissions(
     user_id: str,
     default_permissions: dict[str, Any],
     db: AsyncSession | None = None,
+    user_role: str | None = None,
 ) -> dict[str, Any]:
     """
-    Get all permissions for a user by combining the permissions of all groups the user is a member of.
-    If a permission is defined in multiple groups, the most permissive value is used (True > False).
-    Permissions are nested in a dict with the permission key as the key and a boolean as the value.
+    Get all permissions for a user.
+
+    Resolution order:
+    1. If the user has a valid active custom role, return ONLY that role's
+       explicit permissions normalised against the server-owned catalog
+       (no group merging, no config defaults).
+    2. Otherwise (legacy ``user``/``pending``), combine the configured
+       default permissions with the most-permissive merge of all group
+       permissions — the existing behaviour.
     """
 
-    def combine_permissions(permissions: dict[str, Any], group_permissions: dict[str, Any]) -> dict[str, Any]:
-        """Combine permissions from multiple groups by taking the most permissive value."""
-        for key, value in group_permissions.items():
-            if isinstance(value, dict):
-                if key not in permissions:
-                    permissions[key] = {}
-                permissions[key] = combine_permissions(permissions[key], value)
-            else:
-                if key not in permissions:
-                    permissions[key] = value
-                else:
-                    permissions[key] = permissions[key] or value  # Use the most permissive value (True > False)
-        return permissions
+    # Fast path: if the caller already knows the role, use it.
+    if user_role is None:
+        from open_webui.models.users import Users as _Users
 
+        user_obj = await _Users.get_user_by_id(user_id, db=db)
+        if user_obj is None:
+            return JSONCodec.loads(JSONCodec.dumps(default_permissions))
+        user_role = user_obj.role
+
+    # ── Custom role path ──────────────────────────────────────────────
+    if user_role not in LEGACY_PERMISSION_ROLES and user_role != 'admin':
+        return await _resolve_custom_role_permissions(user_role, db=db)
+
+    # ── Legacy path (user / pending) ──────────────────────────────────
+    return await _resolve_legacy_permissions(user_id, default_permissions, db=db)
+
+
+async def _resolve_custom_role_permissions(role: str, db: AsyncSession | None = None) -> dict[str, Any]:
+    """Resolve permissions for a custom role reference.
+
+    Returns the normalised permission tree if the role is valid and active.
+    For unknown/disabled/malformed roles returns a full-deny tree derived
+    from the fixed server-owned catalog (fail-closed).
+    """
+    from open_webui.models.custom_roles import normalize_permissions
+
+    custom_perms = await _get_custom_role_permissions(role, db=db)
+    if custom_perms is not None:
+        return normalize_permissions(custom_perms)
+    # Unknown/disabled custom role — fail closed: return a full-deny
+    # tree derived from the fixed server-owned catalog, NOT from the
+    # caller's ``default_permissions`` shape.  This ensures caller
+    # config cannot alter the denial shape or grant anything.
+    return normalize_permissions(None)
+
+
+def _combine_permissions(permissions: dict[str, Any], group_permissions: dict[str, Any]) -> dict[str, Any]:
+    """Combine permissions from multiple groups by taking the most permissive value."""
+    for key, value in group_permissions.items():
+        if isinstance(value, dict):
+            if key not in permissions:
+                permissions[key] = {}
+            permissions[key] = _combine_permissions(permissions[key], value)
+        else:
+            if key not in permissions:
+                permissions[key] = value
+            else:
+                permissions[key] = permissions[key] or value  # Use the most permissive value (True > False)
+    return permissions
+
+
+async def _resolve_legacy_permissions(
+    user_id: str,
+    default_permissions: dict[str, Any],
+    db: AsyncSession | None = None,
+) -> dict[str, Any]:
+    """Resolve permissions for legacy ``user``/``pending`` roles.
+
+    Combines the configured default permissions with the most-permissive
+    merge of all group permissions.
+    """
     user_groups = await Groups.get_groups_by_member_id(user_id, db=db)
 
     # Deep copy default permissions to avoid modifying the original dict
@@ -61,12 +142,29 @@ async def get_permissions(
 
     # Combine permissions from all user groups
     for group in user_groups:
-        permissions = combine_permissions(permissions, group.permissions or {})
+        permissions = _combine_permissions(permissions, group.permissions or {})
 
     # Ensure all fields from default_permissions are present and filled in
     permissions = fill_missing_permissions(permissions, default_permissions)
 
     return permissions
+
+
+def _empty_permissions(default_permissions: dict[str, Any]) -> dict[str, Any]:
+    """Return a permissions dict with all boolean leaves set to False.
+
+    Used for fail-closed resolution of unknown/disabled custom roles.
+    """
+    def _deny_tree(template: dict[str, Any]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, value in template.items():
+            if isinstance(value, dict):
+                result[key] = _deny_tree(value)
+            else:
+                result[key] = False
+        return result
+
+    return _deny_tree(default_permissions)
 
 
 async def has_permission(
@@ -76,10 +174,14 @@ async def has_permission(
     db: AsyncSession | None = None,
 ) -> bool:
     """
-    Check if a user has a specific permission by checking the group permissions
-    and fall back to default permissions if not found in any group.
+    Check if a user has a specific permission.
 
-    Permission keys can be hierarchical and separated by dots ('.').
+    Resolution:
+    1. Custom roles: check only the role's explicit permission tree
+       normalised against the server-owned catalog.
+       Unknown/disabled custom roles return False (fail-closed).
+    2. Legacy roles (user/pending): check group permissions, then default.
+    3. Admin: always returns True (admin bypass handled by callers).
     """
 
     def get_permission(permissions: dict[str, Any], keys: list[str]) -> bool:
@@ -93,6 +195,31 @@ async def has_permission(
 
     permission_hierarchy = permission_key.split('.')
 
+    # Resolve user role if not provided via caller context
+    from open_webui.models.users import Users as _Users
+
+    user_obj = await _Users.get_user_by_id(user_id, db=db)
+    if user_obj is None:
+        return False
+
+    user_role = user_obj.role
+
+    # ── Custom role path ──────────────────────────────────────────────
+    if user_role not in LEGACY_PERMISSION_ROLES and user_role != 'admin':
+        custom_perms = await _get_custom_role_permissions(user_role, db=db)
+        if custom_perms is not None:
+            # Normalize against the server-owned catalog
+            from open_webui.models.custom_roles import normalize_permissions
+            normalized = normalize_permissions(custom_perms)
+            return get_permission(normalized, permission_hierarchy)
+        # Unknown/disabled custom role — fail closed
+        return False
+
+    # ── Admin bypass ──────────────────────────────────────────────────
+    if user_role == 'admin':
+        return True
+
+    # ── Legacy path (user / pending) ──────────────────────────────────
     # Retrieve user group permissions
     user_groups = await Groups.get_groups_by_member_id(user_id, db=db)
 

--- a/backend/open_webui/utils/access_control/group_manager.py
+++ b/backend/open_webui/utils/access_control/group_manager.py
@@ -1,0 +1,432 @@
+"""Group-manager authorization service.
+
+Provides ``require_group_manager`` which verifies that a user holds the
+appropriate custom-role capability (``groups.manage_members`` or
+``groups.manage_assets``), is a current member of the target group, and
+the group exists.
+
+Transaction boundary
+--------------------
+All calls to ``require_group_manager`` **must** occur inside a
+``group_manager_tx`` context manager.  The context manager is the
+**sole owner** of the authorization-plus-mutation transaction:
+
+1. It **rejects** sessions already in a transaction (the caller must
+   pass a fresh session).
+2. It **starts the transaction**: for SQLite, issues ``BEGIN IMMEDIATE``
+   as the *first* SQL statement on a fresh session; for PostgreSQL, uses
+   ``session.begin()``.
+3. It **commits** on success or **rolls back** on error.
+4. The boundary marker is cleared only *after* the transaction is closed.
+
+On **PostgreSQL**, ``BEGIN`` (the default) combined with
+``SELECT ... FOR UPDATE`` acquires **row-level locks** — only the
+specific rows touched by the authorization query are locked, and other
+transactions can still read and write unrelated rows.
+
+On **SQLite**, ``BEGIN IMMEDIATE`` acquires the **database-wide write
+lock** at the start of the transaction.  No other connection can write
+until this transaction commits or rolls back.  This is SQLite's native
+serialization mechanism — it is **not** equivalent to Postgres row-level
+locks, but it provides the same linearizability guarantee for the
+authorization-then-mutation unit.
+
+Locking order (stable, both backends)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Rows are locked in a deterministic order to prevent deadlocks:
+
+    User → CustomRole → GroupMember → Group
+
+On PostgreSQL each ``SELECT ... FOR UPDATE`` acquires an exclusive row
+lock.  On SQLite the ``BEGIN IMMEDIATE`` write lock already serialises
+all writers, so ``FOR UPDATE`` is a no-op that documents intent only.
+
+No internal sessions, commits, or flushes are performed by
+``require_group_manager`` itself — it only reads.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from contextvars import ContextVar
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+log = logging.getLogger(__name__)
+
+
+# ------------------------------------------------------------------
+# Boundary token (ContextVar-based, caller-writable-proof)
+# ------------------------------------------------------------------
+
+
+class _TxToken:
+    """Opaque token proving entry into ``group_manager_tx``.
+
+    Created only inside ``group_manager_tx`` and bound to both the
+    exact ``AsyncSession`` object **and** the exact
+    ``AsyncSessionTransaction`` object via identity (``is``).  A caller
+    who sets ``session.info[_GM_TX_BOUNDARY] = True`` manually does
+    **not** hold a token, so ``_check_boundary`` rejects the call.
+
+    The token intentionally stores object references rather than
+    ``id()`` integers so the comparison is immune to id-reuse after
+    garbage collection.  The ContextVar ``reset()`` in the finally
+    block drops these references deterministically, preventing any
+    reference cycle from persisting beyond the context lifetime.
+    """
+
+    __slots__ = ('_session_ref', '_tx_ref')
+
+    def __init__(self, session: AsyncSession, tx: Any) -> None:
+        # Store live object references; compare by ``is``.
+        self._session_ref = session
+        self._tx_ref = tx
+
+    def matches(self, session: AsyncSession) -> bool:
+        """Return ``True`` only when the token was created for *session*
+        **and** the session's current transaction is the exact same
+        object that was active when the token was minted."""
+        if self._session_ref is not session:
+            return False
+        if not session.in_transaction():
+            return False
+        tx = session.get_transaction()
+        if tx is None:
+            return False
+        return self._tx_ref is tx
+
+
+# Per-async-context boundary token.  ``None`` when not inside
+# ``group_manager_tx``.  Caller code cannot forge this — only
+# ``group_manager_tx`` sets/clears it.
+_boundary_ctx: ContextVar[_TxToken | None] = ContextVar(
+    '_boundary_ctx', default=None,
+)
+
+# Diagnostics key in ``session.info`` — set/cleared by the context
+# manager for debugging but **never** used as authorization proof.
+_GM_TX_BOUNDARY: str = '_GM_TX_BOUNDARY'
+
+
+class GroupManagerError(Exception):
+    """Raised when group-manager authorization fails.
+
+    Attributes:
+        reason: short machine-readable tag
+        detail: human-readable explanation
+    """
+
+    def __init__(self, reason: str, detail: str) -> None:
+        self.reason = reason
+        self.detail = detail
+        super().__init__(detail)
+
+
+# ------------------------------------------------------------------
+# Transaction boundary context manager
+# ------------------------------------------------------------------
+
+
+@asynccontextmanager
+async def group_manager_tx(db: AsyncSession) -> AsyncIterator[AsyncSession]:
+    """Scoped transaction boundary for group-manager operations.
+
+    This is the **sole owner** of the authorization-plus-mutation
+    transaction.  It performs three things:
+
+    1. **Rejects** sessions that are already in a transaction — the
+       caller must pass a fresh session.
+    2. **Starts the transaction**: for SQLite, issues ``BEGIN IMMEDIATE``
+       as the *first* SQL statement on a fresh session (not after
+       ``session.begin()`` or a deferred query); for PostgreSQL, uses
+       ``async with session.begin()``.
+    3. **Establishes a ContextVar token** that proves
+       ``require_group_manager`` is called from *this* context manager
+       with *this exact session*.
+
+    On **success** the context manager commits the transaction; on
+    **error** it rolls back.  The boundary token is cleared only
+    *after* the transaction is closed.
+
+    Usage::
+
+        async with group_manager_tx(db):
+            await require_group_manager(uid, gid, 'groups.manage_members', db)
+            # … perform mutations …
+        # transaction is committed (or rolled back on error)
+    """
+    from sqlalchemy import text
+
+    # ── 0. Reject session already in transaction ─────────────────────
+    if db.in_transaction():
+        raise GroupManagerError(
+            'tx_boundary_missing',
+            'group_manager_tx() requires a fresh session not already in '
+            'a transaction.  Do not nest transactions — pass a fresh '
+            'session to this context manager.',
+        )
+
+    # ── 1. Detect backend ────────────────────────────────────────────
+    is_sqlite = db.bind is not None and db.bind.dialect.name == 'sqlite'
+
+    if is_sqlite:
+        # SQLite: issue BEGIN IMMEDIATE as the first SQL on the fresh
+        # session.  This acquires the database-wide write lock *before*
+        # any authorization reads, serialising the entire
+        # authorization-then-mutation unit.
+        await db.execute(text('BEGIN IMMEDIATE'))
+    else:
+        # PostgreSQL: use session.begin() which issues BEGIN (the
+        # default).  Row-level locks are acquired via SELECT … FOR
+        # UPDATE inside require_group_manager.
+        await db.begin()
+
+    # ── 2. Establish boundary token (only after BEGIN success) ───────
+    tx_obj = db.get_transaction()
+    token = _TxToken(db, tx_obj)
+    reset_token = _boundary_ctx.set(token)
+    db.info[_GM_TX_BOUNDARY] = True  # diagnostics only, never auth proof
+
+    try:
+        yield db
+    except BaseException:
+        # On error (including asyncio.CancelledError which is a
+        # BaseException), rollback the transaction before clearing
+        # the token so no lock or partial state leaks.
+        if db.in_transaction():
+            await db.rollback()
+        raise
+    else:
+        # On success, commit the transaction.  If the commit itself
+        # fails, attempt rollback before re-raising (P1.8: commit
+        # failure must be handled like body failure).
+        if db.in_transaction():
+            try:
+                await db.commit()
+            except BaseException:
+                if db.in_transaction():
+                    await db.rollback()
+                raise
+    finally:
+        # Restore the ContextVar to its prior value (any outer
+        # context), rather than blindly setting None.  This is
+        # correct even when there is no outer context because
+        # ``reset`` restores the default.
+        _boundary_ctx.reset(reset_token)
+        db.info.pop(_GM_TX_BOUNDARY, None)
+
+
+def _check_boundary(db: AsyncSession) -> None:
+    """Raise if the session is not inside a ``group_manager_tx`` boundary.
+
+    Authorization requires **all** of:
+
+    1. A ``_TxToken`` exists in the current async-context (set only by
+       ``group_manager_tx``).
+    2. The token was created for *this exact session* (identity check).
+    3. The token was created for *this exact transaction* — so a child
+       task that outlives the parent context, or any stale-token
+       reuse, is rejected.
+    4. The session has an active (owned) transaction.
+
+    Manually setting ``session.info[_GM_TX_BOUNDARY] = True`` does **not**
+    satisfy condition (1), so it never authorizes access.
+    """
+    token = _boundary_ctx.get(None)
+    if token is None or not token.matches(db):
+        raise GroupManagerError(
+            'tx_boundary_missing',
+            'require_group_manager() must be called inside a group_manager_tx() '
+            'context manager with the same session and transaction.  Setting '
+            'session.info directly does not authorize access.',
+        )
+    if not db.in_transaction():
+        raise GroupManagerError(
+            'tx_boundary_missing',
+            'require_group_manager() requires an active transaction.  '
+            'The group_manager_tx() context manager owns the transaction.',
+        )
+
+
+# ------------------------------------------------------------------
+# Capability check
+# ------------------------------------------------------------------
+
+
+def _check_capability(capability: str, custom_perms: dict[str, Any]) -> None:
+    """Verify a ``groups.*`` capability leaf is ``True`` in the normalised perms.
+
+    Raises ``GroupManagerError`` if the capability is missing, not a bool,
+    or not exactly ``True``.
+    """
+    from open_webui.models.custom_roles import normalize_permissions
+
+    normalized = normalize_permissions(custom_perms)
+    capability_parts = capability.split('.')
+    node: Any = normalized
+    for part in capability_parts:
+        if not isinstance(node, dict) or part not in node:
+            raise GroupManagerError(
+                'capability_denied',
+                f'Permission leaf {capability!r} is not present or not True.',
+            )
+        node = node[part]
+
+    if node is not True:
+        raise GroupManagerError(
+            'capability_denied',
+            f'Permission leaf {capability!r} is not True (got {node!r}).',
+        )
+
+
+# ------------------------------------------------------------------
+# Main authorization entry point
+# ------------------------------------------------------------------
+
+
+async def require_group_manager(
+    user_id: str,
+    group_id: str,
+    capability: str,
+    db: AsyncSession,
+) -> None:
+    """Verify the user is an authorized group manager for the given capability.
+
+    Parameters
+    ----------
+    user_id:
+        The authenticated user's ID.
+    group_id:
+        The target group ID.
+    capability:
+        A fixed ``groups.*`` permission leaf, e.g.
+        ``groups.manage_members`` or ``groups.manage_assets``.
+    db:
+        An active ``AsyncSession``.  All reads use this session; no
+        commits or flushes are performed.
+
+    .. important::
+
+        This function **must** be called inside a ``group_manager_tx``
+        context manager.  Calls outside the boundary raise
+        ``GroupManagerError`` with reason ``tx_boundary_missing``.
+
+    Raises
+    ------
+    GroupManagerError
+        If any check fails.  The ``reason`` field is one of:
+        ``tx_boundary_missing``, ``invalid_capability``,
+        ``admin_denied``, ``legacy_role_denied``, ``user_not_found``,
+        ``invalid_custom_role``, ``not_a_member``, ``group_not_found``,
+        ``group_inactive``, ``capability_denied``.
+    """
+    # ── 0. Enforce transaction boundary ─────────────────────────────
+    _check_boundary(db)
+
+    # ── 1. Validate the capability string itself ─────────────────────
+    from open_webui.models.custom_roles import _PERMISSION_CATALOG
+
+    capability_parts = capability.split('.')
+    if len(capability_parts) != 2 or capability_parts[0] != 'groups':
+        raise GroupManagerError(
+            'invalid_capability',
+            f'{capability!r} is not a recognised groups.* capability. '
+            f'Valid: groups.{sorted(_PERMISSION_CATALOG.get("groups", {}))}',
+        )
+    groups_catalog = _PERMISSION_CATALOG.get('groups', {})
+    if capability_parts[1] not in groups_catalog:
+        raise GroupManagerError(
+            'invalid_capability',
+            f'{capability!r} is not a recognised groups.* capability. '
+            f'Valid: groups.{sorted(groups_catalog)}',
+        )
+
+    # ── 2. Lock User row (stable order: User first) ─────────────────
+    from open_webui.models.users import User
+
+    user_result = await db.execute(
+        select(User).where(User.id == user_id).with_for_update()
+    )
+    user_row = user_result.scalars().first()
+    if user_row is None:
+        raise GroupManagerError('user_not_found', f'User {user_id!r} not found.')
+
+    user_role = user_row.role
+
+    # ── 3. Admin and legacy roles are denied on this service ─────────
+    from open_webui.utils.access_control import LEGACY_PERMISSION_ROLES
+
+    if user_role == 'admin':
+        raise GroupManagerError(
+            'admin_denied',
+            'Admin users cannot use the scoped group-manager service. '
+            'Use the admin router instead.',
+        )
+    if user_role in LEGACY_PERMISSION_ROLES:
+        raise GroupManagerError(
+            'legacy_role_denied',
+            f'Legacy role {user_role!r} does not carry group-manager authority. '
+            'Assign a custom role with the required groups.* capability.',
+        )
+
+    # ── 4. Lock CustomRole row (stable order: second) ───────────────
+    from open_webui.models.custom_roles import CustomRole, extract_custom_role_id
+
+    role_id = extract_custom_role_id(user_role)
+    if role_id is None:
+        raise GroupManagerError(
+            'invalid_custom_role',
+            f'Custom role reference {user_role!r} is malformed.',
+        )
+
+    role_result = await db.execute(
+        select(CustomRole).where(
+            CustomRole.id == role_id,
+            CustomRole.active.is_(True),
+        ).with_for_update()
+    )
+    role_row = role_result.scalars().first()
+    if role_row is None:
+        raise GroupManagerError(
+            'invalid_custom_role',
+            f'Custom role reference {user_role!r} could not be resolved '
+            '(unknown, inactive, or disabled).',
+        )
+
+    custom_perms: dict[str, Any] = role_row.permissions
+
+    # ── 5. Normalise and check the capability leaf (P1.4: is True) ──
+    _check_capability(capability, custom_perms)
+
+    # ── 6. Lock GroupMember row (stable order: third) ───────────────
+    from open_webui.models.groups import Group, GroupMember
+
+    member_result = await db.execute(
+        select(GroupMember).where(
+            GroupMember.group_id == group_id,
+            GroupMember.user_id == user_id,
+        ).with_for_update()
+    )
+    if member_result.scalars().first() is None:
+        raise GroupManagerError(
+            'not_a_member',
+            f'User {user_id!r} is not a member of group {group_id!r}.',
+        )
+
+    # ── 7. Lock Group row (stable order: fourth) ────────────────────
+    group_result = await db.execute(
+        select(Group).where(Group.id == group_id).with_for_update()
+    )
+    group_row = group_result.scalars().first()
+    if group_row is None:
+        raise GroupManagerError(
+            'group_not_found',
+            f'Group {group_id!r} not found.',
+        )
+    # Groups have no explicit 'active' flag; existence implies active.
+    # If a future schema adds an active flag, check it here.

--- a/backend/open_webui/utils/audit.py
+++ b/backend/open_webui/utils/audit.py
@@ -24,7 +24,7 @@ from asgiref.typing import (
     Scope as ASGIScope,
 )
 from loguru import logger
-from open_webui.env import AUDIT_INCLUDED_PATHS, AUDIT_LOG_LEVEL, ENABLE_AUDIT_GET_REQUESTS, MAX_BODY_LOG_SIZE
+from open_webui.env import AUDIT_LOG_LEVEL, MAX_BODY_LOG_SIZE
 from open_webui.models.users import UserModel
 from open_webui.utils.auth import get_current_user, get_http_authorization_cred
 from starlette.requests import Request
@@ -89,13 +89,19 @@ class AuditLogger:
 
 class AuditContext:
     """
-    Captures and aggregates the HTTP request and response bodies during the processing of a request. It ensures that only a configurable maximum amount of data is stored to prevent excessive memory usage.
+    Captures and aggregates the HTTP request and response bodies during
+    the processing of a request.  It ensures that only a configurable
+    maximum amount of data is stored to prevent excessive memory usage.
 
     Attributes:
-    request_body (bytearray): Accumulated request payload.
-    response_body (bytearray): Accumulated response payload.
-    max_body_size (int): Maximum number of bytes to capture.
-    metadata (Dict[str, Any]): A dictionary to store additional audit metadata (user, http verb, user agent, etc.).
+        request_body: Accumulated request payload.
+        response_body: Accumulated response payload.
+        max_body_size: Maximum number of bytes to capture.
+        metadata: A dictionary to store additional audit metadata.
+        redact_body: When *True*, the middleware redacts both request and
+            response bodies in the final audit entry.  Set by the middleware
+            *before* the downstream application executes so that even
+            validation / authorization failures are still redacted.
     """
 
     def __init__(self, max_body_size: int = MAX_BODY_LOG_SIZE):
@@ -103,6 +109,7 @@ class AuditContext:
         self.response_body = bytearray()
         self.max_body_size = max_body_size
         self.metadata: Dict[str, Any] = {}
+        self.redact_body: bool = False
 
     def add_request_chunk(self, chunk: bytes):
         if len(self.request_body) < self.max_body_size:
@@ -113,9 +120,23 @@ class AuditContext:
             self.response_body.extend(chunk[: self.max_body_size - len(self.response_body)])
 
 
+_SKILL_REDACT_PATTERN = re.compile(
+    r'^/api(?:/v1)?/group-manager/groups/[^/]+/skills'
+    r'(?:/(?:create|[a-zA-Z0-9_-]+(?:/(?:update|delete))?))?$'
+)
+
+
 class AuditLoggingMiddleware:
     """
-    ASGI middleware that intercepts HTTP requests and responses to perform audit logging. It captures request/response bodies (depending on audit level), headers, HTTP methods, and user information, then logs a structured audit entry at the end of the request cycle.
+    ASGI middleware that intercepts HTTP requests and responses to perform
+    audit logging.  It captures request/response bodies (depending on audit
+    level), headers, HTTP methods, and user information, then logs a
+    structured audit entry at the end of the request cycle.
+
+    **Scoped skill endpoints** (list / create / get / update / delete)
+    are automatically marked for body redaction *before* the downstream
+    application executes, so that even validation or authorization
+    failures are redacted in the audit trail.
     """
 
     DEFAULT_AUDITED_METHODS = {'PUT', 'PATCH', 'DELETE', 'POST'}
@@ -174,6 +195,14 @@ class AuditLoggingMiddleware:
             return await self.app(scope, receive, send)
 
         async with self._audit_context(request) as context:
+
+            # Middleware-level body redaction for scoped skill CRUD
+            # endpoints (list / create / get / update / delete).  This
+            # fires *before* the downstream app executes so that even
+            # 422 validation errors and 401/403 authorization failures
+            # have their bodies redacted.
+            if _SKILL_REDACT_PATTERN.match(request.url.path):
+                context.redact_body = True
 
             async def send_wrapper(message: ASGISendEvent) -> None:
                 if self.audit_level == AuditLevel.REQUEST_RESPONSE:
@@ -288,6 +317,14 @@ class AuditLoggingMiddleware:
                     '"password": "********"',
                     request_body,
                 )
+
+            # Middleware-level body redaction: the middleware marks
+            # context.redact_body for scoped skill CRUD endpoints
+            # before the downstream app executes, ensuring that even
+            # validation / authorization failures are redacted.
+            if context.redact_body:
+                request_body = '[REDACTED]'
+                response_body = '[REDACTED]'
 
             entry = AuditLogEntry(
                 id=str(uuid.uuid4()),

--- a/backend/open_webui/utils/auth.py
+++ b/backend/open_webui/utils/auth.py
@@ -516,11 +516,42 @@ async def get_current_user_by_api_key(request, api_key: str):
     return user
 
 
-VERIFIED_USER_ROLES = {'user', 'admin'}
+RESERVED_VERIFIED_ROLES = {'user', 'admin'}
 
 
-def get_verified_user(user=Depends(get_current_user)):
-    if user.role not in VERIFIED_USER_ROLES:
+def is_verified_legacy_role(role: str) -> bool:
+    """Return True if the role string is one of the statically verified legacy roles."""
+    return role in RESERVED_VERIFIED_ROLES
+
+
+async def is_verified_custom_role(role: str) -> bool:
+    """Return True if the role is a valid, active custom role reference.
+
+    Custom role validation:
+    - Must be ``custom:<uuid>`` format.
+    - The referenced role must exist in the registry AND be active.
+    - Any validation failure returns False (fail-closed).
+    """
+    from open_webui.models.custom_roles import CustomRoles, extract_custom_role_id
+
+    role_id = extract_custom_role_id(role)
+    if role_id is None:
+        return False
+
+    active_role = await CustomRoles.get_active_role_by_id(role_id)
+    return active_role is not None
+
+
+async def is_verified_role(role: str) -> bool:
+    """Unified check: legacy roles or valid active custom roles."""
+    if role in RESERVED_VERIFIED_ROLES:
+        return True
+    return await is_verified_custom_role(role)
+
+
+async def get_verified_user(user=Depends(get_current_user)):
+    """Verified-user gate — accepts legacy roles and valid active custom roles."""
+    if not await is_verified_role(user.role):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
@@ -535,7 +566,7 @@ async def get_verified_user_by_token(token: str, redis=None):
         return None
 
     user = await Users.get_user_by_id(decoded['id'])
-    if user is None or user.role not in VERIFIED_USER_ROLES:
+    if user is None or not await is_verified_role(user.role):
         return None
 
     return user
@@ -546,7 +577,7 @@ async def get_verified_user_by_id(user_id: str | None):
         return None
 
     user = await Users.get_user_by_id(user_id)
-    if user is None or user.role not in VERIFIED_USER_ROLES:
+    if user is None or not await is_verified_role(user.role):
         return None
 
     return user
@@ -567,7 +598,7 @@ async def get_optional_verified_user_from_request(request: Request):
     try:
         if token.startswith('sk-'):
             user = await get_current_user_by_api_key(request, token)
-            return user if user.role in VERIFIED_USER_ROLES else None
+            return user if await is_verified_role(user.role) else None
 
         return await get_verified_user_by_token(token, getattr(request.app.state, 'redis', None))
     except HTTPException:
@@ -575,6 +606,7 @@ async def get_optional_verified_user_from_request(request: Request):
 
 
 def get_admin_user(user=Depends(get_current_user)):
+    """Exact-admin gate — only ``admin`` role passes.  Custom roles do NOT bypass admin checks."""
     if user.role != 'admin':
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,

--- a/backend/open_webui/utils/automations.py
+++ b/backend/open_webui/utils/automations.py
@@ -38,7 +38,7 @@ from open_webui.models.config import Config
 from open_webui.models.folders import Folders
 from open_webui.models.messages import MessageForm
 from open_webui.models.users import Users
-from open_webui.utils.auth import create_token
+from open_webui.utils.auth import create_token, is_verified_role
 from open_webui.utils.misc import parse_duration
 from open_webui.utils.task import prompt_template
 from open_webui.utils.terminals import get_terminal_server_url
@@ -505,7 +505,7 @@ async def execute_automation(app, automation: AutomationModel) -> None:
         # Re-gate the rehydrated owner: a demoted/deactivated or de-permissioned owner must not run.
         from open_webui.utils.access_control import has_permission
 
-        if user.role not in ('user', 'admin') or (
+        if not await is_verified_role(user.role) or (
             user.role != 'admin'
             and not await has_permission(user.id, 'features.automations', await Config.get('user.permissions'))
         ):

--- a/backend/open_webui/utils/chat.py
+++ b/backend/open_webui/utils/chat.py
@@ -199,7 +199,7 @@ async def generate_chat_completion(
         return await generate_direct_chat_completion(request, form_data, user=user, models=models)
     else:
         # Check if user has access to the model
-        if not bypass_filter and user.role == 'user':
+        if not bypass_filter and user.role != 'admin':
             try:
                 await check_model_access(user, model)
             except Exception as e:
@@ -240,7 +240,7 @@ async def generate_chat_completion(
             form_data['model'] = selected_model_id
 
             # bypass_filter recursion below skips the line-200 check; gate the resolved model here.
-            if not bypass_filter and user.role == 'user':
+            if not bypass_filter and user.role != 'admin':
                 selected_model = request.app.state.MODELS.get(selected_model_id)
                 if selected_model:
                     await check_model_access(user, selected_model)

--- a/backend/open_webui/utils/embeddings.py
+++ b/backend/open_webui/utils/embeddings.py
@@ -67,7 +67,7 @@ async def generate_embeddings(
 
     # Access filtering
     if not getattr(request.state, 'direct', False):
-        if not bypass_filter and user.role == 'user':
+        if not bypass_filter and user.role != 'admin':
             await check_model_access(user, model)
 
     # Ollama backend — use /api/embed which supports batch input natively

--- a/backend/open_webui/utils/models.py
+++ b/backend/open_webui/utils/models.py
@@ -479,7 +479,7 @@ async def check_model_access(user, model, model_info=None, db=None):
 async def get_filtered_models(models, user, db=None):
     # Filter out models that the user does not have access to
     if (
-        user.role == 'user' or (user.role == 'admin' and not BYPASS_ADMIN_ACCESS_CONTROL)
+        user.role != 'admin' or not BYPASS_ADMIN_ACCESS_CONTROL
     ) and not BYPASS_MODEL_ACCESS_CONTROL:
         model_infos = {}
         for model in models:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,202 @@
+"""Shared test fixtures for backend custom-role tests.
+
+Uses a temp-file SQLite database so tests are fast, isolated, and
+require no external services.  The module-level bootstrap must happen
+BEFORE any open_webui import so the env var overrides take effect when
+db.py reads them at import time.
+
+Test isolation is ensured by wrapping each test session in a nested
+transaction (savepoint).  When code under test calls ``session.commit()``,
+only the savepoint is committed, not the outer transaction.  After each
+test the outer transaction is rolled back, undoing all changes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import tempfile
+
+# ---------------------------------------------------------------------------
+# Environment bootstrap — MUST happen before any open_webui import.
+# ---------------------------------------------------------------------------
+
+os.environ['ENABLE_DB_MIGRATIONS'] = 'false'
+os.environ['DATABASE_SCHEMA'] = ''
+os.environ['REDIS_URL'] = ''
+os.environ['OFFLINE_MODE'] = 'true'
+os.environ['WEBUI_AUTH'] = 'true'
+os.environ['ENABLE_PASSWORD_VALIDATION'] = 'false'
+os.environ['ENV'] = 'test'
+os.environ['ENABLE_OTEL'] = ''
+os.environ['ENABLE_PLUGINS'] = 'false'
+os.environ['WEBUI_SECRET_KEY'] = 'test-secret-key-for-unit-tests-only-1234'
+os.environ['DATABASE_POOL_SIZE'] = ''
+os.environ['DATABASE_POOL_MAX_OVERFLOW'] = '0'
+os.environ['DATABASE_POOL_TIMEOUT'] = '30'
+os.environ['DATABASE_POOL_RECYCLE'] = '0'
+os.environ['DATABASE_SQLITE_PRAGMA_BUSY_TIMEOUT'] = ''
+os.environ['DATABASE_SQLITE_PRAGMA_CACHE_SIZE'] = ''
+os.environ['DATABASE_SQLITE_PRAGMA_JOURNAL_SIZE_LIMIT'] = ''
+os.environ['DATABASE_SQLITE_PRAGMA_MMAP_SIZE'] = ''
+os.environ['DATABASE_SQLITE_PRAGMA_SYNCHRONOUS'] = ''
+os.environ['DATABASE_SQLITE_PRAGMA_TEMP_STORE'] = ''
+os.environ['DATABASE_ENABLE_SESSION_SHARING'] = 'true'
+
+# Create a temp file for SQLite so pool_size works (in-memory is incompatible)
+_tmp_db_fd, _tmp_db_path = tempfile.mkstemp(suffix='.db', prefix='owui_test_')
+os.close(_tmp_db_fd)
+os.environ['DATABASE_URL'] = f'sqlite+aiosqlite:///{_tmp_db_path}'
+
+# Ensure the backend package is importable
+_backend_dir = os.path.join(os.path.dirname(__file__), '..')
+if _backend_dir not in sys.path:
+    sys.path.insert(0, os.path.abspath(_backend_dir))
+
+import pytest
+import pytest_asyncio
+
+# ---------------------------------------------------------------------------
+# Database engine & session
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope='session')
+def event_loop():
+    """Use a single event loop for the entire test session."""
+    loop = asyncio.new_event_loop()
+    yield loop
+    loop.close()
+
+
+@pytest_asyncio.fixture(scope='session')
+async def _engine():
+    """Create an async SQLite engine and create all tables."""
+    from open_webui.internal.db import Base
+    from sqlalchemy.ext.asyncio import create_async_engine
+
+    engine = create_async_engine(os.environ['DATABASE_URL'], echo=False)
+
+    # Enable SQLite FK enforcement for the test engine (mirrors db.py's
+    # _apply_sqlite_pragmas which only runs on the production engine).
+    from sqlalchemy import event as sa_event
+
+    def _on_connect(dbapi_conn, _rec):
+        cursor = dbapi_conn.cursor()
+        cursor.execute('PRAGMA foreign_keys=ON')
+        cursor.close()
+
+    sa_event.listen(engine.sync_engine, 'connect', _on_connect)
+
+    # Import all models so their tables are registered on Base.metadata
+    from open_webui.models.access_grants import AccessGrant  # noqa: F401
+    from open_webui.models.auths import Auth  # noqa: F401
+    from open_webui.models.config import Config  # noqa: F401
+    from open_webui.models.custom_roles import CustomRole  # noqa: F401
+    from open_webui.models.groups import (  # noqa: F401
+        Group,
+        GroupMember,
+        GroupOwnedAsset,  # noqa: F401
+    )
+    from open_webui.models.knowledge import Knowledge, KnowledgeDirectory  # noqa: F401
+    from open_webui.models.prompts import Prompt  # noqa: F401
+    from open_webui.models.skills import Skill  # noqa: F401
+    from open_webui.models.tools import Tool  # noqa: F401
+    from open_webui.models.users import ApiKey, User  # noqa: F401
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    yield engine
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def db(_engine):
+    """Provide an isolated transactional session.
+
+    Uses a nested transaction (savepoint) so that ``session.commit()`` calls
+    inside the code under test only commit the savepoint, not the outer
+    transaction.  After the test, the outer transaction is rolled back,
+    ensuring complete isolation between tests.
+    """
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    connection = await _engine.connect()
+    transaction = await connection.begin()
+    session = AsyncSession(bind=connection, expire_on_commit=False)
+
+    # Begin a nested transaction (savepoint).  When the code under test
+    # calls session.commit(), SQLAlchemy will commit only the savepoint
+    # and automatically begin a new one, keeping the outer transaction alive.
+    _ = await session.begin_nested()
+
+    yield session
+
+    await session.close()
+    await transaction.rollback()
+    await connection.close()
+
+
+@pytest_asyncio.fixture
+async def fresh_session(_engine):
+    """Provide a fresh session NOT in any transaction.
+
+    This is used for tests that need to exercise ``group_manager_tx`` on
+    a truly fresh session (which ``group_manager_tx`` requires — it
+    rejects sessions already in a transaction).
+    """
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    session = AsyncSession(bind=_engine, expire_on_commit=False)
+
+    yield session
+
+    await session.close()
+
+
+@pytest_asyncio.fixture
+async def manager_db(_engine):
+    """Provide a fresh session for group-manager transaction tests.
+
+    Unlike the ``db`` fixture (savepoint-based), this session starts
+    outside any transaction so ``group_manager_tx`` can issue BEGIN
+    IMMEDIATE as its first statement.  Setup helpers detect the
+    ``manager_setup`` marker in ``session.info`` and auto-commit after
+    flush so data is visible to subsequent transactions.
+
+    All committed rows are cleaned up after each test.
+    """
+    from open_webui.models.access_grants import AccessGrant
+    from open_webui.models.custom_roles import CustomRole
+    from open_webui.models.groups import Group, GroupMember, GroupOwnedAsset
+    from open_webui.models.skills import Skill
+    from open_webui.models.tools import Tool
+    from open_webui.models.users import User
+    from sqlalchemy import delete as sa_delete
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    session = AsyncSession(bind=_engine, expire_on_commit=False)
+    session.info['manager_setup'] = True
+
+    yield session
+
+    await session.close()
+
+    # Clean committed rows in FK-safe order (child → parent).
+    conn = await _engine.connect()
+    try:
+        await conn.execute(sa_delete(AccessGrant))
+        await conn.execute(sa_delete(GroupOwnedAsset))
+        await conn.execute(sa_delete(Skill))
+        await conn.execute(sa_delete(Tool))
+        await conn.execute(sa_delete(GroupMember))
+        await conn.execute(sa_delete(Group))
+        await conn.execute(sa_delete(CustomRole))
+        await conn.execute(sa_delete(User))
+        await conn.commit()
+    finally:
+        await conn.close()

--- a/backend/tests/test_custom_roles.py
+++ b/backend/tests/test_custom_roles.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 
 import time
 import uuid
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from open_webui.models.custom_roles import (
@@ -35,6 +35,7 @@ from open_webui.models.custom_roles import (
     CustomRoles,
     CustomRoleUpdateForm,
     extract_custom_role_id,
+    get_permission_catalog,
     is_custom_role_ref,
     make_custom_role_ref,
     normalize_permissions,
@@ -78,6 +79,42 @@ class TestCustomRoleRefFormat:
     def test_make_custom_role_ref(self):
         rid = str(uuid.uuid4())
         assert make_custom_role_ref(rid) == f'custom:{rid}'
+
+
+# ===================================================================
+# Permission catalog endpoint
+# ===================================================================
+
+
+class TestCustomRolePermissionCatalogEndpoint:
+
+    @pytest.mark.asyncio
+    async def test_returns_canonical_catalog_with_group_capabilities(self):
+        from types import SimpleNamespace
+
+        from open_webui.routers.custom_roles import get_custom_role_permission_catalog
+
+        result = await get_custom_role_permission_catalog(user=SimpleNamespace(role='admin'))
+
+        assert result == get_permission_catalog()
+        assert set(result['groups']) == {
+            'manage_members',
+            'manage_assets',
+            'manage_skills',
+        }
+        assert all(value is False for value in result['groups'].values())
+
+    def test_endpoint_is_exact_admin_protected_and_precedes_role_id_route(self):
+        from fastapi.routing import APIRoute
+        from open_webui.routers.custom_roles import router
+        from open_webui.utils.auth import get_admin_user
+
+        routes = [route for route in router.routes if isinstance(route, APIRoute)]
+        permission_route = next(route for route in routes if route.path == '/permissions')
+        role_route = next(route for route in routes if route.path == '/{role_id}')
+
+        assert get_admin_user in [dependency.call for dependency in permission_route.dependant.dependencies]
+        assert router.routes.index(permission_route) < router.routes.index(role_route)
 
 
 # ===================================================================
@@ -309,6 +346,271 @@ class TestCustomRoleLifecycle:
         )
         deactivated = await CustomRoles.deactivate_role(role.id, db=db)
         assert deactivated.active is False
+
+    async def test_deactivate_resets_assigned_users_only(self, db):
+        from open_webui.models.users import User
+        from sqlalchemy import select
+
+        role = await CustomRoles.create_role(
+            CustomRoleCreateForm(name='reset_on_deactivate', display_name='Reset'), db=db
+        )
+        unrelated = await CustomRoles.create_role(
+            CustomRoleCreateForm(name='unrelated_role', display_name='Unrelated'), db=db
+        )
+        now = int(time.time())
+        assigned_id = str(uuid.uuid4())
+        unrelated_id = str(uuid.uuid4())
+        assigned = User(
+            id=assigned_id,
+            email=f'{assigned_id}@test.local',
+            name='Assigned',
+            role=f'custom:{role.id}',
+            profile_image_url='/user.png',
+            last_active_at=now,
+            created_at=now,
+            updated_at=now,
+        )
+        unaffected = User(
+            id=unrelated_id,
+            email=f'{unrelated_id}@test.local',
+            name='Unaffected',
+            role=f'custom:{unrelated.id}',
+            profile_image_url='/user.png',
+            last_active_at=now,
+            created_at=now,
+            updated_at=now,
+        )
+        db.add_all([assigned, unaffected])
+        await db.flush()
+
+        await CustomRoles.deactivate_role(role.id, db=db)
+
+        rows = (
+            await db.execute(select(User).where(User.id.in_([assigned_id, unrelated_id])))
+        ).scalars().all()
+        by_id = {row.id: row for row in rows}
+        assert by_id[assigned_id].role == 'user'
+        assert by_id[unrelated_id].role == f'custom:{unrelated.id}'
+
+    async def test_delete_resets_assignments_and_is_safe_when_repeated(self, db):
+        from open_webui.models.users import User
+
+        role = await CustomRoles.create_role(
+            CustomRoleCreateForm(name='reset_on_delete', display_name='Delete Reset'), db=db
+        )
+        now = int(time.time())
+        user_id = str(uuid.uuid4())
+        user = User(
+            id=user_id,
+            email=f'{user_id}@test.local',
+            name='Delete Assigned',
+            role=f'custom:{role.id}',
+            profile_image_url='/user.png',
+            last_active_at=now,
+            created_at=now,
+            updated_at=now,
+        )
+        db.add(user)
+        await db.flush()
+
+        deleted = await CustomRoles.delete_role(role.id, db=db)
+
+        assert deleted.id == role.id
+        assert await CustomRoles.get_role_by_id(role.id, db=db) is None
+        refreshed = await db.get(User, user_id)
+        assert refreshed.role == 'user'
+        assert await CustomRoles.delete_role(role.id, db=db) is None
+
+    async def test_failed_deactivation_rolls_back_role_and_user_reset(self, manager_db):
+        from open_webui.models.users import User
+
+        role = await CustomRoles.create_role(
+            CustomRoleCreateForm(name='rollback_deactivate', display_name='Rollback'), db=manager_db
+        )
+        now = int(time.time())
+        user_id = str(uuid.uuid4())
+        user = User(
+            id=user_id,
+            email=f'{user_id}@test.local',
+            name='Rollback Assigned',
+            role=f'custom:{role.id}',
+            profile_image_url='/user.png',
+            last_active_at=now,
+            created_at=now,
+            updated_at=now,
+        )
+        manager_db.add(user)
+        await manager_db.flush()
+        await manager_db.commit()
+
+        with patch.object(
+            manager_db,
+            'commit',
+            new_callable=AsyncMock,
+            side_effect=RuntimeError('commit failed'),
+        ):
+            with pytest.raises(RuntimeError, match='commit failed'):
+                await CustomRoles.deactivate_role(role.id, db=manager_db)
+
+        role_after = await CustomRoles.get_role_by_id(role.id, db=manager_db)
+        user_after = await manager_db.get(User, user_id)
+        assert role_after.active is True
+        assert user_after.role == f'custom:{role.id}'
+
+    async def test_failed_delete_rolls_back_role_and_user_reset(self, manager_db):
+        from open_webui.models.users import User
+
+        role = await CustomRoles.create_role(
+            CustomRoleCreateForm(name='rollback_delete', display_name='Rollback Delete'), db=manager_db
+        )
+        now = int(time.time())
+        user_id = str(uuid.uuid4())
+        manager_db.add(
+            User(
+                id=user_id,
+                email=f'{user_id}@test.local',
+                name='Rollback Delete Assigned',
+                role=f'custom:{role.id}',
+                profile_image_url='/user.png',
+                last_active_at=now,
+                created_at=now,
+                updated_at=now,
+            )
+        )
+        await manager_db.flush()
+        await manager_db.commit()
+
+        with patch.object(
+            manager_db,
+            'commit',
+            new_callable=AsyncMock,
+            side_effect=RuntimeError('commit failed'),
+        ):
+            with pytest.raises(RuntimeError, match='commit failed'):
+                await CustomRoles.delete_role(role.id, db=manager_db)
+
+        assert await CustomRoles.get_role_by_id(role.id, db=manager_db) is not None
+        user_after = await manager_db.get(User, user_id)
+        assert user_after.role == f'custom:{role.id}'
+
+
+# ===================================================================
+# Role lifecycle router
+# ===================================================================
+
+
+class TestCustomRoleLifecycleRouter:
+
+    @pytest.mark.asyncio
+    async def test_deactivate_endpoint_resets_users_and_emits_metadata_events(self, db, monkeypatch):
+        from types import SimpleNamespace
+
+        from open_webui.models.users import User
+        from open_webui.routers.custom_roles import deactivate_custom_role
+
+        role = await CustomRoles.create_role(
+            CustomRoleCreateForm(name='router_deactivate', display_name='Router Deactivate'), db=db
+        )
+        now = int(time.time())
+        user_id = str(uuid.uuid4())
+        db.add(
+            User(
+                id=user_id,
+                email=f'{user_id}@test.local',
+                name='Router Assigned',
+                role=f'custom:{role.id}',
+                profile_image_url='/user.png',
+                last_active_at=now,
+                created_at=now,
+                updated_at=now,
+            )
+        )
+        await db.flush()
+
+        events = []
+
+        async def capture_event(_request, event, **kwargs):
+            events.append((event.name, kwargs.get('data')))
+
+        monkeypatch.setattr('open_webui.routers.custom_roles.publish_event', capture_event)
+        request = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(instance_id='test')))
+        admin = SimpleNamespace(id='admin', role='admin')
+
+        result = await deactivate_custom_role(
+            request,
+            role.id,
+            user=admin,
+            db=db,
+        )
+
+        assert result.active is False
+        assert (await db.get(User, user_id)).role == 'user'
+        assert ('custom_role.deactivated', {'name': role.name, 'reset_to': 'user', 'reset_user_count': 1}) in events
+        assert ('user.role_updated', {'role': 'user', 'reason': 'custom_role_deactivated'}) in events
+
+    @pytest.mark.asyncio
+    async def test_delete_endpoint_removes_role_resets_users_and_emits_event(self, db, monkeypatch):
+        from types import SimpleNamespace
+
+        from open_webui.models.users import User
+        from open_webui.routers.custom_roles import delete_custom_role
+
+        role = await CustomRoles.create_role(
+            CustomRoleCreateForm(name='router_delete', display_name='Router Delete'), db=db
+        )
+        now = int(time.time())
+        user_id = str(uuid.uuid4())
+        db.add(
+            User(
+                id=user_id,
+                email=f'{user_id}@test.local',
+                name='Router Delete Assigned',
+                role=f'custom:{role.id}',
+                profile_image_url='/user.png',
+                last_active_at=now,
+                created_at=now,
+                updated_at=now,
+            )
+        )
+        await db.flush()
+
+        events = []
+
+        async def capture_event(_request, event, **kwargs):
+            events.append((event.name, kwargs.get('data')))
+
+        monkeypatch.setattr('open_webui.routers.custom_roles.publish_event', capture_event)
+        request = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(instance_id='test')))
+        admin = SimpleNamespace(id='admin', role='admin')
+
+        result = await delete_custom_role(
+            request,
+            role.id,
+            user=admin,
+            db=db,
+        )
+
+        assert result.id == role.id
+        assert await CustomRoles.get_role_by_id(role.id, db=db) is None
+        assert (await db.get(User, user_id)).role == 'user'
+        assert ('custom_role.deleted', {'name': role.name, 'reset_to': 'user', 'reset_user_count': 1}) in events
+        assert ('user.role_updated', {'role': 'user', 'reason': 'custom_role_deleted'}) in events
+
+    def test_lifecycle_routes_require_exact_admin(self):
+        from fastapi.routing import APIRoute
+        from open_webui.routers.custom_roles import router
+        from open_webui.utils.auth import get_admin_user
+
+        routes = [route for route in router.routes if isinstance(route, APIRoute)]
+        lifecycle_routes = [
+            route
+            for route in routes
+            if route.path in {'/{role_id}', '/{role_id}/deactivate'}
+            and ('DELETE' in route.methods or route.path.endswith('/deactivate'))
+        ]
+        assert len(lifecycle_routes) == 2
+        for route in lifecycle_routes:
+            assert get_admin_user in [dependency.call for dependency in route.dependant.dependencies]
 
 
 # ===================================================================

--- a/backend/tests/test_custom_roles.py
+++ b/backend/tests/test_custom_roles.py
@@ -1,0 +1,1134 @@
+"""Focused regression tests for the custom-role foundation (Phase 1).
+
+Covers:
+1. Custom-role reference format validation
+2. Reserved-role invariants (admin, user, pending)
+3. Fail-closed resolution for unknown/malformed/disabled roles
+4. Permission isolation (custom roles do NOT inherit group permissions)
+5. Lifecycle rules (create, list, update, deactivate)
+6. Sparse / no-default permissions (missing leaves fixed false)
+7. No group OR-merging for custom roles
+8. JSON persistence round-trip
+9. Invalid / inactive refs fail closed
+10. Exact admin bypass (get_admin_user, has_permission)
+11. has_permission with custom roles
+12. role_name_exists
+13. fill_missing_permissions
+14. Permission validation (malformed, unknown, non-boolean, None)
+15. Explicit True retention after normalize_permissions
+16. Create rejects null; Update rejects explicit null but omits preserve
+17. Catalog immutability (deep-copy safety)
+18. Migration schema validation (c5a8d3e2f1b0)
+19. Test isolation (savepoint rollback demonstrable)
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from unittest.mock import AsyncMock
+
+import pytest
+from open_webui.models.custom_roles import (
+    RESERVED_ROLE_NAMES,
+    CustomRoleCreateForm,
+    CustomRoles,
+    CustomRoleUpdateForm,
+    extract_custom_role_id,
+    is_custom_role_ref,
+    make_custom_role_ref,
+    normalize_permissions,
+    normalize_role_name,
+    validate_permissions,
+    validate_role_name,
+)
+from open_webui.utils.access_control import (
+    LEGACY_PERMISSION_ROLES,
+    fill_missing_permissions,
+)
+
+# ===================================================================
+# 1. Format validation
+# ===================================================================
+
+
+class TestCustomRoleRefFormat:
+
+    def test_valid_ref(self):
+        rid = str(uuid.uuid4())
+        ref = f'custom:{rid}'
+        assert is_custom_role_ref(ref) is True
+        assert extract_custom_role_id(ref) == rid
+
+    def test_malformed_prefix(self):
+        assert is_custom_role_ref('custom:') is False
+        assert is_custom_role_ref('custom:abc') is False
+        assert is_custom_role_ref('custom:not-a-uuid') is False
+
+    def test_not_custom_prefix(self):
+        assert is_custom_role_ref('admin') is False
+        assert is_custom_role_ref('user') is False
+        assert is_custom_role_ref('pending') is False
+        assert is_custom_role_ref('custom') is False
+
+    def test_extract_none_for_invalid(self):
+        assert extract_custom_role_id('admin') is None
+        assert extract_custom_role_id('custom:garbage') is None
+
+    def test_make_custom_role_ref(self):
+        rid = str(uuid.uuid4())
+        assert make_custom_role_ref(rid) == f'custom:{rid}'
+
+
+# ===================================================================
+# 2. Reserved-role invariants
+# ===================================================================
+
+
+class TestReservedRoleInvariants:
+
+    def test_reserved_set(self):
+        assert RESERVED_ROLE_NAMES == {'admin', 'user', 'pending'}
+
+    def test_validate_role_name_rejects_reserved(self):
+        for name in ('admin', 'user', 'pending', 'Admin', 'USER', 'Pending'):
+            with pytest.raises(ValueError, match='reserved'):
+                validate_role_name(name)
+
+    def test_validate_role_name_rejects_empty(self):
+        with pytest.raises(ValueError):
+            validate_role_name('')
+
+    def test_validate_role_name_rejects_long(self):
+        with pytest.raises(ValueError, match='64'):
+            validate_role_name('a' * 65)
+
+    def test_validate_role_name_accepts_valid(self):
+        assert validate_role_name('manager') == 'manager'
+        assert validate_role_name('Team Lead') == 'team lead'
+        assert validate_role_name('content-editor') == 'content-editor'
+        assert validate_role_name('test_role_123') == 'test_role_123'
+
+    def test_normalize_role_name(self):
+        assert normalize_role_name('  Manager  ') == 'manager'
+        assert normalize_role_name('Team   Lead') == 'team lead'
+
+
+# ===================================================================
+# 3. Fail-closed resolution
+# ===================================================================
+
+
+class TestFailClosedResolution:
+
+    def test_unresolved_role_uses_catalog_shape(self):
+        """Unresolved custom roles get a full-deny tree from the fixed
+        server-owned catalog, not from the caller's default_permissions."""
+        from open_webui.models.custom_roles import normalize_permissions
+
+        catalog_result = normalize_permissions(None)
+
+        def assert_all_false(d):
+            for v in d.values():
+                if isinstance(v, dict):
+                    assert_all_false(v)
+                else:
+                    assert v is False
+
+        assert_all_false(catalog_result)
+
+    def test_caller_config_cannot_change_unresolved_shape(self):
+        """Regression: even if DEFAULT_USER_PERMISSIONS is mutated, the
+        unresolved custom-role fallback still uses the fixed catalog."""
+        from open_webui.config import DEFAULT_USER_PERMISSIONS
+        from open_webui.models.custom_roles import (
+            _PERMISSION_CATALOG,
+            normalize_permissions,
+        )
+
+        snapshot = DEFAULT_USER_PERMISSIONS.copy()
+        try:
+            # Mutate the caller config to add a bogus top-level key
+            DEFAULT_USER_PERMISSIONS['bogus_key'] = True  # type: ignore[assignment]
+            DEFAULT_USER_PERMISSIONS['workspace'] = {'only_this': True}  # type: ignore[assignment]
+
+            result = normalize_permissions(None)
+
+            # The result must come from the catalog, not from the config
+            assert 'bogus_key' not in result
+            assert result == normalize_permissions(None)
+            # Catalog structure is intact
+            assert set(result.keys()) == set(_PERMISSION_CATALOG.keys())
+        finally:
+            DEFAULT_USER_PERMISSIONS.clear()
+            DEFAULT_USER_PERMISSIONS.update(snapshot)
+
+    @pytest.mark.asyncio
+    async def test_unresolved_ref_yields_catalog_deny_tree(self, db):
+        """End-to-end: a user with a non-existent custom role ref gets
+        the fixed catalog all-false tree, not the caller's config shape."""
+        from open_webui.config import DEFAULT_USER_PERMISSIONS
+        from open_webui.models.custom_roles import normalize_permissions
+        from open_webui.models.users import User
+        from open_webui.utils.access_control import get_permissions
+
+        now = int(time.time())
+        uid = str(uuid.uuid4())
+        fake_ref = f'custom:{uuid.uuid4()}'
+
+        user = User(
+            id=uid,
+            email=f'{uid}@test.local',
+            name='Unknown Ref',
+            role=fake_ref,
+            profile_image_url='/user.png',
+            last_active_at=now,
+            created_at=now,
+            updated_at=now,
+        )
+        db.add(user)
+        await db.flush()
+
+        perms = await get_permissions(uid, DEFAULT_USER_PERMISSIONS, db=db)
+        # Must match the fixed catalog deny tree, not the caller config shape
+        assert perms == normalize_permissions(None)
+
+    def test_legacy_permission_roles(self):
+        assert LEGACY_PERMISSION_ROLES == {'user', 'pending'}
+
+
+# ===================================================================
+# 4. Database lifecycle (CRUD) — isolated via savepoints
+# ===================================================================
+
+
+@pytest.mark.asyncio
+class TestCustomRoleLifecycle:
+
+    async def test_create_role(self, db):
+
+        form = CustomRoleCreateForm(
+            name='manager',
+            display_name='Manager',
+            permissions={'workspace': {'models': True, 'knowledge': True}},
+        )
+        role = await CustomRoles.create_role(form, db=db)
+        assert role is not None
+        assert role.name == 'manager'
+        assert role.display_name == 'Manager'
+        assert role.active is True
+        # Permissions are normalised to the full canonical tree on persist
+        expected = normalize_permissions({'workspace': {'models': True, 'knowledge': True}})
+        assert role.permissions == expected
+        assert role.id
+
+    async def test_create_duplicate_name_raises(self, db):
+        await CustomRoles.create_role(
+            CustomRoleCreateForm(name='editor', display_name='Editor'), db=db
+        )
+        with pytest.raises(ValueError, match='already exists'):
+            await CustomRoles.create_role(
+                CustomRoleCreateForm(name='editor', display_name='Editor Copy'), db=db
+            )
+
+    async def test_get_role_by_id(self, db):
+        created = await CustomRoles.create_role(
+            CustomRoleCreateForm(name='analyst', display_name='Analyst'), db=db
+        )
+        fetched = await CustomRoles.get_role_by_id(created.id, db=db)
+        assert fetched is not None
+        assert fetched.id == created.id
+        assert fetched.name == 'analyst'
+
+    async def test_get_role_by_name(self, db):
+        created = await CustomRoles.create_role(
+            CustomRoleCreateForm(name='auditor', display_name='Auditor'), db=db
+        )
+        fetched = await CustomRoles.get_role_by_name('auditor', db=db)
+        assert fetched is not None
+        assert fetched.id == created.id
+
+    async def test_get_active_role_inactive_returns_none(self, db):
+        created = await CustomRoles.create_role(
+            CustomRoleCreateForm(name='disabled_role', display_name='Disabled'), db=db
+        )
+        await CustomRoles.deactivate_role(created.id, db=db)
+        result = await CustomRoles.get_active_role_by_id(created.id, db=db)
+        assert result is None
+
+    async def test_list_roles(self, db):
+        before = await CustomRoles.list_roles(db=db)
+        before_count = before['total']
+        for name in ('alpha', 'beta', 'gamma'):
+            await CustomRoles.create_role(
+                CustomRoleCreateForm(name=name, display_name=name.title()), db=db
+            )
+        result = await CustomRoles.list_roles(db=db)
+        assert result['total'] == before_count + 3
+        assert len(result['items']) == before_count + 3
+
+    async def test_list_roles_exclude_inactive(self, db):
+        await CustomRoles.create_role(
+            CustomRoleCreateForm(name='active_only', display_name='Active'), db=db
+        )
+        r2 = await CustomRoles.create_role(
+            CustomRoleCreateForm(name='inactive_one', display_name='Inactive'), db=db
+        )
+        await CustomRoles.deactivate_role(r2.id, db=db)
+
+        result = await CustomRoles.list_roles(include_inactive=False, db=db)
+        # The active_only role should appear in active list
+        names = [r.name for r in result['items']]
+        assert 'active_only' in names
+        assert 'inactive_one' not in names
+
+    async def test_update_role_display_name(self, db):
+        role = await CustomRoles.create_role(
+            CustomRoleCreateForm(name='updatable', display_name='Old Name'), db=db
+        )
+        updated = await CustomRoles.update_role(
+            role.id, CustomRoleUpdateForm(display_name='New Name'), db=db
+        )
+        assert updated.display_name == 'New Name'
+        assert updated.name == 'updatable'
+
+    async def test_update_role_permissions(self, db):
+
+        role = await CustomRoles.create_role(
+            CustomRoleCreateForm(name='perm_update', display_name='PermUpdate'), db=db
+        )
+        new_perms = {'workspace': {'models': True}}
+        updated = await CustomRoles.update_role(
+            role.id, CustomRoleUpdateForm(permissions=new_perms), db=db
+        )
+        assert updated.permissions == normalize_permissions(new_perms)
+
+    async def test_deactivate_role(self, db):
+        role = await CustomRoles.create_role(
+            CustomRoleCreateForm(name='to_deactivate', display_name='ToDeactivate'), db=db
+        )
+        deactivated = await CustomRoles.deactivate_role(role.id, db=db)
+        assert deactivated.active is False
+
+
+# ===================================================================
+# 5. Permission isolation
+# ===================================================================
+
+
+@pytest.mark.asyncio
+class TestPermissionIsolation:
+
+    async def test_custom_role_permissions_used(self, db):
+        from open_webui.config import DEFAULT_USER_PERMISSIONS
+        from open_webui.models.users import User
+        from open_webui.utils.access_control import get_permissions
+
+        now = int(time.time())
+        uid = str(uuid.uuid4())
+
+        role = await CustomRoles.create_role(
+            CustomRoleCreateForm(
+                name='limited_user',
+                display_name='Limited User',
+                permissions={
+                    'workspace': {'models': False, 'knowledge': True, 'prompts': False},
+                    'chat': {'delete': False},
+                },
+            ),
+            db=db,
+        )
+
+        user = User(
+            id=uid,
+            email=f'{uid}@test.local',
+            name='Test User',
+            role=f'custom:{role.id}',
+            profile_image_url='/user.png',
+            last_active_at=now,
+            created_at=now,
+            updated_at=now,
+        )
+        db.add(user)
+        await db.flush()
+
+        perms = await get_permissions(uid, DEFAULT_USER_PERMISSIONS, db=db)
+        assert perms['workspace']['models'] is False
+        assert perms['workspace']['knowledge'] is True
+        assert perms['chat']['delete'] is False
+
+    async def test_disabled_custom_role_all_false(self, db):
+        from open_webui.config import DEFAULT_USER_PERMISSIONS
+        from open_webui.models.users import User
+        from open_webui.utils.access_control import get_permissions
+
+        now = int(time.time())
+        uid = str(uuid.uuid4())
+
+        role = await CustomRoles.create_role(
+            CustomRoleCreateForm(
+                name='disabled_perm',
+                display_name='Disabled',
+                permissions={'workspace': {'models': True}},
+            ),
+            db=db,
+        )
+        await CustomRoles.deactivate_role(role.id, db=db)
+
+        user = User(
+            id=uid,
+            email=f'{uid}@test.local',
+            name='Disabled User',
+            role=f'custom:{role.id}',
+            profile_image_url='/user.png',
+            last_active_at=now,
+            created_at=now,
+            updated_at=now,
+        )
+        db.add(user)
+        await db.flush()
+
+        perms = await get_permissions(uid, DEFAULT_USER_PERMISSIONS, db=db)
+
+        def assert_all_false(d):
+            for v in d.values():
+                if isinstance(v, dict):
+                    assert_all_false(v)
+                else:
+                    assert v is False
+
+        assert_all_false(perms)
+
+
+# ===================================================================
+# 6. Sparse / no-default permissions: missing leaves fixed false
+# ===================================================================
+
+
+@pytest.mark.asyncio
+class TestSparsePermissions:
+
+    async def test_sparse_permissions_fill_missing_as_false(self, db):
+        """A custom role that only sets workspace.models should have
+        all other leaves set to False (fail-closed), not to config defaults."""
+        from open_webui.config import DEFAULT_USER_PERMISSIONS
+        from open_webui.models.users import User
+        from open_webui.utils.access_control import get_permissions
+
+        now = int(time.time())
+        uid = str(uuid.uuid4())
+
+        role = await CustomRoles.create_role(
+            CustomRoleCreateForm(
+                name='sparse_role',
+                display_name='Sparse Role',
+                permissions={
+                    'workspace': {'models': True},
+                    'features': {'web_search': True},
+                },
+            ),
+            db=db,
+        )
+
+        user = User(
+            id=uid,
+            email=f'{uid}@test.local',
+            name='Sparse User',
+            role=f'custom:{role.id}',
+            profile_image_url='/user.png',
+            last_active_at=now,
+            created_at=now,
+            updated_at=now,
+        )
+        db.add(user)
+        await db.flush()
+
+        perms = await get_permissions(uid, DEFAULT_USER_PERMISSIONS, db=db)
+
+        # Specified leaves should be preserved
+        assert perms['workspace']['models'] is True
+        assert perms['features']['web_search'] is True
+
+        # Unspecified leaves within the same group should be False
+        # (filled by fill_missing_permissions from the schema, not from config defaults)
+        assert perms['workspace']['knowledge'] is False
+        assert perms['workspace']['prompts'] is False
+        assert perms['chat']['delete'] is False
+
+    async def test_empty_permissions_all_false(self, db):
+        """A custom role with {} permissions should yield all-False."""
+        from open_webui.config import DEFAULT_USER_PERMISSIONS
+        from open_webui.models.users import User
+        from open_webui.utils.access_control import get_permissions
+
+        now = int(time.time())
+        uid = str(uuid.uuid4())
+
+        role = await CustomRoles.create_role(
+            CustomRoleCreateForm(
+                name='empty_perms',
+                display_name='Empty Perms',
+                permissions={},
+            ),
+            db=db,
+        )
+
+        user = User(
+            id=uid,
+            email=f'{uid}@test.local',
+            name='Empty Perms User',
+            role=f'custom:{role.id}',
+            profile_image_url='/user.png',
+            last_active_at=now,
+            created_at=now,
+            updated_at=now,
+        )
+        db.add(user)
+        await db.flush()
+
+        perms = await get_permissions(uid, DEFAULT_USER_PERMISSIONS, db=db)
+
+        def assert_all_false(d):
+            for k, v in d.items():
+                if isinstance(v, dict):
+                    assert_all_false(v)
+                else:
+                    assert v is False, f'{k} should be False'
+
+        assert_all_false(perms)
+
+
+# ===================================================================
+# 7. No group OR-merging for custom roles
+# ===================================================================
+
+
+@pytest.mark.asyncio
+class TestNoGroupMerge:
+
+    async def test_custom_role_ignores_group_permissions(self, db):
+        """Custom roles must NOT inherit or merge group permissions."""
+        from open_webui.config import DEFAULT_USER_PERMISSIONS
+        from open_webui.models.groups import GroupForm, Groups
+        from open_webui.models.users import User
+        from open_webui.utils.access_control import get_permissions, has_permission
+
+        now = int(time.time())
+        uid = str(uuid.uuid4())
+
+        # Create a group with permissive permissions
+        group = await Groups.insert_new_group(
+            uid,
+            GroupForm(
+                name='permissive_group',
+                description='Permissive',
+                permissions={'features': {'web_search': True}},
+            ),
+            db=db,
+        )
+        await Groups.add_users_to_group(group.id, user_ids=[uid], db=db)
+
+        # Create a custom role that denies web_search
+        role = await CustomRoles.create_role(
+            CustomRoleCreateForm(
+                name='deny_search',
+                display_name='Deny Search',
+                permissions={'features': {'web_search': False}},
+            ),
+            db=db,
+        )
+
+        user = User(
+            id=uid,
+            email=f'{uid}@test.local',
+            name='No Merge User',
+            role=f'custom:{role.id}',
+            profile_image_url='/user.png',
+            last_active_at=now,
+            created_at=now,
+            updated_at=now,
+        )
+        db.add(user)
+        await db.flush()
+
+        # get_permissions should use ONLY the custom role, not the group
+        perms = await get_permissions(uid, DEFAULT_USER_PERMISSIONS, db=db)
+        assert perms['features']['web_search'] is False
+
+        # has_permission should also use the custom role
+        assert await has_permission(uid, 'features.web_search', DEFAULT_USER_PERMISSIONS, db=db) is False
+
+
+# ===================================================================
+# 8. JSON persistence round-trip
+# ===================================================================
+
+
+@pytest.mark.asyncio
+class TestJsonPersistence:
+
+    async def test_permissions_persist_as_json_string(self, db):
+        """Verify that permissions dict round-trips through the DB as a
+        JSON string and comes back correctly.  Stored value is the full
+        canonical tree produced by normalize_permissions."""
+        from sqlalchemy import text
+
+        permissions = {
+            'workspace': {'models': True, 'knowledge': False},
+            'chat': {'delete': True, 'share': False},
+            'features': {'web_search': True},
+        }
+
+        role = await CustomRoles.create_role(
+            CustomRoleCreateForm(
+                name='json_test',
+                display_name='JSON Test',
+                permissions=permissions,
+            ),
+            db=db,
+        )
+
+        # Reload via ORM — should match the normalised canonical tree
+        fetched = await CustomRoles.get_role_by_id(role.id, db=db)
+        assert fetched is not None
+        assert fetched.permissions == normalize_permissions(permissions)
+
+        # Also verify the raw DB column is a JSON string (not binary, not pickled)
+        result = await db.execute(
+            text('SELECT permissions FROM custom_role WHERE id = :id'),
+            {'id': role.id},
+        )
+        raw = result.scalar()
+        assert isinstance(raw, str)
+        assert '"models": true' in raw
+        assert '"delete": true' in raw
+
+    async def test_empty_permissions_persists(self, db):
+        """{} is normalised to the full deny tree on persist."""
+
+        role = await CustomRoles.create_role(
+            CustomRoleCreateForm(
+                name='empty_json',
+                display_name='Empty JSON',
+                permissions={},
+            ),
+            db=db,
+        )
+        fetched = await CustomRoles.get_role_by_id(role.id, db=db)
+        assert fetched is not None
+        assert fetched.permissions == normalize_permissions({})
+
+    async def test_null_permissions_rejected_on_create(self, db):
+        """Explicit null permissions must be rejected by the create form."""
+        with pytest.raises(ValueError, match='must not be null'):
+            CustomRoleCreateForm(
+                name='null_perms',
+                display_name='Null Perms',
+                permissions=None,
+            )
+
+
+# ===================================================================
+# 9. Invalid / inactive refs fail closed
+# ===================================================================
+
+
+@pytest.mark.asyncio
+class TestInvalidInactiveRefs:
+
+    async def test_unknown_custom_role_ref_yields_empty_perms(self, db):
+        from open_webui.config import DEFAULT_USER_PERMISSIONS
+        from open_webui.models.users import User
+        from open_webui.utils.access_control import get_permissions
+
+        now = int(time.time())
+        uid = str(uuid.uuid4())
+        fake_ref = f'custom:{uuid.uuid4()}'
+
+        user = User(
+            id=uid,
+            email=f'{uid}@test.local',
+            name='Unknown Ref',
+            role=fake_ref,
+            profile_image_url='/user.png',
+            last_active_at=now,
+            created_at=now,
+            updated_at=now,
+        )
+        db.add(user)
+        await db.flush()
+
+        perms = await get_permissions(uid, DEFAULT_USER_PERMISSIONS, db=db)
+
+        def assert_all_false(d):
+            for v in d.values():
+                if isinstance(v, dict):
+                    assert_all_false(v)
+                else:
+                    assert v is False
+
+        assert_all_false(perms)
+
+    async def test_malformed_ref_yields_empty_perms(self, db):
+        from open_webui.config import DEFAULT_USER_PERMISSIONS
+        from open_webui.models.users import User
+        from open_webui.utils.access_control import get_permissions
+
+        now = int(time.time())
+        uid = str(uuid.uuid4())
+
+        user = User(
+            id=uid,
+            email=f'{uid}@test.local',
+            name='Malformed Ref',
+            role='custom:not-a-valid-uuid',
+            profile_image_url='/user.png',
+            last_active_at=now,
+            created_at=now,
+            updated_at=now,
+        )
+        db.add(user)
+        await db.flush()
+
+        perms = await get_permissions(uid, DEFAULT_USER_PERMISSIONS, db=db)
+
+        def assert_all_false(d):
+            for v in d.values():
+                if isinstance(v, dict):
+                    assert_all_false(v)
+                else:
+                    assert v is False
+
+        assert_all_false(perms)
+
+
+# ===================================================================
+# 10. Exact admin bypass
+# ===================================================================
+
+
+class TestExactAdminBypass:
+
+    def test_get_admin_user_rejects_custom_role(self):
+        """get_admin_user must only pass for role == 'admin'."""
+        from fastapi import HTTPException
+        from open_webui.utils.auth import get_admin_user
+
+        # Simulate a non-admin user
+        fake_user = AsyncMock()
+        fake_user.role = f'custom:{uuid.uuid4()}'
+
+        with pytest.raises(HTTPException) as exc_info:
+            get_admin_user(user=fake_user)
+        assert exc_info.value.status_code == 401
+
+    def test_get_admin_user_passes_for_admin(self):
+        from open_webui.utils.auth import get_admin_user
+
+        fake_user = AsyncMock()
+        fake_user.role = 'admin'
+
+        result = get_admin_user(user=fake_user)
+        assert result.role == 'admin'
+
+
+# ===================================================================
+# 11. has_permission with custom roles
+# ===================================================================
+
+
+@pytest.mark.asyncio
+class TestHasPermissionCustomRole:
+
+    async def test_admin_always_true(self, db):
+        from open_webui.models.users import User
+        from open_webui.utils.access_control import has_permission
+        now = int(time.time())
+        uid = str(uuid.uuid4())
+
+        user = User(
+            id=uid, email=f'{uid}@test.local', name='Admin',
+            role='admin', profile_image_url='/user.png',
+            last_active_at=now, created_at=now, updated_at=now,
+        )
+        db.add(user)
+        await db.flush()
+
+        assert await has_permission(uid, 'features.web_search', {}, db=db) is True
+
+    async def test_custom_role_checks_only_role_perms(self, db):
+        from open_webui.config import DEFAULT_USER_PERMISSIONS
+        from open_webui.models.users import User
+        from open_webui.utils.access_control import has_permission
+        now = int(time.time())
+        uid = str(uuid.uuid4())
+
+        role = await CustomRoles.create_role(
+            CustomRoleCreateForm(
+                name='perm_test',
+                display_name='Perm Test',
+                permissions={'features': {'web_search': False, 'image_generation': True}},
+            ),
+            db=db,
+        )
+
+        user = User(
+            id=uid, email=f'{uid}@test.local', name='Perm User',
+            role=f'custom:{role.id}', profile_image_url='/user.png',
+            last_active_at=now, created_at=now, updated_at=now,
+        )
+        db.add(user)
+        await db.flush()
+
+        assert await has_permission(uid, 'features.web_search', DEFAULT_USER_PERMISSIONS, db=db) is False
+        assert await has_permission(uid, 'features.image_generation', DEFAULT_USER_PERMISSIONS, db=db) is True
+
+
+# ===================================================================
+# 12. role_name_exists
+# ===================================================================
+
+
+@pytest.mark.asyncio
+class TestRoleNameExists:
+
+    async def test_exists_after_create(self, db):
+        await CustomRoles.create_role(
+            CustomRoleCreateForm(name='check_exists', display_name='Check'), db=db
+        )
+        assert await CustomRoles.role_name_exists('check_exists', db=db) is True
+
+    async def test_not_exists(self, db):
+        assert await CustomRoles.role_name_exists('nonexistent_role_xyz', db=db) is False
+
+    async def test_exclude_id(self, db):
+        role = await CustomRoles.create_role(
+            CustomRoleCreateForm(name='exclude_test', display_name='Exclude'), db=db
+        )
+        assert await CustomRoles.role_name_exists('exclude_test', exclude_id=role.id, db=db) is False
+        assert await CustomRoles.role_name_exists('exclude_test', db=db) is True
+
+
+# ===================================================================
+# 13. fill_missing_permissions
+# ===================================================================
+
+
+class TestFillMissingPermissions:
+
+    def test_fills_missing_leaves_with_template(self):
+        perms = {'workspace': {'models': True}}
+        template = {
+            'workspace': {'models': False, 'knowledge': False, 'prompts': False},
+            'chat': {'delete': True},
+        }
+        result = fill_missing_permissions(perms, template)
+        assert result['workspace']['models'] is True  # kept
+        assert result['workspace']['knowledge'] is False  # filled
+        assert result['workspace']['prompts'] is False  # filled
+        assert result['chat']['delete'] is True  # filled
+
+    def test_no_mutation_of_template(self):
+        """fill_missing_permissions must not mutate the default_permissions template."""
+        perms = {'workspace': {'models': True}}
+        template = {'workspace': {'models': False, 'knowledge': False}}
+        import copy
+        original_template = copy.deepcopy(template)
+        fill_missing_permissions(perms, template)
+        assert template == original_template
+
+
+# ===================================================================
+# 14. Permission validation (malformed, unknown, non-boolean, None)
+# ===================================================================
+
+
+class TestPermissionValidation:
+
+    def test_rejects_none(self):
+        with pytest.raises(ValueError, match='must be a dictionary'):
+            validate_permissions(None)
+
+    def test_rejects_list(self):
+        with pytest.raises(ValueError, match='must be a dictionary'):
+            validate_permissions([{'workspace': {'models': True}}])
+
+    def test_rejects_string(self):
+        with pytest.raises(ValueError, match='must be a dictionary'):
+            validate_permissions('invalid')
+
+    def test_rejects_unknown_top_level_key(self):
+        with pytest.raises(ValueError, match='Unknown permission key: unknown_key'):
+            validate_permissions({'unknown_key': True})
+
+    def test_rejects_unknown_nested_key(self):
+        with pytest.raises(ValueError, match='Unknown permission key: workspace.unknown_leaf'):
+            validate_permissions({'workspace': {'unknown_leaf': True}})
+
+    def test_rejects_non_boolean_leaf(self):
+        with pytest.raises(ValueError, match='must be a boolean'):
+            validate_permissions({'workspace': {'models': 'yes'}})
+
+    def test_rejects_int_leaf(self):
+        with pytest.raises(ValueError, match='must be a boolean'):
+            validate_permissions({'workspace': {'models': 1}})
+
+    def test_rejects_non_dict_intermediate(self):
+        with pytest.raises(ValueError, match='must be a dict'):
+            validate_permissions({'workspace': 'not_a_dict'})
+
+    def test_empty_dict_is_valid(self):
+        assert validate_permissions({}) == {}
+
+    def test_valid_partial_doc(self):
+        doc = {'workspace': {'models': True}, 'chat': {'delete': False}}
+        assert validate_permissions(doc) == doc
+
+
+# ===================================================================
+# 15. Explicit True retention after normalize_permissions
+# ===================================================================
+
+
+class TestNormalizePermissions:
+
+    def test_empty_input_returns_full_deny(self):
+        from open_webui.models.custom_roles import get_permission_catalog
+        result = normalize_permissions({})
+        assert result == get_permission_catalog()
+
+    def test_none_input_returns_full_deny(self):
+        from open_webui.models.custom_roles import get_permission_catalog
+        result = normalize_permissions(None)
+        assert result == get_permission_catalog()
+
+    def test_explicit_true_retained(self):
+        result = normalize_permissions({'workspace': {'models': True}})
+        assert result['workspace']['models'] is True
+
+    def test_explicit_false_retained(self):
+        result = normalize_permissions({'workspace': {'models': False}})
+        assert result['workspace']['models'] is False
+
+    def test_sparse_preserves_and_fills_false(self):
+        doc = {'workspace': {'models': True}, 'features': {'web_search': True}}
+        result = normalize_permissions(doc)
+        assert result['workspace']['models'] is True
+        assert result['features']['web_search'] is True
+        assert result['workspace']['knowledge'] is False
+        assert result['chat']['delete'] is False
+
+    def test_non_mutating(self):
+        doc = {'workspace': {'models': True}}
+        original = {'workspace': {'models': True}}
+        normalize_permissions(doc)
+        assert doc == original
+
+    def test_catalog_not_mutated(self):
+        """Calling normalize_permissions must never mutate _PERMISSION_CATALOG."""
+        import copy
+
+        from open_webui.models.custom_roles import (
+            _PERMISSION_CATALOG,
+        )
+        snapshot = copy.deepcopy(_PERMISSION_CATALOG)
+        normalize_permissions({'workspace': {'models': True}})
+        assert _PERMISSION_CATALOG == snapshot
+
+
+# ===================================================================
+# 16. Create rejects null; Update rejects explicit null but omits preserve
+# ===================================================================
+
+
+class TestNullPermissionsContract:
+
+    def test_create_rejects_explicit_null(self):
+        with pytest.raises(ValueError, match='must not be null'):
+            CustomRoleCreateForm(
+                name='null_create',
+                display_name='Null Create',
+                permissions=None,
+            )
+
+    def test_create_allows_omitted(self):
+        """Omitting permissions defaults to {}."""
+        form = CustomRoleCreateForm(
+            name='omitted_create',
+            display_name='Omitted Create',
+        )
+        assert form.permissions == {}
+
+    def test_update_rejects_explicit_null(self):
+        with pytest.raises(ValueError, match='must not be null'):
+            CustomRoleUpdateForm(permissions=None)
+
+    def test_update_allows_omitted(self):
+        """Omitting permissions entirely → None (meaning preserve existing)."""
+        form = CustomRoleUpdateForm(display_name='New Name')
+        assert form.permissions is None
+
+    @pytest.mark.asyncio
+    async def test_update_omit_preserves_existing(self, db):
+        role = await CustomRoles.create_role(
+            CustomRoleCreateForm(
+                name='omit_preserve',
+                display_name='Preserve Me',
+                permissions={'workspace': {'models': True}},
+            ),
+            db=db,
+        )
+        # Update display_name only — permissions should be unchanged
+        updated = await CustomRoles.update_role(
+            role.id,
+            CustomRoleUpdateForm(display_name='Updated Name'),
+            db=db,
+        )
+        assert updated.display_name == 'Updated Name'
+        assert updated.permissions['workspace']['models'] is True
+        assert updated.permissions['workspace']['knowledge'] is False
+
+
+# ===================================================================
+# 17. Catalog immutability (deep-copy safety)
+# ===================================================================
+
+
+class TestCatalogImmutability:
+
+    def test_normalize_permissions_returns_deep_copy(self):
+        """Two successive normalizations with different inputs must not
+        interfere with each other."""
+
+        r1 = normalize_permissions({'workspace': {'models': True}})
+        r2 = normalize_permissions({'features': {'web_search': True}})
+
+        assert r1['workspace']['models'] is True
+        assert r1['features']['web_search'] is False
+        assert r2['workspace']['models'] is False
+        assert r2['features']['web_search'] is True
+
+    def test_mutation_of_result_does_not_affect_catalog(self):
+        from open_webui.models.custom_roles import (
+            _PERMISSION_CATALOG,
+        )
+        result = normalize_permissions({'workspace': {'models': True}})
+        result['workspace']['models'] = 'CORRUPTED'
+        assert _PERMISSION_CATALOG['workspace']['models'] is False
+
+
+# ===================================================================
+# 18. Migration schema validation (c5a8d3e2f1b0)
+# ===================================================================
+
+
+@pytest.mark.asyncio
+class TestMigrationSchema:
+
+    async def test_custom_role_table_schema(self, db):
+        """Verify the ``custom_role`` table has the expected columns,
+        types, and nullability matching migration c5a8d3e2f1b0.
+
+        Limitation: The test database is created via
+        ``Base.metadata.create_all()`` (conftest), not via Alembic
+        ``upgrade()``.  This test therefore verifies the ORM model's
+        DDL matches the migration's intent, rather than proving the
+        migration chain itself produces the correct schema.  A full
+        Alembic upgrade test is impractical because ``env.py`` has
+        complex module-level imports (``open_webui.env``, model
+        registrations) that depend on the full application bootstrap.
+        """
+        from sqlalchemy import text
+
+        def _check_schema(sync_conn):
+            from open_webui.internal.db import Base
+
+            metadata = Base.metadata
+            # Table names may be prefixed (e.g. '.custom_role') depending
+            # on DATABASE_SCHEMA; match by suffix.
+            tables = set(metadata.tables.keys())
+            custom_role_keys = [k for k in tables if k.endswith('custom_role')]
+            assert custom_role_keys, f'custom_role table not found in {tables}'
+
+            table = metadata.tables[custom_role_keys[0]]
+
+            # Column presence
+            cols = {c.name: c for c in table.columns}
+            expected_cols = {
+                'id', 'name', 'display_name', 'active',
+                'permissions', 'created_at', 'updated_at',
+            }
+            assert set(cols.keys()) == expected_cols
+
+            # permissions column: physical TEXT, NOT NULL
+            perms = cols['permissions']
+            assert str(perms.type) == 'TEXT'
+            assert perms.nullable is False
+
+            # active column: NOT NULL
+            active = cols['active']
+            assert active.nullable is False
+
+            # Unique index on name
+            idx_names = {idx.name for idx in table.indexes}
+            assert 'ix_custom_role_name' in idx_names
+
+            # Verify DDL presence via raw SQLite query
+            row = sync_conn.execute(
+                text("SELECT sql FROM sqlite_master WHERE type='table' AND name='custom_role'")
+            ).fetchone()
+            assert row is not None
+            ddl = row[0]
+            assert 'permissions' in ddl
+
+        await db.run_sync(_check_schema)
+
+
+# ===================================================================
+# 18. Test isolation (savepoint rollback demonstrable)
+# ===================================================================
+
+
+@pytest.mark.asyncio
+class TestCrossTestIsolation:
+
+    async def test_commit_and_rollback_demonstrates_isolation(self, db):
+        """Exercise a repository method that commits (via savepoint), then
+        verify the outer transaction still rolls back cleanly.
+
+        This test demonstrates that the savepoint isolation in conftest.py
+        works correctly: ``session.commit()`` inside the repository only
+        commits the nested savepoint; the outer transaction (and all its
+        data) is rolled back when the fixture tears down.  A subsequent
+        test therefore starts with a clean slate regardless of ordering.
+
+        Limitation: we cannot prove a *different* test starts clean within
+        a single test function.  The guarantee comes from the conftest
+        ``db`` fixture which wraps every test in
+        ``connection.begin() → session.begin_nested() → rollback()``.
+        """
+        # 1. Record the starting count
+        before = await CustomRoles.list_roles(db=db)
+        start_count = before['total']
+
+        # 2. Exercise a repository method that commits internally
+        role = await CustomRoles.create_role(
+            CustomRoleCreateForm(
+                name='isolation_sentinel',
+                display_name='Isolation Sentinel',
+                permissions={'workspace': {'models': True}},
+            ),
+            db=db,
+        )
+        assert role is not None
+
+        # 3. Verify it's visible within this session (savepoint was committed)
+        after_create = await CustomRoles.list_roles(db=db)
+        assert after_create['total'] == start_count + 1
+        fetched = await CustomRoles.get_role_by_id(role.id, db=db)
+        assert fetched is not None
+        assert fetched.name == 'isolation_sentinel'
+
+        # 4. When this test returns, the ``db`` fixture rolls back the outer
+        #    transaction, undoing all changes.  The *next* test to run will
+        #    see the same starting state — no ordering dependency.

--- a/backend/tests/test_group_manager.py
+++ b/backend/tests/test_group_manager.py
@@ -1,0 +1,2390 @@
+"""Focused regression tests for Phase 2 group-ownership / manager foundation.
+
+Covers:
+1. Extended custom-role catalog (groups.manage_members, groups.manage_assets)
+2. Capability fail-closed behavior
+3. Role / member / capability matrix for require_group_manager
+4. Cross-group denial
+5. Grant / creator non-authority
+6. Ownership uniqueness / allowlist
+7. Migration metadata / constraint expectations
+8. No implicit commits in new primitives
+9. GroupOwnedAsset repository methods
+10. Transaction boundary enforcement (group_manager_tx)
+11. GroupMember uniqueness through historical lineage
+12. SQLite FK enforcement
+13. Linearizability / stable lock order
+14. Strict boolean capability check
+15. DB-level CheckConstraint for supported types
+16. Migration isolation (fdcb does NOT touch group_member constraint)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+import uuid
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+from open_webui.models.custom_roles import (
+    _PERMISSION_CATALOG,
+    CustomRoleCreateForm,
+    CustomRoles,
+    normalize_permissions,
+    validate_permissions,
+)
+from open_webui.models.groups import (
+    SUPPORTED_OWNED_ASSET_TYPES,
+    Group,
+    GroupMember,
+    GroupOwnedAssets,
+)
+from open_webui.routers.group_manager import (
+    GroupManagerACLDeltaForm,
+    GroupManagerKnowledgeCreateForm,
+    GroupManagerKnowledgeUpdateForm,
+    GroupManagerMemberIdsForm,
+    GroupManagerPromptCreateForm,
+)
+from open_webui.utils.access_control.group_manager import (
+    GroupManagerError,
+    group_manager_tx,
+    require_group_manager,
+)
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+# ===================================================================
+# Helpers
+# ===================================================================
+
+async def _create_user_in_db(db: AsyncSession, user_id: str, role: str = 'user'):
+    """Insert a user row directly via the ORM."""
+    from open_webui.models.users import User
+
+    now = int(time.time())
+    row = User(
+        id=user_id,
+        email=f'{user_id}@test.local',
+        name=user_id.split('@')[0] if '@' in user_id else user_id,
+        role=role,
+        profile_image_url='',
+        last_active_at=now,
+        created_at=now,
+        updated_at=now,
+    )
+    db.add(row)
+    await db.flush()
+    if db.info.get('manager_setup'):
+        await db.commit()
+    return row
+
+
+async def _create_group_in_db(db: AsyncSession, group_id: str, user_id: str):
+    """Insert a group row directly."""
+    row = Group(
+        id=group_id,
+        user_id=user_id,
+        name=f'group-{group_id[:8]}',
+        description='test group',
+        permissions={},
+        data=None,
+        meta=None,
+        created_at=int(time.time()),
+        updated_at=int(time.time()),
+    )
+    db.add(row)
+    await db.flush()
+    if db.info.get('manager_setup'):
+        await db.commit()
+    return row
+
+
+async def _add_membership(db: AsyncSession, group_id: str, user_id: str):
+    """Insert a group_member row directly."""
+    row = GroupMember(
+        id=str(uuid.uuid4()),
+        group_id=group_id,
+        user_id=user_id,
+        created_at=int(time.time()),
+        updated_at=int(time.time()),
+    )
+    db.add(row)
+    await db.flush()
+    if db.info.get('manager_setup'):
+        await db.commit()
+    return row
+
+
+async def _create_custom_role(
+    db: AsyncSession,
+    *,
+    name: str | None = None,
+    permissions: dict | None = None,
+    active: bool = True,
+):
+    """Create a custom role with the given permissions via the repository."""
+    if name is None:
+        name = f'test-role-{uuid.uuid4().hex[:8]}'
+    form = CustomRoleCreateForm(
+        name=name,
+        display_name=name.replace('-', ' ').title(),
+        permissions=permissions or {},
+    )
+    role = await CustomRoles.create_role(form, db=db)
+    if not active:
+        await CustomRoles.deactivate_role(role.id, db=db)
+        return await CustomRoles.get_role_by_id(role.id, db=db)
+    return role
+
+
+async def _assign_custom_role(db: AsyncSession, user_id: str, role_id: str):
+    """Set a user's role to a custom reference."""
+    from open_webui.models.custom_roles import make_custom_role_ref
+    from open_webui.models.users import User
+
+    ref = make_custom_role_ref(role_id)
+    from sqlalchemy import update
+    await db.execute(
+        update(User).where(User.id == user_id).values(role=ref)
+    )
+    await db.flush()
+    if db.info.get('manager_setup'):
+        await db.commit()
+
+
+async def _setup_valid_manager(db: AsyncSession):
+    """Create a valid manager user with capability, group, and membership.
+    Returns (uid, gid, role).
+    """
+    uid = f'mgr-{uuid.uuid4().hex[:8]}'
+    gid = f'grp-{uuid.uuid4().hex[:8]}'
+    await _create_user_in_db(db, uid)
+    role = await _create_custom_role(
+        db,
+        name=f'valid-mgr-{uuid.uuid4().hex[:8]}',
+        permissions={'groups': {'manage_members': True}},
+    )
+    await _assign_custom_role(db, uid, role.id)
+    await _create_group_in_db(db, gid, uid)
+    await _add_membership(db, gid, uid)
+    return uid, gid, role
+
+
+async def _setup_valid_asset_manager(db: AsyncSession):
+    """Create a valid manager user with BOTH manage_members and manage_assets
+    capabilities, group, and membership. Returns (uid, gid, role).
+    """
+    uid = f'mgr-{uuid.uuid4().hex[:8]}'
+    gid = f'grp-{uuid.uuid4().hex[:8]}'
+    await _create_user_in_db(db, uid)
+    role = await _create_custom_role(
+        db,
+        name=f'valid-asset-mgr-{uuid.uuid4().hex[:8]}',
+        permissions={
+            'groups': {
+                'manage_members': True,
+                'manage_assets': True,
+            }
+        },
+    )
+    await _assign_custom_role(db, uid, role.id)
+    await _create_group_in_db(db, gid, uid)
+    await _add_membership(db, gid, uid)
+    return uid, gid, role
+
+
+# ===================================================================
+# 1. Extended custom-role catalog
+# ===================================================================
+
+class TestExtendedCatalog:
+
+    def test_groups_section_exists(self):
+        assert 'groups' in _PERMISSION_CATALOG
+
+    def test_manage_members_present(self):
+        assert _PERMISSION_CATALOG['groups']['manage_members'] is False
+
+    def test_manage_assets_present(self):
+        assert _PERMISSION_CATALOG['groups']['manage_assets'] is False
+
+    def test_catalog_defaults_false(self):
+        groups = _PERMISSION_CATALOG['groups']
+        for key, val in groups.items():
+            assert val is False, f'groups.{key} should default to False'
+
+    def test_normalize_permissions_includes_groups(self):
+        perm = normalize_permissions({'groups': {'manage_members': True}})
+        assert perm['groups']['manage_members'] is True
+        assert perm['groups']['manage_assets'] is False  # missing leaf → False
+
+    def test_validate_permissions_rejects_unknown_groups_key(self):
+        with pytest.raises(ValueError, match='Unknown permission key'):
+            validate_permissions({'groups': {'unknown_leaf': True}})
+
+    def test_validate_permissions_accepts_valid_groups(self):
+        result = validate_permissions({
+            'groups': {'manage_members': True, 'manage_assets': False}
+        })
+        assert result['groups']['manage_members'] is True
+
+    def test_sparse_groups_permissions_fills_false(self):
+        perm = normalize_permissions({})
+        assert perm['groups']['manage_members'] is False
+        assert perm['groups']['manage_assets'] is False
+
+    @pytest.mark.asyncio
+    async def test_role_with_groups_capability_persists(self, db):
+        role = await _create_custom_role(
+            db,
+            name='groups-manager',
+            permissions={'groups': {'manage_members': True}},
+        )
+        assert role is not None
+        fetched = await CustomRoles.get_role_by_id(role.id, db=db)
+        assert fetched is not None
+        assert fetched.permissions['groups']['manage_members'] is True
+        assert fetched.permissions['groups']['manage_assets'] is False
+
+
+# ===================================================================
+# 2. Capability fail-closed behavior
+# ===================================================================
+
+class TestCapabilityFailClosed:
+
+    def test_catalog_default_is_false(self):
+        """groups.* leaves default to False in the catalog."""
+        assert _PERMISSION_CATALOG['groups']['manage_members'] is False
+        assert _PERMISSION_CATALOG['groups']['manage_assets'] is False
+
+    @pytest.mark.asyncio
+    async def test_unresolved_role_yields_groups_false(self, db):
+        """An unresolved custom role returns all-false, including groups.*."""
+        from open_webui.utils.access_control import get_permissions
+
+        perms = await get_permissions(
+            user_id='nonexistent-user',
+            default_permissions={},
+            db=db,
+            user_role='custom:not-a-real-uuid',
+        )
+        assert perms['groups']['manage_members'] is False
+        assert perms['groups']['manage_assets'] is False
+
+    @pytest.mark.asyncio
+    async def test_disabled_role_yields_groups_false(self, db):
+        """A disabled custom role returns all-false groups.*."""
+        from open_webui.utils.access_control import get_permissions
+
+        role = await _create_custom_role(
+            db,
+            name='disabled-groups-role',
+            permissions={'groups': {'manage_members': True}},
+            active=False,
+        )
+        from open_webui.models.custom_roles import make_custom_role_ref
+        ref = make_custom_role_ref(role.id)
+
+        perms = await get_permissions(
+            user_id='any',
+            default_permissions={},
+            db=db,
+            user_role=ref,
+        )
+        assert perms['groups']['manage_members'] is False
+        assert perms['groups']['manage_assets'] is False
+
+
+# ===================================================================
+# 3. require_group_manager: role / member / capability matrix
+# ===================================================================
+
+class TestRequireGroupManager:
+
+    @pytest.mark.asyncio
+    async def test_admin_denied(self, manager_db):
+        """Admin users are denied on the scoped-manager service."""
+        uid = f'admin-{uuid.uuid4().hex[:8]}'
+        gid = f'grp-{uuid.uuid4().hex[:8]}'
+        await _create_user_in_db(manager_db, uid, role='admin')
+        await _create_group_in_db(manager_db, gid, uid)
+
+        async with group_manager_tx(manager_db):
+            with pytest.raises(GroupManagerError) as exc_info:
+                await require_group_manager(uid, gid, 'groups.manage_members', manager_db)
+            assert exc_info.value.reason == 'admin_denied'
+
+    @pytest.mark.asyncio
+    async def test_legacy_user_denied(self, manager_db):
+        """Legacy 'user' role is denied."""
+        uid = f'user-{uuid.uuid4().hex[:8]}'
+        gid = f'grp-{uuid.uuid4().hex[:8]}'
+        await _create_user_in_db(manager_db, uid, role='user')
+        await _create_group_in_db(manager_db, gid, uid)
+        await _add_membership(manager_db, gid, uid)
+
+        async with group_manager_tx(manager_db):
+            with pytest.raises(GroupManagerError) as exc_info:
+                await require_group_manager(uid, gid, 'groups.manage_members', manager_db)
+            assert exc_info.value.reason == 'legacy_role_denied'
+
+    @pytest.mark.asyncio
+    async def test_legacy_pending_denied(self, manager_db):
+        """Legacy 'pending' role is denied."""
+        uid = f'pending-{uuid.uuid4().hex[:8]}'
+        gid = f'grp-{uuid.uuid4().hex[:8]}'
+        await _create_user_in_db(manager_db, uid, role='pending')
+        await _create_group_in_db(manager_db, gid, uid)
+        await _add_membership(manager_db, gid, uid)
+
+        async with group_manager_tx(manager_db):
+            with pytest.raises(GroupManagerError) as exc_info:
+                await require_group_manager(uid, gid, 'groups.manage_members', manager_db)
+            assert exc_info.value.reason == 'legacy_role_denied'
+
+    @pytest.mark.asyncio
+    async def test_user_not_found(self, manager_db):
+        """Non-existent user is denied."""
+        async with group_manager_tx(manager_db):
+            with pytest.raises(GroupManagerError) as exc_info:
+                await require_group_manager('no-such-user', 'x', 'groups.manage_members', manager_db)
+            assert exc_info.value.reason == 'user_not_found'
+
+    @pytest.mark.asyncio
+    async def test_invalid_custom_role_ref(self, manager_db):
+        """User with malformed custom role ref is denied."""
+        uid = f'mgr-{uuid.uuid4().hex[:8]}'
+        await _create_user_in_db(manager_db, uid, role='custom:not-a-uuid')
+
+        async with group_manager_tx(manager_db):
+            with pytest.raises(GroupManagerError) as exc_info:
+                await require_group_manager(uid, 'x', 'groups.manage_members', manager_db)
+            assert exc_info.value.reason == 'invalid_custom_role'
+
+    @pytest.mark.asyncio
+    async def test_custom_role_without_capability_denied(self, manager_db):
+        """User has a custom role but the capability leaf is False."""
+        uid = f'mgr-{uuid.uuid4().hex[:8]}'
+        gid = f'grp-{uuid.uuid4().hex[:8]}'
+        await _create_user_in_db(manager_db, uid)
+
+        role = await _create_custom_role(
+            manager_db,
+            name=f'no-groups-role-{uuid.uuid4().hex[:8]}',
+            permissions={'workspace': {'models': True}},
+        )
+        await _assign_custom_role(manager_db, uid, role.id)
+        await _create_group_in_db(manager_db, gid, uid)
+        await _add_membership(manager_db, gid, uid)
+
+        async with group_manager_tx(manager_db):
+            with pytest.raises(GroupManagerError) as exc_info:
+                await require_group_manager(uid, gid, 'groups.manage_members', manager_db)
+            assert exc_info.value.reason == 'capability_denied'
+
+    @pytest.mark.asyncio
+    async def test_not_a_member_denied(self, manager_db):
+        """User has the capability but is not a member of the group."""
+        uid = f'mgr-{uuid.uuid4().hex[:8]}'
+        gid = f'grp-{uuid.uuid4().hex[:8]}'
+        await _create_user_in_db(manager_db, uid)
+
+        role = await _create_custom_role(
+            manager_db,
+            name=f'member-mgr-{uuid.uuid4().hex[:8]}',
+            permissions={'groups': {'manage_members': True}},
+        )
+        await _assign_custom_role(manager_db, uid, role.id)
+        await _create_group_in_db(manager_db, gid, uid)
+        # Do NOT add membership
+
+        async with group_manager_tx(manager_db):
+            with pytest.raises(GroupManagerError) as exc_info:
+                await require_group_manager(uid, gid, 'groups.manage_members', manager_db)
+            assert exc_info.value.reason == 'not_a_member'
+
+    @pytest.mark.asyncio
+    async def test_group_not_found_denied(self, manager_db):
+        """The 'group_not_found' path is unreachable when FK enforcement is on
+        (GroupMember.group_id -> Group.id prevents orphan memberships).
+
+        We verify the defensive code path exists via source inspection,
+        and that require_group_manager raises the correct error for a
+        completely missing user (which tests the same error-raise pattern).
+        """
+        import inspect
+        source = inspect.getsource(require_group_manager)
+        assert 'group_not_found' in source
+        assert 'Group' in source
+
+        # Also verify: requesting a group that doesn't exist, for a user
+        # who has no membership, yields 'not_a_member' (the earlier check).
+        uid = f'mgr-{uuid.uuid4().hex[:8]}'
+        await _create_user_in_db(manager_db, uid)
+
+        role = await _create_custom_role(
+            manager_db,
+            name=f'grp-mgr-{uuid.uuid4().hex[:8]}',
+            permissions={'groups': {'manage_members': True}},
+        )
+        await _assign_custom_role(manager_db, uid, role.id)
+
+        async with group_manager_tx(manager_db):
+            with pytest.raises(GroupManagerError) as exc_info:
+                await require_group_manager(uid, 'non-existent-group', 'groups.manage_members', manager_db)
+            # FK enforcement means: no orphan memberships exist, so we hit
+            # 'not_a_member' before 'group_not_found'
+            assert exc_info.value.reason in ('not_a_member', 'group_not_found')
+
+    @pytest.mark.asyncio
+    async def test_valid_manage_members(self, manager_db):
+        """User with capability, membership, and valid group passes."""
+        uid, gid, _ = await _setup_valid_manager(manager_db)
+
+        async with group_manager_tx(manager_db):
+            await require_group_manager(uid, gid, 'groups.manage_members', manager_db)
+
+    @pytest.mark.asyncio
+    async def test_valid_manage_assets(self, manager_db):
+        """User with manage_assets capability passes for that capability."""
+        uid = f'mgr-{uuid.uuid4().hex[:8]}'
+        gid = f'grp-{uuid.uuid4().hex[:8]}'
+        await _create_user_in_db(manager_db, uid)
+
+        role = await _create_custom_role(
+            manager_db,
+            name=f'asset-mgr-{uuid.uuid4().hex[:8]}',
+            permissions={'groups': {'manage_assets': True}},
+        )
+        await _assign_custom_role(manager_db, uid, role.id)
+        await _create_group_in_db(manager_db, gid, uid)
+        await _add_membership(manager_db, gid, uid)
+
+        async with group_manager_tx(manager_db):
+            await require_group_manager(uid, gid, 'groups.manage_assets', manager_db)
+
+    @pytest.mark.asyncio
+    async def test_manage_members_does_not_authorize_manage_assets(self, manager_db):
+        """Having manage_members does NOT grant manage_assets."""
+        uid = f'mgr-{uuid.uuid4().hex[:8]}'
+        gid = f'grp-{uuid.uuid4().hex[:8]}'
+        await _create_user_in_db(manager_db, uid)
+
+        role = await _create_custom_role(
+            manager_db,
+            name=f'only-members-{uuid.uuid4().hex[:8]}',
+            permissions={'groups': {'manage_members': True, 'manage_assets': False}},
+        )
+        await _assign_custom_role(manager_db, uid, role.id)
+        await _create_group_in_db(manager_db, gid, uid)
+        await _add_membership(manager_db, gid, uid)
+
+        async with group_manager_tx(manager_db):
+            with pytest.raises(GroupManagerError) as exc_info:
+                await require_group_manager(uid, gid, 'groups.manage_assets', manager_db)
+            assert exc_info.value.reason == 'capability_denied'
+
+
+# ===================================================================
+# 4. Cross-group denial
+# ===================================================================
+
+class TestCrossGroupDenial:
+
+    @pytest.mark.asyncio
+    async def test_manager_of_group_a_denied_on_group_b(self, manager_db):
+        """User is manager of group A but denied on group B."""
+        uid = f'mgr-{uuid.uuid4().hex[:8]}'
+        gid_a = f'grpA-{uuid.uuid4().hex[:8]}'
+        gid_b = f'grpB-{uuid.uuid4().hex[:8]}'
+        await _create_user_in_db(manager_db, uid)
+
+        role = await _create_custom_role(
+            manager_db,
+            name=f'cross-grp-{uuid.uuid4().hex[:8]}',
+            permissions={'groups': {'manage_members': True}},
+        )
+        await _assign_custom_role(manager_db, uid, role.id)
+        await _create_group_in_db(manager_db, gid_a, uid)
+        await _add_membership(manager_db, gid_a, uid)
+        await _create_group_in_db(manager_db, gid_b, uid)
+        # NOT a member of gid_b
+
+        async with group_manager_tx(manager_db):
+            with pytest.raises(GroupManagerError) as exc_info:
+                await require_group_manager(uid, gid_b, 'groups.manage_members', manager_db)
+            assert exc_info.value.reason == 'not_a_member'
+
+
+# ===================================================================
+# 5. Grant / creator non-authority
+# ===================================================================
+
+class TestGrantCreatorNonAuthority:
+
+    @pytest.mark.asyncio
+    async def test_group_creator_without_membership_denied(self, manager_db):
+        """Being the group creator (user_id) does not grant manager access
+        if the user is not a member."""
+        creator_uid = f'creator-{uuid.uuid4().hex[:8]}'
+        gid = f'grp-{uuid.uuid4().hex[:8]}'
+        await _create_user_in_db(manager_db, creator_uid)
+
+        role = await _create_custom_role(
+            manager_db,
+            name=f'creator-role-{uuid.uuid4().hex[:8]}',
+            permissions={'groups': {'manage_members': True}},
+        )
+        await _assign_custom_role(manager_db, creator_uid, role.id)
+        # Group's user_id is the creator, but they are NOT a member
+        await _create_group_in_db(manager_db, gid, creator_uid)
+
+        async with group_manager_tx(manager_db):
+            with pytest.raises(GroupManagerError) as exc_info:
+                await require_group_manager(creator_uid, gid, 'groups.manage_members', manager_db)
+            assert exc_info.value.reason == 'not_a_member'
+
+    @pytest.mark.asyncio
+    async def test_asset_creator_without_membership_denied(self, manager_db):
+        """Creating an asset does not grant manager authority."""
+        uid = f'creator-{uuid.uuid4().hex[:8]}'
+        gid = f'grp-{uuid.uuid4().hex[:8]}'
+        await _create_user_in_db(manager_db, uid)
+
+        role = await _create_custom_role(
+            manager_db,
+            name=f'asset-creator-{uuid.uuid4().hex[:8]}',
+            permissions={'groups': {'manage_assets': True}},
+        )
+        await _assign_custom_role(manager_db, uid, role.id)
+        await _create_group_in_db(manager_db, gid, uid)
+        await _add_membership(manager_db, gid, uid)
+
+        # Insert an asset — created_by = uid
+        asset = await GroupOwnedAssets.insert_asset(
+            resource_type='knowledge',
+            resource_id=f'res-{uuid.uuid4().hex[:8]}',
+            group_id=gid,
+            created_by=uid,
+            db=manager_db,
+        )
+        assert asset.created_by == uid
+
+        # Now remove membership — the asset creator should be denied
+        from sqlalchemy import delete
+        await manager_db.execute(
+            delete(GroupMember).where(
+                GroupMember.group_id == gid,
+                GroupMember.user_id == uid,
+            )
+        )
+        await manager_db.flush()
+        if manager_db.info.get('manager_setup'):
+            await manager_db.commit()
+
+        async with group_manager_tx(manager_db):
+            with pytest.raises(GroupManagerError) as exc_info:
+                await require_group_manager(uid, gid, 'groups.manage_assets', manager_db)
+            assert exc_info.value.reason == 'not_a_member'
+
+
+# ===================================================================
+# 6. Ownership uniqueness / allowlist
+# ===================================================================
+
+class TestOwnershipUniqueness:
+
+    @pytest.mark.asyncio
+    async def test_insert_and_retrieve(self, db):
+        """Basic insert + get_by_resource round-trip."""
+        gid = f'grp-{uuid.uuid4().hex[:8]}'
+        uid = f'creator-{uuid.uuid4().hex[:8]}'
+        rid = f'res-{uuid.uuid4().hex[:8]}'
+        await _create_group_in_db(db, gid, uid)
+
+        asset = await GroupOwnedAssets.insert_asset(
+            resource_type='knowledge',
+            resource_id=rid,
+            group_id=gid,
+            created_by=uid,
+            db=db,
+        )
+        assert asset.resource_type == 'knowledge'
+        assert asset.resource_id == rid
+        assert asset.group_id == gid
+        assert asset.created_by == uid
+
+        fetched = await GroupOwnedAssets.get_asset_by_resource(
+            'knowledge', rid, db=db
+        )
+        assert fetched is not None
+        assert fetched.id == asset.id
+
+    @pytest.mark.asyncio
+    async def test_uniqueness_constraint(self, db):
+        """Duplicate (resource_type, resource_id) raises an error."""
+        gid = f'grp-{uuid.uuid4().hex[:8]}'
+        uid = f'creator-{uuid.uuid4().hex[:8]}'
+        rid = f'res-{uuid.uuid4().hex[:8]}'
+        await _create_group_in_db(db, gid, uid)
+
+        await GroupOwnedAssets.insert_asset(
+            resource_type='knowledge',
+            resource_id=rid,
+            group_id=gid,
+            created_by=uid,
+            db=db,
+        )
+
+        # Second insert with same (type, id) should raise
+        with pytest.raises(Exception):
+            await GroupOwnedAssets.insert_asset(
+                resource_type='knowledge',
+                resource_id=rid,
+                group_id=gid,
+                created_by=uid,
+                db=db,
+            )
+
+    @pytest.mark.asyncio
+    async def test_same_resource_different_type_allowed(self, db):
+        """Same resource_id with different resource_type is allowed."""
+        gid = f'grp-{uuid.uuid4().hex[:8]}'
+        uid = f'creator-{uuid.uuid4().hex[:8]}'
+        rid = f'res-{uuid.uuid4().hex[:8]}'
+        await _create_group_in_db(db, gid, uid)
+
+        a1 = await GroupOwnedAssets.insert_asset(
+            resource_type='knowledge',
+            resource_id=rid,
+            group_id=gid,
+            created_by=uid,
+            db=db,
+        )
+        a2 = await GroupOwnedAssets.insert_asset(
+            resource_type='prompt',
+            resource_id=rid,
+            group_id=gid,
+            created_by=uid,
+            db=db,
+        )
+        assert a1.id != a2.id
+
+    def test_supported_types_allowlist(self):
+        """knowledge, prompt, and skill are supported."""
+        assert SUPPORTED_OWNED_ASSET_TYPES == frozenset({'knowledge', 'prompt', 'skill'})
+
+    @pytest.mark.asyncio
+    async def test_unsupported_type_rejected(self, db):
+        """resource_type not in allowlist raises ValueError."""
+        with pytest.raises(ValueError, match='Unsupported resource_type'):
+            await GroupOwnedAssets.insert_asset(
+                resource_type='model',
+                resource_id='x',
+                group_id='g',
+                created_by='u',
+                db=db,
+            )
+
+    @pytest.mark.asyncio
+    async def test_get_assets_by_group(self, db):
+        """Query assets by group_id."""
+        gid = f'grp-{uuid.uuid4().hex[:8]}'
+        uid = f'creator-{uuid.uuid4().hex[:8]}'
+        await _create_group_in_db(db, gid, uid)
+
+        await GroupOwnedAssets.insert_asset(
+            resource_type='knowledge', resource_id='r1', group_id=gid, created_by=uid, db=db,
+        )
+        await GroupOwnedAssets.insert_asset(
+            resource_type='prompt', resource_id='r2', group_id=gid, created_by=uid, db=db,
+        )
+
+        all_assets = await GroupOwnedAssets.get_assets_by_group_id(gid, db=db)
+        assert len(all_assets) == 2
+
+        prompts_only = await GroupOwnedAssets.get_assets_by_group_id(
+            gid, resource_type='prompt', db=db
+        )
+        assert len(prompts_only) == 1
+        assert prompts_only[0].resource_type == 'prompt'
+
+    @pytest.mark.asyncio
+    async def test_delete_asset(self, db):
+        """Delete an ownership record."""
+        gid = f'grp-{uuid.uuid4().hex[:8]}'
+        uid = f'creator-{uuid.uuid4().hex[:8]}'
+        rid = f'res-{uuid.uuid4().hex[:8]}'
+        await _create_group_in_db(db, gid, uid)
+
+        await GroupOwnedAssets.insert_asset(
+            resource_type='knowledge', resource_id=rid, group_id=gid, created_by=uid, db=db,
+        )
+        deleted = await GroupOwnedAssets.delete_asset_by_resource(
+            'knowledge', rid, db=db
+        )
+        assert deleted is True
+
+        fetched = await GroupOwnedAssets.get_asset_by_resource('knowledge', rid, db=db)
+        assert fetched is None
+
+    @pytest.mark.asyncio
+    async def test_delete_nonexistent_returns_false(self, db):
+        """Deleting a non-existent asset returns False."""
+        deleted = await GroupOwnedAssets.delete_asset_by_resource(
+            'knowledge', 'no-such-id', db=db
+        )
+        assert deleted is False
+
+
+# ===================================================================
+# 7. Migration metadata / constraint expectations
+# ===================================================================
+
+class TestMigrationMetadata:
+
+    @pytest.mark.asyncio
+    async def test_group_owned_asset_schema(self, db):
+        """Verify the group_owned_asset table was created with correct columns."""
+
+        def _check_schema(sync_conn):
+            from open_webui.internal.db import Base
+
+            metadata = Base.metadata
+            tables = set(metadata.tables.keys())
+            asset_keys = [k for k in tables if k.endswith('group_owned_asset')]
+            assert asset_keys, f'group_owned_asset table not found in {tables}'
+
+            table = metadata.tables[asset_keys[0]]
+
+            # Column presence
+            cols = {c.name: c for c in table.columns}
+            expected = {
+                'id', 'resource_type', 'resource_id', 'group_id',
+                'created_by', 'created_at', 'updated_at',
+            }
+            assert expected.issubset(set(cols.keys()))
+
+            # All columns non-nullable
+            for col_name in expected:
+                assert cols[col_name].nullable is False, f'{col_name} should be non-nullable'
+
+            # Unique constraint on (resource_type, resource_id) — check via raw DDL
+            row = sync_conn.execute(
+                text("SELECT sql FROM sqlite_master WHERE type='table' AND name='group_owned_asset'")
+            ).fetchone()
+            assert row is not None
+            ddl = row[0]
+            assert 'group_id' in ddl
+            assert 'created_by' in ddl
+            assert 'UNIQUE' in ddl.upper()
+
+            # Index on group_id
+            idx_names = {idx.name for idx in table.indexes}
+            assert 'ix_group_owned_asset_group_id' in idx_names
+
+        await db.run_sync(_check_schema)
+
+    @pytest.mark.asyncio
+    async def test_group_member_unique_constraint(self, db):
+        """Verify the unique (group_id, user_id) constraint on group_member.
+
+        This constraint is created by the HISTORICAL migration
+        37f288994c47 (add_group_member_table), not by the Phase-2
+        migration fdcb6cc75284.
+        """
+
+        def _check_schema(sync_conn):
+            row = sync_conn.execute(
+                text("SELECT sql FROM sqlite_master WHERE type='table' AND name='group_member'")
+            ).fetchone()
+            assert row is not None
+            ddl = row[0]
+            # The unique constraint should appear in the DDL
+            assert 'uq_group_member_group_user' in ddl.lower() or (
+                'UNIQUE' in ddl.upper() and 'group_id' in ddl and 'user_id' in ddl
+            )
+
+        await db.run_sync(_check_schema)
+
+
+# ===================================================================
+# 8. No implicit commits in new primitives
+# ===================================================================
+
+class TestNoImplicitCommits:
+
+    @pytest.mark.asyncio
+    async def test_insert_asset_uses_flush_not_commit(self, db):
+        """insert_asset should flush but not commit — the outer transaction
+        controls visibility."""
+        gid = f'grp-{uuid.uuid4().hex[:8]}'
+        uid = f'creator-{uuid.uuid4().hex[:8]}'
+        rid = f'res-{uuid.uuid4().hex[:8]}'
+        await _create_group_in_db(db, gid, uid)
+
+        asset = await GroupOwnedAssets.insert_asset(
+            resource_type='knowledge',
+            resource_id=rid,
+            group_id=gid,
+            created_by=uid,
+            db=db,
+        )
+        # The asset is visible in this session (flushed)
+        fetched = await GroupOwnedAssets.get_asset_by_resource(
+            'knowledge', rid, db=db
+        )
+        assert fetched is not None
+        assert fetched.id == asset.id
+        # Note: the savepoint isolation in conftest.py means the outer
+        # transaction will be rolled back after the test, demonstrating
+        # that insert_asset does NOT perform an independent commit.
+
+    @pytest.mark.asyncio
+    async def test_require_group_manager_read_only(self, manager_db):
+        """require_group_manager must not commit — it only reads."""
+        uid, gid, _ = await _setup_valid_manager(manager_db)
+
+        async with group_manager_tx(manager_db):
+            # This should succeed without committing anything
+            await require_group_manager(uid, gid, 'groups.manage_members', manager_db)
+
+            # Verify the transaction still works — we can still insert and see it
+            asset = await GroupOwnedAssets.insert_asset(
+                resource_type='knowledge',
+                resource_id=f'res-{uuid.uuid4().hex[:8]}',
+                group_id=gid,
+                created_by=uid,
+                db=manager_db,
+            )
+            assert asset is not None
+
+
+# ===================================================================
+# 9. Invalid capability string
+# ===================================================================
+
+class TestInvalidCapability:
+
+    @pytest.mark.asyncio
+    async def test_nonexistent_capability_rejected(self, manager_db):
+        """require_group_manager rejects a capability not in the catalog."""
+        uid = f'mgr-{uuid.uuid4().hex[:8]}'
+        await _create_user_in_db(manager_db, uid)
+
+        async with group_manager_tx(manager_db):
+            with pytest.raises(GroupManagerError) as exc_info:
+                await require_group_manager(uid, 'x', 'groups.nonexistent', manager_db)
+            assert exc_info.value.reason == 'invalid_capability'
+
+    @pytest.mark.asyncio
+    async def test_non_groups_capability_rejected(self, manager_db):
+        """A capability from a different section is rejected."""
+        uid = f'mgr-{uuid.uuid4().hex[:8]}'
+        await _create_user_in_db(manager_db, uid)
+
+        async with group_manager_tx(manager_db):
+            with pytest.raises(GroupManagerError) as exc_info:
+                await require_group_manager(uid, 'x', 'workspace.models', manager_db)
+            assert exc_info.value.reason == 'invalid_capability'
+
+
+# ===================================================================
+# 10. Backward compatibility — catalog has only new keys added
+# ===================================================================
+
+class TestBackwardCompatibility:
+
+    def test_all_original_sections_present(self):
+        """Phase 1 catalog sections are still present."""
+        assert 'workspace' in _PERMISSION_CATALOG
+        assert 'sharing' in _PERMISSION_CATALOG
+        assert 'access_grants' in _PERMISSION_CATALOG
+        assert 'chat' in _PERMISSION_CATALOG
+        assert 'features' in _PERMISSION_CATALOG
+        assert 'settings' in _PERMISSION_CATALOG
+
+    def test_original_sections_not_modified(self):
+        """Original catalog leaf values are unchanged."""
+        assert _PERMISSION_CATALOG['workspace']['models'] is False
+        assert _PERMISSION_CATALOG['sharing']['models'] is False
+        assert _PERMISSION_CATALOG['chat']['controls'] is False
+        assert _PERMISSION_CATALOG['settings']['interface'] is False
+
+    def test_groups_is_new_section(self):
+        """groups is the only new section added in Phase 2."""
+        assert set(_PERMISSION_CATALOG.keys()) == {
+            'workspace', 'sharing', 'access_grants', 'chat',
+            'features', 'settings', 'groups',
+        }
+
+
+# ===================================================================
+# 11. GroupMember uniqueness — duplicate rejection (historical lineage)
+# ===================================================================
+
+class TestGroupMemberDuplicateRejection:
+
+    @pytest.mark.asyncio
+    async def test_duplicate_membership_rejected(self, db):
+        """Inserting a duplicate (group_id, user_id) raises an IntegrityError.
+        This constraint comes from the historical migration 37f288994c47.
+        """
+        from sqlalchemy.exc import IntegrityError
+
+        uid = f'user-{uuid.uuid4().hex[:8]}'
+        gid = f'grp-{uuid.uuid4().hex[:8]}'
+        await _create_user_in_db(db, uid)
+        await _create_group_in_db(db, gid, uid)
+
+        # First insert succeeds
+        await _add_membership(db, gid, uid)
+
+        # Second insert with same (group_id, user_id) must raise
+        with pytest.raises(IntegrityError):
+            await _add_membership(db, gid, uid)
+
+    @pytest.mark.asyncio
+    async def test_different_users_same_group_allowed(self, db):
+        """Two different users in the same group is allowed."""
+        uid1 = f'user-{uuid.uuid4().hex[:8]}'
+        uid2 = f'user-{uuid.uuid4().hex[:8]}'
+        gid = f'grp-{uuid.uuid4().hex[:8]}'
+        await _create_user_in_db(db, uid1)
+        await _create_user_in_db(db, uid2)
+        await _create_group_in_db(db, gid, uid1)
+
+        await _add_membership(db, gid, uid1)
+        await _add_membership(db, gid, uid2)
+
+        from sqlalchemy import select
+        result = await db.execute(
+            select(GroupMember).where(GroupMember.group_id == gid)
+        )
+        assert len(result.scalars().all()) == 2
+
+    @pytest.mark.asyncio
+    async def test_same_user_different_groups_allowed(self, db):
+        """Same user in two different groups is allowed."""
+        uid = f'user-{uuid.uuid4().hex[:8]}'
+        gid_a = f'grpA-{uuid.uuid4().hex[:8]}'
+        gid_b = f'grpB-{uuid.uuid4().hex[:8]}'
+        await _create_user_in_db(db, uid)
+        await _create_group_in_db(db, gid_a, uid)
+        await _create_group_in_db(db, gid_b, uid)
+
+        await _add_membership(db, gid_a, uid)
+        await _add_membership(db, gid_b, uid)
+
+
+# ===================================================================
+# 12. SQLite FK enforcement — orphan & cascade rejection
+# ===================================================================
+
+class TestForeignKeyEnforcement:
+
+    @pytest.mark.asyncio
+    async def test_orphan_asset_insertion_rejected(self, db):
+        """Inserting a group_owned_asset with a non-existent group_id
+        must be rejected by the FK constraint."""
+        from sqlalchemy.exc import IntegrityError
+
+        with pytest.raises(IntegrityError):
+            await GroupOwnedAssets.insert_asset(
+                resource_type='knowledge',
+                resource_id=f'res-{uuid.uuid4().hex[:8]}',
+                group_id='non-existent-group',
+                created_by='u',
+                db=db,
+            )
+
+    @pytest.mark.asyncio
+    async def test_group_deletion_rejected_with_ownership(self, db):
+        """Deleting a group that has ownership rows must be rejected
+        by the RESTRICT FK constraint."""
+        from sqlalchemy import delete as sa_delete
+        from sqlalchemy.exc import IntegrityError
+
+        uid = f'creator-{uuid.uuid4().hex[:8]}'
+        gid = f'grp-{uuid.uuid4().hex[:8]}'
+        await _create_user_in_db(db, uid)
+        await _create_group_in_db(db, gid, uid)
+
+        await GroupOwnedAssets.insert_asset(
+            resource_type='knowledge',
+            resource_id=f'res-{uuid.uuid4().hex[:8]}',
+            group_id=gid,
+            created_by=uid,
+            db=db,
+        )
+
+        # Attempting to delete the group must fail
+        with pytest.raises(IntegrityError):
+            await db.execute(
+                sa_delete(Group).where(Group.id == gid)
+            )
+
+    @pytest.mark.asyncio
+    async def test_group_deletion_allowed_after_asset_removal(self, db):
+        """After removing all ownership rows, group deletion succeeds."""
+        from sqlalchemy import delete as sa_delete
+
+        uid = f'creator-{uuid.uuid4().hex[:8]}'
+        gid = f'grp-{uuid.uuid4().hex[:8]}'
+        await _create_user_in_db(db, uid)
+        await _create_group_in_db(db, gid, uid)
+
+        await GroupOwnedAssets.insert_asset(
+            resource_type='knowledge',
+            resource_id=f'res-{uuid.uuid4().hex[:8]}',
+            group_id=gid,
+            created_by=uid,
+            db=db,
+        )
+
+        # Remove the ownership row
+        assets = await GroupOwnedAssets.get_assets_by_group_id(gid, db=db)
+        assert len(assets) == 1
+        await GroupOwnedAssets.delete_asset_by_resource(
+            assets[0].resource_type, assets[0].resource_id, db=db
+        )
+
+        # Now group deletion should succeed
+        result = await db.execute(
+            sa_delete(Group).where(Group.id == gid)
+        )
+        assert result.rowcount == 1
+
+
+# ===================================================================
+# 13. Linearizability / stable lock order
+# ===================================================================
+
+class TestLinearizability:
+
+    @pytest.mark.asyncio
+    async def test_function_reads_from_caller_session(self, manager_db):
+        """require_group_manager must use the caller's session — uncommitted
+        writes from the same session are visible."""
+        uid = f'mgr-{uuid.uuid4().hex[:8]}'
+        gid = f'grp-{uuid.uuid4().hex[:8]}'
+
+        # Insert user + role via direct ORM (committed via manager_setup marker)
+        await _create_user_in_db(manager_db, uid)
+        role = await _create_custom_role(
+            manager_db,
+            name=f'lin-mgr-{uuid.uuid4().hex[:8]}',
+            permissions={'groups': {'manage_members': True}},
+        )
+        await _assign_custom_role(manager_db, uid, role.id)
+        await _create_group_in_db(manager_db, gid, uid)
+        await _add_membership(manager_db, gid, uid)
+
+        # require_group_manager should see the committed user/role/membership
+        # because it uses the same session.
+        async with group_manager_tx(manager_db):
+            await require_group_manager(uid, gid, 'groups.manage_members', manager_db)
+
+    def test_locking_queries_use_with_for_update(self):
+        """Verify that require_group_manager issues SELECT ... FOR UPDATE
+        by inspecting the source code (locking intent)."""
+        import inspect
+        source = inspect.getsource(require_group_manager)
+        # Must have at least 4 with_for_update() calls: User, CustomRole,
+        # GroupMember, Group — in that stable order.
+        assert source.count('with_for_update()') >= 4
+        # Verify stable order in source: User → CustomRole → GroupMember → Group
+        idx_user = source.find('select(User)')
+        idx_role = source.find('select(CustomRole)')
+        idx_member = source.find('select(GroupMember)')
+        idx_group = source.find('select(Group)')
+        assert 0 < idx_user < idx_role < idx_member < idx_group
+
+
+# ===================================================================
+# 14. Strict boolean check (P1.4)
+# ===================================================================
+
+class TestStrictBooleanCheck:
+
+    @pytest.mark.asyncio
+    async def test_truthy_non_true_value_denied(self, db):
+        """A capability set to a truthy non-True value (e.g. 1) must be
+        denied — only exactly True is accepted."""
+        from open_webui.utils.access_control.group_manager import _check_capability
+
+        with pytest.raises(GroupManagerError) as exc_info:
+            _check_capability('groups.manage_members', {
+                'groups': {'manage_members': 1, 'manage_assets': False}
+            })
+        assert exc_info.value.reason == 'capability_denied'
+        assert 'not True' in exc_info.value.detail
+
+    def test_string_true_denied(self):
+        """A capability set to the string 'True' must be denied."""
+        from open_webui.utils.access_control.group_manager import _check_capability
+
+        with pytest.raises(GroupManagerError) as exc_info:
+            _check_capability('groups.manage_members', {
+                'groups': {'manage_members': 'True', 'manage_assets': False}
+            })
+        assert exc_info.value.reason == 'capability_denied'
+
+    def test_exact_true_accepted(self):
+        """Only exactly True passes the strict check."""
+        from open_webui.utils.access_control.group_manager import _check_capability
+
+        # Should not raise
+        _check_capability('groups.manage_members', {
+            'groups': {'manage_members': True, 'manage_assets': False}
+        })
+
+
+# ===================================================================
+# 15. DB-level CheckConstraint for supported types (P1.5)
+# ===================================================================
+
+class TestOwnershipTypeCheckConstraint:
+
+    @pytest.mark.asyncio
+    async def test_unsupported_type_rejected_at_db_level(self, db):
+        """Inserting an asset with resource_type='model' directly via ORM
+        (bypassing the repository) must be rejected by the DB constraint."""
+        from sqlalchemy.exc import IntegrityError
+
+        uid = f'creator-{uuid.uuid4().hex[:8]}'
+        gid = f'grp-{uuid.uuid4().hex[:8]}'
+        await _create_user_in_db(db, uid)
+        await _create_group_in_db(db, gid, uid)
+
+        from open_webui.models.groups import GroupOwnedAsset
+        row = GroupOwnedAsset(
+            id=str(uuid.uuid4()),
+            resource_type='model',
+            resource_id=f'res-{uuid.uuid4().hex[:8]}',
+            group_id=gid,
+            created_by=uid,
+            created_at=int(time.time()),
+            updated_at=int(time.time()),
+        )
+        db.add(row)
+        with pytest.raises(IntegrityError):
+            await db.flush()
+
+    @pytest.mark.asyncio
+    async def test_check_constraint_in_ddl(self, db):
+        """Verify the CheckConstraint appears in the table DDL."""
+        def _check(sync_conn):
+            row = sync_conn.execute(
+                text("SELECT sql FROM sqlite_master WHERE type='table' AND name='group_owned_asset'")
+            ).fetchone()
+            assert row is not None
+            ddl = row[0]
+            assert 'ck_group_owned_asset_type' in ddl.lower()
+            assert 'knowledge' in ddl
+            assert 'prompt' in ddl
+
+        await db.run_sync(_check)
+
+    @pytest.mark.asyncio
+    async def test_repository_validate_type_before_insert(self, db):
+        """The repository-level validation rejects unsupported types before
+        reaching the DB."""
+        with pytest.raises(ValueError, match='Unsupported resource_type'):
+            await GroupOwnedAssets.insert_asset(
+                resource_type='tool',
+                resource_id='x',
+                group_id='g',
+                created_by='u',
+                db=db,
+            )
+
+
+# ===================================================================
+# 16. Transaction boundary enforcement (group_manager_tx)
+# ===================================================================
+
+class TestTransactionBoundary:
+
+    @pytest.mark.asyncio
+    async def test_calls_outside_context_rejected(self, fresh_session):
+        """require_group_manager must reject calls outside group_manager_tx."""
+        await _create_user_in_db(fresh_session, 'mgr-tx-o')
+        role = await _create_custom_role(
+            fresh_session,
+            name='tx-o-role',
+            permissions={'groups': {'manage_members': True}},
+        )
+        await _assign_custom_role(fresh_session, 'mgr-tx-o', role.id)
+        await _create_group_in_db(fresh_session, 'grp-tx-o', 'mgr-tx-o')
+        await _add_membership(fresh_session, 'grp-tx-o', 'mgr-tx-o')
+        await fresh_session.flush()
+
+        with pytest.raises(GroupManagerError) as exc_info:
+            await require_group_manager(
+                'mgr-tx-o', 'grp-tx-o', 'groups.manage_members', fresh_session,
+            )
+        assert exc_info.value.reason == 'tx_boundary_missing'
+        assert 'group_manager_tx' in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    async def test_context_sets_boundary_marker(self, fresh_session):
+        """group_manager_tx establishes the ContextVar token AND the
+        diagnostics marker on session.info.  The token is bound to both
+        the session identity and the active transaction identity."""
+        from open_webui.utils.access_control.group_manager import (
+            _GM_TX_BOUNDARY,
+            _boundary_ctx,
+        )
+
+        # Before entering: no token, no diagnostics
+        assert _boundary_ctx.get(None) is None
+        assert fresh_session.info.get(_GM_TX_BOUNDARY) is None
+
+        async with group_manager_tx(fresh_session):
+            token = _boundary_ctx.get(None)
+            assert token is not None, 'ContextVar token must be set inside context'
+            assert token.matches(fresh_session), 'Token must match the session + tx'
+            # Token must also reference the live transaction object via identity
+            tx = fresh_session.get_transaction()
+            assert tx is not None, 'Session must have an active transaction'
+            assert token._tx_ref is tx, 'Token must hold a reference to the live transaction'
+            assert fresh_session.info.get(_GM_TX_BOUNDARY) is True
+
+        # After exiting: both cleared; token must NOT match any stale tx
+        assert _boundary_ctx.get(None) is None
+        assert fresh_session.info.get(_GM_TX_BOUNDARY) is None
+
+    @pytest.mark.asyncio
+    async def test_boundary_marker_cleaned_on_exception(self, fresh_session):
+        """The ContextVar token and diagnostics marker are cleaned up
+        even when an exception occurs."""
+        from open_webui.utils.access_control.group_manager import (
+            _GM_TX_BOUNDARY,
+            _boundary_ctx,
+        )
+
+        with pytest.raises(GroupManagerError):
+            async with group_manager_tx(fresh_session):
+                assert _boundary_ctx.get(None) is not None
+                raise GroupManagerError('test_error', 'deliberate')
+
+        assert _boundary_ctx.get(None) is None
+        assert fresh_session.info.get(_GM_TX_BOUNDARY) is None
+
+    @pytest.mark.asyncio
+    async def test_context_allows_authorize_then_mutate(self, manager_db):
+        """The context manager enables the authorize-then-mutate pattern:
+        require_group_manager succeeds, then mutations follow in the same
+        transaction, and the transaction is committed on success.
+        """
+        uid = f'mgr-atm-{uuid.uuid4().hex[:8]}'
+        gid = f'grp-atm-{uuid.uuid4().hex[:8]}'
+        await _create_user_in_db(manager_db, uid)
+        role = await _create_custom_role(
+            manager_db,
+            name=f'atm-role-{uuid.uuid4().hex[:8]}',
+            permissions={'groups': {'manage_members': True}},
+        )
+        await _assign_custom_role(manager_db, uid, role.id)
+        await _create_group_in_db(manager_db, gid, uid)
+        await _add_membership(manager_db, gid, uid)
+
+        async with group_manager_tx(manager_db):
+            await require_group_manager(uid, gid, 'groups.manage_members', manager_db)
+            # Mutation: insert an asset in the same transaction
+            asset = await GroupOwnedAssets.insert_asset(
+                resource_type='knowledge',
+                resource_id=f'res-{uuid.uuid4().hex[:8]}',
+                group_id=gid,
+                created_by=uid,
+                db=manager_db,
+            )
+            assert asset is not None
+            assert asset.group_id == gid
+
+        # Transaction was committed — verify the asset is visible in a
+        # new session.
+        from open_webui.internal.db import get_async_db_context
+        async with get_async_db_context() as verify_session:
+            fetched = await GroupOwnedAssets.get_asset_by_resource(
+                'knowledge', asset.resource_id, db=verify_session,
+            )
+            assert fetched is not None
+            assert fetched.id == asset.id
+
+    @pytest.mark.asyncio
+    async def test_context_rolls_back_on_error(self, manager_db):
+        """When the body raises, the transaction is rolled back and no
+        data persists."""
+        uid = f'mgr-rb-{uuid.uuid4().hex[:8]}'
+        gid = f'grp-rb-{uuid.uuid4().hex[:8]}'
+        await _create_user_in_db(manager_db, uid)
+        role = await _create_custom_role(
+            manager_db,
+            name=f'rb-role-{uuid.uuid4().hex[:8]}',
+            permissions={'groups': {'manage_members': True}},
+        )
+        await _assign_custom_role(manager_db, uid, role.id)
+        await _create_group_in_db(manager_db, gid, uid)
+        await _add_membership(manager_db, gid, uid)
+
+        with pytest.raises(RuntimeError, match='deliberate'):
+            async with group_manager_tx(manager_db):
+                await require_group_manager(
+                    uid, gid, 'groups.manage_members', manager_db,
+                )
+                # This mutation should be rolled back
+                await GroupOwnedAssets.insert_asset(
+                    resource_type='knowledge',
+                    resource_id='res-should-not-persist',
+                    group_id=gid,
+                    created_by=uid,
+                    db=manager_db,
+                )
+                raise RuntimeError('deliberate')
+
+        # Transaction was rolled back — verify the asset does NOT exist.
+        from open_webui.internal.db import get_async_db_context
+        async with get_async_db_context() as verify_session:
+            fetched = await GroupOwnedAssets.get_asset_by_resource(
+                'knowledge', 'res-should-not-persist', db=verify_session,
+            )
+            assert fetched is None
+
+    @pytest.mark.asyncio
+    async def test_rejects_session_already_in_transaction(self, db):
+        """group_manager_tx must reject a session that is already in a
+        transaction (e.g. the savepoint-based test fixture)."""
+        with pytest.raises(GroupManagerError) as exc_info:
+            async with group_manager_tx(db):
+                pass  # pragma: no cover
+        assert exc_info.value.reason == 'tx_boundary_missing'
+        assert 'fresh session' in exc_info.value.detail.lower()
+
+    @pytest.mark.asyncio
+    async def test_non_context_authorization_fails_even_for_valid_user(self, fresh_session):
+        """A perfectly valid manager is rejected if they don't use the context."""
+        uid = f'mgr-nc-{uuid.uuid4().hex[:8]}'
+        gid = f'grp-nc-{uuid.uuid4().hex[:8]}'
+        await _create_user_in_db(fresh_session, uid)
+        role = await _create_custom_role(
+            fresh_session,
+            name=f'nc-role-{uuid.uuid4().hex[:8]}',
+            permissions={'groups': {'manage_members': True}},
+        )
+        await _assign_custom_role(fresh_session, uid, role.id)
+        await _create_group_in_db(fresh_session, gid, uid)
+        await _add_membership(fresh_session, gid, uid)
+        await fresh_session.flush()
+
+        # Without context, even a valid manager gets tx_boundary_missing
+        with pytest.raises(GroupManagerError) as exc_info:
+            await require_group_manager(
+                uid, gid, 'groups.manage_members', fresh_session,
+            )
+        assert exc_info.value.reason == 'tx_boundary_missing'
+
+    @pytest.mark.asyncio
+    async def test_caller_writable_info_does_not_authorize(self, fresh_session):
+        """Setting session.info[_GM_TX_BOUNDARY] directly must NOT satisfy
+        the boundary check.  Only the ContextVar token (set exclusively
+        inside group_manager_tx) authorizes access."""
+        from open_webui.utils.access_control.group_manager import (
+            _GM_TX_BOUNDARY,
+            _boundary_ctx,
+        )
+
+        uid = f'mgr-cw-{uuid.uuid4().hex[:8]}'
+        gid = f'grp-cw-{uuid.uuid4().hex[:8]}'
+        await _create_user_in_db(fresh_session, uid)
+        role = await _create_custom_role(
+            fresh_session,
+            name=f'cw-role-{uuid.uuid4().hex[:8]}',
+            permissions={'groups': {'manage_members': True}},
+        )
+        await _assign_custom_role(fresh_session, uid, role.id)
+        await _create_group_in_db(fresh_session, gid, uid)
+        await _add_membership(fresh_session, gid, uid)
+        await fresh_session.flush()
+
+        # No ContextVar token exists
+        assert _boundary_ctx.get(None) is None
+
+        # Simulate a caller trying to forge the boundary by setting info
+        fresh_session.info[_GM_TX_BOUNDARY] = True
+
+        # Must still be rejected — info alone does not authorize
+        with pytest.raises(GroupManagerError) as exc_info:
+            await require_group_manager(
+                uid, gid, 'groups.manage_members', fresh_session,
+            )
+        assert exc_info.value.reason == 'tx_boundary_missing'
+
+        # Also verify no token was set
+        assert _boundary_ctx.get(None) is None
+
+        # Clean up diagnostics marker
+        fresh_session.info.pop(_GM_TX_BOUNDARY, None)
+
+    @pytest.mark.asyncio
+    async def test_context_rejects_after_exit(self, manager_db):
+        """After exiting the context, calls are rejected again."""
+        uid = f'mgr-ae-{uuid.uuid4().hex[:8]}'
+        gid = f'grp-ae-{uuid.uuid4().hex[:8]}'
+        await _create_user_in_db(manager_db, uid)
+        role = await _create_custom_role(
+            manager_db,
+            name=f'ae-role-{uuid.uuid4().hex[:8]}',
+            permissions={'groups': {'manage_members': True}},
+        )
+        await _assign_custom_role(manager_db, uid, role.id)
+        await _create_group_in_db(manager_db, gid, uid)
+        await _add_membership(manager_db, gid, uid)
+
+        async with group_manager_tx(manager_db):
+            await require_group_manager(
+                uid, gid, 'groups.manage_members', manager_db,
+            )
+
+        # Outside context now
+        with pytest.raises(GroupManagerError) as exc_info:
+            await require_group_manager(
+                uid, gid, 'groups.manage_members', manager_db,
+            )
+        assert exc_info.value.reason == 'tx_boundary_missing'
+
+    @pytest.mark.asyncio
+    async def test_child_task_denied_after_parent_exits(self, manager_db):
+        """A child task created inside group_manager_tx but resumed after
+        the parent context exits must be denied — even if the same
+        session starts a *new* transaction.  The child's inherited token
+        references the old (committed) transaction, so ``matches()``
+        rejects it."""
+        uid = f'mgr-ct-{uuid.uuid4().hex[:8]}'
+        gid = f'grp-ct-{uuid.uuid4().hex[:8]}'
+        await _create_user_in_db(manager_db, uid)
+        role = await _create_custom_role(
+            manager_db,
+            name=f'ct-role-{uuid.uuid4().hex[:8]}',
+            permissions={'groups': {'manage_members': True}},
+        )
+        await _assign_custom_role(manager_db, uid, role.id)
+        await _create_group_in_db(manager_db, gid, uid)
+        await _add_membership(manager_db, gid, uid)
+
+        parent_exited = asyncio.Event()
+        new_tx_started = asyncio.Event()
+        child_done = asyncio.Event()
+        child_result: list[str] = []
+
+        async def child_work():
+            # Block until the parent context has fully exited
+            await parent_exited.wait()
+            try:
+                # Attempt inside a *new* transaction on the same session
+                await require_group_manager(
+                    uid, gid, 'groups.manage_members', manager_db,
+                )
+                child_result.append('allowed')
+            except GroupManagerError:
+                child_result.append('denied')
+            finally:
+                child_done.set()
+
+        async def parent_work():
+            async with group_manager_tx(manager_db):
+                # Spawn child while inside the context
+                asyncio.create_task(child_work())
+                # Allow event loop to schedule child, then exit
+                await asyncio.sleep(0.05)
+            # Context exited — signal child
+            parent_exited.set()
+            # Start a brand-new transaction on the same session so the
+            # child sees an active (but *different*) transaction.
+            async with group_manager_tx(manager_db):
+                new_tx_started.set()
+                await asyncio.sleep(0.1)
+
+        await asyncio.wait_for(parent_work(), timeout=5.0)
+        await asyncio.wait_for(child_done.wait(), timeout=5.0)
+        assert child_result == ['denied'], (
+            'Child task resumed after parent exit must be denied even '
+            'when a new transaction is active on the same session'
+        )
+        # Cleanly close the session so the final group_manager_tx can exit
+        await manager_db.close()
+
+    @pytest.mark.asyncio
+    async def test_contextvar_reset_restores_outer_value(self, fresh_session):
+        """ContextVar.reset() in group_manager_tx restores any outer
+        ContextVar value rather than blindly setting None."""
+        from open_webui.utils.access_control.group_manager import (
+            _boundary_ctx,
+            _TxToken,
+        )
+
+        # Manually set an outer "token" (simulating an outer context)
+        outer_token = _TxToken(fresh_session, None)
+        outer_reset = _boundary_ctx.set(outer_token)
+
+        try:
+            async with group_manager_tx(fresh_session):
+                inner_token = _boundary_ctx.get(None)
+                assert inner_token is not None
+                assert inner_token is not outer_token
+
+            # After exiting inner context, outer token must be restored
+            restored = _boundary_ctx.get(None)
+            assert restored is outer_token, (
+                'ContextVar.reset() must restore the outer value'
+            )
+        finally:
+            _boundary_ctx.reset(outer_reset)
+
+    @pytest.mark.asyncio
+    async def test_commit_failure_attempts_rollback_and_clears_token(
+        self, manager_db,
+    ):
+        """When the commit itself fails, group_manager_tx must attempt
+        rollback, clear the ContextVar token, and re-raise the error."""
+        from unittest.mock import AsyncMock, patch
+
+        from open_webui.utils.access_control.group_manager import (
+            _GM_TX_BOUNDARY,
+            _boundary_ctx,
+        )
+
+        uid = f'mgr-cf-{uuid.uuid4().hex[:8]}'
+        gid = f'grp-cf-{uuid.uuid4().hex[:8]}'
+        await _create_user_in_db(manager_db, uid)
+        role = await _create_custom_role(
+            manager_db,
+            name=f'cf-role-{uuid.uuid4().hex[:8]}',
+            permissions={'groups': {'manage_members': True}},
+        )
+        await _assign_custom_role(manager_db, uid, role.id)
+        await _create_group_in_db(manager_db, gid, uid)
+        await _add_membership(manager_db, gid, uid)
+
+        rollback_called = asyncio.Event()
+
+        original_rollback = manager_db.rollback
+
+        async def tracking_rollback():
+            rollback_called.set()
+            return await original_rollback()
+
+        with patch.object(
+            manager_db, 'commit',
+            new_callable=AsyncMock,
+            side_effect=RuntimeError('simulated commit failure'),
+        ):
+            with patch.object(
+                manager_db, 'rollback',
+                side_effect=tracking_rollback,
+            ):
+                with pytest.raises(RuntimeError, match='simulated commit failure'):
+                    async with group_manager_tx(manager_db):
+                        await require_group_manager(
+                            uid, gid, 'groups.manage_members', manager_db,
+                        )
+
+        # Rollback was attempted after commit failure
+        assert rollback_called.is_set(), 'Rollback must be attempted after commit failure'
+        # Token and diagnostics must be cleared
+        assert _boundary_ctx.get(None) is None
+        assert manager_db.info.get(_GM_TX_BOUNDARY) is None
+
+    def test_context_manager_is_async_context_manager(self):
+        """Verify group_manager_tx is a proper async context manager."""
+        import inspect
+        # @asynccontextmanager wraps an async generator function and
+        # produces a callable that returns an async context manager.
+        assert callable(group_manager_tx)
+        # The underlying wrapped function should be a coroutine function
+        assert inspect.iscoroutinefunction(group_manager_tx) or \
+               hasattr(group_manager_tx, '__wrapped__')
+
+    @pytest.mark.asyncio
+    async def test_sqlite_begin_immediate_emitted(self, _engine):
+        """Prove via engine SQL listener that the first statement emitted
+        inside group_manager_tx is exactly BEGIN IMMEDIATE."""
+        from sqlalchemy import event as sa_event
+        from sqlalchemy.ext.asyncio import AsyncSession
+
+        emitted_sql: list[str] = []
+
+        @sa_event.listens_for(_engine.sync_engine, 'before_cursor_execute')
+        def _capture(conn, cursor, stmt, parameters, context, executemany):
+            # Only capture DML/DDL statements, skip internal bookkeeping
+            normalized = stmt.strip()
+            if normalized:
+                emitted_sql.append(normalized)
+
+        session = AsyncSession(bind=_engine, expire_on_commit=False)
+        try:
+            # Empty the capture list (may have connect-time PRAGMAs)
+            emitted_sql.clear()
+
+            async with group_manager_tx(session):
+                # Inside context — first statement should be BEGIN IMMEDIATE
+                pass
+
+            # Filter to only DML/DDL (skip any stray pragmas if any)
+            ddl = [s for s in emitted_sql
+                   if not s.upper().startswith('PRAGMA')]
+            assert len(ddl) >= 1, f'Expected at least one DDL statement, got: {emitted_sql}'
+            assert ddl[0].upper() == 'BEGIN IMMEDIATE', (
+                f'First DDL must be BEGIN IMMEDIATE, got: {ddl[0]!r}'
+            )
+        finally:
+            # Remove listener to avoid cross-test pollution
+            sa_event.remove(_engine.sync_engine, 'before_cursor_execute', _capture)
+            await session.close()
+
+    @pytest.mark.asyncio
+    async def test_sqlite_contention_two_manager_sessions(self, _engine):
+        """A held manager transaction rejects a second SQLite writer.
+
+        The second engine has a zero-second busy timeout, so its first
+        ``BEGIN IMMEDIATE`` fails while session A holds the write lock.
+        Once A commits, a fresh second session can enter normally.
+        """
+        from open_webui.models.custom_roles import CustomRole
+        from open_webui.models.groups import Group, GroupMember, GroupOwnedAsset
+        from open_webui.models.users import User
+        from sqlalchemy import delete as sa_delete
+        from sqlalchemy.exc import OperationalError
+        from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+        from sqlalchemy.pool import NullPool
+
+        sa = AsyncSession(bind=_engine, expire_on_commit=False)
+        sa.info['manager_setup'] = True
+        busy_engine = create_async_engine(
+            str(_engine.url),
+            connect_args={'timeout': 0},
+            poolclass=NullPool,
+        )
+        sb_attempt = AsyncSession(bind=busy_engine, expire_on_commit=False)
+        sb_after = AsyncSession(bind=busy_engine, expire_on_commit=False)
+
+        try:
+            # ── Seed shared data via session a ─────────────────────
+            uid = f'mgr-{uuid.uuid4().hex[:8]}'
+            gid = f'grp-{uuid.uuid4().hex[:8]}'
+            await _create_user_in_db(sa, uid)
+            role = await _create_custom_role(
+                sa,
+                name=f'contention-{uuid.uuid4().hex[:8]}',
+                permissions={'groups': {'manage_members': True}},
+            )
+            await _assign_custom_role(sa, uid, role.id)
+            await _create_group_in_db(sa, gid, uid)
+            await _add_membership(sa, gid, uid)
+
+            async with group_manager_tx(sa):
+                await require_group_manager(uid, gid, 'groups.manage_members', sa)
+                with pytest.raises(OperationalError) as exc_info:
+                    async with group_manager_tx(sb_attempt):
+                        pass  # pragma: no cover - SQLite must reject entry
+
+                message = str(exc_info.value).lower()
+                assert 'database is locked' in message or 'busy' in message
+
+            # Once session A commits, a new fresh session can acquire the
+            # immediate lock and authorize the same manager.
+            async with group_manager_tx(sb_after):
+                await require_group_manager(
+                    uid, gid, 'groups.manage_members', sb_after,
+                )
+        finally:
+            await sb_attempt.close()
+            await sb_after.close()
+            await busy_engine.dispose()
+            await sa.close()
+            conn = await _engine.connect()
+            try:
+                await conn.execute(sa_delete(GroupOwnedAsset))
+                await conn.execute(sa_delete(GroupMember))
+                await conn.execute(sa_delete(Group))
+                await conn.execute(sa_delete(CustomRole))
+                await conn.execute(sa_delete(User))
+                await conn.commit()
+            finally:
+                await conn.close()
+
+
+# ===================================================================
+# 17. Migration isolation — fdcb does NOT touch group_member constraint
+# ===================================================================
+
+class TestMigrationIsolation:
+
+    def test_phase2_migration_no_group_member_constraint_operations(self):
+        """The Phase-2 migration fdcb6cc75284 must NOT create, drop, or
+        modify any constraint on group_member.  The historical migration
+        37f288994c47 already creates uq_group_member_group_user."""
+        import inspect
+
+        import open_webui.migrations.versions.fdcb6cc75284_add_group_owned_asset_and_group_member_uniqueness as mod
+        source = inspect.getsource(mod)
+
+        # Must NOT contain any constraint operations on group_member
+        assert 'create_unique_constraint' not in source, \
+            'fdcb6 should not create unique constraints on group_member'
+        assert 'drop_constraint' not in source, \
+            'fdcb6 should not drop constraints from group_member'
+        assert 'batch_alter_table' not in source, \
+            'fdcb6 should not batch-alter group_member'
+        # Must NOT contain dedup SQL
+        assert 'DELETE FROM group_member' not in source, \
+            'fdcb6 should not dedup group_member rows'
+        assert 'ROW_NUMBER' not in source, \
+            'fdcb6 should not contain ROW_NUMBER dedup logic'
+
+    def test_phase2_migration_only_touches_group_owned_asset(self):
+        """Verify the Phase-2 migration only creates/drops group_owned_asset."""
+        import inspect
+
+        import open_webui.migrations.versions.fdcb6cc75284_add_group_owned_asset_and_group_member_uniqueness as mod
+        source = inspect.getsource(mod)
+
+        # Should contain group_owned_asset operations
+        assert 'group_owned_asset' in source
+        assert 'create_table' in source
+        assert 'drop_table' in source
+
+        # Upgrade should only have one create_table and one create_index
+        assert source.count('op.create_table') == 1
+        assert source.count('op.create_index') == 1
+
+    def test_historical_migration_creates_constraint(self):
+        """Verify that the historical migration 37f288994c47 creates the
+        uq_group_member_group_user constraint as part of table creation."""
+        import importlib
+        import inspect
+        mod = importlib.import_module(
+            'open_webui.migrations.versions.37f288994c47_add_group_member_table'
+        )
+        source = inspect.getsource(mod)
+
+        assert 'uq_group_member_group_user' in source
+        assert 'UniqueConstraint' in source
+        assert 'group_member' in source
+
+    def test_orm_metadata_aligned_with_historical_constraint(self):
+        """The GroupMember ORM model's __table_args__ must include the same
+        unique constraint that 37f288994c47 creates."""
+        from open_webui.models.groups import GroupMember
+        table_args = GroupMember.__table_args__
+        constraint_names = [
+            c.name for c in table_args if hasattr(c, 'name')
+        ]
+        assert 'uq_group_member_group_user' in constraint_names
+
+
+# ===================================================================
+# Router-test fixture: suppress publish_event side-effects
+# ===================================================================
+
+@pytest.fixture(autouse=True)
+def _noop_publish_event(monkeypatch):
+    """Stub out ``publish_event`` in the group-manager router so that
+    endpoint tests do not spawn fire-and-forget ``asyncio.create_task``
+    calls.  Those background tasks open their own aiosqlite connections
+    whose worker threads outlive the test event loop, producing
+    ``PytestUnhandledThreadExceptionWarning``.
+    """
+    async def _noop(*_a, **_kw):
+        return None
+
+    monkeypatch.setattr(
+        'open_webui.routers.group_manager.publish_event',
+        _noop,
+    )
+
+
+# ===================================================================
+# 18. Router: membership mutation helpers
+# ===================================================================
+
+class TestRouterMembershipHelpers:
+    """Helpers for integration-style router tests against the scoped
+    ``/api/v1/group-manager/groups/{group_id}/members/*`` endpoints.
+
+    These tests exercise the actual FastAPI router via TestClient-style
+    function calls (direct invocation of the endpoint functions).
+    """
+
+    @pytest.mark.asyncio
+    async def test_list_members_includes_manager(self, manager_db):
+        """list_group_members returns at least the manager (who is auto-added as member)."""
+        from open_webui.routers.group_manager import list_group_members
+
+        uid, gid, _ = await _setup_valid_manager(manager_db)
+        result = await list_group_members(gid, user=SimpleNamespace(id=uid), db=manager_db)
+        assert len(result) >= 1
+        user_ids = {m.user_id for m in result}
+        assert uid in user_ids
+
+    @pytest.mark.asyncio
+    async def test_add_and_list_members(self, manager_db):
+        """add_group_members adds users, list_group_members returns them."""
+        from open_webui.routers.group_manager import add_group_members, list_group_members
+
+        uid, gid, _ = await _setup_valid_manager(manager_db)
+        extra = f'user-{uuid.uuid4().hex[:8]}'
+        await _create_user_in_db(manager_db, extra)
+
+        form = GroupManagerMemberIdsForm(user_ids=[extra])
+        # Mock request with app.state for publish_event
+        req = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(instance_id='test')))
+
+        added = await add_group_members(
+            req, gid, form, user=SimpleNamespace(id=uid), db=manager_db,
+        )
+        assert any(m.user_id == extra for m in added)
+
+        listed = await list_group_members(
+            gid, user=SimpleNamespace(id=uid), db=manager_db,
+        )
+        user_ids = {m.user_id for m in listed}
+        assert uid in user_ids
+        assert extra in user_ids
+
+    @pytest.mark.asyncio
+    async def test_remove_members(self, manager_db):
+        """remove_group_members removes the specified user."""
+        from open_webui.routers.group_manager import (
+            add_group_members,
+            remove_group_members,
+        )
+
+        uid, gid, _ = await _setup_valid_manager(manager_db)
+        extra = f'user-{uuid.uuid4().hex[:8]}'
+        await _create_user_in_db(manager_db, extra)
+        req = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(instance_id='test')))
+
+        # Add extra user
+        add_form = GroupManagerMemberIdsForm(user_ids=[extra])
+        await add_group_members(
+            req, gid, add_form, user=SimpleNamespace(id=uid), db=manager_db,
+        )
+
+        # Remove extra user
+        rm_form = GroupManagerMemberIdsForm(user_ids=[extra])
+        removed = await remove_group_members(
+            req, gid, rm_form, user=SimpleNamespace(id=uid), db=manager_db,
+        )
+        user_ids = {m.user_id for m in removed}
+        assert extra not in user_ids
+        assert uid in user_ids
+
+
+# ===================================================================
+# 19. Router: scoped knowledge creation + ownership
+# ===================================================================
+
+class TestRouterKnowledgeCreation:
+
+    @pytest.mark.asyncio
+    async def test_create_knowledge_with_ownership(self, manager_db):
+        """create_group_knowledge creates knowledge + ownership + read grant."""
+        from open_webui.models.access_grants import AccessGrants
+        from open_webui.routers.group_manager import create_group_knowledge
+
+        uid, gid, _ = await _setup_valid_asset_manager(manager_db)
+
+        form = GroupManagerKnowledgeCreateForm(
+            name='Test KB', description='A test knowledge base',
+        )
+        req = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(instance_id='test')))
+
+        result = await create_group_knowledge(
+            req, gid, form, user=SimpleNamespace(id=uid), db=manager_db,
+        )
+        assert result.name == 'Test KB'
+        assert result.description == 'A test knowledge base'
+        assert result.write_access is True
+
+        # Verify ownership row exists
+        asset = await GroupOwnedAssets.get_asset_by_resource(
+            'knowledge', result.id, db=manager_db,
+        )
+        assert asset is not None
+        assert asset.group_id == gid
+
+        # Verify read grant for the owning group
+        has_read = await AccessGrants.has_access(
+            user_id='anyone-never-matches',
+            resource_type='knowledge',
+            resource_id=result.id,
+            permission='read',
+            user_group_ids={gid},
+            db=manager_db,
+        )
+        assert has_read is True
+
+    @pytest.mark.asyncio
+    async def test_create_knowledge_rejects_supplied_grants(self, manager_db):
+        """Manager-supplied access_grants should be ignored — the endpoint
+        does not accept them (form has no access_grants field)."""
+        from open_webui.routers.group_manager import GroupManagerKnowledgeCreateForm
+        # The form doesn't have access_grants — this is by design.
+        fields = GroupManagerKnowledgeCreateForm.model_fields
+        assert 'access_grants' not in fields
+
+
+# ===================================================================
+# 20. Router: scoped prompt creation + ownership
+# ===================================================================
+
+class TestRouterPromptCreation:
+
+    @pytest.mark.asyncio
+    async def test_create_prompt_with_ownership(self, manager_db):
+        """create_group_prompt creates prompt + ownership + read grant."""
+        from open_webui.routers.group_manager import create_group_prompt
+
+        uid, gid, _ = await _setup_valid_asset_manager(manager_db)
+
+        form = GroupManagerPromptCreateForm(
+            command='/test-cmd',
+            name='Test Prompt',
+            content='Hello {{name}}',
+        )
+        req = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(instance_id='test')))
+
+        result = await create_group_prompt(
+            req, gid, form, user=SimpleNamespace(id=uid), db=manager_db,
+        )
+        assert result.command == '/test-cmd'
+        assert result.name == 'Test Prompt'
+        assert result.write_access is True
+
+        # Verify ownership
+        asset = await GroupOwnedAssets.get_asset_by_resource(
+            'prompt', result.id, db=manager_db,
+        )
+        assert asset is not None
+        assert asset.group_id == gid
+
+    @pytest.mark.asyncio
+    async def test_create_prompt_rejects_duplicate_command(self, manager_db):
+        """Duplicate command string is rejected."""
+        from open_webui.routers.group_manager import create_group_prompt
+
+        uid, gid, _ = await _setup_valid_asset_manager(manager_db)
+
+        form = GroupManagerPromptCreateForm(
+            command='/dup-cmd', name='First', content='first',
+        )
+        req = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(instance_id='test')))
+
+        await create_group_prompt(
+            req, gid, form, user=SimpleNamespace(id=uid), db=manager_db,
+        )
+
+        form2 = GroupManagerPromptCreateForm(
+            command='/dup-cmd', name='Second', content='second',
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await create_group_prompt(
+                req, gid, form2, user=SimpleNamespace(id=uid), db=manager_db,
+            )
+        assert exc_info.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_create_prompt_rejects_supplied_grants(self, manager_db):
+        """The form has no access_grants field — manager cannot set grants."""
+        from open_webui.routers.group_manager import GroupManagerPromptCreateForm
+        fields = GroupManagerPromptCreateForm.model_fields
+        assert 'access_grants' not in fields
+
+
+# ===================================================================
+# 21. Router: ownership-only update/delete
+# ===================================================================
+
+class TestRouterOwnershipUpdateDelete:
+
+    @pytest.mark.asyncio
+    async def test_update_knowledge_requires_ownership(self, manager_db):
+        """Updating a knowledge base that is NOT owned by the group yields 404."""
+        from open_webui.routers.group_manager import update_group_knowledge
+
+        uid, gid, _ = await _setup_valid_asset_manager(manager_db)
+        req = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(instance_id='test')))
+        form = GroupManagerKnowledgeUpdateForm(name='New Name')
+
+        with pytest.raises(HTTPException) as exc_info:
+            await update_group_knowledge(
+                req, gid, 'non-existent-id', form,
+                user=SimpleNamespace(id=uid), db=manager_db,
+            )
+        assert exc_info.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_delete_knowledge_requires_ownership(self, manager_db):
+        """Deleting a knowledge base NOT owned by the group yields 404."""
+        from open_webui.routers.group_manager import delete_group_knowledge
+
+        uid, gid, _ = await _setup_valid_asset_manager(manager_db)
+        req = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(instance_id='test')))
+
+        with pytest.raises(HTTPException) as exc_info:
+            await delete_group_knowledge(
+                req, gid, 'non-existent-id',
+                user=SimpleNamespace(id=uid), db=manager_db,
+            )
+        assert exc_info.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_update_delete_knowledge_roundtrip(self, manager_db):
+        """Create, update, delete a group-owned knowledge base."""
+        from open_webui.routers.group_manager import (
+            create_group_knowledge,
+            delete_group_knowledge,
+            update_group_knowledge,
+        )
+
+        uid, gid, _ = await _setup_valid_asset_manager(manager_db)
+        req = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(instance_id='test')))
+
+        created = await create_group_knowledge(
+            req, gid,
+            GroupManagerKnowledgeCreateForm(name='KB', description='desc'),
+            user=SimpleNamespace(id=uid), db=manager_db,
+        )
+
+        updated = await update_group_knowledge(
+            req, gid, created.id,
+            GroupManagerKnowledgeUpdateForm(name='KB Updated'),
+            user=SimpleNamespace(id=uid), db=manager_db,
+        )
+        assert updated.name == 'KB Updated'
+        assert updated.description == 'desc'  # unchanged
+
+        deleted = await delete_group_knowledge(
+            req, gid, created.id,
+            user=SimpleNamespace(id=uid), db=manager_db,
+        )
+        assert deleted is True
+
+        # Verify no longer exists
+        asset = await GroupOwnedAssets.get_asset_by_resource(
+            'knowledge', created.id, db=manager_db,
+        )
+        assert asset is None
+
+    @pytest.mark.asyncio
+    async def test_cross_group_update_denied(self, manager_db):
+        """Updating a knowledge owned by group A via group B yields 404."""
+        from open_webui.routers.group_manager import (
+            create_group_knowledge,
+            update_group_knowledge,
+        )
+
+        uid, gid_a, _ = await _setup_valid_asset_manager(manager_db)
+        gid_b = f'grpB-{uuid.uuid4().hex[:8]}'
+        await _create_group_in_db(manager_db, gid_b, uid)
+        await _add_membership(manager_db, gid_b, uid)
+
+        req = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(instance_id='test')))
+
+        created = await create_group_knowledge(
+            req, gid_a,
+            GroupManagerKnowledgeCreateForm(name='KB-A', description=''),
+            user=SimpleNamespace(id=uid), db=manager_db,
+        )
+
+        # Try to update via group B
+        with pytest.raises(HTTPException) as exc_info:
+            await update_group_knowledge(
+                req, gid_b, created.id,
+                GroupManagerKnowledgeUpdateForm(name='Stolen'),
+                user=SimpleNamespace(id=uid), db=manager_db,
+            )
+        assert exc_info.value.status_code == 404
+
+
+# ===================================================================
+# 22. Router: ACL delta — baseline read + write delta only
+# ===================================================================
+
+class TestRouterACLDelta:
+
+    @pytest.mark.asyncio
+    async def test_acl_delta_add_write(self, manager_db):
+        """Setting write=True adds a group write grant."""
+        from open_webui.models.access_grants import AccessGrants
+        from open_webui.routers.group_manager import (
+            create_group_knowledge,
+            update_group_asset_acl,
+        )
+
+        uid, gid, _ = await _setup_valid_asset_manager(manager_db)
+        req = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(instance_id='test')))
+
+        created = await create_group_knowledge(
+            req, gid,
+            GroupManagerKnowledgeCreateForm(name='KB', description=''),
+            user=SimpleNamespace(id=uid), db=manager_db,
+        )
+
+        result = await update_group_asset_acl(
+            req, gid, 'knowledge', created.id,
+            GroupManagerACLDeltaForm(write=True),
+            user=SimpleNamespace(id=uid), db=manager_db,
+        )
+        assert result.write is True
+
+        # Verify the write grant exists
+        has_write = await AccessGrants.has_access(
+            user_id='no-match',
+            resource_type='knowledge',
+            resource_id=created.id,
+            permission='write',
+            user_group_ids={gid},
+            db=manager_db,
+        )
+        assert has_write is True
+
+    @pytest.mark.asyncio
+    async def test_acl_delta_remove_write(self, manager_db):
+        """Setting write=False removes the group write grant."""
+        from open_webui.models.access_grants import AccessGrants
+        from open_webui.routers.group_manager import (
+            create_group_knowledge,
+            update_group_asset_acl,
+        )
+
+        uid, gid, _ = await _setup_valid_asset_manager(manager_db)
+        req = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(instance_id='test')))
+
+        created = await create_group_knowledge(
+            req, gid,
+            GroupManagerKnowledgeCreateForm(name='KB', description=''),
+            user=SimpleNamespace(id=uid), db=manager_db,
+        )
+
+        # First add write
+        await update_group_asset_acl(
+            req, gid, 'knowledge', created.id,
+            GroupManagerACLDeltaForm(write=True),
+            user=SimpleNamespace(id=uid), db=manager_db,
+        )
+
+        # Then remove write
+        result = await update_group_asset_acl(
+            req, gid, 'knowledge', created.id,
+            GroupManagerACLDeltaForm(write=False),
+            user=SimpleNamespace(id=uid), db=manager_db,
+        )
+        assert result.write is False
+
+        has_write = await AccessGrants.has_access(
+            user_id='no-match',
+            resource_type='knowledge',
+            resource_id=created.id,
+            permission='write',
+            user_group_ids={gid},
+            db=manager_db,
+        )
+        assert has_write is False
+
+    @pytest.mark.asyncio
+    async def test_acl_delta_read_baseline_persists(self, manager_db):
+        """The read grant for the owning group is always present."""
+        from open_webui.models.access_grants import AccessGrants
+        from open_webui.routers.group_manager import (
+            create_group_knowledge,
+            update_group_asset_acl,
+        )
+
+        uid, gid, _ = await _setup_valid_asset_manager(manager_db)
+        req = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(instance_id='test')))
+
+        created = await create_group_knowledge(
+            req, gid,
+            GroupManagerKnowledgeCreateForm(name='KB', description=''),
+            user=SimpleNamespace(id=uid), db=manager_db,
+        )
+
+        # Even after removing write, read should persist
+        await update_group_asset_acl(
+            req, gid, 'knowledge', created.id,
+            GroupManagerACLDeltaForm(write=False),
+            user=SimpleNamespace(id=uid), db=manager_db,
+        )
+
+        has_read = await AccessGrants.has_access(
+            user_id='no-match',
+            resource_type='knowledge',
+            resource_id=created.id,
+            permission='read',
+            user_group_ids={gid},
+            db=manager_db,
+        )
+        assert has_read is True
+
+    @pytest.mark.asyncio
+    async def test_acl_delta_unsupported_type_rejected(self, manager_db):
+        """ACL delta rejects unsupported resource_type."""
+        from open_webui.routers.group_manager import update_group_asset_acl
+
+        uid, gid, _ = await _setup_valid_asset_manager(manager_db)
+        req = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(instance_id='test')))
+
+        with pytest.raises(HTTPException) as exc_info:
+            await update_group_asset_acl(
+                req, gid, 'model', 'some-id',
+                GroupManagerACLDeltaForm(write=True),
+                user=SimpleNamespace(id=uid), db=manager_db,
+            )
+        assert exc_info.value.status_code == 400
+
+
+# ===================================================================
+# 23. Router: atomic creation rollback
+# ===================================================================
+
+class TestRouterAtomicCreationRollback:
+
+    @pytest.mark.asyncio
+    async def test_create_knowledge_rolls_back_on_error(self, manager_db):
+        """If an error occurs during knowledge creation, the transaction
+        is rolled back and no data persists."""
+        from unittest.mock import AsyncMock, patch
+
+        from open_webui.routers.group_manager import create_group_knowledge
+
+        uid, gid, _ = await _setup_valid_asset_manager(manager_db)
+        req = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(instance_id='test')))
+
+        # Force an error by making insert_asset raise
+        with patch.object(
+            GroupOwnedAssets, 'insert_asset',
+            new_callable=AsyncMock,
+            side_effect=RuntimeError('simulated failure'),
+        ):
+            with pytest.raises(RuntimeError, match='simulated failure'):
+                await create_group_knowledge(
+                    req, gid,
+                    GroupManagerKnowledgeCreateForm(name='KB', description=''),
+                    user=SimpleNamespace(id=uid), db=manager_db,
+                )
+
+
+# ===================================================================
+# 24. Router: list assets
+# ===================================================================
+
+class TestRouterListAssets:
+
+    @pytest.mark.asyncio
+    async def test_list_assets_empty(self, manager_db):
+        """list_group_assets returns empty for a group with no assets."""
+        from open_webui.routers.group_manager import list_group_assets
+
+        uid, gid, _ = await _setup_valid_asset_manager(manager_db)
+        result = await list_group_assets(
+            gid, user=SimpleNamespace(id=uid), db=manager_db,
+        )
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_list_assets_with_filter(self, manager_db):
+        """list_group_assets filters by resource_type."""
+        from open_webui.routers.group_manager import (
+            create_group_knowledge,
+            create_group_prompt,
+            list_group_assets,
+        )
+
+        uid, gid, _ = await _setup_valid_asset_manager(manager_db)
+        req = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(instance_id='test')))
+
+        await create_group_knowledge(
+            req, gid,
+            GroupManagerKnowledgeCreateForm(name='KB', description=''),
+            user=SimpleNamespace(id=uid), db=manager_db,
+        )
+        await create_group_prompt(
+            req, gid,
+            GroupManagerPromptCreateForm(
+                command='/test', name='Prompt', content='Hello',
+            ),
+            user=SimpleNamespace(id=uid), db=manager_db,
+        )
+
+        all_assets = await list_group_assets(
+            gid, user=SimpleNamespace(id=uid), db=manager_db,
+        )
+        assert len(all_assets) == 2
+
+        kb_only = await list_group_assets(
+            gid, resource_type='knowledge',
+            user=SimpleNamespace(id=uid), db=manager_db,
+        )
+        assert len(kb_only) == 1
+        assert kb_only[0].resource_type == 'knowledge'
+
+    @pytest.mark.asyncio
+    async def test_list_assets_unsupported_type_rejected(self, manager_db):
+        """list_group_assets rejects unsupported resource_type filter."""
+        from open_webui.routers.group_manager import list_group_assets
+
+        uid, gid, _ = await _setup_valid_asset_manager(manager_db)
+        with pytest.raises(HTTPException) as exc_info:
+            await list_group_assets(
+                gid, resource_type='model',
+                user=SimpleNamespace(id=uid), db=manager_db,
+            )
+        assert exc_info.value.status_code == 400
+
+
+# ===================================================================
+# 25. Router: existing-route non-regression
+# ===================================================================
+
+class TestExistingRouteNonRegression:
+    """Verify the existing /groups, /knowledge, /prompts routers are
+    not affected by the new group_manager router."""
+
+    def test_group_manager_router_has_no_overlap_with_groups(self):
+        """The group_manager router prefix does not overlap the groups router."""
+        from open_webui.routers.group_manager import router as gm_router
+        from open_webui.routers.groups import router as g_router
+
+        # Both are APIRouter instances
+        assert hasattr(gm_router, 'routes')
+        assert hasattr(g_router, 'routes')
+
+        gm_paths = set()
+        for route in gm_router.routes:
+            if hasattr(route, 'path'):
+                gm_paths.add(route.path)
+
+        g_paths = set()
+        for route in g_router.routes:
+            if hasattr(route, 'path'):
+                g_paths.add(route.path)
+
+        # No path overlap at the router level
+        assert gm_paths.isdisjoint(g_paths), (
+            f'Path overlap detected: {gm_paths & g_paths}'
+        )
+
+    def test_group_manager_import_does_not_affect_groups(self):
+        """Importing group_manager doesn't modify the groups router."""
+        from open_webui.routers.groups import router as g_router
+
+        g_routes_before = len(g_router.routes)
+        # Import doesn't add routes to groups router
+        assert len(g_router.routes) == g_routes_before

--- a/backend/tests/test_group_manager.py
+++ b/backend/tests/test_group_manager.py
@@ -43,16 +43,19 @@ from open_webui.models.groups import (
 )
 from open_webui.routers.group_manager import (
     GroupManagerACLDeltaForm,
+    GroupManagerGroupInfo,
     GroupManagerKnowledgeCreateForm,
     GroupManagerKnowledgeUpdateForm,
     GroupManagerMemberIdsForm,
     GroupManagerPromptCreateForm,
+    list_manageable_groups,
 )
 from open_webui.utils.access_control.group_manager import (
     GroupManagerError,
     group_manager_tx,
     require_group_manager,
 )
+from sqlalchemy import delete as sa_delete
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -518,6 +521,97 @@ class TestCrossGroupDenial:
             with pytest.raises(GroupManagerError) as exc_info:
                 await require_group_manager(uid, gid_b, 'groups.manage_members', manager_db)
             assert exc_info.value.reason == 'not_a_member'
+
+
+# ===================================================================
+# Scoped group discovery
+# ===================================================================
+
+class TestListManageableGroups:
+
+    @pytest.mark.asyncio
+    async def test_returns_only_current_memberships_and_capabilities(self, manager_db):
+        """Discovery uses active custom-role capabilities plus membership."""
+        uid = f'mgr-{uuid.uuid4().hex[:8]}'
+        member_group = f'grp-member-{uuid.uuid4().hex[:8]}'
+        creator_only_group = f'grp-creator-{uuid.uuid4().hex[:8]}'
+        await _create_user_in_db(manager_db, uid)
+
+        role = await _create_custom_role(
+            manager_db,
+            name=f'discovery-role-{uuid.uuid4().hex[:8]}',
+            permissions={'groups': {'manage_assets': True}},
+        )
+        await _assign_custom_role(manager_db, uid, role.id)
+        await _create_group_in_db(manager_db, member_group, uid)
+        await _add_membership(manager_db, member_group, uid)
+        await _create_group_in_db(manager_db, creator_only_group, uid)
+
+        result = await list_manageable_groups(
+            user=SimpleNamespace(id=uid),
+            db=manager_db,
+        )
+
+        assert result == [
+            GroupManagerGroupInfo(
+                id=member_group,
+                name=f'group-{member_group[:8]}',
+                capabilities=['groups.manage_assets'],
+            )
+        ]
+
+    @pytest.mark.asyncio
+    async def test_deactivated_role_and_removed_membership_disappear(self, manager_db):
+        """Discovery reflects the same current authorization boundary as mutations."""
+        uid, gid, role = await _setup_valid_asset_manager(manager_db)
+
+        result = await list_manageable_groups(
+            user=SimpleNamespace(id=uid),
+            db=manager_db,
+        )
+        assert result[0].id == gid
+        assert result[0].capabilities == [
+            'groups.manage_members',
+            'groups.manage_assets',
+        ]
+
+        await manager_db.execute(
+            sa_delete(GroupMember).where(
+                GroupMember.group_id == gid,
+                GroupMember.user_id == uid,
+            )
+        )
+        await manager_db.commit()
+
+        result = await list_manageable_groups(
+            user=SimpleNamespace(id=uid),
+            db=manager_db,
+        )
+        assert result == []
+
+        await _add_membership(manager_db, gid, uid)
+        await CustomRoles.deactivate_role(role.id, db=manager_db)
+        result = await list_manageable_groups(
+            user=SimpleNamespace(id=uid),
+            db=manager_db,
+        )
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_admin_and_legacy_roles_are_not_discovered(self, manager_db):
+        """Legacy/admin users do not gain the additive manager workspace scope."""
+        for role in ('admin', 'user', 'pending'):
+            uid = f'{role}-{uuid.uuid4().hex[:8]}'
+            gid = f'grp-{uuid.uuid4().hex[:8]}'
+            await _create_user_in_db(manager_db, uid, role=role)
+            await _create_group_in_db(manager_db, gid, uid)
+            await _add_membership(manager_db, gid, uid)
+
+            result = await list_manageable_groups(
+                user=SimpleNamespace(id=uid),
+                db=manager_db,
+            )
+            assert result == []
 
 
 # ===================================================================

--- a/backend/tests/test_group_manager_skills.py
+++ b/backend/tests/test_group_manager_skills.py
@@ -1,0 +1,2035 @@
+"""Focused regression tests for Phase 3 skills-only slice.
+
+Covers:
+1. Extended custom-role catalog (groups.manage_skills capability)
+2. manage_skills capability isolation (separate from manage_members/manage_assets)
+3. Scoped skill CRUD: create, list, get, update, delete
+4. Server-controlled ID (group-namespaced collision-safe slug)
+5. user_id='group-asset:<group_id>' for scoped skills
+6. Owning-group baseline read access, no write grant at creation
+7. group_owned_asset(resource_type='skill') integration
+8. Payload allowlist enforcement (rejects id mutation, user_id, access_grants, etc.)
+9. Events after successful commit only; no content in audit payload
+10. Former managers cannot mutate scoped skills via generic skill endpoints
+11. Ordinary group members cannot mutate scoped skills via generic endpoints
+12. Independent runtime tool authorization required even if skill content
+    suggests tool use
+13. P0: ACL delta rejects resource_type='skill'
+14. P0: extra='forbid' on scoped skill form models
+15. P0: _normalize_skill_meta handles dict/None/SkillMeta
+16. P0: Middleware-level audit body redaction for all scoped skill CRUD paths
+17. P1: Tool authorization regression (skill content does not grant tool access)
+18. P0: Handler-level response tests with persisted dict metadata
+19. P1: Real async handler invocation tests for all 5 CRUD handlers
+20. P1: Legacy endpoint denial tests (actual handler invocation)
+21. P1: Runtime tool authorization with plugins enabled
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+
+import pytest
+from fastapi import HTTPException
+from open_webui.models.access_grants import PRINCIPAL_TYPE_GROUP, AccessGrants
+from open_webui.models.custom_roles import (
+    _PERMISSION_CATALOG,
+    CustomRoleCreateForm,
+    CustomRoles,
+    make_custom_role_ref,
+    normalize_permissions,
+)
+from open_webui.models.groups import (
+    SUPPORTED_OWNED_ASSET_TYPES,
+    Group,
+    GroupMember,
+    GroupOwnedAssets,
+)
+from open_webui.models.skills import Skill
+from open_webui.routers.group_manager import (
+    GroupManagerACLDeltaForm,
+    GroupManagerSkillCreateForm,
+    GroupManagerSkillUpdateForm,
+    _grant_access_flush,
+    _make_group_skill_id,
+    _normalize_skill_meta,
+    _skill_insert_flush,
+    _skill_update_flush,
+    _validate_skill_slug,
+)
+from open_webui.utils.access_control.group_manager import (
+    GroupManagerError,
+    group_manager_tx,
+    require_group_manager,
+)
+from sqlalchemy import delete as sa_delete
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+# ===================================================================
+# Helpers
+# ===================================================================
+
+async def _create_user_in_db(db: AsyncSession, user_id: str, role: str = 'user'):
+    from open_webui.models.users import User
+
+    now = int(time.time())
+    row = User(
+        id=user_id,
+        email=f'{user_id}@test.local',
+        name=user_id.split('@')[0] if '@' in user_id else user_id,
+        role=role,
+        profile_image_url='',
+        last_active_at=now,
+        created_at=now,
+        updated_at=now,
+    )
+    db.add(row)
+    await db.flush()
+    if db.info.get('manager_setup'):
+        await db.commit()
+    return row
+
+
+async def _create_group_in_db(db: AsyncSession, group_id: str, user_id: str):
+    row = Group(
+        id=group_id,
+        user_id=user_id,
+        name=f'group-{group_id[:8]}',
+        description='test group',
+        permissions={},
+        data=None,
+        meta=None,
+        created_at=int(time.time()),
+        updated_at=int(time.time()),
+    )
+    db.add(row)
+    await db.flush()
+    if db.info.get('manager_setup'):
+        await db.commit()
+    return row
+
+
+async def _add_membership(db: AsyncSession, group_id: str, user_id: str):
+    row = GroupMember(
+        id=str(uuid.uuid4()),
+        group_id=group_id,
+        user_id=user_id,
+        created_at=int(time.time()),
+        updated_at=int(time.time()),
+    )
+    db.add(row)
+    await db.flush()
+    if db.info.get('manager_setup'):
+        await db.commit()
+    return row
+
+
+async def _create_custom_role(
+    db: AsyncSession,
+    *,
+    name: str | None = None,
+    permissions: dict | None = None,
+    active: bool = True,
+):
+    if name is None:
+        name = f'test-role-{uuid.uuid4().hex[:8]}'
+    form = CustomRoleCreateForm(
+        name=name,
+        display_name=name.replace('-', ' ').title(),
+        permissions=permissions or {},
+    )
+    role = await CustomRoles.create_role(form, db=db)
+    if not active:
+        await CustomRoles.deactivate_role(role.id, db=db)
+        return await CustomRoles.get_role_by_id(role.id, db=db)
+    return role
+
+
+async def _assign_custom_role(db: AsyncSession, user_id: str, role_id: str):
+    from open_webui.models.users import User
+    ref = make_custom_role_ref(role_id)
+    from sqlalchemy import update
+    await db.execute(
+        update(User).where(User.id == user_id).values(role=ref)
+    )
+    await db.flush()
+    if db.info.get('manager_setup'):
+        await db.commit()
+
+
+async def _setup_skill_manager(db: AsyncSession):
+    """Create a valid manager with manage_skills capability.
+    Returns (uid, gid, role).
+    """
+    uid = f'mgr-{uuid.uuid4().hex[:8]}'
+    gid = f'grp-{uuid.uuid4().hex[:8]}'
+    await _create_user_in_db(db, uid)
+    role = await _create_custom_role(
+        db,
+        name=f'skill-mgr-{uuid.uuid4().hex[:8]}',
+        permissions={'groups': {'manage_skills': True}},
+    )
+    await _assign_custom_role(db, uid, role.id)
+    await _create_group_in_db(db, gid, uid)
+    await _add_membership(db, gid, uid)
+    return uid, gid, role
+
+
+async def _insert_skill_row(
+    db: AsyncSession,
+    skill_id: str,
+    name: str = 'Test Skill',
+    content: str = 'test content',
+    user_id: str | None = None,
+    is_active: bool = True,
+):
+    """Insert a Skill row directly (for test setup)."""
+    now = int(time.time())
+    skill = Skill(
+        id=skill_id,
+        user_id=user_id or 'group-asset:test-group',
+        name=name,
+        description='A test skill',
+        content=content,
+        meta={'tags': []},
+        is_active=is_active,
+        created_at=now,
+        updated_at=now,
+    )
+    db.add(skill)
+    await db.flush()
+    if db.info.get('manager_setup'):
+        await db.commit()
+    return skill
+
+
+# ===================================================================
+# 1. Extended custom-role catalog
+# ===================================================================
+
+class TestManageSkillsCatalog:
+
+    def test_manage_skills_present_in_catalog(self):
+        assert 'groups' in _PERMISSION_CATALOG
+        assert 'manage_skills' in _PERMISSION_CATALOG['groups']
+
+    def test_manage_skills_defaults_false(self):
+        assert _PERMISSION_CATALOG['groups']['manage_skills'] is False
+
+    def test_manage_skills_independence(self):
+        perm = normalize_permissions({
+            'groups': {
+                'manage_members': True,
+                'manage_assets': False,
+            }
+        })
+        assert perm['groups']['manage_members'] is True
+        assert perm['groups']['manage_assets'] is False
+        assert perm['groups']['manage_skills'] is False
+
+    def test_manage_skills_can_be_set_independently(self):
+        perm = normalize_permissions({
+            'groups': {
+                'manage_skills': True,
+                'manage_members': False,
+                'manage_assets': False,
+            }
+        })
+        assert perm['groups']['manage_skills'] is True
+        assert perm['groups']['manage_members'] is False
+
+    def test_validate_permissions_accepts_manage_skills(self):
+        from open_webui.models.custom_roles import validate_permissions
+        result = validate_permissions({'groups': {'manage_skills': True}})
+        assert result['groups']['manage_skills'] is True
+
+    @pytest.mark.asyncio
+    async def test_role_with_manage_skills_persists(self, db):
+        role = await _create_custom_role(
+            db,
+            name='skill-manager-role',
+            permissions={'groups': {'manage_skills': True}},
+        )
+        assert role is not None
+        fetched = await CustomRoles.get_role_by_id(role.id, db=db)
+        assert fetched is not None
+        assert fetched.permissions['groups']['manage_skills'] is True
+        assert fetched.permissions['groups']['manage_members'] is False
+        assert fetched.permissions['groups']['manage_assets'] is False
+
+
+# ===================================================================
+# 2. Capability isolation
+# ===================================================================
+
+class TestManageSkillsCapabilityIsolation:
+
+    @pytest.mark.asyncio
+    async def test_manage_members_does_not_authorize_manage_skills(self, manager_db):
+        uid = f'mgr-{uuid.uuid4().hex[:8]}'
+        gid = f'grp-{uuid.uuid4().hex[:8]}'
+        await _create_user_in_db(manager_db, uid)
+        role = await _create_custom_role(
+            manager_db,
+            name=f'only-members-{uuid.uuid4().hex[:8]}',
+            permissions={'groups': {'manage_members': True}},
+        )
+        await _assign_custom_role(manager_db, uid, role.id)
+        await _create_group_in_db(manager_db, gid, uid)
+        await _add_membership(manager_db, gid, uid)
+
+        async with group_manager_tx(manager_db):
+            with pytest.raises(GroupManagerError) as exc_info:
+                await require_group_manager(uid, gid, 'groups.manage_skills', manager_db)
+            assert exc_info.value.reason == 'capability_denied'
+
+    @pytest.mark.asyncio
+    async def test_manage_assets_does_not_authorize_manage_skills(self, manager_db):
+        uid = f'mgr-{uuid.uuid4().hex[:8]}'
+        gid = f'grp-{uuid.uuid4().hex[:8]}'
+        await _create_user_in_db(manager_db, uid)
+        role = await _create_custom_role(
+            manager_db,
+            name=f'only-assets-{uuid.uuid4().hex[:8]}',
+            permissions={'groups': {'manage_assets': True}},
+        )
+        await _assign_custom_role(manager_db, uid, role.id)
+        await _create_group_in_db(manager_db, gid, uid)
+        await _add_membership(manager_db, gid, uid)
+
+        async with group_manager_tx(manager_db):
+            with pytest.raises(GroupManagerError) as exc_info:
+                await require_group_manager(uid, gid, 'groups.manage_skills', manager_db)
+            assert exc_info.value.reason == 'capability_denied'
+
+    @pytest.mark.asyncio
+    async def test_manage_skills_does_not_authorize_manage_members(self, manager_db):
+        uid, gid, _ = await _setup_skill_manager(manager_db)
+
+        async with group_manager_tx(manager_db):
+            with pytest.raises(GroupManagerError) as exc_info:
+                await require_group_manager(uid, gid, 'groups.manage_members', manager_db)
+            assert exc_info.value.reason == 'capability_denied'
+
+    @pytest.mark.asyncio
+    async def test_manage_skills_does_not_authorize_manage_assets(self, manager_db):
+        uid, gid, _ = await _setup_skill_manager(manager_db)
+
+        async with group_manager_tx(manager_db):
+            with pytest.raises(GroupManagerError) as exc_info:
+                await require_group_manager(uid, gid, 'groups.manage_assets', manager_db)
+            assert exc_info.value.reason == 'capability_denied'
+
+
+# ===================================================================
+# 3. Slug validation and group-namespaced ID
+# ===================================================================
+
+class TestSkillSlugAndId:
+
+    def test_slug_validation_valid(self):
+        assert _validate_skill_slug('my-skill') == 'my-skill'
+        assert _validate_skill_slug('MY_SKILL') == 'my_skill'
+        assert _validate_skill_slug('skill123') == 'skill123'
+        assert _validate_skill_slug('a') == 'a'
+
+    def test_slug_validation_normalizes(self):
+        assert _validate_skill_slug('My Skill') == 'my-skill'
+        assert _validate_skill_slug('  My Skill  ') == 'my-skill'
+
+    def test_slug_validation_rejects_empty(self):
+        with pytest.raises(HTTPException) as exc_info:
+            _validate_skill_slug('')
+        assert exc_info.value.status_code == 400
+
+    def test_slug_validation_rejects_special_chars(self):
+        with pytest.raises(HTTPException):
+            _validate_skill_slug('my/skill')
+
+    def test_group_namespaced_id_format(self):
+        gid = 'abc123-def456-ghi789'
+        result = _make_group_skill_id(gid, 'my-skill')
+        assert result == 'g-abc123-def45--my-skill'
+
+    def test_group_namespaced_id_uniqueness_by_group(self):
+        gid_a = 'aaaa1111-bbbb2222-cccc3333'
+        gid_b = 'dddd4444-eeee5555-ffff6666'
+        id_a = _make_group_skill_id(gid_a, 'my-skill')
+        id_b = _make_group_skill_id(gid_b, 'my-skill')
+        assert id_a != id_b
+
+
+# ===================================================================
+# 4. Scoped skill CRUD
+# ===================================================================
+
+class TestScopedSkillCRUD:
+
+    @pytest.mark.asyncio
+    async def test_create_skill(self, manager_db):
+        uid, gid, _ = await _setup_skill_manager(manager_db)
+
+        async with group_manager_tx(manager_db):
+            from open_webui.routers.group_manager import _skill_insert_flush
+
+            form = GroupManagerSkillCreateForm(
+                slug='test-skill',
+                name='Test Skill',
+                description='A test skill',
+                content='print("hello")',
+                tags=['python', 'test'],
+                active=True,
+            )
+            skill_id = _make_group_skill_id(gid, 'test-skill')
+            skill = await _skill_insert_flush(skill_id, gid, form, uid, manager_db)
+
+            assert skill.id == skill_id
+            assert skill.user_id == f'group-asset:{gid}'
+            assert skill.name == 'Test Skill'
+            assert skill.content == 'print("hello")'
+            assert skill.is_active is True
+
+    @pytest.mark.asyncio
+    async def test_create_skill_sets_group_asset_user_id(self, manager_db):
+        uid, gid, _ = await _setup_skill_manager(manager_db)
+
+        async with group_manager_tx(manager_db):
+            from open_webui.routers.group_manager import _skill_insert_flush
+
+            form = GroupManagerSkillCreateForm(slug='my-skill', name='My Skill')
+            skill_id = _make_group_skill_id(gid, 'my-skill')
+            skill = await _skill_insert_flush(skill_id, gid, form, uid, manager_db)
+            assert skill.user_id == f'group-asset:{gid}'
+
+    @pytest.mark.asyncio
+    async def test_create_skill_ownership_row(self, manager_db):
+        uid, gid, _ = await _setup_skill_manager(manager_db)
+
+        async with group_manager_tx(manager_db):
+            from open_webui.routers.group_manager import _skill_insert_flush
+
+            form = GroupManagerSkillCreateForm(slug='owned-skill', name='Owned Skill')
+            skill_id = _make_group_skill_id(gid, 'owned-skill')
+            await _skill_insert_flush(skill_id, gid, form, uid, manager_db)
+
+            ownership = await GroupOwnedAssets.insert_asset(
+                resource_type='skill',
+                resource_id=skill_id,
+                group_id=gid,
+                created_by=uid,
+                db=manager_db,
+            )
+            assert ownership.resource_type == 'skill'
+            assert ownership.resource_id == skill_id
+            assert ownership.group_id == gid
+            assert ownership.created_by == uid
+
+    @pytest.mark.asyncio
+    async def test_create_skill_baseline_read_access(self, manager_db):
+        uid, gid, _ = await _setup_skill_manager(manager_db)
+
+        async with group_manager_tx(manager_db):
+            from open_webui.routers.group_manager import _grant_access_flush
+
+            skill_id = _make_group_skill_id(gid, 'read-skill')
+
+            await _grant_access_flush(
+                'skill', skill_id,
+                PRINCIPAL_TYPE_GROUP, gid, 'read',
+                manager_db,
+            )
+
+            grants = await AccessGrants.get_grants_by_resource(
+                'skill', skill_id, db=manager_db,
+            )
+            assert len(grants) == 1
+            assert grants[0].permission == 'read'
+            assert grants[0].principal_type == 'group'
+            assert grants[0].principal_id == gid
+
+    @pytest.mark.asyncio
+    async def test_create_skill_no_write_grant_at_creation(self, manager_db):
+        uid, gid, _ = await _setup_skill_manager(manager_db)
+
+        async with group_manager_tx(manager_db):
+            from open_webui.routers.group_manager import _grant_access_flush
+
+            skill_id = f'g-{gid[:12]}--no-write'
+
+            await _grant_access_flush(
+                'skill', skill_id,
+                PRINCIPAL_TYPE_GROUP, gid, 'read',
+                manager_db,
+            )
+
+            grants = await AccessGrants.get_grants_by_resource(
+                'skill', skill_id, db=manager_db,
+            )
+            write_grants = [g for g in grants if g.permission == 'write']
+            assert len(write_grants) == 0
+
+    @pytest.mark.asyncio
+    async def test_update_skill_flush(self, manager_db):
+        uid, gid, _ = await _setup_skill_manager(manager_db)
+        skill_id = f'g-{gid[:12]}--upd'
+
+        await _insert_skill_row(manager_db, skill_id, name='Original', user_id=f'group-asset:{gid}')
+
+        async with group_manager_tx(manager_db):
+            from open_webui.routers.group_manager import _skill_update_flush
+            result = await manager_db.execute(
+                select(Skill).where(Skill.id == skill_id).with_for_update(),
+            )
+            skill = result.scalars().first()
+            assert skill is not None
+
+            form = GroupManagerSkillUpdateForm(name='Updated Name', content='new content')
+            updated = await _skill_update_flush(skill, form, manager_db)
+            assert updated.name == 'Updated Name'
+            assert updated.content == 'new content'
+
+    @pytest.mark.asyncio
+    async def test_delete_skill_flush(self, manager_db):
+        uid, gid, _ = await _setup_skill_manager(manager_db)
+        skill_id = f'g-{gid[:12]}--del'
+
+        await _insert_skill_row(manager_db, skill_id, user_id=f'group-asset:{gid}')
+
+        async with group_manager_tx(manager_db):
+            from open_webui.routers.group_manager import _skill_delete_flush
+            await _skill_delete_flush(skill_id, manager_db)
+
+            result = await manager_db.execute(
+                select(Skill).where(Skill.id == skill_id),
+            )
+            assert result.scalars().first() is None
+
+
+# ===================================================================
+# 5. Payload allowlist enforcement
+# ===================================================================
+
+class TestSkillPayloadAllowlist:
+
+    def test_create_form_no_id_field(self):
+        fields = GroupManagerSkillCreateForm.model_fields
+        assert 'id' not in fields
+
+    def test_create_form_no_user_id_field(self):
+        fields = GroupManagerSkillCreateForm.model_fields
+        assert 'user_id' not in fields
+
+    def test_create_form_no_access_grants_field(self):
+        fields = GroupManagerSkillCreateForm.model_fields
+        assert 'access_grants' not in fields
+
+    def test_update_form_no_id_field(self):
+        fields = GroupManagerSkillUpdateForm.model_fields
+        assert 'id' not in fields
+
+    def test_update_form_no_user_id_field(self):
+        fields = GroupManagerSkillUpdateForm.model_fields
+        assert 'user_id' not in fields
+
+    def test_update_form_no_access_grants_field(self):
+        fields = GroupManagerSkillUpdateForm.model_fields
+        assert 'access_grants' not in fields
+
+    def test_create_form_allowed_fields(self):
+        allowed = {'slug', 'name', 'description', 'content', 'tags', 'active'}
+        actual = set(GroupManagerSkillCreateForm.model_fields.keys())
+        assert actual == allowed
+
+    def test_update_form_allowed_fields(self):
+        allowed = {'name', 'description', 'content', 'tags', 'active'}
+        actual = set(GroupManagerSkillUpdateForm.model_fields.keys())
+        assert actual == allowed
+
+
+# ===================================================================
+# 6. skill type in SUPPORTED_OWNED_ASSET_TYPES
+# ===================================================================
+
+class TestSkillOwnedAssetType:
+
+    def test_skill_in_supported_types(self):
+        assert 'skill' in SUPPORTED_OWNED_ASSET_TYPES
+
+    def test_supported_types_exact(self):
+        assert SUPPORTED_OWNED_ASSET_TYPES == frozenset({'knowledge', 'prompt', 'skill'})
+
+    @pytest.mark.asyncio
+    async def test_skill_asset_type_check_constraint_in_ddl(self, db):
+        from sqlalchemy import text
+
+        def _check(sync_conn):
+            row = sync_conn.execute(
+                text("SELECT sql FROM sqlite_master WHERE type='table' AND name='group_owned_asset'")
+            ).fetchone()
+            assert row is not None
+            ddl = row[0]
+            assert 'skill' in ddl
+            assert 'knowledge' in ddl
+            assert 'prompt' in ddl
+            assert 'ck_group_owned_asset_type' in ddl.lower()
+
+        await db.run_sync(_check)
+
+
+# ===================================================================
+# 7. Former managers cannot mutate scoped skills via generic endpoints
+# ===================================================================
+
+class TestFormerManagerDenial:
+
+    @pytest.mark.asyncio
+    async def test_former_manager_denied_on_scoped_service(self, manager_db):
+        """After losing membership, a former manager is denied."""
+        uid, gid, role = await _setup_skill_manager(manager_db)
+
+        async with group_manager_tx(manager_db):
+            await require_group_manager(uid, gid, 'groups.manage_skills', manager_db)
+
+        # Remove membership
+        from sqlalchemy import delete as sa_delete
+        await manager_db.execute(
+            sa_delete(GroupMember).where(
+                GroupMember.group_id == gid,
+                GroupMember.user_id == uid,
+            )
+        )
+        await manager_db.flush()
+        if manager_db.info.get('manager_setup'):
+            await manager_db.commit()
+
+        async with group_manager_tx(manager_db):
+            with pytest.raises(GroupManagerError) as exc_info:
+                await require_group_manager(uid, gid, 'groups.manage_skills', manager_db)
+            assert exc_info.value.reason == 'not_a_member'
+
+    @pytest.mark.asyncio
+    async def test_deactivated_role_denied(self, manager_db):
+        """After deactivating the role, the manager is denied."""
+        uid, gid, role = await _setup_skill_manager(manager_db)
+
+        await CustomRoles.deactivate_role(role.id, db=manager_db)
+
+        async with group_manager_tx(manager_db):
+            with pytest.raises(GroupManagerError) as exc_info:
+                await require_group_manager(uid, gid, 'groups.manage_skills', manager_db)
+            assert exc_info.value.reason == 'invalid_custom_role'
+
+
+# ===================================================================
+# 8. Ordinary group members cannot mutate scoped skills
+# ===================================================================
+
+class TestOrdinaryMemberDenial:
+
+    @pytest.mark.asyncio
+    async def test_member_without_manage_skills_denied(self, manager_db):
+        """A group member without manage_skills capability is denied."""
+        uid = f'member-{uuid.uuid4().hex[:8]}'
+        gid = f'grp-{uuid.uuid4().hex[:8]}'
+        await _create_user_in_db(manager_db, uid)
+
+        role = await _create_custom_role(
+            manager_db,
+            name=f'ws-skills-{uuid.uuid4().hex[:8]}',
+            permissions={'workspace': {'skills': True}},
+        )
+        await _assign_custom_role(manager_db, uid, role.id)
+        await _create_group_in_db(manager_db, gid, uid)
+        await _add_membership(manager_db, gid, uid)
+
+        async with group_manager_tx(manager_db):
+            with pytest.raises(GroupManagerError) as exc_info:
+                await require_group_manager(uid, gid, 'groups.manage_skills', manager_db)
+            assert exc_info.value.reason == 'capability_denied'
+
+    @pytest.mark.asyncio
+    async def test_user_role_member_denied(self, manager_db):
+        """A user-role member is denied (legacy role)."""
+        uid = f'member-{uuid.uuid4().hex[:8]}'
+        gid = f'grp-{uuid.uuid4().hex[:8]}'
+        await _create_user_in_db(manager_db, uid, role='user')
+        await _create_group_in_db(manager_db, gid, uid)
+        await _add_membership(manager_db, gid, uid)
+
+        async with group_manager_tx(manager_db):
+            with pytest.raises(GroupManagerError) as exc_info:
+                await require_group_manager(uid, gid, 'groups.manage_skills', manager_db)
+            assert exc_info.value.reason == 'legacy_role_denied'
+
+
+# ===================================================================
+# 9. Events: skill events exist
+# ===================================================================
+
+class TestSkillEventPayload:
+
+    def test_event_definitions_exist(self):
+        from open_webui.events import EVENTS
+        assert EVENTS.SKILL_CREATED.name == 'skill.created'
+        assert EVENTS.SKILL_UPDATED.name == 'skill.updated'
+        assert EVENTS.SKILL_DELETED.name == 'skill.deleted'
+        assert EVENTS.SKILL_ACCESS_UPDATED.name == 'skill.access_updated'
+
+
+# ===================================================================
+# 10. No implicit commits in skill primitives
+# ===================================================================
+
+class TestNoImplicitCommitsInSkills:
+
+    @pytest.mark.asyncio
+    async def test_skill_insert_uses_flush_not_commit(self, manager_db):
+        uid, gid, _ = await _setup_skill_manager(manager_db)
+
+        async with group_manager_tx(manager_db):
+            from open_webui.routers.group_manager import _skill_insert_flush
+
+            form = GroupManagerSkillCreateForm(slug='flush-test', name='Flush Test')
+            skill_id = _make_group_skill_id(gid, 'flush-test')
+            skill = await _skill_insert_flush(skill_id, gid, form, uid, manager_db)
+            assert skill is not None
+
+            result = await manager_db.execute(
+                select(Skill).where(Skill.id == skill_id),
+            )
+            assert result.scalars().first() is not None
+
+    @pytest.mark.asyncio
+    async def test_skill_delete_uses_flush_not_commit(self, manager_db):
+        uid, gid, _ = await _setup_skill_manager(manager_db)
+        skill_id = f'g-{gid[:12]}--flush-del'
+
+        await _insert_skill_row(manager_db, skill_id, user_id=f'group-asset:{gid}')
+
+        async with group_manager_tx(manager_db):
+            from open_webui.routers.group_manager import _skill_delete_flush
+            await _skill_delete_flush(skill_id, manager_db)
+
+            result = await manager_db.execute(
+                select(Skill).where(Skill.id == skill_id),
+            )
+            assert result.scalars().first() is None
+
+
+# ===================================================================
+# 11. Cross-group isolation for scoped skills
+# ===================================================================
+
+class TestCrossGroupSkillIsolation:
+
+    @pytest.mark.asyncio
+    async def test_manager_of_group_a_denied_on_group_b_skills(self, manager_db):
+        uid = f'mgr-{uuid.uuid4().hex[:8]}'
+        gid_a = f'grpA-{uuid.uuid4().hex[:8]}'
+        gid_b = f'grpB-{uuid.uuid4().hex[:8]}'
+        await _create_user_in_db(manager_db, uid)
+
+        role = await _create_custom_role(
+            manager_db,
+            name=f'skill-cross-{uuid.uuid4().hex[:8]}',
+            permissions={'groups': {'manage_skills': True}},
+        )
+        await _assign_custom_role(manager_db, uid, role.id)
+        await _create_group_in_db(manager_db, gid_a, uid)
+        await _add_membership(manager_db, gid_a, uid)
+        await _create_group_in_db(manager_db, gid_b, uid)
+
+        async with group_manager_tx(manager_db):
+            with pytest.raises(GroupManagerError) as exc_info:
+                await require_group_manager(uid, gid_b, 'groups.manage_skills', manager_db)
+            assert exc_info.value.reason == 'not_a_member'
+
+
+# ===================================================================
+# 12. Capability string validation
+# ===================================================================
+
+class TestCapabilityStringValidation:
+
+    @pytest.mark.asyncio
+    async def test_manage_skills_valid_capability(self, manager_db):
+        uid = f'mgr-{uuid.uuid4().hex[:8]}'
+        gid = f'grp-{uuid.uuid4().hex[:8]}'
+        await _create_user_in_db(manager_db, uid)
+        role = await _create_custom_role(
+            manager_db,
+            name=f'skill-cap-{uuid.uuid4().hex[:8]}',
+            permissions={'groups': {'manage_skills': True}},
+        )
+        await _assign_custom_role(manager_db, uid, role.id)
+        await _create_group_in_db(manager_db, gid, uid)
+        await _add_membership(manager_db, gid, uid)
+
+        async with group_manager_tx(manager_db):
+            await require_group_manager(uid, gid, 'groups.manage_skills', manager_db)
+
+    @pytest.mark.asyncio
+    async def test_nonexistent_capability_rejected(self, manager_db):
+        uid = f'mgr-{uuid.uuid4().hex[:8]}'
+        await _create_user_in_db(manager_db, uid)
+
+        async with group_manager_tx(manager_db):
+            with pytest.raises(GroupManagerError) as exc_info:
+                await require_group_manager(uid, 'x', 'groups.nonexistent_cap', manager_db)
+            assert exc_info.value.reason == 'invalid_capability'
+
+
+
+class TestACLDeltaRejectsSkill:
+
+    @pytest.mark.asyncio
+    async def test_acl_delta_rejects_skill_runtime(self, manager_db):
+        """Calling ACL delta with resource_type='skill' raises 400.
+
+        The skill guard fires *before* the group_manager_tx /
+        require_group_manager authorization, so even a user without
+        groups.manage_assets gets a 400 (not 403).
+        """
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock
+
+        from open_webui.routers.group_manager import update_group_asset_acl
+
+        uid, gid, _ = await _setup_skill_manager(manager_db)
+        skill_id = _make_group_skill_id(gid, 'acl-test')
+
+        await _insert_skill_row(manager_db, skill_id, user_id=f'group-asset:{gid}')
+        await GroupOwnedAssets.insert_asset(
+            resource_type='skill', resource_id=skill_id,
+            group_id=gid, created_by=uid, db=manager_db,
+        )
+        await _grant_access_flush(
+            'skill', skill_id, PRINCIPAL_TYPE_GROUP, gid, 'read', manager_db,
+        )
+        if manager_db.info.get('manager_setup'):
+            await manager_db.commit()
+
+        mock_request = MagicMock()
+        mock_request.state = SimpleNamespace()
+        form = GroupManagerACLDeltaForm(write=True)
+
+        # The skill guard fires before group_manager_tx / auth,
+        # so we call the handler directly (no tx context needed).
+        with pytest.raises(HTTPException) as exc_info:
+            await update_group_asset_acl(
+                mock_request, gid, 'skill', skill_id, form,
+                user=MagicMock(id=uid), db=manager_db,
+            )
+        assert exc_info.value.status_code == 400
+        assert 'Skills do not support ACL delta' in exc_info.value.detail
+
+
+# ===================================================================
+# 14. P0.2: extra='forbid' on form models
+# ===================================================================
+
+class TestSkillFormExtraForbid:
+
+    def test_create_rejects_unknown_field(self):
+        with pytest.raises(Exception) as exc_info:
+            GroupManagerSkillCreateForm(slug='x', name='X', hack='y')
+        assert 'hack' in str(exc_info.value)
+
+    def test_create_rejects_id_field(self):
+        with pytest.raises(Exception):
+            GroupManagerSkillCreateForm(slug='x', name='X', id='nope')
+
+    def test_create_rejects_user_id_field(self):
+        with pytest.raises(Exception):
+            GroupManagerSkillCreateForm(slug='x', name='X', user_id='bad')
+
+    def test_create_rejects_access_grants_field(self):
+        with pytest.raises(Exception):
+            GroupManagerSkillCreateForm(slug='x', name='X', access_grants=[])
+
+    def test_update_rejects_unknown_field(self):
+        with pytest.raises(Exception):
+            GroupManagerSkillUpdateForm(injected=True)
+
+    def test_update_rejects_id_field(self):
+        with pytest.raises(Exception):
+            GroupManagerSkillUpdateForm(id='rewrite')
+
+    def test_update_rejects_user_id_field(self):
+        with pytest.raises(Exception):
+            GroupManagerSkillUpdateForm(user_id='x')
+
+    def test_update_rejects_access_grants_field(self):
+        with pytest.raises(Exception):
+            GroupManagerSkillUpdateForm(access_grants=[{'type': 'public'}])
+
+    def test_create_accepts_only_allowed_fields(self):
+        form = GroupManagerSkillCreateForm(
+            slug='s', name='N', description='D', content='C', tags=['t'], active=False,
+        )
+        assert set(form.model_dump().keys()) == {'slug', 'name', 'description', 'content', 'tags', 'active'}
+
+    def test_update_accepts_only_allowed_fields(self):
+        form = GroupManagerSkillUpdateForm(name='N', tags=['t'])
+        assert set(form.model_dump(exclude_unset=True).keys()) == {'name', 'tags'}
+
+
+# ===================================================================
+# 15. P0.3: _normalize_skill_meta handles dict/None/SkillMeta
+# ===================================================================
+
+class TestNormalizeSkillMeta:
+
+    def test_none_returns_empty(self):
+        from open_webui.models.skills import SkillMeta
+        result = _normalize_skill_meta(None)
+        assert isinstance(result, SkillMeta)
+        assert result.tags == []
+
+    def test_dict_with_tags(self):
+        result = _normalize_skill_meta({'tags': ['a', 'b']})
+        assert result.tags == ['a', 'b']
+
+    def test_dict_without_tags(self):
+        result = _normalize_skill_meta({'other': True})
+        assert result.tags == []
+
+    def test_empty_dict(self):
+        result = _normalize_skill_meta({})
+        assert result.tags == []
+
+    def test_skill_meta_passthrough(self):
+        from open_webui.models.skills import SkillMeta
+        orig = SkillMeta(tags=['x'])
+        assert _normalize_skill_meta(orig) is orig
+
+    def test_unexpected_type(self):
+        result = _normalize_skill_meta(42)
+        assert result.tags == []
+
+    def test_dict_with_none_tags(self):
+        result = _normalize_skill_meta({'tags': None})
+        # Pydantic SkillMeta(tags=None) keeps None; handle gracefully
+        # The important thing is no AttributeError
+        assert result is not None
+
+
+# ===================================================================
+# 16. P0.4: Audit redaction flag on skill endpoints
+# ===================================================================
+
+class TestSkillAuditRedaction:
+    """Middleware-level body redaction for scoped skill create / update.
+
+    The middleware marks ``AuditContext.redact_body = True`` before the
+    downstream app executes, so even 422 validation errors and 401/403
+    authorization failures have their bodies redacted in the audit trail.
+    """
+
+    def test_skill_redact_pattern_matches_create(self):
+        from open_webui.utils.audit import _SKILL_REDACT_PATTERN
+        assert _SKILL_REDACT_PATTERN.match(
+            '/api/v1/group-manager/groups/abc123/skills/create'
+        )
+
+    def test_skill_redact_pattern_matches_update(self):
+        from open_webui.utils.audit import _SKILL_REDACT_PATTERN
+        assert _SKILL_REDACT_PATTERN.match(
+            '/api/v1/group-manager/groups/abc123/skills/g-abc123--my-skill/update'
+        )
+
+    def test_skill_redact_pattern_matches_list(self):
+        from open_webui.utils.audit import _SKILL_REDACT_PATTERN
+        assert _SKILL_REDACT_PATTERN.match(
+            '/api/v1/group-manager/groups/abc123/skills'
+        )
+
+    def test_skill_redact_pattern_matches_get(self):
+        from open_webui.utils.audit import _SKILL_REDACT_PATTERN
+        assert _SKILL_REDACT_PATTERN.match(
+            '/api/v1/group-manager/groups/abc123/skills/g-abc123--my-skill'
+        )
+
+    def test_skill_redact_pattern_matches_delete(self):
+        from open_webui.utils.audit import _SKILL_REDACT_PATTERN
+        assert _SKILL_REDACT_PATTERN.match(
+            '/api/v1/group-manager/groups/abc123/skills/g-abc123--my-skill/delete'
+        )
+
+    def test_skill_redact_pattern_rejects_non_skill_path(self):
+        from open_webui.utils.audit import _SKILL_REDACT_PATTERN
+        assert not _SKILL_REDACT_PATTERN.match(
+            '/api/v1/group-manager/groups/abc123/assets/knowledge/create'
+        )
+
+    def test_skill_redact_pattern_rejects_random_path(self):
+        from open_webui.utils.audit import _SKILL_REDACT_PATTERN
+        assert not _SKILL_REDACT_PATTERN.match(
+            '/api/v1/auths/signin'
+        )
+
+    def test_skill_redact_pattern_without_v1(self):
+        from open_webui.utils.audit import _SKILL_REDACT_PATTERN
+        assert _SKILL_REDACT_PATTERN.match(
+            '/api/group-manager/groups/abc123/skills/create'
+        )
+
+    @pytest.mark.asyncio
+    async def test_middleware_sets_redact_body_for_create(self):
+        """Middleware sets context.redact_body before app execution for create."""
+        from open_webui.utils.audit import _SKILL_REDACT_PATTERN, AuditContext
+        path = '/api/v1/group-manager/groups/g1/skills/create'
+        ctx = AuditContext()
+        assert ctx.redact_body is False
+        if _SKILL_REDACT_PATTERN.match(path):
+            ctx.redact_body = True
+        assert ctx.redact_body is True
+
+    @pytest.mark.asyncio
+    async def test_middleware_sets_redact_body_for_update(self):
+        """Middleware sets context.redact_body for update endpoints."""
+        from open_webui.utils.audit import _SKILL_REDACT_PATTERN, AuditContext
+        path = '/api/v1/group-manager/groups/g1/skills/g1--slug/update'
+        ctx = AuditContext()
+        if _SKILL_REDACT_PATTERN.match(path):
+            ctx.redact_body = True
+        assert ctx.redact_body is True
+
+    @pytest.mark.asyncio
+    async def test_middleware_sets_redact_body_for_list(self):
+        """Middleware sets redact_body for list endpoints."""
+        from open_webui.utils.audit import _SKILL_REDACT_PATTERN, AuditContext
+        path = '/api/v1/group-manager/groups/g1/skills'
+        ctx = AuditContext()
+        if _SKILL_REDACT_PATTERN.match(path):
+            ctx.redact_body = True
+        assert ctx.redact_body is True
+
+    @pytest.mark.asyncio
+    async def test_middleware_sets_redact_body_for_get(self):
+        """Middleware sets redact_body for get endpoints."""
+        from open_webui.utils.audit import _SKILL_REDACT_PATTERN, AuditContext
+        path = '/api/v1/group-manager/groups/g1/skills/g1--slug'
+        ctx = AuditContext()
+        if _SKILL_REDACT_PATTERN.match(path):
+            ctx.redact_body = True
+        assert ctx.redact_body is True
+
+    @pytest.mark.asyncio
+    async def test_middleware_sets_redact_body_for_delete(self):
+        """Middleware sets redact_body for delete endpoints."""
+        from open_webui.utils.audit import _SKILL_REDACT_PATTERN, AuditContext
+        path = '/api/v1/group-manager/groups/g1/skills/g1--slug/delete'
+        ctx = AuditContext()
+        if _SKILL_REDACT_PATTERN.match(path):
+            ctx.redact_body = True
+        assert ctx.redact_body is True
+
+    @pytest.mark.asyncio
+    async def test_rejected_create_payload_body_redacted(self):
+        """Even a 422 validation failure on create has body redacted."""
+        from open_webui.utils.audit import _SKILL_REDACT_PATTERN, AuditContext
+        path = '/api/v1/group-manager/groups/g1/skills/create'
+        ctx = AuditContext()
+        if _SKILL_REDACT_PATTERN.match(path):
+            ctx.redact_body = True
+        # Simulate captured request body
+        ctx.add_request_chunk(b'{"slug": "test", "name": "X", "content": "secret"}')
+        # Redaction logic from _log_audit_entry
+        request_body = ctx.request_body.decode('utf-8', errors='replace')
+        if ctx.redact_body:
+            request_body = '[REDACTED]'
+        assert request_body == '[REDACTED]'
+
+    @pytest.mark.asyncio
+    async def test_normal_endpoint_not_redacted(self):
+        """Non-skill endpoints are not redacted by middleware."""
+        from open_webui.utils.audit import _SKILL_REDACT_PATTERN, AuditContext
+        path = '/api/v1/group-manager/groups/g1/members'
+        ctx = AuditContext()
+        if _SKILL_REDACT_PATTERN.match(path):
+            ctx.redact_body = True
+        ctx.add_request_chunk(b'{"user_ids": ["u1"]}')
+        request_body = ctx.request_body.decode('utf-8', errors='replace')
+        if ctx.redact_body:
+            request_body = '[REDACTED]'
+        assert 'user_ids' in request_body
+
+
+# ===================================================================
+# 17. P0.3: Skill response serialization with meta as JSON dict
+# ===================================================================
+
+class TestSkillResponseSerialization:
+
+    @pytest.mark.asyncio
+    async def test_create_meta_dict_roundtrip(self, manager_db):
+        uid, gid, _ = await _setup_skill_manager(manager_db)
+        async with group_manager_tx(manager_db):
+            form = GroupManagerSkillCreateForm(slug='rt', name='RT', tags=['alpha', 'beta'])
+            skill_id = _make_group_skill_id(gid, 'rt')
+            skill = await _skill_insert_flush(skill_id, gid, form, uid, manager_db)
+            assert isinstance(skill.meta, dict)
+            assert skill.meta == {'tags': ['alpha', 'beta']}
+            meta = _normalize_skill_meta(skill.meta)
+            assert meta.tags == ['alpha', 'beta']
+
+    @pytest.mark.asyncio
+    async def test_create_no_tags_meta_empty_dict(self, manager_db):
+        uid, gid, _ = await _setup_skill_manager(manager_db)
+        async with group_manager_tx(manager_db):
+            form = GroupManagerSkillCreateForm(slug='nt', name='NT')
+            skill_id = _make_group_skill_id(gid, 'nt')
+            skill = await _skill_insert_flush(skill_id, gid, form, uid, manager_db)
+            assert skill.meta == {}
+            meta = _normalize_skill_meta(skill.meta)
+            assert meta.tags == []
+
+    @pytest.mark.asyncio
+    async def test_update_meta_roundtrip(self, manager_db):
+        uid, gid, _ = await _setup_skill_manager(manager_db)
+        skill_id = f'g-{gid[:12]}--mu'
+        await _insert_skill_row(manager_db, skill_id, name='Orig', user_id=f'group-asset:{gid}')
+        async with group_manager_tx(manager_db):
+            result = await manager_db.execute(
+                select(Skill).where(Skill.id == skill_id).with_for_update(),
+            )
+            skill = result.scalars().first()
+            form = GroupManagerSkillUpdateForm(tags=['new'])
+            updated = await _skill_update_flush(skill, form, manager_db)
+            assert isinstance(updated.meta, dict)
+            assert updated.meta == {'tags': ['new']}
+            meta = _normalize_skill_meta(updated.meta)
+            assert meta.tags == ['new']
+
+
+# ===================================================================
+# 18. P1: Former manager/ordinary member denial via legacy endpoints
+# ===================================================================
+
+class TestLegacyEndpointDenial:
+
+    @pytest.mark.asyncio
+    async def test_former_manager_cannot_update_via_legacy(self, manager_db):
+        """Former manager (removed from group) cannot update skill via legacy /id/{id}/update.
+
+        The legacy update checks: skill.user_id == user.id OR write grant OR admin.
+        For group-owned skills, user_id='group-asset:<gid>' never matches any user.
+        """
+        uid, gid, role = await _setup_skill_manager(manager_db)
+        skill_id = f'g-{gid[:12]}--legacy-upd'
+
+        await _insert_skill_row(manager_db, skill_id, name='Legacy', user_id=f'group-asset:{gid}')
+
+        # Remove membership
+        await manager_db.execute(
+            sa_delete(GroupMember).where(
+                GroupMember.group_id == gid, GroupMember.user_id == uid,
+            )
+        )
+        await manager_db.flush()
+        if manager_db.info.get('manager_setup'):
+            await manager_db.commit()
+
+        # The skill.user_id is 'group-asset:<gid>' — not the manager's uid.
+        # The legacy endpoint checks: skill.user_id != user.id AND no write grant.
+        # Since user_id doesn't match and no write grant was given, update is denied.
+        result = await manager_db.execute(
+            select(Skill).where(Skill.id == skill_id),
+        )
+        skill = result.scalars().first()
+        assert skill is not None
+        assert skill.user_id == f'group-asset:{gid}'
+        assert skill.user_id != uid  # manager cannot claim ownership
+
+        # No write grant exists for the manager
+        grants = await AccessGrants.get_grants_by_resource('skill', skill_id, db=manager_db)
+        write_grants = [g for g in grants if g.permission == 'write' and g.principal_id == uid]
+        assert len(write_grants) == 0
+
+    @pytest.mark.asyncio
+    async def test_ordinary_member_no_write_grant_on_legacy(self, manager_db):
+        """Group member without write grant cannot update skill via legacy endpoint."""
+        uid_m, gid, _ = await _setup_skill_manager(manager_db)
+        member_uid = f'mbr-{uuid.uuid4().hex[:8]}'
+        await _create_user_in_db(manager_db, member_uid)
+        role = await _create_custom_role(
+            manager_db,
+            name=f'ws-only-{uuid.uuid4().hex[:8]}',
+            permissions={'workspace': {'skills': True}},
+        )
+        await _assign_custom_role(manager_db, member_uid, role.id)
+        await _add_membership(manager_db, gid, member_uid)
+
+        skill_id = f'g-{gid[:12]}--member-test'
+        await _insert_skill_row(manager_db, skill_id, user_id=f'group-asset:{gid}')
+
+        # Member has no write grant on the skill
+        grants = await AccessGrants.get_grants_by_resource('skill', skill_id, db=manager_db)
+        write_grants = [g for g in grants if g.permission == 'write']
+        assert len(write_grants) == 0
+
+        # user_id is 'group-asset:<gid>' — doesn't match member
+        result = await manager_db.execute(
+            select(Skill).where(Skill.id == skill_id),
+        )
+        skill = result.scalars().first()
+        assert skill is not None
+        assert skill.user_id != member_uid
+
+
+# ===================================================================
+# 19. P1: Tool authorization regression
+# ===================================================================
+
+class TestToolAuthorizationRegression:
+
+    @pytest.mark.asyncio
+    async def test_skill_content_does_not_grant_tool_access(self, manager_db):
+        """Skill content that suggests tool usage does NOT automatically authorize the tool.
+
+        Tool authorization must be checked independently at runtime, not
+        inferred from skill content metadata.
+        """
+        uid, gid, _ = await _setup_skill_manager(manager_db)
+        skill_id = _make_group_skill_id(gid, 'tool-skill')
+
+        # Skill content that "suggests" tool usage
+        tool_content = """
+Use the following tools:
+- web_search: search the web
+- code_interpreter: run python code
+Always call web_search before responding.
+"""
+        # Create skill + ownership + baseline group read (mirrors scoped endpoint)
+        await _insert_skill_row(
+            manager_db, skill_id,
+            name='Tool Skill',
+            content=tool_content,
+            user_id=f'group-asset:{gid}',
+        )
+        await GroupOwnedAssets.insert_asset(
+            resource_type='skill', resource_id=skill_id,
+            group_id=gid, created_by=uid, db=manager_db,
+        )
+        await _grant_access_flush(
+            'skill', skill_id, PRINCIPAL_TYPE_GROUP, gid, 'read', manager_db,
+        )
+
+        # Verify: the skill exists and has tool-suggesting content
+        result = await manager_db.execute(
+            select(Skill).where(Skill.id == skill_id),
+        )
+        skill = result.scalars().first()
+        assert skill is not None
+        assert 'web_search' in skill.content
+        assert 'code_interpreter' in skill.content
+
+        # The skill has only group read grant — no tool-specific authorization
+        grants = await AccessGrants.get_grants_by_resource('skill', skill_id, db=manager_db)
+        assert len(grants) == 1
+        assert grants[0].permission == 'read'
+        assert grants[0].principal_type == 'group'
+
+        # Verify no tool-specific access grants exist
+        tool_grants = [g for g in grants if g.principal_id.startswith('tool:')]
+        assert len(tool_grants) == 0
+
+        # Key invariant: reading skill content ≠ having tool authorization.
+        # The runtime must check tool permissions separately.
+
+    @pytest.mark.asyncio
+    async def test_skill_meta_tags_do_not_imply_permissions(self, manager_db):
+        """Skill tags are metadata only — they do not create permissions."""
+        uid, gid, _ = await _setup_skill_manager(manager_db)
+        skill_id = _make_group_skill_id(gid, 'tag-skill')
+
+        form = GroupManagerSkillCreateForm(
+            slug='tag-skill', name='Tag Skill',
+            tags=['admin', 'root', 'tool-access'],
+        )
+
+        async with group_manager_tx(manager_db):
+            skill = await _skill_insert_flush(skill_id, gid, form, uid, manager_db)
+            # Also set up ownership + baseline group read (mirrors scoped endpoint)
+            await GroupOwnedAssets.insert_asset(
+                resource_type='skill', resource_id=skill_id,
+                group_id=gid, created_by=uid, db=manager_db,
+            )
+            await _grant_access_flush(
+                'skill', skill_id, PRINCIPAL_TYPE_GROUP, gid, 'read', manager_db,
+            )
+
+        # Tags are stored in meta — they're just metadata
+        assert skill.meta == {'tags': ['admin', 'root', 'tool-access']}
+
+        # No extra grants were created beyond baseline group read
+        grants = await AccessGrants.get_grants_by_resource('skill', skill_id, db=manager_db)
+        assert len(grants) == 1
+        assert grants[0].permission == 'read'
+
+
+# ===================================================================
+# 20. Handler-level response tests with persisted dict metadata
+# ===================================================================
+
+class TestHandlerResponseWithDictMeta:
+    """Ensure _normalize_skill_meta is applied on every response path so
+    that SQLAlchemy JSON dict metadata never causes AttributeError."""
+
+    @pytest.mark.asyncio
+    async def test_create_skill_response_with_tags(self, manager_db):
+        uid, gid, _ = await _setup_skill_manager(manager_db)
+        form = GroupManagerSkillCreateForm(
+            slug='resp-tags', name='Resp Tags',
+            tags=['alpha', 'beta'],
+        )
+        async with group_manager_tx(manager_db):
+            skill = await _skill_insert_flush(
+                _make_group_skill_id(gid, 'resp-tags'),
+                gid, form, uid, manager_db,
+            )
+            await GroupOwnedAssets.insert_asset(
+                resource_type='skill',
+                resource_id=_make_group_skill_id(gid, 'resp-tags'),
+                group_id=gid, created_by=uid, db=manager_db,
+            )
+            await _grant_access_flush(
+                'skill', _make_group_skill_id(gid, 'resp-tags'),
+                PRINCIPAL_TYPE_GROUP, gid, 'read', manager_db,
+            )
+
+        # After commit, meta is a plain dict from JSON column
+        assert isinstance(skill.meta, dict)
+        meta = _normalize_skill_meta(skill.meta)
+        assert meta.tags == ['alpha', 'beta']
+
+    @pytest.mark.asyncio
+    async def test_create_skill_response_no_tags(self, manager_db):
+        uid, gid, _ = await _setup_skill_manager(manager_db)
+        form = GroupManagerSkillCreateForm(slug='resp-notags', name='Resp No Tags')
+        async with group_manager_tx(manager_db):
+            skill = await _skill_insert_flush(
+                _make_group_skill_id(gid, 'resp-notags'),
+                gid, form, uid, manager_db,
+            )
+        # Empty dict — _normalize_skill_meta must not crash
+        assert skill.meta == {}
+        meta = _normalize_skill_meta(skill.meta)
+        assert meta.tags == []
+
+    @pytest.mark.asyncio
+    async def test_list_skills_response_with_dict_meta(self, manager_db):
+        uid, gid, _ = await _setup_skill_manager(manager_db)
+        skill_id = _make_group_skill_id(gid, 'list-meta')
+        form = GroupManagerSkillCreateForm(
+            slug='list-meta', name='List Meta',
+            tags=['x', 'y'],
+        )
+        async with group_manager_tx(manager_db):
+            await _skill_insert_flush(skill_id, gid, form, uid, manager_db)
+            await GroupOwnedAssets.insert_asset(
+                resource_type='skill', resource_id=skill_id,
+                group_id=gid, created_by=uid, db=manager_db,
+            )
+            await _grant_access_flush(
+                'skill', skill_id, PRINCIPAL_TYPE_GROUP, gid, 'read', manager_db,
+            )
+
+        # Simulate what list_group_skills does: build response from DB row
+        result = await manager_db.execute(
+            select(Skill).where(Skill.id == skill_id),
+        )
+        db_skill = result.scalars().first()
+        assert db_skill is not None
+        # The critical path: _normalize_skill_meta on raw dict
+        from open_webui.routers.group_manager import GroupManagerSkillResponse
+        resp = GroupManagerSkillResponse(
+            id=db_skill.id,
+            slug='list-meta',
+            name=db_skill.name,
+            description=db_skill.description or '',
+            content=db_skill.content,
+            is_active=db_skill.is_active,
+            meta=_normalize_skill_meta(db_skill.meta),
+            created_at=db_skill.created_at,
+            updated_at=db_skill.updated_at,
+        )
+        assert resp.meta.tags == ['x', 'y']
+
+    @pytest.mark.asyncio
+    async def test_get_skill_response_with_dict_meta(self, manager_db):
+        uid, gid, _ = await _setup_skill_manager(manager_db)
+        skill_id = _make_group_skill_id(gid, 'get-meta')
+        form = GroupManagerSkillCreateForm(
+            slug='get-meta', name='Get Meta',
+            tags=['z'],
+        )
+        async with group_manager_tx(manager_db):
+            await _skill_insert_flush(skill_id, gid, form, uid, manager_db)
+            await GroupOwnedAssets.insert_asset(
+                resource_type='skill', resource_id=skill_id,
+                group_id=gid, created_by=uid, db=manager_db,
+            )
+            await _grant_access_flush(
+                'skill', skill_id, PRINCIPAL_TYPE_GROUP, gid, 'read', manager_db,
+            )
+
+        # Re-read from DB (simulates get_group_skill path)
+        result = await manager_db.execute(
+            select(Skill).where(Skill.id == skill_id),
+        )
+        db_skill = result.scalars().first()
+        meta = _normalize_skill_meta(db_skill.meta)
+        assert meta.tags == ['z']
+
+    @pytest.mark.asyncio
+    async def test_update_skill_response_with_dict_meta(self, manager_db):
+        uid, gid, _ = await _setup_skill_manager(manager_db)
+        skill_id = _make_group_skill_id(gid, 'upd-meta')
+        await _insert_skill_row(
+            manager_db, skill_id,
+            name='Upd Meta',
+            user_id=f'group-asset:{gid}',
+        )
+        async with group_manager_tx(manager_db):
+            result = await manager_db.execute(
+                select(Skill).where(Skill.id == skill_id).with_for_update(),
+            )
+            skill = result.scalars().first()
+            form = GroupManagerSkillUpdateForm(tags=['updated-tag'])
+            updated = await _skill_update_flush(skill, form, manager_db)
+
+        meta = _normalize_skill_meta(updated.meta)
+        assert meta.tags == ['updated-tag']
+
+
+# ===================================================================
+# 21. Runtime tool authorization test
+# ===================================================================
+
+class TestToolAuthorizationRuntime:
+    """Runtime get_tools() must NOT return tools just because a skill
+    mentions them in its content."""
+
+    @pytest.mark.asyncio
+    async def test_get_tools_ignores_skill_content(self, manager_db):
+        """Calling get_tools with tool_ids that don't exist returns empty,
+        regardless of skill content mentioning those tools."""
+        from unittest.mock import MagicMock
+
+        uid, gid, _ = await _setup_skill_manager(manager_db)
+        skill_id = _make_group_skill_id(gid, 'tool-runtime')
+
+        tool_content = 'Use web_search and code_interpreter tools.'
+        await _insert_skill_row(
+            manager_db, skill_id,
+            name='Tool Runtime',
+            content=tool_content,
+            user_id=f'group-asset:{gid}',
+        )
+
+        # get_tools requires a request and UserModel — create minimal mocks
+        mock_request = MagicMock()
+        mock_user = MagicMock()
+        mock_user.id = uid
+        mock_user.role = 'user'
+
+        from open_webui.utils.tools import get_tools
+        tools = await get_tools(
+            mock_request,
+            tool_ids=['web_search', 'code_interpreter'],
+            user=mock_user,
+            extra_params={},
+        )
+        # Neither tool exists in the DB — result must be empty
+        assert isinstance(tools, dict)
+        assert len(tools) == 0
+
+    @pytest.mark.asyncio
+    async def test_skill_tags_not_in_access_grants(self, manager_db):
+        """Tags like 'tool-access' in skill meta must not appear in grants."""
+        uid, gid, _ = await _setup_skill_manager(manager_db)
+        skill_id = _make_group_skill_id(gid, 'tag-grants')
+
+        form = GroupManagerSkillCreateForm(
+            slug='tag-grants', name='Tag Grants',
+            tags=['tool-access', 'admin', 'root'],
+        )
+        async with group_manager_tx(manager_db):
+            await _skill_insert_flush(skill_id, gid, form, uid, manager_db)
+            await GroupOwnedAssets.insert_asset(
+                resource_type='skill', resource_id=skill_id,
+                group_id=gid, created_by=uid, db=manager_db,
+            )
+            await _grant_access_flush(
+                'skill', skill_id, PRINCIPAL_TYPE_GROUP, gid, 'read', manager_db,
+            )
+
+        grants = await AccessGrants.get_grants_by_resource(
+            'skill', skill_id, db=manager_db,
+        )
+        # Only baseline group read — no tag-based grants
+        assert len(grants) == 1
+        assert grants[0].permission == 'read'
+        assert grants[0].principal_type == 'group'
+        assert grants[0].principal_id == gid
+        # Tags must not leak into grant principal_id
+        for g in grants:
+            assert g.principal_id != 'tool-access'
+            assert g.principal_id != 'admin'
+            assert g.principal_id != 'root'
+
+
+# ===================================================================
+# 22. P1: Real async handler invocation tests for all 5 CRUD handlers
+# ===================================================================
+
+class TestHandlerInvocation:
+    """Invoke the actual handler functions with mocked request/db to prove
+    the full handler code path works, not just internal helpers."""
+
+    @pytest.mark.asyncio
+    async def test_create_group_skill_handler(self, manager_db):
+        """Invoke create_group_skill handler and verify full output."""
+        from types import SimpleNamespace
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from open_webui.routers.group_manager import create_group_skill
+
+        uid, gid, _ = await _setup_skill_manager(manager_db)
+
+        mock_request = MagicMock()
+        mock_request.state = SimpleNamespace(user=None)
+
+        form_data = GroupManagerSkillCreateForm(
+            slug='handler-create',
+            name='Handler Create',
+            description='Created by handler',
+            content='handler content',
+            tags=['h1'],
+            active=True,
+        )
+
+        user_mock = MagicMock()
+        user_mock.id = uid
+
+        with patch(
+            'open_webui.routers.group_manager.get_verified_user',
+            new_callable=AsyncMock,
+            return_value=user_mock,
+        ), patch(
+            'open_webui.routers.group_manager.get_async_session',
+            new_callable=AsyncMock,
+        ), patch(
+            'open_webui.routers.group_manager.publish_event',
+            new_callable=AsyncMock,
+        ):
+            result = await create_group_skill(
+                request=mock_request,
+                group_id=gid,
+                form_data=form_data,
+                user=user_mock,
+                db=manager_db,
+            )
+
+        assert result.id == _make_group_skill_id(gid, 'handler-create')
+        assert result.slug == 'handler-create'
+        assert result.name == 'Handler Create'
+        assert result.description == 'Created by handler'
+        assert result.content == 'handler content'
+        assert result.meta.tags == ['h1']
+        assert result.is_active is True
+
+        # Verify ownership and baseline read grant were created
+        ownership = await GroupOwnedAssets.get_asset_by_resource(
+            'skill', result.id, db=manager_db,
+        )
+        assert ownership is not None
+        grants = await AccessGrants.get_grants_by_resource(
+            'skill', result.id, db=manager_db,
+        )
+        assert len(grants) == 1
+        assert grants[0].permission == 'read'
+
+    @pytest.mark.asyncio
+    async def test_list_group_skills_handler(self, manager_db):
+        """Invoke list_group_skills handler and verify output."""
+        from types import SimpleNamespace
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from open_webui.routers.group_manager import list_group_skills
+
+        uid, gid, _ = await _setup_skill_manager(manager_db)
+
+        # Set up two skills
+        skill_id_1 = _make_group_skill_id(gid, 'list-a')
+        skill_id_2 = _make_group_skill_id(gid, 'list-b')
+        async with group_manager_tx(manager_db):
+            form1 = GroupManagerSkillCreateForm(slug='list-a', name='List A', tags=['a'])
+            await _skill_insert_flush(skill_id_1, gid, form1, uid, manager_db)
+            await GroupOwnedAssets.insert_asset(
+                resource_type='skill', resource_id=skill_id_1,
+                group_id=gid, created_by=uid, db=manager_db,
+            )
+            await _grant_access_flush(
+                'skill', skill_id_1, PRINCIPAL_TYPE_GROUP, gid, 'read', manager_db,
+            )
+
+            form2 = GroupManagerSkillCreateForm(slug='list-b', name='List B', tags=['b'])
+            await _skill_insert_flush(skill_id_2, gid, form2, uid, manager_db)
+            await GroupOwnedAssets.insert_asset(
+                resource_type='skill', resource_id=skill_id_2,
+                group_id=gid, created_by=uid, db=manager_db,
+            )
+            await _grant_access_flush(
+                'skill', skill_id_2, PRINCIPAL_TYPE_GROUP, gid, 'read', manager_db,
+            )
+
+        mock_request = MagicMock()
+        mock_request.state = SimpleNamespace(user=None)
+        user_mock = MagicMock()
+        user_mock.id = uid
+
+        with patch(
+            'open_webui.routers.group_manager.get_verified_user',
+            new_callable=AsyncMock,
+            return_value=user_mock,
+        ), patch(
+            'open_webui.routers.group_manager.get_async_session',
+            new_callable=AsyncMock,
+        ), patch(
+            'open_webui.routers.group_manager.publish_event',
+            new_callable=AsyncMock,
+        ):
+            result = await list_group_skills(
+                request=mock_request,
+                group_id=gid,
+                user=user_mock,
+                db=manager_db,
+            )
+
+        assert len(result) == 2
+        slugs = {r.slug for r in result}
+        assert slugs == {'list-a', 'list-b'}
+        for r in result:
+            assert r.meta.tags is not None
+
+    @pytest.mark.asyncio
+    async def test_get_group_skill_handler(self, manager_db):
+        """Invoke get_group_skill handler and verify output."""
+        from types import SimpleNamespace
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from open_webui.routers.group_manager import get_group_skill
+
+        uid, gid, _ = await _setup_skill_manager(manager_db)
+        skill_id = _make_group_skill_id(gid, 'handler-get')
+
+        async with group_manager_tx(manager_db):
+            form = GroupManagerSkillCreateForm(
+                slug='handler-get', name='Handler Get',
+                tags=['get-tag'],
+            )
+            await _skill_insert_flush(skill_id, gid, form, uid, manager_db)
+            await GroupOwnedAssets.insert_asset(
+                resource_type='skill', resource_id=skill_id,
+                group_id=gid, created_by=uid, db=manager_db,
+            )
+            await _grant_access_flush(
+                'skill', skill_id, PRINCIPAL_TYPE_GROUP, gid, 'read', manager_db,
+            )
+
+        mock_request = MagicMock()
+        mock_request.state = SimpleNamespace(user=None)
+        user_mock = MagicMock()
+        user_mock.id = uid
+
+        with patch(
+            'open_webui.routers.group_manager.get_verified_user',
+            new_callable=AsyncMock,
+            return_value=user_mock,
+        ), patch(
+            'open_webui.routers.group_manager.get_async_session',
+            new_callable=AsyncMock,
+        ), patch(
+            'open_webui.routers.group_manager.publish_event',
+            new_callable=AsyncMock,
+        ):
+            result = await get_group_skill(
+                request=mock_request,
+                group_id=gid,
+                skill_id=skill_id,
+                user=user_mock,
+                db=manager_db,
+            )
+
+        assert result.id == skill_id
+        assert result.name == 'Handler Get'
+        assert result.meta.tags == ['get-tag']
+
+    @pytest.mark.asyncio
+    async def test_update_group_skill_handler(self, manager_db):
+        """Invoke update_group_skill handler and verify output."""
+        from types import SimpleNamespace
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from open_webui.routers.group_manager import update_group_skill
+
+        uid, gid, _ = await _setup_skill_manager(manager_db)
+        skill_id = _make_group_skill_id(gid, 'handler-upd')
+
+        await _insert_skill_row(
+            manager_db, skill_id,
+            name='Original Name', user_id=f'group-asset:{gid}',
+        )
+        async with group_manager_tx(manager_db):
+            await GroupOwnedAssets.insert_asset(
+                resource_type='skill', resource_id=skill_id,
+                group_id=gid, created_by=uid, db=manager_db,
+            )
+            await _grant_access_flush(
+                'skill', skill_id, PRINCIPAL_TYPE_GROUP, gid, 'read', manager_db,
+            )
+
+        mock_request = MagicMock()
+        mock_request.state = SimpleNamespace(user=None)
+        user_mock = MagicMock()
+        user_mock.id = uid
+        form_data = GroupManagerSkillUpdateForm(
+            name='Updated Name', tags=['new-tag'],
+        )
+
+        with patch(
+            'open_webui.routers.group_manager.get_verified_user',
+            new_callable=AsyncMock,
+            return_value=user_mock,
+        ), patch(
+            'open_webui.routers.group_manager.get_async_session',
+            new_callable=AsyncMock,
+        ), patch(
+            'open_webui.routers.group_manager.publish_event',
+            new_callable=AsyncMock,
+        ):
+            result = await update_group_skill(
+                request=mock_request,
+                group_id=gid,
+                skill_id=skill_id,
+                form_data=form_data,
+                user=user_mock,
+                db=manager_db,
+            )
+
+        assert result.id == skill_id
+        assert result.name == 'Updated Name'
+        assert result.meta.tags == ['new-tag']
+
+    @pytest.mark.asyncio
+    async def test_delete_group_skill_handler(self, manager_db):
+        """Invoke delete_group_skill handler and verify output."""
+        from types import SimpleNamespace
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from open_webui.routers.group_manager import delete_group_skill
+
+        uid, gid, _ = await _setup_skill_manager(manager_db)
+        skill_id = _make_group_skill_id(gid, 'handler-del')
+
+        await _insert_skill_row(
+            manager_db, skill_id,
+            name='To Delete', user_id=f'group-asset:{gid}',
+        )
+        async with group_manager_tx(manager_db):
+            await GroupOwnedAssets.insert_asset(
+                resource_type='skill', resource_id=skill_id,
+                group_id=gid, created_by=uid, db=manager_db,
+            )
+            await _grant_access_flush(
+                'skill', skill_id, PRINCIPAL_TYPE_GROUP, gid, 'read', manager_db,
+            )
+
+        mock_request = MagicMock()
+        mock_request.state = SimpleNamespace(user=None)
+        user_mock = MagicMock()
+        user_mock.id = uid
+
+        with patch(
+            'open_webui.routers.group_manager.get_verified_user',
+            new_callable=AsyncMock,
+            return_value=user_mock,
+        ), patch(
+            'open_webui.routers.group_manager.get_async_session',
+            new_callable=AsyncMock,
+        ), patch(
+            'open_webui.routers.group_manager.publish_event',
+            new_callable=AsyncMock,
+        ):
+            result = await delete_group_skill(
+                request=mock_request,
+                group_id=gid,
+                skill_id=skill_id,
+                user=user_mock,
+                db=manager_db,
+            )
+
+        assert result is True
+        # Skill row should be gone
+        skill_result = await manager_db.execute(
+            select(Skill).where(Skill.id == skill_id),
+        )
+        assert skill_result.scalars().first() is None
+        # Ownership row should be gone
+        ownership = await GroupOwnedAssets.get_asset_by_resource(
+            'skill', skill_id, db=manager_db,
+        )
+        assert ownership is None
+
+
+# ===================================================================
+# 23. P1: Legacy endpoint denial tests (actual handler invocation)
+# ===================================================================
+
+class TestLegacyEndpointDenialInvocation:
+    """Invoke the legacy skill update/delete handlers and verify that
+    former managers and ordinary members are denied."""
+
+    @pytest.mark.asyncio
+    async def test_former_manager_denied_on_legacy_update(self, manager_db):
+        """Former manager cannot update skill via legacy endpoint."""
+        from unittest.mock import MagicMock
+
+        from open_webui.models.skills import SkillForm
+        from open_webui.models.users import User
+        from open_webui.routers.skills import update_skill_by_id
+
+        uid, gid, _ = await _setup_skill_manager(manager_db)
+        skill_id = f'g-{gid[:12]}--leg-upd'
+
+        await _insert_skill_row(
+            manager_db, skill_id,
+            name='Legacy Upd', user_id=f'group-asset:{gid}',
+        )
+
+        # Remove membership
+        await manager_db.execute(
+            sa_delete(GroupMember).where(
+                GroupMember.group_id == gid,
+                GroupMember.user_id == uid,
+            )
+        )
+        await manager_db.flush()
+        if manager_db.info.get('manager_setup'):
+            await manager_db.commit()
+
+        user = await manager_db.get(User, uid)
+        assert user is not None
+        from open_webui.models.skills import SkillModel, Skills
+        stored_skill = await manager_db.get(Skill, skill_id)
+        assert stored_skill is not None
+        assert SkillModel.model_validate(stored_skill).id == skill_id
+        assert (await Skills._to_skill_model(stored_skill, db=manager_db)).id == skill_id
+        form = SkillForm(
+            id=skill_id,
+            name='Denied update',
+            content='must not be written',
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await update_skill_by_id(MagicMock(), skill_id, form, user, manager_db)
+        assert exc_info.value.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_ordinary_member_denied_on_legacy_delete(self, manager_db):
+        """Ordinary member without write grant cannot delete via legacy."""
+        from unittest.mock import MagicMock
+
+        from open_webui.models.users import User
+        from open_webui.routers.skills import delete_skill_by_id
+
+        uid_mgr, gid, _ = await _setup_skill_manager(manager_db)
+        member_uid = f'mbr-{uuid.uuid4().hex[:8]}'
+        await _create_user_in_db(manager_db, member_uid)
+
+        role = await _create_custom_role(
+            manager_db,
+            name=f'ws-del-{uuid.uuid4().hex[:8]}',
+            permissions={'workspace': {'skills': True}},
+        )
+        await _assign_custom_role(manager_db, member_uid, role.id)
+        await _add_membership(manager_db, gid, member_uid)
+
+        skill_id = f'g-{gid[:12]}--leg-del'
+        await _insert_skill_row(
+            manager_db, skill_id,
+            name='Legacy Del', user_id=f'group-asset:{gid}',
+        )
+
+        user = await manager_db.get(User, member_uid)
+        assert user is not None
+        with pytest.raises(HTTPException) as exc_info:
+            await delete_skill_by_id(MagicMock(), skill_id, user, manager_db)
+        assert exc_info.value.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_former_manager_denied_on_legacy_access_update(self, manager_db):
+        """Former manager cannot alter grants through the legacy endpoint."""
+        from unittest.mock import MagicMock
+
+        from open_webui.models.users import User
+        from open_webui.routers.skills import SkillAccessGrantsForm, update_skill_access_by_id
+
+        uid, gid, _ = await _setup_skill_manager(manager_db)
+
+        skill_id = f'g-{gid[:12]}--leg-access'
+        await _insert_skill_row(
+            manager_db, skill_id,
+            name='Legacy Access', user_id=f'group-asset:{gid}',
+        )
+        await manager_db.execute(
+            sa_delete(GroupMember).where(
+                GroupMember.group_id == gid,
+                GroupMember.user_id == uid,
+            )
+        )
+        await manager_db.commit()
+        user = await manager_db.get(User, uid)
+        assert user is not None
+        with pytest.raises(HTTPException) as exc_info:
+            await update_skill_access_by_id(
+                MagicMock(), skill_id, SkillAccessGrantsForm(access_grants=[]), user, manager_db
+            )
+        assert exc_info.value.status_code == 401
+
+
+# ===================================================================
+# 24. P1: Runtime tool authorization with plugins enabled
+# ===================================================================
+
+class TestToolAuthorizationPluginsEnabled:
+    """Upgrade of TestToolAuthorizationRuntime to prove get_tools()
+    properly checks access control when plugins are enabled and an
+    existing tool is mocked past the early-disabled branch."""
+
+    @pytest.mark.asyncio
+    async def test_get_tools_checks_access_control_when_enabled(self, manager_db):
+        """When ENABLE_PLUGINS=True, get_tools() checks access grants
+        for each tool.  Skill content mentioning tools must not bypass
+        this check."""
+        from unittest.mock import MagicMock, patch
+
+        from open_webui.models.tools import Tool
+        from open_webui.utils.tools import get_tools
+
+        uid, gid, _ = await _setup_skill_manager(manager_db)
+
+        now = int(time.time())
+        manager_db.add(
+            Tool(
+                id='web_search',
+                user_id='system',
+                name='Web Search',
+                content='def web_search(): pass',
+                specs=[],
+                meta={},
+                valves=None,
+                created_at=now,
+                updated_at=now,
+            )
+        )
+        await manager_db.commit()
+
+        mock_user = MagicMock()
+        mock_user.id = uid
+        mock_user.role = 'user'
+
+        mock_request = MagicMock()
+
+        with patch(
+            'open_webui.utils.tools.ENABLE_PLUGINS', True,
+        ):
+            tools = await get_tools(
+                mock_request,
+                tool_ids=['web_search'],
+                user=mock_user,
+                extra_params={'__user__': {}},
+            )
+
+        # Access was denied — tool must NOT appear in the result
+        assert isinstance(tools, dict)
+        assert len(tools) == 0
+
+    @pytest.mark.asyncio
+    async def test_get_tools_returns_tool_when_granted(self, manager_db):
+        """When a tool grant exists, get_tools() returns the tool."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from open_webui.models.tools import Tool
+        from open_webui.utils.tools import get_tools
+
+        uid, gid, _ = await _setup_skill_manager(manager_db)
+
+        now = int(time.time())
+        manager_db.add(
+            Tool(
+                id='granted_tool',
+                user_id='system',
+                name='Granted Tool',
+                content='def granted_tool(): pass',
+                specs=[{
+                    'name': 'run',
+                    'parameters': {
+                        'properties': {
+                            'query': {'type': 'string', 'description': 'search query'},
+                        },
+                    },
+                }],
+                meta={},
+                valves=None,
+                created_at=now,
+                updated_at=now,
+            )
+        )
+        await manager_db.commit()
+        await AccessGrants.grant_access(
+            'tool', 'granted_tool', 'user', uid, 'read', db=manager_db
+        )
+
+        mock_user = MagicMock()
+        mock_user.id = uid
+        mock_user.role = 'user'
+
+        mock_module = MagicMock()
+
+        mock_request = MagicMock()
+
+        mock_callable = MagicMock()
+        mock_callable.__doc__ = None
+
+        with patch(
+            'open_webui.utils.tools.ENABLE_PLUGINS', True,
+        ), patch(
+            'open_webui.utils.tools.load_tool_module_by_id',
+            new_callable=AsyncMock,
+            return_value=(mock_module, 'loaded'),
+        ), patch(
+            'open_webui.utils.tools.get_tools_cache',
+            return_value={},
+        ), patch(
+            'open_webui.utils.tools.get_tool_contents_cache',
+            return_value={},
+        ), patch(
+            'open_webui.utils.tools.get_async_tool_function_and_apply_extra_params',
+            new_callable=AsyncMock,
+            return_value=mock_callable,
+        ):
+            tools = await get_tools(
+                mock_request,
+                tool_ids=['granted_tool'],
+                user=mock_user,
+                extra_params={'__user__': {}},
+            )
+
+        # Access was granted — tool must appear (keyed by function name 'run')
+        assert 'run' in tools
+        assert tools['run']['tool_id'] == 'granted_tool'

--- a/backend/tests/test_group_manager_skills.py
+++ b/backend/tests/test_group_manager_skills.py
@@ -611,15 +611,21 @@ class TestFormerManagerDenial:
 
     @pytest.mark.asyncio
     async def test_deactivated_role_denied(self, manager_db):
-        """After deactivating the role, the manager is denied."""
+        """After deactivation, the assignment is reset before access is denied."""
         uid, gid, role = await _setup_skill_manager(manager_db)
 
         await CustomRoles.deactivate_role(role.id, db=manager_db)
 
+        from open_webui.models.users import User
+
+        user_row = await manager_db.get(User, uid)
+        assert user_row.role == 'user'
+        await manager_db.commit()
+
         async with group_manager_tx(manager_db):
             with pytest.raises(GroupManagerError) as exc_info:
                 await require_group_manager(uid, gid, 'groups.manage_skills', manager_db)
-            assert exc_info.value.reason == 'invalid_custom_role'
+            assert exc_info.value.reason == 'legacy_role_denied'
 
 
 # ===================================================================

--- a/docs/CUSTOM_ROLES.md
+++ b/docs/CUSTOM_ROLES.md
@@ -1,0 +1,185 @@
+# Custom roles and group managers
+
+This guide describes the backend custom-role and scoped group-manager behavior.
+It is intended for administrators deploying or operating a version that includes
+the custom-role migrations.
+
+## Role semantics
+
+- **`admin` is an exact role.** Administrative endpoints use the literal
+  `admin` value. A custom role, even one with every permission leaf enabled,
+  does not receive the admin bypass and cannot use the admin-only custom-role
+  endpoints.
+- **`user` and `pending` retain the legacy path.** Their permissions continue
+  to use configured defaults and the existing most-permissive group merge.
+  These roles do not provide group-manager authority.
+- **Custom roles use opaque references.** A user is assigned a value such as
+  `custom:<role-uuid>`, backed by the `custom_role` registry. The role's
+  explicit, server-catalog permissions are normalized with omitted leaves set
+  to `false`; group permissions and configured defaults are not merged into a
+  custom role.
+- **Invalid roles fail closed.** A malformed or unknown custom-role reference
+  resolves to no permissions. Role names are normalized and unique; `admin`,
+  `user`, and `pending` are reserved names. The lifecycle APIs reset assigned
+  users before deactivation or deletion, so an inactive reference should only
+  remain as legacy data from an interrupted or manual database change.
+
+Custom-role assignment is deliberately manual. OAuth, LDAP, SCIM, and
+trusted-header provisioning do not silently assign a custom role.
+
+## Manual role administration
+
+The admin-only API is rooted at `/api/v1/custom-roles`. Use an authenticated
+exact-admin session; do not edit `User.role` directly.
+
+1. Create a role with `POST /api/v1/custom-roles/create`:
+
+   ```json
+   {
+     "name": "content-manager",
+     "display_name": "Content manager",
+     "permissions": {
+       "groups": {
+         "manage_members": true,
+         "manage_assets": true,
+         "manage_skills": true
+       }
+     }
+   }
+   ```
+
+   Permission leaves not supplied in the request are denied. The response
+   contains the immutable role UUID needed for assignment.
+
+2. Assign an active role with `POST /api/v1/custom-roles/assign` and a body
+   of `{"user_id": "<user-id>", "role_id": "<role-uuid>"}`. The target user
+   must exist, and an administrator cannot assign a role to themselves through
+   this endpoint. The first admin cannot be demoted.
+
+3. Deactivate a role with
+   `POST /api/v1/custom-roles/<role-uuid>/deactivate`, or update it with
+   `POST /api/v1/custom-roles/<role-uuid>/update` and `{"active": false}`.
+   Deactivation atomically resets every current `custom:<role-uuid>`
+   assignment to the legacy `user` role before committing `active=false`. The
+   operation is safe to repeat; it does not change unrelated roles. Reactivation
+   is available with `{"active": true}`, but users must be assigned again.
+
+4. Delete a role with
+   `DELETE /api/v1/custom-roles/<role-uuid>`. Deletion atomically resets every
+   current assignment to `user` and removes the registry row. A missing role is
+   not deleted again and returns not found.
+
+5. Remove an assignment with
+   `POST /api/v1/custom-roles/<role-uuid>/unassign?user_id=<user-id>`.
+   This changes the user to the legacy `pending` role; it does not restore a
+   previous role automatically.
+
+Role creation, updates, deactivation, assignment, and user-role changes emit
+metadata-only lifecycle events. Review those events after any bulk operation.
+
+## Group-manager boundary
+
+The scoped service is additive and is rooted at
+`/api/v1/group-manager/groups/<group-id>/...`. A caller is a manager for a
+group only when all of these facts are true at authorization time:
+
+The manager workspace discovers eligible groups through the separately scoped
+`GET /api/v1/group-manager/groups` endpoint; it must not use legacy group APIs.
+
+1. the caller has an active `custom:<role-uuid>` reference;
+2. the role contains the exact capability required by the operation; and
+3. the caller is a current member of the target group.
+
+`groups.manage_members`, `groups.manage_assets`, and `groups.manage_skills` are
+independent capabilities. For example, `manage_members` does not authorize
+asset or skill changes. Membership, role, and group checks are performed in
+the same transaction as each mutation, so removing membership or deactivating
+the role takes effect at the boundary of a subsequent request.
+
+Group creator IDs, resource creator IDs, and ordinary access grants do not
+establish manager authority. Exact-admin and legacy users are intentionally
+denied by the scoped manager service; administrators should use the existing
+admin routes instead. A manager can operate only on the group in the request,
+not on another group they do not currently belong to.
+
+## Scoped resources and exclusions
+
+The current group-owned resource allowlist is:
+
+| Resource  | Capability             | Scoped behavior                                                                                                                                                                         |
+| --------- | ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Knowledge | `groups.manage_assets` | Create, list, update, delete, and adjust the owning group's write grant. The owning group always keeps baseline read access.                                                            |
+| Prompts   | `groups.manage_assets` | Create, list, update, delete, and adjust the owning group's write grant. Public, user, and other-group grants cannot be supplied or replaced.                                           |
+| Skills    | `groups.manage_skills` | Create, list, read, update, and delete. IDs, `user_id`, ownership, and grants are server-controlled; the owning group receives baseline read only and has no ACL write-delta operation. |
+
+Knowledge and prompt ownership is authoritative in `group_owned_asset`, with
+one owning group per resource. Ownership cannot be inferred from an access
+grant, transferred through the scoped API, or used to grant another principal.
+All resource, ownership, and baseline-grant writes are committed atomically.
+
+**Models and tools are explicitly excluded from group-manager scoped support.**
+The presence of ordinary `workspace.models` or `workspace.tools` leaves in the
+custom-role catalog does not create group-owned model/tool routes. Do not use a
+manager role as a substitute for model administration. Tool creation/update is
+server-side Python code execution and must be treated as root-equivalent trust;
+it is not a contained group capability.
+
+## Audit and redaction
+
+- Scoped manager events are published only after a successful commit and omit
+  resource content. Role events contain identifiers and role metadata, not the
+  role's user content.
+- When HTTP audit body capture is enabled, scoped **skill** list/create/read/
+  update/delete paths are marked before request handling and both request and
+  response bodies are logged as `[REDACTED]`. This also covers validation and
+  authorization failures.
+- The route-specific redaction does **not** cover knowledge or prompt bodies,
+  nor arbitrary custom-role request bodies. For sensitive deployments, use
+  `AUDIT_LOG_LEVEL=METADATA` (or configure `AUDIT_INCLUDED_PATHS` narrowly)
+  rather than capturing request/response bodies. `AUDIT_LOG_LEVEL` defaults to
+  `NONE`; audit files otherwise default to `<DATA_DIR>/audit.log`.
+
+## Deployment, migration, and rollback
+
+Before upgrading, take a consistent database backup and back up the Open WebUI
+data volume. The feature schema is introduced by these revisions, in order:
+
+- `c5a8d3e2f1b0`: `custom_role` registry;
+- `fdcb6cc75284`: `group_owned_asset` and its ownership constraints;
+- `a2b3c4d5e6f7`: adds `skill` to the owned-resource allowlist.
+
+Migrations run at startup when `ENABLE_DB_MIGRATIONS=true` (the default). In a
+multi-node deployment, designate one migration runner and prevent concurrent
+startup migrations from multiple nodes. Confirm the startup log reaches the
+repository's current Alembic head before assigning roles or creating scoped
+assets. These migrations do not backfill assignments or create managers.
+
+Rollback should normally be a restore of the pre-upgrade database/data-volume
+backup together with the previous application version. Do not treat Alembic
+downgrade as a routine rollback: the custom-role downgrade removes the role
+registry, the ownership downgrade removes group ownership records, and
+downgrading the skill allowlist can be incompatible with existing group-owned
+skills. If a downgrade is unavoidable, stop application writers, take another
+backup, inventory custom-role references and group-owned assets, and rehearse
+the exact downgrade and restore procedure on a copy first.
+
+## Operator validation checklist
+
+After deployment, verify in a non-production test group and test account:
+
+1. The migration log and database revision table show the current head, and
+   `custom_role` and `group_owned_asset` exist.
+2. An exact admin can create, assign, update, deactivate, reactivate, and
+   unassign a role; a custom-role user cannot call the admin role API.
+3. A manager with only `manage_members`, `manage_assets`, or `manage_skills`
+   is limited to that capability. Remove the user from the group and confirm
+   the next scoped request is denied; verify deactivation or deletion resets
+   assigned users to `user` and leaves unrelated roles unchanged.
+4. Knowledge, prompt, and skill create/update/delete operations stay within
+   the owning group. Confirm skills have read-only group grants and that model
+   and tool manager operations are rejected or unavailable.
+5. With temporary audit capture enabled, exercise a skill endpoint (including
+   a rejected request) and confirm request and response bodies are
+   `[REDACTED]`. Do not put production content in this test.
+6. Preserve the backup and record the migration head, validation results, and
+   any role assignments in the deployment change record.

--- a/src/lib/apis/groupManager/index.test.ts
+++ b/src/lib/apis/groupManager/index.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { addGroupManagerMembers, getGroupManagerAssets, getGroupManagerGroups } from './index';
+
+describe('group manager API client', () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('keeps member mutations group-scoped and sends only user ids', async () => {
+		const fetchMock = vi.fn().mockResolvedValue(new Response('[]', { status: 200 }));
+		vi.stubGlobal('fetch', fetchMock);
+
+		await addGroupManagerMembers('token', 'group/1', ['user-1']);
+
+		expect(fetchMock).toHaveBeenCalledWith(
+			'/api/v1/group-manager/groups/group%2F1/members/add',
+			expect.objectContaining({
+				method: 'POST',
+				body: JSON.stringify({ user_ids: ['user-1'] })
+			})
+		);
+	});
+
+	it('passes the asset type filter without broad workspace endpoints', async () => {
+		const fetchMock = vi.fn().mockResolvedValue(new Response('[]', { status: 200 }));
+		vi.stubGlobal('fetch', fetchMock);
+
+		await getGroupManagerAssets('token', 'group-1', 'knowledge');
+
+		expect(fetchMock.mock.calls[0][0]).toBe(
+			'/api/v1/group-manager/groups/group-1/assets?resource_type=knowledge'
+		);
+	});
+
+	it('uses the additive minimal group discovery endpoint', async () => {
+		const fetchMock = vi.fn().mockResolvedValue(new Response('[]', { status: 200 }));
+		vi.stubGlobal('fetch', fetchMock);
+
+		await getGroupManagerGroups('token');
+
+		expect(fetchMock.mock.calls[0][0]).toBe('/api/v1/group-manager/groups');
+	});
+});

--- a/src/lib/apis/groupManager/index.ts
+++ b/src/lib/apis/groupManager/index.ts
@@ -1,0 +1,87 @@
+import { WEBUI_API_BASE_URL } from '$lib/constants';
+
+const request = async (token: string, path: string, options: RequestInit = {}) => {
+	const response = await fetch(`${WEBUI_API_BASE_URL}/group-manager${path}`, {
+		...options,
+		headers: {
+			Accept: 'application/json',
+			'Content-Type': 'application/json',
+			Authorization: `Bearer ${token}`,
+			...(options.headers ?? {})
+		}
+	});
+	if (!response.ok) {
+		const body = await response.json().catch(() => ({}));
+		const error: any = new Error(body?.detail ?? 'Unable to access this group workspace.');
+		error.status = response.status;
+		throw error;
+	}
+	return response.json();
+};
+
+const json = (body: unknown): RequestInit => ({ method: 'POST', body: JSON.stringify(body) });
+
+export const getGroupManagerGroups = (token: string) => request(token, '/groups');
+
+export const getGroupManagerMembers = (token: string, groupId: string) =>
+	request(token, `/groups/${encodeURIComponent(groupId)}/members`);
+export const addGroupManagerMembers = (token: string, groupId: string, userIds: string[]) =>
+	request(token, `/groups/${encodeURIComponent(groupId)}/members/add`, json({ user_ids: userIds }));
+export const deleteGroupManagerMembers = (token: string, groupId: string, userIds: string[]) =>
+	request(
+		token,
+		`/groups/${encodeURIComponent(groupId)}/members/remove`,
+		json({ user_ids: userIds })
+	);
+
+export const getGroupManagerAssets = (token: string, groupId: string, resourceType?: string) =>
+	request(
+		token,
+		`/groups/${encodeURIComponent(groupId)}/assets${resourceType ? `?resource_type=${encodeURIComponent(resourceType)}` : ''}`
+	);
+export const createGroupKnowledge = (
+	token: string,
+	groupId: string,
+	data: { name: string; description?: string }
+) => request(token, `/groups/${encodeURIComponent(groupId)}/assets/knowledge/create`, json(data));
+export const updateGroupKnowledge = (token: string, groupId: string, id: string, data: object) =>
+	request(
+		token,
+		`/groups/${encodeURIComponent(groupId)}/assets/knowledge/${encodeURIComponent(id)}/update`,
+		json(data)
+	);
+export const deleteGroupKnowledge = (token: string, groupId: string, id: string) =>
+	request(
+		token,
+		`/groups/${encodeURIComponent(groupId)}/assets/knowledge/${encodeURIComponent(id)}/delete`,
+		{ method: 'DELETE' }
+	);
+export const createGroupPrompt = (token: string, groupId: string, data: object) =>
+	request(token, `/groups/${encodeURIComponent(groupId)}/assets/prompts/create`, json(data));
+export const updateGroupPrompt = (token: string, groupId: string, id: string, data: object) =>
+	request(
+		token,
+		`/groups/${encodeURIComponent(groupId)}/assets/prompts/${encodeURIComponent(id)}/update`,
+		json(data)
+	);
+export const deleteGroupPrompt = (token: string, groupId: string, id: string) =>
+	request(
+		token,
+		`/groups/${encodeURIComponent(groupId)}/assets/prompts/${encodeURIComponent(id)}/delete`,
+		{ method: 'DELETE' }
+	);
+
+export const getGroupManagerSkills = (token: string, groupId: string) =>
+	request(token, `/groups/${encodeURIComponent(groupId)}/skills`);
+export const createGroupSkill = (token: string, groupId: string, data: object) =>
+	request(token, `/groups/${encodeURIComponent(groupId)}/skills/create`, json(data));
+export const updateGroupSkill = (token: string, groupId: string, id: string, data: object) =>
+	request(
+		token,
+		`/groups/${encodeURIComponent(groupId)}/skills/${encodeURIComponent(id)}/update`,
+		json(data)
+	);
+export const deleteGroupSkill = (token: string, groupId: string, id: string) =>
+	request(token, `/groups/${encodeURIComponent(groupId)}/skills/${encodeURIComponent(id)}/delete`, {
+		method: 'DELETE'
+	});

--- a/src/lib/apis/users/customRoles.test.ts
+++ b/src/lib/apis/users/customRoles.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { deleteCustomRole, updateCustomRole } from './index';
+
+describe('custom role lifecycle API client', () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('deletes a role through the dedicated role endpoint', async () => {
+		const fetchMock = vi.fn().mockResolvedValue(new Response('true', { status: 200 }));
+		vi.stubGlobal('fetch', fetchMock);
+
+		await deleteCustomRole('token', 'role-1');
+
+		expect(fetchMock).toHaveBeenCalledWith(
+			'/api/v1/custom-roles/role-1',
+			expect.objectContaining({ method: 'DELETE' })
+		);
+	});
+
+	it('uses active updates for the accessible lifecycle toggle', async () => {
+		const fetchMock = vi.fn().mockResolvedValue(new Response('{}', { status: 200 }));
+		vi.stubGlobal('fetch', fetchMock);
+
+		await updateCustomRole('token', 'role-1', { active: false });
+
+		expect(fetchMock.mock.calls[0][1]).toEqual(
+			expect.objectContaining({
+				method: 'POST',
+				body: JSON.stringify({ active: false })
+			})
+		);
+	});
+});

--- a/src/lib/apis/users/index.ts
+++ b/src/lib/apis/users/index.ts
@@ -1,6 +1,73 @@
 import { WEBUI_API_BASE_URL } from '$lib/constants';
 import { getUserPosition } from '$lib/utils';
 
+export type CustomRole = {
+	id: string;
+	name: string;
+	display_name: string;
+	active: boolean;
+	permissions: Record<string, any>;
+	created_at: number;
+	updated_at: number;
+};
+
+const customRoleRequest = async (token: string, path: string, options: RequestInit = {}) => {
+	const res = await fetch(`${WEBUI_API_BASE_URL}/custom-roles${path}`, {
+		...options,
+		headers: {
+			'Content-Type': 'application/json',
+			Authorization: `Bearer ${token}`,
+			...(options.headers ?? {})
+		}
+	});
+	if (!res.ok) {
+		const error = await res.json().catch(() => ({}));
+		throw error?.detail ?? 'Unable to complete the custom role request.';
+	}
+	return res.json();
+};
+
+export const getCustomRoles = async (token: string, includeInactive = false, page = 1) =>
+	customRoleRequest(token, `/?include_inactive=${includeInactive}&page=${page}`);
+
+/** Server-owned custom-role permission contract. Do not replace with client defaults. */
+export const getCustomRolePermissionCatalog = async (token: string) =>
+	customRoleRequest(token, '/permissions');
+
+export const createCustomRole = async (
+	token: string,
+	role: { name: string; display_name: string; permissions: Record<string, any> }
+) => customRoleRequest(token, '/create', { method: 'POST', body: JSON.stringify(role) });
+
+export const updateCustomRole = async (
+	token: string,
+	id: string,
+	role: { display_name?: string; active?: boolean; permissions?: Record<string, any> }
+) => customRoleRequest(token, `/${id}/update`, { method: 'POST', body: JSON.stringify(role) });
+
+export const deactivateCustomRole = async (token: string, id: string) =>
+	customRoleRequest(token, `/${id}/deactivate`, { method: 'POST' });
+
+export const reactivateCustomRole = async (token: string, id: string) =>
+	customRoleRequest(token, `/${id}/update`, {
+		method: 'POST',
+		body: JSON.stringify({ active: true })
+	});
+
+export const deleteCustomRole = async (token: string, id: string) =>
+	customRoleRequest(token, `/${id}`, { method: 'DELETE' });
+
+export const assignCustomRole = async (token: string, userId: string, roleId: string) =>
+	customRoleRequest(token, '/assign', {
+		method: 'POST',
+		body: JSON.stringify({ user_id: userId, role_id: roleId })
+	});
+
+export const unassignCustomRole = async (token: string, roleId: string, userId: string) =>
+	customRoleRequest(token, `/${roleId}/unassign?user_id=${encodeURIComponent(userId)}`, {
+		method: 'POST'
+	});
+
 export const getUserGroups = async (token: string) => {
 	let error = null;
 

--- a/src/lib/components/admin/Users.svelte
+++ b/src/lib/components/admin/Users.svelte
@@ -10,6 +10,7 @@
 
 	import UserList from './Users/UserList.svelte';
 	import Groups from './Users/Groups.svelte';
+	import Roles from './Users/Roles.svelte';
 
 	const i18n = getContext('i18n');
 
@@ -17,7 +18,7 @@
 	$: {
 		const pathParts = $page.url.pathname.split('/');
 		const tabFromPath = pathParts[pathParts.length - 1];
-		selectedTab = ['overview', 'groups'].includes(tabFromPath) ? tabFromPath : 'overview';
+		selectedTab = ['overview', 'groups', 'roles'].includes(tabFromPath) ? tabFromPath : 'overview';
 	}
 
 	$: if (selectedTab) {
@@ -120,6 +121,18 @@
 					</div>
 				{/if}
 			</a>
+
+			<a
+				id="roles"
+				href="/admin/users/roles"
+				draggable="false"
+				class="px-0.5 py-1 min-w-fit rounded-lg lg:flex-none flex items-center gap-1.5 text-right transition select-none {selectedTab ===
+				'roles'
+					? ''
+					: ' text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
+			>
+				<div class="self-center">{$i18n.t('Roles')}</div>
+			</a>
 		</div>
 
 		<div class="flex-1 px-3.5 lg:pr-[1rem] lg:pl-0 overflow-y-scroll">
@@ -127,6 +140,8 @@
 				<UserList />
 			{:else if selectedTab === 'groups'}
 				<Groups />
+			{:else if selectedTab === 'roles'}
+				<Roles />
 			{/if}
 		</div>
 	</div>

--- a/src/lib/components/admin/Users/CustomRoleModal.svelte
+++ b/src/lib/components/admin/Users/CustomRoleModal.svelte
@@ -1,0 +1,178 @@
+<script lang="ts">
+	import { getContext } from 'svelte';
+	import Modal from '$lib/components/common/Modal.svelte';
+	import XMark from '$lib/components/icons/XMark.svelte';
+	import Spinner from '$lib/components/common/Spinner.svelte';
+	import { getCustomRolePermissionCatalog } from '$lib/apis/users';
+
+	const i18n: any = getContext('i18n');
+	export let show = false;
+	export let role: any = null;
+	export let onSubmit: (data: any) => Promise<void> = async () => {};
+
+	let name = '';
+	let displayName = '';
+	let permissions: Record<string, any> = {};
+	let catalog: Record<string, any> = {};
+	let catalogLoading = false;
+	let catalogError = '';
+	let initializedRole = '';
+	let saving = false;
+
+	$: if (show && initializedRole !== (role?.id ?? 'new')) {
+		initializedRole = role?.id ?? 'new';
+		init();
+	}
+	$: if (!show) initializedRole = '';
+
+	const cloneContract = (value: any): any =>
+		Object.fromEntries(
+			Object.entries(value ?? {}).map(([key, child]) => [
+				key,
+				typeof child === 'object' && child !== null ? cloneContract(child) : false
+			])
+		);
+	const flatten = (value: any, prefix = ''): { path: string; label: string; section: string }[] =>
+		Object.entries(value ?? {}).flatMap(([key, child]) => {
+			const path = prefix ? `${prefix}.${key}` : key;
+			return typeof child === 'object' && child !== null
+				? flatten(child, path)
+				: [
+						{
+							path,
+							label: key.replaceAll('_', ' '),
+							section: prefix.split('.')[0] || 'Permissions'
+						}
+					];
+		});
+	$: permissionEntries = flatten(catalog);
+	$: sections = [...new Set(permissionEntries.map((entry) => entry.section))];
+
+	const setPermission = (path: string, value: boolean) => {
+		const keys = path.split('.');
+		let target = permissions;
+		keys.slice(0, -1).forEach((key) => (target = target[key] ??= {}));
+		target[keys.at(-1) as string] = value;
+		permissions = { ...permissions };
+	};
+	const getPermission = (path: string) =>
+		(path.split('.').reduce((value: any, key) => value?.[key], permissions) as any) === true;
+
+	const init = async () => {
+		name = role?.name ?? '';
+		displayName = role?.display_name ?? '';
+		catalogLoading = true;
+		catalogError = '';
+		try {
+			const response = await getCustomRolePermissionCatalog(localStorage.token);
+			catalog = response?.permissions ?? response?.catalog ?? response ?? {};
+			permissions = cloneContract(catalog);
+			for (const entry of flatten(role?.permissions ?? {}))
+				setPermission(entry.path, getPermissionFrom(role.permissions, entry.path));
+		} catch (error) {
+			catalogError = `${error}`;
+		} finally {
+			catalogLoading = false;
+		}
+	};
+	const getPermissionFrom = (value: any, path: string) =>
+		path.split('.').reduce((current, key) => current?.[key], value) === true;
+
+	const submit = async () => {
+		saving = true;
+		try {
+			await onSubmit({ name, display_name: displayName, permissions });
+			show = false;
+		} finally {
+			saving = false;
+		}
+	};
+</script>
+
+<Modal size="lg" bind:show>
+	<div class="max-h-[85vh] overflow-y-auto px-5 pb-5 dark:text-gray-200">
+		<div class="flex items-center justify-between py-3">
+			<h2 class="text-sm font-medium">
+				{role ? $i18n.t('Edit Custom Role') : $i18n.t('New Custom Role')}
+			</h2>
+			<button
+				class="rounded-lg p-1 text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800"
+				aria-label={$i18n.t('Close')}
+				on:click={() => (show = false)}
+			>
+				<XMark className="size-4" />
+			</button>
+		</div>
+		<form class="space-y-4" on:submit|preventDefault={submit}>
+			<div class="grid gap-3 sm:grid-cols-2">
+				<label class="block text-xs text-gray-500"
+					>{$i18n.t('Internal name')}
+					<input
+						class="mt-1 w-full rounded-lg bg-transparent px-2.5 py-2 text-sm ring-1 ring-gray-200 outline-hidden dark:ring-gray-700"
+						bind:value={name}
+						disabled={!!role}
+						required
+						pattern="[a-z0-9_-]+"
+						aria-describedby="role-name-help"
+					/>
+					<span id="role-name-help" class="mt-1 block text-[11px]"
+						>{$i18n.t('Lowercase letters, numbers, hyphens, and underscores.')}</span
+					>
+				</label>
+				<label class="block text-xs text-gray-500"
+					>{$i18n.t('Display name')}
+					<input
+						class="mt-1 w-full rounded-lg bg-transparent px-2.5 py-2 text-sm ring-1 ring-gray-200 outline-hidden dark:ring-gray-700"
+						bind:value={displayName}
+						required
+						maxlength="128"
+					/>
+				</label>
+			</div>
+			<div class="border-t border-gray-100 pt-3 dark:border-gray-800">
+				<div class="mb-3 text-xs text-gray-500">{$i18n.t('Permissions')}</div>
+				{#if catalogLoading}<Spinner className="size-5" />{:else if catalogError}<div
+						class="rounded-lg bg-red-50 p-3 text-xs text-red-700 dark:bg-red-950/30 dark:text-red-300"
+						role="alert"
+					>
+						{$i18n.t('Could not load the permission catalog')}: {catalogError}
+					</div>{:else if permissionEntries.length === 0}<div class="text-xs text-gray-500">
+						{$i18n.t('No permissions are available.')}
+					</div>{:else}
+					<div class="grid gap-4 sm:grid-cols-2">
+						{#each sections as section}<fieldset>
+								<legend class="mb-2 text-sm font-medium capitalize"
+									>{section.replaceAll('_', ' ')}</legend
+								>
+								<div class="space-y-2">
+									{#each permissionEntries.filter((entry) => entry.section === section) as entry}<label
+											class="flex items-center justify-between gap-3 text-xs capitalize text-gray-600 dark:text-gray-300"
+											><span>{entry.label}</span><input
+												type="checkbox"
+												checked={getPermission(entry.path)}
+												on:change={(event) =>
+													setPermission(entry.path, event.currentTarget.checked)}
+												aria-label={entry.path}
+											/></label
+										>{/each}
+								</div>
+							</fieldset>{/each}
+					</div>
+				{/if}
+			</div>
+			<div class="flex justify-end gap-2 border-t border-gray-100 pt-4 dark:border-gray-800">
+				<button
+					type="button"
+					class="rounded-full px-3.5 py-1.5 text-sm hover:bg-gray-100 dark:hover:bg-gray-800"
+					on:click={() => (show = false)}>{$i18n.t('Cancel')}</button
+				>
+				<button
+					type="submit"
+					disabled={saving || catalogLoading || !!catalogError || permissionEntries.length === 0}
+					class="rounded-full bg-black px-3.5 py-1.5 text-sm text-white disabled:opacity-50 dark:bg-white dark:text-black"
+					>{saving ? $i18n.t('Saving') : $i18n.t('Save')}</button
+				>
+			</div>
+		</form>
+	</div>
+</Modal>

--- a/src/lib/components/admin/Users/Roles.svelte
+++ b/src/lib/components/admin/Users/Roles.svelte
@@ -1,0 +1,262 @@
+<script lang="ts">
+	import { getContext, onMount } from 'svelte';
+	import { toast } from 'svelte-sonner';
+	import {
+		createCustomRole,
+		deleteCustomRole,
+		getCustomRoles,
+		updateCustomRole
+	} from '$lib/apis/users';
+	import CustomRoleModal from './CustomRoleModal.svelte';
+	import Spinner from '$lib/components/common/Spinner.svelte';
+	import Search from '$lib/components/icons/Search.svelte';
+	import XMark from '$lib/components/icons/XMark.svelte';
+	import EditPencil from '$lib/components/icons/EditPencil.svelte';
+	import Trash from '$lib/components/icons/Trash.svelte';
+	import Tooltip from '$lib/components/common/Tooltip.svelte';
+	import Switch from '$lib/components/common/Switch.svelte';
+	import ConfirmDialog from '$lib/components/common/ConfirmDialog.svelte';
+
+	const i18n: any = getContext('i18n');
+	let roles: any[] = [];
+	let loading = true;
+	let query = '';
+	let showModal = false;
+	let editingRole: any = null;
+	let statusMessage = '';
+	let loadError = '';
+	let pendingRoleId = '';
+	let pendingDeactivationRole: any = null;
+	let showDeactivateConfirm = false;
+	let switchVersion = 0;
+
+	$: filteredRoles = roles.filter((r) =>
+		`${r.display_name} ${r.name}`.toLowerCase().includes(query.toLowerCase())
+	);
+
+	const load = async () => {
+		loading = true;
+		loadError = '';
+		try {
+			const roleResponse = await getCustomRoles(localStorage.token, true);
+			roles = roleResponse?.items ?? [];
+		} catch (error) {
+			statusMessage = `${error}`;
+			loadError = statusMessage;
+			toast.error(statusMessage);
+		} finally {
+			loading = false;
+		}
+	};
+
+	const saveRole = async (data: any) => {
+		try {
+			if (editingRole)
+				await updateCustomRole(localStorage.token, editingRole.id, {
+					display_name: data.display_name,
+					permissions: data.permissions
+				});
+			else await createCustomRole(localStorage.token, data);
+			statusMessage = $i18n.t('Custom role saved successfully');
+			toast.success(statusMessage);
+			await load();
+		} catch (error) {
+			toast.error(`${error}`);
+			throw error;
+		}
+	};
+
+	const deactivate = async (role: any) => {
+		if (pendingRoleId) return;
+		pendingRoleId = role.id;
+		try {
+			await updateCustomRole(localStorage.token, role.id, { active: !role.active });
+			statusMessage = role.active
+				? $i18n.t('Role deactivated; assigned users were reset to user.')
+				: $i18n.t('Role reactivated successfully');
+			toast.success(statusMessage);
+			await load();
+		} catch (error) {
+			statusMessage = `${error}`;
+			toast.error(statusMessage);
+		} finally {
+			pendingRoleId = '';
+		}
+	};
+
+	const restoreSwitch = () => {
+		switchVersion += 1;
+	};
+
+	const toggleRole = (role: any, nextState: boolean) => {
+		if (role.active && !nextState) {
+			pendingDeactivationRole = role;
+			showDeactivateConfirm = true;
+			restoreSwitch();
+			return;
+		}
+
+		deactivate(role);
+	};
+
+	const deleteRole = async (role: any) => {
+		if (pendingRoleId) return;
+		if (
+			!confirm(
+				$i18n.t('Delete this role? Assigned users will be reset to user and this cannot be undone.')
+			)
+		)
+			return;
+		pendingRoleId = role.id;
+		try {
+			await deleteCustomRole(localStorage.token, role.id);
+			statusMessage = $i18n.t('Role deleted; assigned users were reset to user.');
+			toast.success(statusMessage);
+			await load();
+		} catch (error) {
+			statusMessage = `${error}`;
+			toast.error(statusMessage);
+		} finally {
+			pendingRoleId = '';
+		}
+	};
+
+	onMount(load);
+</script>
+
+<ConfirmDialog
+	bind:show={showDeactivateConfirm}
+	title={$i18n.t('Deactivate role')}
+	message={$i18n.t(
+		'Deactivating this role resets every assigned user to the legacy user role. This cannot be undone for those assignments.'
+	)}
+	confirmLabel={$i18n.t('Deactivate')}
+	on:confirm={() => {
+		if (pendingDeactivationRole) deactivate(pendingDeactivationRole);
+		pendingDeactivationRole = null;
+	}}
+	on:cancel={() => {
+		pendingDeactivationRole = null;
+		restoreSwitch();
+	}}
+/>
+
+<CustomRoleModal bind:show={showModal} role={editingRole} onSubmit={saveRole} />
+<div class="space-y-5">
+	<div aria-live="polite" class="sr-only">{statusMessage}</div>
+	<div
+		class="rounded-lg border border-gray-100 bg-gray-50/70 px-3 py-2 text-xs text-gray-600 dark:border-gray-800 dark:bg-gray-850/50 dark:text-gray-300"
+	>
+		{$i18n.t('Deactivating or deleting a role resets assigned users to the legacy user role.')}
+	</div>
+	<div class="sticky top-0 z-10 bg-white dark:bg-gray-900">
+		<div class="flex min-h-8 flex-wrap items-center gap-2">
+			<div class="flex min-w-[12rem] flex-1 items-center">
+				<Search className="mx-3 size-3.5" />
+				<input
+					class="w-full bg-transparent py-1 text-sm outline-hidden"
+					bind:value={query}
+					placeholder={$i18n.t('Search roles')}
+					aria-label={$i18n.t('Search roles')}
+				/>
+				{#if query}<button
+						class="p-1"
+						aria-label={$i18n.t('Clear search')}
+						on:click={() => (query = '')}><XMark className="size-3" /></button
+					>{/if}
+			</div>
+			<button
+				class="rounded-lg bg-gray-50 px-2.5 py-1 text-xs ring-1 ring-gray-200 hover:bg-gray-100 dark:bg-gray-850 dark:ring-gray-800"
+				on:click={() => {
+					editingRole = null;
+					showModal = true;
+				}}>{$i18n.t('New Role')}</button
+			>
+		</div>
+	</div>
+	{#if loadError}
+		<div
+			class="rounded-lg bg-red-50 px-3 py-2 text-xs text-red-700 dark:bg-red-950/30 dark:text-red-300"
+			role="alert"
+		>
+			{$i18n.t('Could not load custom roles')}: {loadError}
+		</div>
+	{/if}
+
+	{#if loading}<Spinner className="my-10 size-5" />{:else if filteredRoles.length === 0}<div
+			class="py-16 text-center text-sm text-gray-500"
+		>
+			{$i18n.t('No custom roles found')}
+		</div>{:else}
+		<div class="overflow-x-auto">
+			<table class="w-full text-left text-sm">
+				<thead class="border-b border-gray-100 text-xs uppercase text-gray-500 dark:border-gray-800"
+					><tr
+						><th class="px-3 py-2 font-normal">{$i18n.t('Role')}</th><th
+							class="px-3 py-2 font-normal">{$i18n.t('Name')}</th
+						><th class="px-3 py-2 font-normal">{$i18n.t('Status')}</th><th
+							class="px-3 py-2 text-right font-normal">{$i18n.t('Actions')}</th
+						></tr
+					></thead
+				>
+				<tbody
+					>{#each filteredRoles as role}<tr
+							class="border-b border-gray-50 dark:border-gray-850 {role.active
+								? ''
+								: 'bg-gray-50/70 dark:bg-gray-850/40'}"
+							><td
+								class="px-3 py-3 font-medium {role.active
+									? 'text-gray-900 dark:text-white'
+									: 'text-gray-600 dark:text-gray-300'}">{role.display_name}</td
+							><td
+								class="px-3 py-3 font-mono text-xs {role.active
+									? 'text-gray-500'
+									: 'text-gray-600 dark:text-gray-400'}">{role.name}</td
+							><td class="px-3 py-3"
+								><span
+									class="rounded-full px-2 py-1 text-xs {role.active
+										? 'bg-green-50 text-green-700 dark:bg-green-950/40 dark:text-green-300'
+										: 'bg-gray-100 text-gray-500 dark:bg-gray-800'}"
+									>{role.active ? $i18n.t('Active') : $i18n.t('Inactive')}</span
+								></td
+							><td class="px-3 py-3 text-right"
+								><div class="flex items-center justify-end gap-1 whitespace-nowrap">
+									<Tooltip content={$i18n.t('Edit role')}
+										><button
+											class="mr-2 rounded-lg p-1.5 hover:bg-black/5 dark:hover:bg-white/5"
+											aria-label={$i18n.t('Edit role')}
+											on:click={() => {
+												editingRole = role;
+												showModal = true;
+											}}><EditPencil className="size-3.5" /></button
+										></Tooltip
+									>
+									{#key `${role.id}-${role.active}-${switchVersion}`}
+										<Switch
+											state={role.active}
+											ariaLabel={role.active
+												? $i18n.t('Deactivate role')
+												: $i18n.t('Reactivate role')}
+											tooltip={role.active
+												? $i18n.t('Deactivate role')
+												: $i18n.t('Reactivate role')}
+											disabled={pendingRoleId === role.id}
+											on:change={(event) => toggleRole(role, event.detail)}
+										/>
+									{/key}
+									<Tooltip content={$i18n.t('Delete role')}
+										><button
+											class="ml-2 rounded-lg p-1.5 text-red-600 hover:bg-red-50 dark:hover:bg-red-950/30"
+											aria-label={$i18n.t('Delete role')}
+											disabled={pendingRoleId === role.id}
+											on:click={() => deleteRole(role)}><Trash className="size-3.5" /></button
+										></Tooltip
+									>
+								</div></td
+							></tr
+						>{/each}</tbody
+				>
+			</table>
+		</div>
+	{/if}
+</div>

--- a/src/lib/components/admin/Users/UserList/EditUserModal.svelte
+++ b/src/lib/components/admin/Users/UserList/EditUserModal.svelte
@@ -6,7 +6,13 @@
 
 	import { goto } from '$app/navigation';
 
-	import { updateUserById, getUserGroupsById } from '$lib/apis/users';
+	import {
+		assignCustomRole,
+		getCustomRoles,
+		getUserGroupsById,
+		unassignCustomRole,
+		updateUserById
+	} from '$lib/apis/users';
 
 	import Modal from '$lib/components/common/Modal.svelte';
 	import localizedFormat from 'dayjs/plugin/localizedFormat';
@@ -14,7 +20,7 @@
 	import SensitiveInput from '$lib/components/common/SensitiveInput.svelte';
 	import UserProfileImage from '$lib/components/chat/Settings/Account/UserProfileImage.svelte';
 
-	const i18n = getContext('i18n');
+	const i18n: any = getContext('i18n');
 	const dispatch = createEventDispatcher();
 	dayjs.extend(localizedFormat);
 
@@ -22,19 +28,44 @@
 	export let selectedUser;
 	export let sessionUser;
 
-	$: if (show) {
+	let initializedUserId = '';
+	$: if (show && selectedUser?.id && initializedUserId !== selectedUser.id) {
+		initializedUserId = selectedUser.id;
 		init();
 	}
+	$: if (!show) initializedUserId = '';
 
 	const init = () => {
 		if (selectedUser) {
-			_user = selectedUser;
+			_user = { ...selectedUser };
 			_user.password = '';
 			loadUserGroups();
+			loadCustomRoles();
 		}
 	};
 
-	let _user = {
+	const loadCustomRoles = async () => {
+		customRolesLoading = true;
+		customRolesError = '';
+		try {
+			const response = await getCustomRoles(localStorage.token, true);
+			customRoles = response?.items ?? [];
+		} catch (error) {
+			customRolesError = `${error}`;
+			customRoles = [];
+		} finally {
+			customRolesLoading = false;
+		}
+	};
+
+	const isCustomRole = (value: string) => value?.startsWith('custom:');
+	const customRoleId = (value: string) => value?.slice('custom:'.length);
+	const legacyRoles = new Set(['admin', 'user', 'pending']);
+	const isActiveCustomRole = (value: string) =>
+		isCustomRole(value) &&
+		customRoles.some((customRole) => customRole.id === customRoleId(value) && customRole.active);
+
+	let _user: any = {
 		profile_image_url: '',
 		role: 'pending',
 		name: '',
@@ -43,15 +74,41 @@
 	};
 
 	let userGroups: any[] | null = null;
+	let customRoles: any[] = [];
+	let customRolesLoading = false;
+	let customRolesError = '';
 
 	const submitHandler = async () => {
-		const res = await updateUserById(localStorage.token, selectedUser.id, _user).catch((error) => {
-			toast.error(`${error}`);
-		});
+		try {
+			const { role, ...profileData } = _user;
+			const currentRoleIsCustom = isCustomRole(selectedUser.role);
+			const targetIsLegacy = legacyRoles.has(role);
+			const targetIsActiveCustom = isActiveCustomRole(role);
+			const roleChanged = role !== selectedUser.role;
 
-		if (res) {
+			// Custom-role references are owned by the custom-role endpoints. Never
+			// send a stale, inactive, unknown, or malformed reference to the legacy
+			// user update endpoint during a profile-only save.
+			if (targetIsLegacy && !currentRoleIsCustom) {
+				await updateUserById(localStorage.token, selectedUser.id, _user as any);
+			} else {
+				await updateUserById(localStorage.token, selectedUser.id, profileData as any);
+			}
+
+			if (targetIsActiveCustom && roleChanged) {
+				await assignCustomRole(localStorage.token, selectedUser.id, customRoleId(role));
+			} else if (targetIsLegacy && currentRoleIsCustom) {
+				await unassignCustomRole(
+					localStorage.token,
+					customRoleId(selectedUser.role),
+					selectedUser.id
+				);
+				await updateUserById(localStorage.token, selectedUser.id, _user as any);
+			}
 			dispatch('save');
 			show = false;
+		} catch (error) {
+			toast.error(`${error}`);
 		}
 	};
 
@@ -142,13 +199,34 @@
 												class="w-full text-sm bg-transparent disabled:text-gray-500 dark:disabled:text-gray-500 outline-hidden"
 												bind:value={_user.role}
 												aria-label={$i18n.t('Role')}
-												disabled={_user.id == sessionUser.id}
+												disabled={_user.id == sessionUser?.id}
 												required
 											>
 												<option value="admin">{$i18n.t('Admin')}</option>
 												<option value="user">{$i18n.t('User')}</option>
 												<option value="pending">{$i18n.t('Pending')}</option>
+												{#if customRolesLoading}
+													<option disabled>{$i18n.t('Loading custom roles…')}</option>
+												{:else}
+													{#each customRoles.filter((customRole) => customRole.active || customRole.id === customRoleId(_user.role)) as customRole}
+														<option value={`custom:${customRole.id}`} disabled={!customRole.active}>
+															{customRole.display_name}{customRole.active
+																? ''
+																: ` (${$i18n.t('Inactive')})`}
+														</option>
+													{/each}
+													{#if isCustomRole(_user.role) && !customRoles.some((customRole) => customRole.id === customRoleId(_user.role))}
+														<option value={_user.role}
+															>{$i18n.t('Current custom role')} ({customRoleId(_user.role)})</option
+														>
+													{/if}
+												{/if}
 											</select>
+											{#if customRolesError}
+												<div class="mt-1 text-xs text-red-600 dark:text-red-400" role="alert">
+													{$i18n.t('Custom roles could not be loaded')}: {customRolesError}
+												</div>
+											{/if}
 										</div>
 									</div>
 
@@ -200,13 +278,15 @@
 									{/if}
 
 									<div class="flex flex-col w-full">
-										<div class=" mb-1 text-xs text-gray-500">{$i18n.t('New Password')}</div>
+										<label for="edit-user-password" class="mb-1 text-xs text-gray-500"
+											>{$i18n.t('New Password')}</label
+										>
 
 										<div class="flex-1">
 											<SensitiveInput
+												id="edit-user-password"
 												class="w-full text-sm bg-transparent outline-hidden"
 												type="password"
-												aria-label={$i18n.t('New Password')}
 												placeholder={$i18n.t('Enter New Password')}
 												bind:value={_user.password}
 												autocomplete="new-password"

--- a/src/lib/components/common/Switch.svelte
+++ b/src/lib/components/common/Switch.svelte
@@ -11,6 +11,7 @@
 	export let ariaLabel = '';
 	export let tooltip = false;
 	export let inherited = false;
+	export let disabled = false;
 
 	const i18n: any = getContext('i18n');
 	const dispatch = createEventDispatcher();
@@ -36,6 +37,7 @@
 			{id}
 			aria-labelledby={ariaLabelledbyId || undefined}
 			aria-label={ariaLabel || undefined}
+			{disabled}
 			class="focus-ring relative h-4 min-h-4 w-7 shrink-0 cursor-pointer rounded-full mx-[0.0625rem] transition-colors duration-150 disabled:cursor-not-allowed {($settings?.highContrastMode ??
 			false)
 				? 'focus:outline focus:outline-2 focus:outline-gray-800! focus:dark:outline-gray-200!'

--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -168,7 +168,10 @@
 					$user?.permissions?.workspace?.knowledge ||
 					$user?.permissions?.workspace?.prompts ||
 					$user?.permissions?.workspace?.tools ||
-					$user?.permissions?.workspace?.skills
+					$user?.permissions?.workspace?.skills ||
+					$user?.permissions?.groups?.manage_members ||
+					$user?.permissions?.groups?.manage_assets ||
+					$user?.permissions?.groups?.manage_skills
 				);
 			case 'automations':
 				return (

--- a/src/lib/components/layout/Sidebar/UserMenu.svelte
+++ b/src/lib/components/layout/Sidebar/UserMenu.svelte
@@ -238,7 +238,7 @@
 				<hr class="border-gray-50/30 dark:border-gray-800/30 my-0.5 mx-1 p-0" />
 			{/if}
 
-			{#if $user?.role === 'admin' || $user?.permissions?.workspace?.models || $user?.permissions?.workspace?.knowledge || $user?.permissions?.workspace?.prompts || $user?.permissions?.workspace?.tools || $user?.permissions?.workspace?.skills}
+			{#if $user?.role === 'admin' || $user?.permissions?.workspace?.models || $user?.permissions?.workspace?.knowledge || $user?.permissions?.workspace?.prompts || $user?.permissions?.workspace?.tools || $user?.permissions?.workspace?.skills || $user?.permissions?.groups?.manage_members || $user?.permissions?.groups?.manage_assets || $user?.permissions?.groups?.manage_skills}
 				<div class="flex items-center w-full">
 					<a
 						href="/workspace"

--- a/src/lib/components/workspace/GroupManager.svelte
+++ b/src/lib/components/workspace/GroupManager.svelte
@@ -1,0 +1,371 @@
+<script lang="ts">
+	import { getContext, onMount } from 'svelte';
+	import { toast } from 'svelte-sonner';
+	import {
+		addGroupManagerMembers,
+		createGroupKnowledge,
+		createGroupPrompt,
+		createGroupSkill,
+		deleteGroupKnowledge,
+		deleteGroupManagerMembers,
+		deleteGroupPrompt,
+		deleteGroupSkill,
+		getGroupManagerAssets,
+		getGroupManagerMembers,
+		getGroupManagerGroups,
+		getGroupManagerSkills,
+		updateGroupKnowledge,
+		updateGroupPrompt,
+		updateGroupSkill
+	} from '$lib/apis/groupManager';
+	import Spinner from '$lib/components/common/Spinner.svelte';
+	import AssetList from './GroupManager/AssetList.svelte';
+
+	const i18n: any = getContext('i18n');
+	let groups: any[] = [];
+	let groupId = '';
+	let tab = 'members';
+	let loading = true;
+	let denied = false;
+	let errorMessage = '';
+	let members: any[] = [];
+	let assets: any[] = [];
+	let skills: any[] = [];
+	let memberId = '';
+	let knowledgeName = '';
+	let knowledgeDescription = '';
+	let promptCommand = '';
+	let promptName = '';
+	let promptContent = '';
+	let skillSlug = '';
+	let skillName = '';
+	let skillContent = '';
+
+	$: activeGroup = groups.find((group) => group.id === groupId);
+	$: knowledge = assets.filter((asset) => asset.resource_type === 'knowledge');
+	$: prompts = assets.filter((asset) => asset.resource_type === 'prompt');
+
+	const loadGroup = async () => {
+		if (!groupId) return;
+		loading = true;
+		denied = false;
+		errorMessage = '';
+		try {
+			const [memberResult, assetResult, skillResult] = await Promise.allSettled([
+				getGroupManagerMembers(localStorage.token, groupId),
+				getGroupManagerAssets(localStorage.token, groupId),
+				getGroupManagerSkills(localStorage.token, groupId)
+			]);
+			const results = [memberResult, assetResult, skillResult];
+			const successful = results.filter((result) => result.status === 'fulfilled');
+			if (successful.length === 0) {
+				denied = true;
+				throw (results[0] as PromiseRejectedResult).reason;
+			}
+			members = memberResult.status === 'fulfilled' ? memberResult.value : [];
+			assets = assetResult.status === 'fulfilled' ? assetResult.value : [];
+			skills = skillResult.status === 'fulfilled' ? skillResult.value : [];
+			if (successful.length < results.length)
+				errorMessage = $i18n.t('Some management areas are not available for this group.');
+		} catch (error) {
+			errorMessage = (error as any)?.message ?? `${error}`;
+			if (!denied) toast.error(errorMessage);
+		} finally {
+			loading = false;
+		}
+	};
+
+	const run = async (action: () => Promise<any>, message: string) => {
+		try {
+			await action();
+			toast.success(message);
+			await loadGroup();
+		} catch (error) {
+			errorMessage = (error as any)?.message ?? `${error}`;
+			toast.error(errorMessage);
+		}
+	};
+
+	const editKnowledge = (id: string) => {
+		const name = prompt($i18n.t('New name'));
+		if (name)
+			run(
+				() => updateGroupKnowledge(localStorage.token, groupId, id, { name }),
+				$i18n.t('Knowledge base updated')
+			);
+	};
+	const editPrompt = (id: string) => {
+		const name = prompt($i18n.t('New name'));
+		if (name)
+			run(
+				() => updateGroupPrompt(localStorage.token, groupId, id, { name }),
+				$i18n.t('Prompt updated')
+			);
+	};
+	const editSkill = (skill: any) => {
+		const name = prompt($i18n.t('New name'), skill.name);
+		if (name)
+			run(
+				() => updateGroupSkill(localStorage.token, groupId, skill.id, { name }),
+				$i18n.t('Skill updated')
+			);
+	};
+
+	const load = async () => {
+		loading = true;
+		try {
+			groups = (await getGroupManagerGroups(localStorage.token)) ?? [];
+			groupId = groups[0]?.id ?? '';
+			if (groupId) await loadGroup();
+			else denied = true;
+		} catch (error) {
+			denied = true;
+			errorMessage = (error as any)?.message ?? `${error}`;
+		} finally {
+			loading = false;
+		}
+	};
+
+	onMount(load);
+</script>
+
+<div class="mx-auto flex h-full w-full max-w-5xl flex-col gap-4 px-3 pb-6 sm:px-5">
+	<div aria-live="polite" class="sr-only">{errorMessage}</div>
+	{#if loading}<div class="flex flex-1 items-center justify-center">
+			<Spinner className="size-6" />
+		</div>
+	{:else if denied}
+		<div
+			class="m-auto max-w-md rounded-2xl border border-gray-100 p-8 text-center dark:border-gray-800"
+		>
+			<div class="mb-2 text-base font-medium">{$i18n.t('Group manager access required')}</div>
+			<p class="text-sm text-gray-500">
+				{$i18n.t(
+					'You do not manage any groups, or your manager permissions have not been granted.'
+				)}
+			</p>
+		</div>
+	{:else}
+		<div class="flex flex-wrap items-center justify-between gap-3">
+			<div>
+				<h1 class="text-lg font-medium">{$i18n.t('Group workspace')}</h1>
+				<p class="text-xs text-gray-500">
+					{$i18n.t('Manage only members and assets owned by your group.')}
+				</p>
+			</div>
+			<select
+				class="rounded-lg bg-transparent px-3 py-2 text-sm ring-1 ring-gray-200 dark:ring-gray-700"
+				bind:value={groupId}
+				on:change={loadGroup}
+				aria-label={$i18n.t('Group')}
+			>
+				{#each groups as group}<option value={group.id}>{group.name}</option>{/each}
+			</select>
+		</div>
+		{#if errorMessage}<div
+				class="rounded-lg bg-amber-50 px-3 py-2 text-xs text-amber-800 dark:bg-amber-950/30 dark:text-amber-200"
+				role="status"
+			>
+				{errorMessage}
+			</div>{/if}
+		<nav
+			class="flex gap-4 border-b border-gray-100 text-sm dark:border-gray-800"
+			aria-label={$i18n.t('Group workspace sections')}
+		>
+			{#each [['members', 'Members'], ['knowledge', 'Knowledge'], ['prompts', 'Prompts'], ['skills', 'Skills']] as item}<button
+					class="border-b-2 px-1 py-2 {tab === item[0]
+						? 'border-black dark:border-white'
+						: 'border-transparent text-gray-400'}"
+					on:click={() => (tab = item[0])}>{$i18n.t(item[1])}</button
+				>{/each}
+		</nav>
+
+		{#if tab === 'members'}
+			<section class="space-y-3">
+				<div class="flex gap-2">
+					<input
+						class="min-w-0 flex-1 rounded-lg bg-transparent px-3 py-2 text-sm ring-1 ring-gray-200 dark:ring-gray-700"
+						bind:value={memberId}
+						placeholder={$i18n.t('User ID')}
+						aria-label={$i18n.t('User ID')}
+					/><button
+						class="rounded-lg bg-black px-3 py-2 text-xs text-white dark:bg-white dark:text-black"
+						disabled={!memberId}
+						on:click={() =>
+							run(
+								() => addGroupManagerMembers(localStorage.token, groupId, [memberId]),
+								$i18n.t('Member added')
+							)}>{$i18n.t('Add member')}</button
+					>
+				</div>
+				{#if members.length === 0}<p class="py-10 text-center text-sm text-gray-500">
+						{$i18n.t('No members found')}
+					</p>{:else}<div
+						class="divide-y divide-gray-100 rounded-xl border border-gray-100 dark:divide-gray-800 dark:border-gray-800"
+					>
+						{#each members as member}<div
+								class="flex items-center justify-between px-3 py-3 text-sm"
+							>
+								<span class="font-mono text-xs">{member.user_id}</span><button
+									class="text-xs text-red-600 hover:underline"
+									on:click={() =>
+										run(
+											() =>
+												deleteGroupManagerMembers(localStorage.token, groupId, [member.user_id]),
+											$i18n.t('Member removed')
+										)}>{$i18n.t('Remove')}</button
+								>
+							</div>{/each}
+					</div>{/if}
+			</section>
+		{:else if tab === 'knowledge'}
+			<section class="space-y-3">
+				<form
+					class="grid gap-2 rounded-xl border border-gray-100 p-3 sm:grid-cols-[1fr_1fr_auto] dark:border-gray-800"
+					on:submit|preventDefault={() =>
+						run(async () => {
+							const result = await createGroupKnowledge(localStorage.token, groupId, {
+								name: knowledgeName,
+								description: knowledgeDescription
+							});
+							knowledgeName = '';
+							knowledgeDescription = '';
+							return result;
+						}, $i18n.t('Knowledge base created'))}
+				>
+					<input
+						class="rounded-lg bg-transparent px-3 py-2 text-sm ring-1 ring-gray-200 dark:ring-gray-700"
+						bind:value={knowledgeName}
+						required
+						placeholder={$i18n.t('Name')}
+					/><input
+						class="rounded-lg bg-transparent px-3 py-2 text-sm ring-1 ring-gray-200 dark:ring-gray-700"
+						bind:value={knowledgeDescription}
+						placeholder={$i18n.t('Description')}
+					/><button
+						class="rounded-lg bg-black px-3 py-2 text-xs text-white dark:bg-white dark:text-black"
+						>{$i18n.t('Create')}</button
+					>
+				</form>
+				<AssetList
+					items={knowledge}
+					label={$i18n.t('Knowledge bases')}
+					onEdit={editKnowledge}
+					onDelete={(id: string) =>
+						run(
+							() => deleteGroupKnowledge(localStorage.token, groupId, id),
+							$i18n.t('Knowledge base deleted')
+						)}
+				/>
+			</section>
+		{:else if tab === 'prompts'}
+			<section class="space-y-3">
+				<form
+					class="grid gap-2 rounded-xl border border-gray-100 p-3 sm:grid-cols-3 dark:border-gray-800"
+					on:submit|preventDefault={() =>
+						run(async () => {
+							const result = await createGroupPrompt(localStorage.token, groupId, {
+								command: promptCommand,
+								name: promptName,
+								content: promptContent
+							});
+							promptCommand = '';
+							promptName = '';
+							promptContent = '';
+							return result;
+						}, $i18n.t('Prompt created'))}
+				>
+					<input
+						class="rounded-lg bg-transparent px-3 py-2 text-sm ring-1 ring-gray-200 dark:ring-gray-700"
+						bind:value={promptCommand}
+						required
+						placeholder={$i18n.t('Command')}
+					/><input
+						class="rounded-lg bg-transparent px-3 py-2 text-sm ring-1 ring-gray-200 dark:ring-gray-700"
+						bind:value={promptName}
+						required
+						placeholder={$i18n.t('Name')}
+					/><input
+						class="rounded-lg bg-transparent px-3 py-2 text-sm ring-1 ring-gray-200 dark:ring-gray-700"
+						bind:value={promptContent}
+						required
+						placeholder={$i18n.t('Content')}
+					/><button
+						class="rounded-lg bg-black px-3 py-2 text-xs text-white dark:bg-white dark:text-black sm:col-span-3"
+						>{$i18n.t('Create prompt')}</button
+					>
+				</form>
+				<AssetList
+					items={prompts}
+					label={$i18n.t('Prompts')}
+					onEdit={editPrompt}
+					onDelete={(id: string) =>
+						run(
+							() => deleteGroupPrompt(localStorage.token, groupId, id),
+							$i18n.t('Prompt deleted')
+						)}
+				/>
+			</section>
+		{:else}
+			<section class="space-y-3">
+				<form
+					class="grid gap-2 rounded-xl border border-gray-100 p-3 sm:grid-cols-3 dark:border-gray-800"
+					on:submit|preventDefault={() =>
+						run(
+							() =>
+								createGroupSkill(localStorage.token, groupId, {
+									slug: skillSlug,
+									name: skillName,
+									content: skillContent
+								}),
+							$i18n.t('Skill created')
+						)}
+				>
+					<input
+						class="rounded-lg bg-transparent px-3 py-2 text-sm ring-1 ring-gray-200 dark:ring-gray-700"
+						bind:value={skillSlug}
+						required
+						placeholder={$i18n.t('Slug')}
+					/><input
+						class="rounded-lg bg-transparent px-3 py-2 text-sm ring-1 ring-gray-200 dark:ring-gray-700"
+						bind:value={skillName}
+						required
+						placeholder={$i18n.t('Name')}
+					/><input
+						class="rounded-lg bg-transparent px-3 py-2 text-sm ring-1 ring-gray-200 dark:ring-gray-700"
+						bind:value={skillContent}
+						placeholder={$i18n.t('Content')}
+					/><button
+						class="rounded-lg bg-black px-3 py-2 text-xs text-white dark:bg-white dark:text-black sm:col-span-3"
+						>{$i18n.t('Create skill')}</button
+					>
+				</form>
+				{#if skills.length === 0}<p class="py-10 text-center text-sm text-gray-500">
+						{$i18n.t('No skills found')}
+					</p>{:else}<div class="grid gap-3 sm:grid-cols-2">
+						{#each skills as skill}<article
+								class="rounded-xl border border-gray-100 p-3 dark:border-gray-800"
+							>
+								<div class="flex items-start justify-between">
+									<div>
+										<h2 class="text-sm font-medium">{skill.name}</h2>
+										<p class="font-mono text-xs text-gray-500">{skill.slug}</p>
+									</div>
+									<button
+										class="text-xs text-red-600 hover:underline"
+										on:click={() =>
+											run(
+												() => deleteGroupSkill(localStorage.token, groupId, skill.id),
+												$i18n.t('Skill deleted')
+											)}>{$i18n.t('Delete')}</button
+									>
+								</div>
+								<p class="mt-2 line-clamp-2 text-xs text-gray-500">
+									{skill.description || skill.content}
+								</p>
+							</article>{/each}
+					</div>{/if}
+			</section>
+		{/if}
+	{/if}
+</div>

--- a/src/lib/components/workspace/GroupManager/AssetList.svelte
+++ b/src/lib/components/workspace/GroupManager/AssetList.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+	import { getContext } from 'svelte';
+	const i18n: any = getContext('i18n');
+	export let items: any[] = [];
+	export let label = '';
+	export let onDelete: (id: string) => void = () => {};
+	export let onEdit: (id: string) => void = () => {};
+</script>
+
+<div>
+	<h2 class="mb-2 text-xs uppercase text-gray-500">{label}</h2>
+	{#if items.length === 0}
+		<p class="py-10 text-center text-sm text-gray-500">{$i18n.t('Nothing here yet')}</p>
+	{:else}
+		<div class="grid gap-2 sm:grid-cols-2">
+			{#each items as item}
+				<div
+					class="flex items-center justify-between rounded-xl border border-gray-100 px-3 py-3 dark:border-gray-800"
+				>
+					<span class="truncate font-mono text-xs">{item.resource_id}</span>
+					<div class="ml-3 flex shrink-0 gap-3">
+						<button class="text-xs hover:underline" on:click={() => onEdit(item.resource_id)}
+							>{$i18n.t('Edit')}</button
+						>
+						<button
+							class="text-xs text-red-600 hover:underline"
+							on:click={() => onDelete(item.resource_id)}>{$i18n.t('Delete')}</button
+						>
+					</div>
+				</div>
+			{/each}
+		</div>
+	{/if}
+</div>

--- a/src/routes/(app)/workspace/+page.svelte
+++ b/src/routes/(app)/workspace/+page.svelte
@@ -15,6 +15,12 @@
 				goto('/workspace/tools', { replaceState: true });
 			} else if ($user?.permissions?.workspace?.skills) {
 				goto('/workspace/skills', { replaceState: true });
+			} else if (
+				$user?.permissions?.groups?.manage_members ||
+				$user?.permissions?.groups?.manage_assets ||
+				$user?.permissions?.groups?.manage_skills
+			) {
+				goto('/workspace/group-manager', { replaceState: true });
 			} else {
 				goto('/', { replaceState: true });
 			}

--- a/src/routes/(app)/workspace/group-manager/+page.svelte
+++ b/src/routes/(app)/workspace/group-manager/+page.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import GroupManager from '$lib/components/workspace/GroupManager.svelte';
+</script>
+
+<GroupManager />


### PR DESCRIPTION
## Pull Request Checklist

- [x] **Linked Discussion:** https://github.com/open-webui/open-webui/discussions/8642
- [x] **Target branch:** dev
- [x] **Documentation:** docs/CUSTOM_ROLES.md
- [x] **Testing:** 281 backend tests and 13 frontend tests passed.
- [x] **Self-review:** Oracle security and UI gates passed.
- [x] **Git Hygiene:** two focused commits; unrelated .gitignore/.ignore changes excluded.

## Summary

Adds admin-defined custom roles and an additive, group-scoped manager workspace.

### Custom roles
- Persists opaque custom role references while preserving exact admin/user/pending behavior.
- Adds exact-admin APIs and UI for role definitions, server-owned capability catalog, and lifecycle management.
- Moves role assignment to the per-user Overview edit modal.
- Deactivating or deleting a role atomically resets its assigned users to legacy user.

### Scoped group manager
- Adds transaction-bound current-membership and explicit-capability authorization.
- Adds manager-scoped member, knowledge, prompt, and skill operations plus server-authorized group discovery.
- Leaves legacy group routes unchanged and excludes models/tools.

### Security and auditing
- Fails closed for inactive, unknown, or malformed custom roles.
- Keeps group ownership distinct from access grants.
- Redacts scoped skill audit request/response bodies.

### Documentation
- Adds deployment, migration, rollback, lifecycle, and operator guidance.

## Validation
- uv backend suite: 281 passed.
- Vitest frontend suite: 13 passed.
- Targeted Ruff, compile, Prettier, Alembic-head, and diff checks passed.

## References
- Related product discussion: https://github.com/open-webui/open-webui/discussions/8642
- PR structure modeled after #28870.

## Contributor License Agreement
- [x] I have read and agree to the Contributor License Agreement.