### PR TITLE
fix: allow-forms sandbox setting is ignored for tool and action embeds

### DIFF
--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -721,7 +721,7 @@
 										<FullHeightIframe
 											src={embed}
 											allowScripts={true}
-											allowForms={true}
+											allowForms={$settings?.iframeSandboxAllowForms ?? false}
 											allowSameOrigin={$settings?.iframeSandboxAllowSameOrigin ?? false}
 											allowPopups={true}
 										/>


### PR DESCRIPTION
Rich UI embeds rendered under a response ignore "iframe Sandbox Allow Forms" under Settings > Interface. That surface passes the sandbox flag as a constant, so forms are allowed there whether the switch is on or off.

The same embeds shown through the tool call display and the grouped details view already read the setting, so this makes all three behave the same way.

Behavior change: forms inside tool and action embeds now need "iframe Sandbox Allow Forms" enabled, and it defaults to off. Scripts, fetch and XHR still work. Only form submission is gated, including submits triggered from script.

Popups and same-origin handling are unchanged.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
