### PR TITLE
fix: apply model overrides when base_model_id equals model id

### DIFF
--- a/backend/open_webui/utils/models.py
+++ b/backend/open_webui/utils/models.py
@@ -159,7 +159,7 @@ async def get_all_models(request, refresh: bool = False, user: UserModel = None)
     existing_ids = {m['id'] for m in models}
 
     for custom_model in custom_models:
-        if custom_model.base_model_id is None:
+        if custom_model.base_model_id is None or custom_model.base_model_id == custom_model.id:
             # Override applied directly to a base model (shares the same ID)
             model = base_model_lookup.get(custom_model.id)
 


### PR DESCRIPTION
**Before submitting, make sure you've checked and filled out the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing, well-described [Issue](https://github.com/open-webui/open-webui/issues) for a real bug or an active, substantive [Discussion](https://github.com/open-webui/open-webui/discussions) for a feature request or enhancement — Closes #28952.
- [ ] **First-time contributor policy:** This is not my first contribution to Open WebUI, this PR contains only i18n/localization updates, or a maintainer explicitly asked me to open this PR after reviewing the linked Issue or Discussion.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** **Manual** end-to-end tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [ ] **User-facing changes:** I have confirmed whether this PR changes the UI. If it does, screenshots are required, and a video recording is recommended.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes: **fix**

# Changelog Entry

### Description

When a workspace model override has `base_model_id` set to the same value as `id` (which is the default behavior when editing an existing provider model via the admin panel), the `get_all_models()` function in `utils/models.py` silently skips merging the DB customizations into the runtime model dict.

The first branch (`base_model_id is None`) doesn't match because `base_model_id` is set (to the same value as `id`). The second branch (`elif`) skips it because `custom_model.id in existing_ids` is true. Result: all model-level settings saved via the admin panel (builtinTools, toolIds, defaultFeatureIds, system prompts, function_calling params) are stored in the database but never applied at runtime.

The fix adds `or custom_model.base_model_id == custom_model.id` to the first condition, treating self-referencing `base_model_id` the same as `None` — both represent a direct override of a base model.

### Added

- N/A

### Changed

- N/A

### Deprecated

- N/A

### Removed

- N/A

### Fixed

- Model workspace overrides (builtinTools, toolIds, defaultFeatureIds, system prompt, function_calling, tags) now apply correctly when `base_model_id` equals the model `id`.

### Security

- N/A

### Breaking Changes

- N/A

---

### Additional Information

- Closes #28952
- One-line change in `backend/open_webui/utils/models.py`
- No UI changes — this is a backend data-merge fix
- Manually tested by verifying that `builtinTools` and `toolIds` appear in the `/api/models` response and are respected at runtime after saving via the admin panel

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.