### PR TITLE
security: don't send credentials with wildcard CORS origins

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -803,10 +803,14 @@ app.add_middleware(AuthTokenMiddleware, fastapi_app=app)
 app.add_middleware(WebsocketUpgradeGuardMiddleware)
 
 
+# 'Access-Control-Allow-Origin: *' must not be combined with credentials;
+# Starlette instead reflects the request origin, which grants every site
+# credentialed cross-origin access. Only allow credentials when explicit
+# origins are configured.
 app.add_middleware(
     CORSMiddleware,
     allow_origins=CORS_ALLOW_ORIGIN,
-    allow_credentials=True,
+    allow_credentials='*' not in CORS_ALLOW_ORIGIN,
     allow_methods=['*'],
     allow_headers=['*'],
 )


### PR DESCRIPTION
CORS_ALLOW_ORIGIN defaults to '*', and with allow_credentials=True
Starlette reflects the request origin instead of sending the literal
wildcard, granting every website credentialed cross-origin access to
the API. This becomes exploitable whenever the session cookie is sent
cross-site (e.g. WEBUI_SESSION_COOKIE_SAME_SITE=none) or on browsers
with weakened defaults. The CORS spec forbids wildcard together with
credentials; only allow the latter when explicit origins are
configured

Closes #28971

### Changelog

**security** — wildcard CORS origins no longer send credentials; credentials require explicitly configured origins.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.