### PR TITLE
fix: normalize OAuth sub claim to str to prevent PostgreSQL type mismatch

### DIFF
--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -1919,6 +1919,12 @@ class OAuthManager:
             else:
                 # Fallback to the default sub claim if not configured
                 sub = user_data.get(OAUTH_PROVIDERS[provider].get('sub_claim', 'sub'))
+            if sub is not None:
+                # Some providers use a numeric id as the sub claim (e.g. GitHub's
+                # "id"); normalize to str so DB lookups compare text to text
+                # instead of failing on PostgreSQL with "operator does not exist:
+                # text = integer", and so stored subs are consistent
+                sub = str(sub)
             if not sub:
                 log.warning(f'OAuth callback failed, sub is missing: {user_data}')
                 raise HTTPException(400, detail=ERROR_MESSAGES.INVALID_CRED)


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #27760. Relates to #27989 / #27990 (same fix, closed for targeting `main` / missing CLA text — credit to @loulanyue for the original submission).
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [x] **Documentation:** No documentation impact — behavior-preserving bug fix for providers with string subs; restores documented GitHub OAuth behavior on PostgreSQL.
- [x] **Dependencies:** No new or updated dependencies.
- [x] **Testing:** The equivalent normalization has been running in my production deployment (v0.11.0, PostgreSQL 15/pgvector, GitHub OAuth) since 2026-07-30: GitHub logins work for new and existing accounts, no regressions observed on the OIDC path. Independently reproduced and confirmed by another user in #27760.
- [x] **No Unchecked AI Code:** The change has been human-reviewed and manually tested in a production deployment for over three weeks.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new settings; a smart default (normalize once at extraction).
- [x] **Git Hygiene:** The PR is atomic (one logical change, one commit), based on current `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

GitHub OAuth login fails on PostgreSQL-backed instances with `psycopg.errors.UndefinedFunction: operator does not exist: text = integer` (#27760). The GitHub provider's sub claim is the numeric `id` field from GitHub's `/user` API, so `sub` is a Python `int`. `Users.get_user_by_oauth_sub` extracts the stored JSON sub as text (`->>`), while SQLAlchemy infers the bind parameter type from the `int` literal — producing `text = integer`, which PostgreSQL rejects. Every GitHub login on PostgreSQL crashes with HTTP 500.

This PR normalizes the sub claim to `str` once at extraction in `handle_callback`, before the `if not sub:` guard. Fixing it at extraction (rather than in the DB lookup) also normalizes the **stored** sub, keeping records consistent across providers and dialects — including the SQLite path, where an `int` sub would otherwise never match a string-stored record. Applying `str()` before the emptiness guard means a hypothetical numeric id of `0` becomes the truthy `"0"` instead of being rejected as missing.

The OIDC back-channel logout lookup is untouched: its `sub` comes from a JWT claim, which is a string per spec.

### Fixed

- Fixed GitHub OAuth login failing on PostgreSQL with `operator does not exist: text = integer` by normalizing the OAuth sub claim to `str` at extraction, so user lookups compare text to text and stored subs are consistent across providers (#27760).

---

### Additional Information

- Root-cause analysis with full traceback and code trace: #27760.
- The same fix was previously submitted as #27989 (closed: targeted `main`) and #27990 (closed without review). This resubmission targets `dev` and includes the CLA text.
- Existing user records that stored a numeric sub while the bug was live still match after this fix, since PostgreSQL's `->>` renders JSON numbers in their text form — no data migration needed.

### Screenshots or Videos

- N/A (server-side fix; the observable change is that GitHub OAuth login completes instead of returning HTTP 500 — logs and traceback in #27760).

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
