### PR TITLE
fix: keep the chat composer's controls reachable in narrow containers

### DIFF
--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -2161,8 +2161,11 @@
 								</div>
 							</div>
 
-							<div class=" flex justify-between mt-0.5 mb-2 mx-0.5 max-w-full" dir="ltr">
-								<div class="ml-1 self-end flex items-center shrink-0">
+							<div
+								class=" flex flex-wrap justify-between gap-y-1 mt-0.5 mb-2 mx-0.5 max-w-full overflow-hidden"
+								dir="ltr"
+							>
+								<div class="ml-1 self-end flex items-center shrink-0 max-w-full @max-md:basis-full">
 									<InputMenu
 										bind:files
 										selectedModels={selectedModelIds}
@@ -2299,7 +2302,7 @@
 											</div>
 										{/if}
 
-										<div class="ml-1 flex gap-1.5 shrink-0">
+										<div class="ml-1 flex gap-1.5 shrink-0 has-[>*]:mr-1.5">
 											{#if (selectedToolIds ?? []).length > 0}
 												<Tooltip
 													content={$i18n.t('{{COUNT}} Available Tools', {
@@ -2483,22 +2486,25 @@
 													</button>
 												</Tooltip>
 											{/each}
-
-											{#if !history?.currentId || history.messages[history.currentId]?.done == true}
-												<!-- Terminal Server Selector -->
-												{@const hasDirectToolServerAccess =
-													$_user?.role === 'admin' ||
-													($_user?.permissions?.features?.direct_tool_servers ?? true)}
-												{#if terminalCapableModels.length > 0 && (($terminalServers ?? []).some((t) => t.id) || (hasDirectToolServerAccess && (($terminalServers ?? []).some((t) => !t.id) || ($settings?.terminalServers ?? []).some((s) => s.url))))}
-													<TerminalMenu bind:show={showTerminalMenu} />
-												{/if}
-											{/if}
 										</div>
 									</div>
 								</div>
 
-								<div class="self-end flex space-x-1 mr-1 min-w-0 gap-[0.03125rem]">
-									<div class="flex min-w-0 max-w-[10rem] items-center sm:max-w-[13rem]">
+								<div
+									class="self-end flex grow justify-end space-x-1 mr-1 min-w-0 gap-[0.03125rem] @max-md:ml-1"
+								>
+									{#if !history?.currentId || history.messages[history.currentId]?.done == true}
+										<!-- Terminal Server Selector -->
+										{@const hasDirectToolServerAccess =
+											$_user?.role === 'admin' ||
+											($_user?.permissions?.features?.direct_tool_servers ?? true)}
+										{#if terminalCapableModels.length > 0 && (($terminalServers ?? []).some((t) => t.id) || (hasDirectToolServerAccess && (($terminalServers ?? []).some((t) => !t.id) || ($settings?.terminalServers ?? []).some((s) => s.url))))}
+											<div class="mr-auto flex min-w-[4.5rem] items-center">
+												<TerminalMenu bind:show={showTerminalMenu} />
+											</div>
+										{/if}
+									{/if}
+									<div class="flex min-w-0 max-w-[10rem] items-center @sm:max-w-[13rem]">
 										<ModelSelector
 											bind:this={modelSelector}
 											bind:selectedModels

--- a/src/lib/components/chat/MessageInput/TerminalMenu.svelte
+++ b/src/lib/components/chat/MessageInput/TerminalMenu.svelte
@@ -119,12 +119,12 @@
 		$i18n.t('Terminal');
 </script>
 
-<div class="flex items-center translate-x-0.5">
+<div class="flex min-w-0 items-center translate-x-0.5">
 	<Dropdown bind:show align="start">
-		<Tooltip content={$i18n.t('Terminal')} placement="top">
+		<Tooltip className="flex min-w-0" content={$i18n.t('Terminal')} placement="top">
 			<button
 				type="button"
-				class="flex items-center gap-1.5 translate-y-[1px] text-[0.8125rem] text-gray-600 hover:bg-gray-50/40 hover:text-gray-700 dark:text-gray-300 dark:hover:bg-gray-800/40 dark:hover:text-gray-200 transition rounded-lg cursor-pointer {$selectedTerminalId &&
+				class="flex min-w-0 items-center gap-1.5 translate-y-[1px] text-[0.8125rem] text-gray-600 hover:bg-gray-50/40 hover:text-gray-700 dark:text-gray-300 dark:hover:bg-gray-800/40 dark:hover:text-gray-200 transition rounded-lg cursor-pointer {$selectedTerminalId &&
 				selectedLabel
 					? ' p-1 '
 					: ' p-1 opacity-50'}"
@@ -132,7 +132,9 @@
 				<Cloud className="size-3.5" strokeWidth="2" />
 
 				{#if $selectedTerminalId && selectedLabel}
-					<span class="truncate text-[0.8125rem] max-w-[6.25rem] sm:max-w-[9.375rem]">{selectedLabel}</span>
+					<span class="truncate text-[0.8125rem] max-w-[6.25rem] @sm:max-w-[9.375rem]"
+						>{selectedLabel}</span
+					>
 				{/if}
 			</button>
 		</Tooltip>


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked and filled out the following:**

- [x] **Linked Issue/Discussion:** Closes #28957. Follow-up to #28911 and #28912; the regression exists only on `dev` and has not shipped in a release.
- [x] **First-time contributor policy:** not my first contribution.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** **Manual** end-to-end tests have been performed to verify the fix/feature works correctly and does not introduce regressions.
- [x] **User-facing changes:** I have confirmed whether this PR changes the UI. It restores the model selector in narrow composers; wide and mobile layouts are unchanged.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

In a narrow chat composer the bottom row runs out of width, and whichever control loses the contest becomes unreachable. On `dev` today, in a note's `Chat` panel at its 350px minimum with a terminal connection selected, the model selector is squeezed to 0px and disappears. Toggle the terminal off and turn on a couple of integrations instead, and the terminal button itself scrolls out of the row, so re-enabling it means widening the panel first.

**Root cause.** The row is `flex justify-between` over two groups that both want more width than the row has: a left group with the `+` button, the integrations button, the toggled chips, and the terminal selector, and a right group with the model selector, the microphone, and send. #28912 pinned the left group with `shrink-0` so it would stop collapsing under the model selector (#28911), which left the right group as the only side that could give, down to 0px for the selector. Letting the left group shrink instead only moves the casualty into the chip strip's `overflow-x-auto`. The pressure is real rather than a layout bug: at 1.2x `UI Scale` the selector's `13rem` cap alone is 250px of a 319px row, and the caps are rem based, so they grow with `UI Scale` while the panel's 350px minimum does not. On top of that both caps use viewport breakpoints (`sm:`), so a 350px panel inside a 1280px window is handed the widest cap.

**Fix.** Give the composer a second row when its container is narrow, and put the two connection selectors together.

- The terminal selector moves out of the chip strip and into the group with the model selector, carrying `mr-auto` so it stays at the start of that group. On one row this leaves it exactly where it is today, right after the chips; on two rows it starts the second row, under the `+` button.
- The row becomes `flex-wrap` and the left group takes `@max-md:basis-full`, so in containers under `28rem` the buttons keep the first row and the selector pair, microphone, and send take the second. Above that the row behaves as one line, exactly as before. The selector group picks up `@max-md:ml-1` in that same narrow range so the terminal selector lines up under the `+` button on the second row, while one row layouts keep their current spacing to the pixel.
- The two label caps move from viewport breakpoints (`sm:`) to container breakpoints (`@sm:`), which is what the composer actually sits in. `#chat-pane` is already a `@container`, so the caps now respond to the panel rather than the window.
- The left group keeps `max-w-full` so an overlong chip strip still scrolls instead of pushing the row, and the selector group keeps `min-w-0` so the model name truncates rather than overflowing.
- Because the terminal selector is no longer a sibling of the toggled chips, it no longer inherits their `gap-1.5`. The chip container takes `has-[>*]:mr-1.5` so that spacing comes back exactly when at least one chip is showing, which reproduces `dev`'s spacing in both cases to the pixel.
- The terminal selector's label can now truncate. Its `min-w-0` chain was broken by the `Tooltip` wrapper, so the label could only ever render at full width and pushed the rest of the row out of the container. It keeps a `4.5rem` floor so it stays identifiable rather than collapsing to its icon.
- The row takes `overflow-hidden`, so a container too narrow even for the floors clips inside the composer instead of painting controls outside it.

### Fixed

- Fixed controls becoming unreachable in a narrow chat composer, such as a note's chat panel at its minimum width, where the model selector could be squeezed to zero width or the terminal selector scrolled out of the row.

### Changed

- The chat composer lays its controls out over two rows when its container is narrower than `28rem`, with the terminal selector starting the second row.

---

### Additional Information

Verified manually on top of `16c2a9eda`, measuring element bounding boxes rather than eyeballing. Panel numbers come from a note's chat panel at 1.2x `UI Scale`, so `1rem` is 19.2px.

| Case | rows | model selector | terminal selector |
|---|---|---|---|
| `dev`, 350px panel, terminal selected | 1 | 0px, send button clipped | visible |
| `dev`, 350px panel, terminal off, 2 integrations on | 1 | 145.9px | scrolled out of the row |
| this branch, 350px panel, terminal selected | 2 | 70.3px | 153.6px, second row |
| this branch, 350px panel, no terminal selected | 2 | 192px, at its cap | 26.4px icon, second row |
| this branch, 500px panel | 2 | 201.3px | 172.6px |
| this branch, 560px and 640px panels | 1 | 249.6px, at its cap | 172.6px |
| this branch, main chat at 847.9px | 1 | 249.6px, at its cap | 172.6px, in place |
| this branch, 375px viewport | 2 | 95.3px | 153.6px, second row |

1. Above the `28rem` container width the composer is a single 36px row and the terminal selector sits where it does on `dev`, right after the chips, so wide layouts are visually unchanged. Measured against the row's left edge, both branches agree to the pixel: with no chips showing, `+` at 4.8px, integrations at 51.6px, terminal selector at 94.8px; with one chip showing, the chip at 92.4px and the terminal selector at 137.5px.
2. On the second row the terminal selector starts at 7.2px against the `+` button's 4.8px, the 2.4px coming from the selector's existing `translate-x-0.5`.
3. Below it the composer's control area is two rows, which is the visible cost of the change. It applies to narrow phone viewports as well as narrow panels.
4. An overlong chip strip still scrolls inside its own container, as it does today.
5. Dragging the `Controls` panel until the chat pane is 278.6px wide: `dev` runs the terminal label past the composer's right edge and pushes the model selector, microphone, and send out of view entirely, while this branch keeps all of them inside the composer on two rows. At a 78.6px pane `dev` overflows its container by 211.3px and this branch overflows by none.
6. #28911 stays fixed: no control is painted over another at any width tested.

This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Screenshots or Videos

Before is `dev` at `16c2a9eda`, after is this branch. Same account, same window, same `UI Scale`, captured in pairs.

| Surface | Before | After |
|---|---|---|
| Note `Chat` panel at its 350px minimum, terminal connection selected | <img width="700" height="264" alt="image" src="https://github.com/user-attachments/assets/20cdfd98-ddc5-4464-b173-32ff6abf3698" /> | <img width="700" height="346" alt="image" src="https://github.com/user-attachments/assets/f04f90eb-2216-4c3f-8d9f-ab6f4c62f8f1" /> |
| Note `Chat` panel at its 350px minimum, terminal off with `Web Search` and `Image` enabled | <img width="700" height="264" alt="image" src="https://github.com/user-attachments/assets/5ebe6589-febc-4221-8a61-796a7b3f4d56" /> | <img width="700" height="346" alt="image" src="https://github.com/user-attachments/assets/ef85d003-ddf2-476d-aef8-91917abcf6ae" /> |
| Chat page with the `Controls` panel dragged to a 278.6px chat pane | <img width="678" height="264" alt="image" src="https://github.com/user-attachments/assets/6a0d7aed-be71-4262-870e-8bd4871920df" /> | <img width="678" height="346" alt="image" src="https://github.com/user-attachments/assets/2b3db7d1-11d7-457a-918e-0fa70a4c0c4e" /> |
| Main chat at full width, unchanged | <img width="1758" height="264" alt="image" src="https://github.com/user-attachments/assets/164b9549-bb6e-481e-9dc8-2a5614ed0d59" /> | <img width="1758" height="264" alt="image" src="https://github.com/user-attachments/assets/0158e087-7dce-4210-83c7-ceaaed0a707c" /> |

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
