### PR TITLE
fix: apply connection prefix id to the model display name as well as the id

### DIFF
--- a/backend/open_webui/routers/ollama.py
+++ b/backend/open_webui/routers/ollama.py
@@ -427,6 +427,8 @@ async def get_all_models(request: Request, user: UserModel | None = None):
         for m in response.get('models', []):
             if prefix_id:
                 m['model'] = f'{prefix_id}.{m["model"]}'
+                if m.get('name'):
+                    m['name'] = f'{prefix_id}.{m["name"]}'
             if allowed_tags:
                 m['tags'] = allowed_tags
             if connection_type:

--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -747,6 +747,8 @@ async def get_all_models_responses(request: Request, user: UserModel) -> list:
 
                 if prefix_id:
                     model['id'] = f'{prefix_id}.{model.get("id", model.get("name", ""))}'
+                    if model.get('name'):
+                        model['name'] = f'{prefix_id}.{model["name"]}'
 
                 if tags:
                     model['tags'] = tags


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. First-time contributors should not open pull requests directly unless the pull request contains only i18n/localization updates.
   Do not open a PR as the first step.
   For real, reproducible bugs, start with a well-described Issue that explains the problem, why it matters, and what outcome you are looking for.
   For feature requests, enhancements, behavior changes, UI/UX changes, architecture changes, suspected fixes, or unconfirmed approaches, start with an active Discussion.
   If you want to propose an implementation, include it only as a reference in the Issue or Discussion, such as a local diff, patch, or branch.
   Opening an Issue or Discussion does not mean a PR is the right next step. Maintainers will confirm when a PR would be useful.
   We ask for this because PRs, especially from first-time contributors, often need broader maintainer context on product direction, scope, architecture, UX, edge cases, compatibility, documentation, and long-term maintenance before implementation.
   We may close unsolicited PRs without review.
   Contributors with a history of successful merged PRs may be given more latitude.
3. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

**Before submitting, make sure you've checked and filled out the following:**

- [x] **Linked Issue/Discussion:** Closes #28929
- [x] **First-time contributor policy:** not my first contribution.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** **Manual** end-to-end tests have been performed to verify the fix/feature works correctly and does not introduce regressions.
- [x] **User-facing changes:** I have confirmed whether this PR changes the UI. Model names from prefixed connections now carry the prefix consistently; connections without a `Prefix ID` are untouched.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

A connection's `Prefix ID` reaches the model name on some connections and not others, and the deciding factor is invisible to the administrator: the shape of the upstream provider's model list response. With four connections that all set a `Prefix ID`, only one shows the prefix in the model selector.

**Root cause.** The prefix is applied to the model id only. The selector renders the model's `name`, which is a separate field, so the prefix reaches the label only when `name` happens to be derived from the already prefixed id. That happens when the provider returns no `name` of its own. When the provider supplies a `name`, when a `Model IDs` allowlist synthesizes the list with `'name': model_id`, or when the connection is Ollama (whose `/api/tags` always carries a `name`), the unprefixed value wins and the prefix never appears. The prefix is still in the id, so it keeps showing in the admin tooltip, which renders `name (id)`, and that mismatch is what the reports describe.

**Fix.** Prefix the display name wherever the id is prefixed, in both the OpenAI and Ollama model list paths.

### Fixed

- Fixed a connection's `Prefix ID` appearing in model names only for some connections. The prefix now applies consistently, including connections that use a `Model IDs` allowlist, connections whose provider returns its own model names, and Ollama connections.

---

### Additional Information

Verified on `dev` @ `4807866a1` with four connections, each setting a `Prefix ID`, covering all four ways the name can be produced. The branch is rebased onto `e623c02ac`, and neither touched file changed in between. Values read from `GET /api/models`:

| Connection | Case | Name before | Name after |
|---|---|---|---|
| `NoName` | provider sends no `name` | `NoName.noname-alpha` | `NoName.noname-alpha` |
| `WithName` | provider sends a `name` | `withname-alpha` | `WithName.withname-alpha` |
| `Whitelisted` | `Model IDs` allowlist | `deepseek-r1` | `Whitelisted.deepseek-r1` |
| `MockOlla` | Ollama `/api/tags` | `mockolla:latest` | `MockOlla.mockolla:latest` |

Regression checks on the same instance:

1. Connections without a `Prefix ID` are untouched, including models whose provider supplies a friendly display name, which keeps its wording.
2. No name is prefixed twice. The case that already worked (`NoName`) is unchanged, because the name is only prefixed when the provider actually supplied one, before the id fallback runs.
3. Three consecutive `GET /api/models` calls return identical names, so prefixes do not accumulate across refreshes or through the base model list cache.
4. Model routing is unaffected. Outbound requests resolve the upstream model from the id via `strip_provider_model_prefix` and never read the name.

The reports behind this are discussion #9819 and the related #9786, #7999 and #8941. The workaround shared in those threads is to add the prefix to each entry of the `Model IDs` allowlist by hand, which also double prefixes the id.

This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Screenshots or Videos

Before is current `dev`, after is this branch, both showing the model selector with several prefixed connections.

| Surface | Before | After |
|---|---|---|
| Model selector with several prefixed connections | <img width="770" height="404" alt="image" src="https://github.com/user-attachments/assets/3b50f22d-1a61-47ac-96b6-901feec240d4" /> | <img width="770" height="404" alt="image" src="https://github.com/user-attachments/assets/61b2d048-b711-48ec-9395-d913facd5f9c" /> |

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
