### PR TITLE
fix: drop orphaned file vector collection on delete; expose batch-add warnings

### DIFF
--- a/backend/open_webui/routers/files.py
+++ b/backend/open_webui/routers/files.py
@@ -1027,7 +1027,9 @@ async def delete_file_by_id(
         if result:
             try:
                 await asyncio.to_thread(Storage.delete_file, file.path)
-                await ASYNC_VECTOR_DB_CLIENT.delete(collection_name=f'file-{id}')
+                file_collection = f'file-{id}'
+                if await ASYNC_VECTOR_DB_CLIENT.has_collection(collection_name=file_collection):
+                    await ASYNC_VECTOR_DB_CLIENT.delete_collection(collection_name=file_collection)
             except Exception as e:
                 log.exception(e)
                 log.error('Error deleting files')

--- a/backend/open_webui/routers/knowledge.py
+++ b/backend/open_webui/routers/knowledge.py
@@ -1041,6 +1041,7 @@ async def update_external_knowledge_source(
 class KnowledgeFilesResponse(KnowledgeResponse):
     files: list[FileMetadataResponse | None] = None
     write_access: bool | None = False
+    warnings: dict | None = None
 
 
 @router.get('/{id}', response_model=KnowledgeFilesResponse | None)


### PR DESCRIPTION
delete_file_by_id called VECTOR_DB.delete() with no ids/filter, which
is a no-op on most backends, orphaning the file-{id} collection. Use
has_collection + delete_collection, the same pattern as the knowledge
file-remove path.

KnowledgeFilesResponse has no warnings field, so pydantic (extra=ignore)
silently dropped the warnings kwarg the batch-add endpoint passes when
some files fail — the response was identical to full success. Declare
the field.