### PR TITLE
refac: bound how far an archive-based document may unpack

### DIFF
--- a/backend/open_webui/env.py
+++ b/backend/open_webui/env.py
@@ -812,6 +812,10 @@ MINERU_MAX_MARKDOWN_BYTES = (
     int(os.getenv('MINERU_MAX_MARKDOWN_BYTES')) if os.getenv('MINERU_MAX_MARKDOWN_BYTES') else None
 )
 
+# Most an archive-based document may unpack to. A 120k-row spreadsheet reaches ~33 MB.
+# Set to 0 to disable the check.
+RAG_FILE_MAX_UNPACKED_SIZE = int(os.getenv('RAG_FILE_MAX_UNPACKED_SIZE', 100 * 1024 * 1024))
+
 # When enabled, skips pydub-based preprocessing (format conversion, compression,
 # and chunked splitting) before sending files to processing engines. Useful when
 # the upstream provider handles these steps or when ffmpeg is unavailable.

--- a/backend/open_webui/retrieval/loaders/main.py
+++ b/backend/open_webui/retrieval/loaders/main.py
@@ -4,6 +4,7 @@ import logging
 import os
 import sys
 import zipfile
+import zlib
 
 import ftfy
 import requests
@@ -21,6 +22,7 @@ from open_webui.env import (
     AIOHTTP_CLIENT_SESSION_SSL,
     GLOBAL_LOG_LEVEL,
     MINERU_MAX_MARKDOWN_BYTES,
+    RAG_FILE_MAX_UNPACKED_SIZE,
     REQUESTS_VERIFY,
 )
 from open_webui.retrieval.loaders.datalab_marker import DatalabMarkerLoader
@@ -300,6 +302,42 @@ class DoclingLoader:
                 except Exception:
                     error_msg += f' - {r.text}'
             raise Exception(f'Error calling Docling: {error_msg}')
+
+
+def _reject_overexpanding_archive(file_path: str) -> None:
+    """Reject a zip-based document that unpacks to far more than it stores."""
+    if not RAG_FILE_MAX_UNPACKED_SIZE:
+        return
+
+    try:
+        archive = zipfile.ZipFile(file_path)
+    except (zipfile.BadZipFile, OSError):
+        return  # not a zip-based document, so there is nothing here to expand
+    except (NotImplementedError, UnicodeDecodeError) as e:
+        # It parsed as a zip far enough to reject it on its own contents, so fail closed.
+        raise ValueError('Document could not be read as a well-formed archive') from e
+
+    with archive:
+        # Small documents get a flat 10 MB, larger ones 100x what they store, and nothing
+        # gets past the ceiling: padding an archive with junk inflates the stored size for free.
+        limit = min(max(10 * 1024 * 1024, 100 * os.path.getsize(file_path)), RAG_FILE_MAX_UNPACKED_SIZE)
+        unpacked = 0
+        try:
+            for entry in archive.infolist():
+                # Only deflate honours a block size; bzip2 and lzma expand a whole member per
+                # read(), which would put the payload in memory before we could count it. The
+                # document formats we parse here all mandate stored or deflate anyway.
+                if entry.compress_type not in (zipfile.ZIP_STORED, zipfile.ZIP_DEFLATED):
+                    raise ValueError('Document uses an unsupported archive compression method')
+
+                with archive.open(entry) as part:
+                    while block := part.read(1024 * 1024):
+                        unpacked += len(block)
+                        if unpacked > limit:
+                            raise ValueError('Document unpacks to far more than it stores and was rejected')
+        except (zipfile.BadZipFile, OSError, RuntimeError, zlib.error, UnicodeDecodeError, EOFError) as e:
+            # Fail closed: an archive we can open but cannot walk is one we cannot bound.
+            raise ValueError('Document could not be read as a well-formed archive') from e
 
 
 class Loader:
@@ -666,6 +704,8 @@ class Loader:
                 file_path=file_path,
             )
         else:
+            _reject_overexpanding_archive(file_path)
+
             if file_ext == 'pdf':
                 loader = PyPDFLoader(
                     file_path,


### PR DESCRIPTION
Zip-based documents (docx, xlsx, pptx, odt, epub) are checked before parsing and rejected when they unpack to far more than they store, or when a member uses a compression method the block-wise reader cannot bound.

RAG_FILE_MAX_UNPACKED_SIZE sets the upper bound and defaults to 100 MB, well clear of ordinary documents: a 120k-row spreadsheet unpacks to about 33 MB. Set it to 0 to disable the check. Only the local parsing path is affected, so deployments that hand documents to Tika, Docling or another external engine are unchanged.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
