### PR TITLE
fix: stop routing Office documents fetched by URL to the HTML loader

### DIFF
--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -200,11 +200,12 @@ def _extract_text_from_binary_response(
 def _is_text_content_type(content_type: str) -> bool:
     """Return True if the content type should be handled by the web loader."""
     ct = content_type.split(';')[0].strip().lower()
+    if not ct:  # empty / missing → assume HTML
+        return True
     if ct.startswith('text/'):
         return True
-    if any(t in ct for t in ['xml', 'json', 'javascript']):
-        return True
-    return not ct  # empty / missing → assume HTML
+    # Matching "xml" anywhere also claimed every Office type, whose name contains "openxmlformats".
+    return ct.endswith(('+xml', '+json')) or ct in ('application/xml', 'application/json', 'application/javascript')
 
 
 async def get_content_from_url(request, url: str) -> str:


### PR DESCRIPTION
A fetched content type counted as text whenever the string "xml" appeared anywhere in it. Every Office type contains "openxmlformats", so DOCX, XLSX and PPTX URLs were handed to the HTML loader, which refetched the URL and ran an HTML parser over zip bytes, producing empty or garbage text. Matching is now on the structured-syntax suffix, so those documents reach their real loader.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
