### PR TITLE
fix: download links in HTML citations do nothing when clicked

### DIFF
--- a/src/lib/components/chat/Messages/Citations/CitationModal.svelte
+++ b/src/lib/components/chat/Messages/Citations/CitationModal.svelte
@@ -215,8 +215,10 @@
 							{#if document.metadata?.html}
 								<iframe
 									class="w-full border-0 h-auto rounded-none"
-									sandbox="allow-scripts allow-forms{($settings?.iframeSandboxAllowSameOrigin ??
+									sandbox="allow-scripts allow-downloads{($settings?.iframeSandboxAllowForms ??
 									false)
+										? ' allow-forms'
+										: ''}{($settings?.iframeSandboxAllowSameOrigin ?? false)
 										? ' allow-same-origin'
 										: ''}"
 									srcdoc={injectCsp(document.document, $config?.ui?.iframe_csp ?? '')}


### PR DESCRIPTION
The iframe that renders HTML citation content does not grant allow-downloads, so a click on a link that should save a file is dropped with nothing shown to the user. Links that navigate the frame itself already work and are unaffected.

The same attribute also hardcoded allow-forms, so the "iframe Sandbox Allow Forms" setting under Settings > Interface did not apply to citations, unlike artifacts, markdown HTML blocks and file previews. Gating it here means forms inside citation HTML now need that setting enabled, and it defaults to off. The resulting sandbox string is identical to the one HTMLToken, Artifacts and FilePreview build.

Links using target="_blank" stay blocked, since allow-popups is not granted here or on those surfaces.

Fixes #28924

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
