### PR TITLE
refac: remove unreachable rate limit handler from DuckDuckGo web search

### DIFF
--- a/backend/open_webui/retrieval/web/duckduckgo.py
+++ b/backend/open_webui/retrieval/web/duckduckgo.py
@@ -4,7 +4,6 @@ import logging
 import urllib.request
 
 from ddgs import DDGS
-from ddgs.exceptions import RatelimitException
 from open_webui.retrieval.web.main import SearchResult, get_filtered_results
 
 log = logging.getLogger(__name__)
@@ -31,21 +30,11 @@ def search_duckduckgo(
     # Resolve via stdlib getproxies() — same pattern as the other loaders.
     env_proxies = urllib.request.getproxies()
     proxy = env_proxies.get('https') or env_proxies.get('http')
-    search_results = []
     with DDGS(proxy=proxy) as ddgs:
         if concurrent_requests:
             ddgs.threads = concurrent_requests
 
-        # Use the ddgs.text() method to perform the search
-        try:
-            kwargs = {'safesearch': 'moderate', 'max_results': count}
-            if backend and backend != 'auto':
-                kwargs['backend'] = backend
-            results = ddgs.text(query, **kwargs)
-            search_results = results if results is not None else []
-        except RatelimitException as e:
-            log.error(f'RatelimitException: {e}')
-            search_results = []
+        search_results = ddgs.text(query, safesearch='moderate', max_results=count, backend=backend or 'auto')
     if filter_list:
         search_results = get_filtered_results(search_results, filter_list)
 


### PR DESCRIPTION
The DDGS search path catches RatelimitException from the ddgs library. That exception is defined by the library but never raised anywhere in it, checked against the pinned 9.14.4 and against 9.11.3, so the handler could never run. The two fallbacks around it were dead for the same reason: ddgs.text() returns a non-empty list or raises, so None and an empty list are not outcomes it can produce.

Removing all three leaves one call and changes nothing observable. A refused or rate limited search already came out as a failed search, with the error shown to the user and the traceback in the log, and it still does.

The backend argument is now passed as backend or 'auto' rather than conditionally omitted, because 'auto' is the library's own default for that parameter, so every configured value including unset and empty resolves exactly as before. Verified by running the old and the new function side by side against a stubbed library covering normal results, the domain filter, all four backend settings and a failing search, with identical results in every case.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
