### PR TITLE
i18n: fix Azure STT/TTS endpoint placeholder grammar

### DIFF
--- a/src/lib/components/admin/Settings/Audio.svelte
+++ b/src/lib/components/admin/Settings/Audio.svelte
@@ -368,7 +368,7 @@
 						<input
 							class={inputClass}
 							bind:value={STT_AZURE_BASE_URL}
-							placeholder={$i18n.t('(leave blank for to use commercial endpoint)')}
+							placeholder={$i18n.t('(leave blank to use the commercial endpoint)')}
 						/>
 					</AdminSettingField>
 					<AdminSettingField label={$i18n.t('Max Speakers')}>
@@ -557,7 +557,7 @@
 						<input
 							class={inputClass}
 							bind:value={TTS_AZURE_SPEECH_BASE_URL}
-							placeholder={$i18n.t('(leave blank for to use commercial endpoint)')}
+							placeholder={$i18n.t('(leave blank to use the commercial endpoint)')}
 						/>
 					</AdminSettingField>
 				</div>

--- a/src/lib/i18n/locales/ar-BH/translation.json
+++ b/src/lib/i18n/locales/ar-BH/translation.json
@@ -1,7 +1,7 @@
 {
 	"-1 for no limit, or a positive integer for a specific limit": "",
 	"(latest)": "(الأخير)",
-	"(leave blank for to use commercial endpoint)": "",
+	"(leave blank to use the commercial endpoint)": "",
 	"[Last] dddd [at] h:mm A": "",
 	"[Today at] h:mm A": "",
 	"[Yesterday at] h:mm A": "",

--- a/src/lib/i18n/locales/ar/translation.json
+++ b/src/lib/i18n/locales/ar/translation.json
@@ -1,7 +1,7 @@
 {
 	"-1 for no limit, or a positive integer for a specific limit": "-1 لعدم وجود حد، أو عدد صحيح موجب لحد معين",
 	"(latest)": "(أحدث)",
-	"(leave blank for to use commercial endpoint)": "",
+	"(leave blank to use the commercial endpoint)": "",
 	"[Last] dddd [at] h:mm A": "",
 	"[Today at] h:mm A": "",
 	"[Yesterday at] h:mm A": "",

--- a/src/lib/i18n/locales/az-AZ/translation.json
+++ b/src/lib/i18n/locales/az-AZ/translation.json
@@ -1,7 +1,7 @@
 {
 	"-1 for no limit, or a positive integer for a specific limit": "Limitsiz üçün -1, yaxud konkret limit üçün müsbət tam ədəd daxil edin",
 	"(latest)": "(ən sonuncu)",
-	"(leave blank for to use commercial endpoint)": "(kommersiya son nöqtəsindən istifadə etmək üçün boş buraxın)",
+	"(leave blank to use the commercial endpoint)": "(kommersiya son nöqtəsindən istifadə etmək üçün boş buraxın)",
 	"[Last] dddd [at] h:mm A": "[Sonuncu] dddd [saat] h:mm A",
 	"[Today at] h:mm A": "[Bu gün saat] h:mm A",
 	"[Yesterday at] h:mm A": "[Dünən saat] h:mm A",

--- a/src/lib/i18n/locales/bg-BG/translation.json
+++ b/src/lib/i18n/locales/bg-BG/translation.json
@@ -1,7 +1,7 @@
 {
 	"-1 for no limit, or a positive integer for a specific limit": "-1 за липса на ограничение или положително цяло число за определено ограничение.",
 	"(latest)": "(последна)",
-	"(leave blank for to use commercial endpoint)": "",
+	"(leave blank to use the commercial endpoint)": "",
 	"[Last] dddd [at] h:mm A": "",
 	"[Today at] h:mm A": "",
 	"[Yesterday at] h:mm A": "",

--- a/src/lib/i18n/locales/bn-BD/translation.json
+++ b/src/lib/i18n/locales/bn-BD/translation.json
@@ -1,7 +1,7 @@
 {
 	"-1 for no limit, or a positive integer for a specific limit": "",
 	"(latest)": "(সর্বশেষ)",
-	"(leave blank for to use commercial endpoint)": "",
+	"(leave blank to use the commercial endpoint)": "",
 	"[Last] dddd [at] h:mm A": "",
 	"[Today at] h:mm A": "",
 	"[Yesterday at] h:mm A": "",

--- a/src/lib/i18n/locales/bo-TB/translation.json
+++ b/src/lib/i18n/locales/bo-TB/translation.json
@@ -1,7 +1,7 @@
 {
 	"-1 for no limit, or a positive integer for a specific limit": "-1 ནི་ཚད་མེད་པའི་ཆེད་དམ། ཡང་ན་ཧྲིལ་གྲངས་དགོས་ངེས་ཤིག་ཚད་བཀག་ངེས་ཅན་ཞིག་གི་ཆེད་དུ།",
 	"(latest)": "(ཆེས་གསར།)",
-	"(leave blank for to use commercial endpoint)": "",
+	"(leave blank to use the commercial endpoint)": "",
 	"[Last] dddd [at] h:mm A": "",
 	"[Today at] h:mm A": "",
 	"[Yesterday at] h:mm A": "",

--- a/src/lib/i18n/locales/bs-BA/translation.json
+++ b/src/lib/i18n/locales/bs-BA/translation.json
@@ -1,7 +1,7 @@
 {
 	"-1 for no limit, or a positive integer for a specific limit": "",
 	"(latest)": "(najnovije)",
-	"(leave blank for to use commercial endpoint)": "",
+	"(leave blank to use the commercial endpoint)": "",
 	"[Last] dddd [at] h:mm A": "",
 	"[Today at] h:mm A": "",
 	"[Yesterday at] h:mm A": "",

--- a/src/lib/i18n/locales/ca-ES/translation.json
+++ b/src/lib/i18n/locales/ca-ES/translation.json
@@ -1,7 +1,7 @@
 {
 	"-1 for no limit, or a positive integer for a specific limit": "-1 per a cap límit, o un nombre positiu per a un límit específic",
 	"(latest)": "(últim)",
-	"(leave blank for to use commercial endpoint)": "(deixa-ho buit per utilitzar un punt d'accés comercial)",
+	"(leave blank to use the commercial endpoint)": "(deixa-ho buit per utilitzar un punt d'accés comercial)",
 	"[Last] dddd [at] h:mm A": "[Darrer] dddd [a] h:mm A",
 	"[Today at] h:mm A": "[Avui a les] h:mm A",
 	"[Yesterday at] h:mm A": "[Ahir a les] h:mm A",

--- a/src/lib/i18n/locales/ceb-PH/translation.json
+++ b/src/lib/i18n/locales/ceb-PH/translation.json
@@ -1,7 +1,7 @@
 {
 	"-1 for no limit, or a positive integer for a specific limit": "",
 	"(latest)": "",
-	"(leave blank for to use commercial endpoint)": "",
+	"(leave blank to use the commercial endpoint)": "",
 	"[Last] dddd [at] h:mm A": "",
 	"[Today at] h:mm A": "",
 	"[Yesterday at] h:mm A": "",

--- a/src/lib/i18n/locales/cs-CZ/translation.json
+++ b/src/lib/i18n/locales/cs-CZ/translation.json
@@ -1,7 +1,7 @@
 {
 	"-1 for no limit, or a positive integer for a specific limit": "-1 pro žádný limit, nebo kladné celé číslo pro specifický limit",
 	"(latest)": "(nejnovější)",
-	"(leave blank for to use commercial endpoint)": "(ponechte prázdné pro použití komerčního koncového bodu)",
+	"(leave blank to use the commercial endpoint)": "(ponechte prázdné pro použití komerčního koncového bodu)",
 	"[Last] dddd [at] h:mm A": "[Naposledy] dddd [v] h:mm A",
 	"[Today at] h:mm A": "[Dnes v] h:mm A",
 	"[Yesterday at] h:mm A": "[Včera v] h:mm A",

--- a/src/lib/i18n/locales/da-DK/translation.json
+++ b/src/lib/i18n/locales/da-DK/translation.json
@@ -1,7 +1,7 @@
 {
 	"-1 for no limit, or a positive integer for a specific limit": "-1 for ingen grænse, eller et positivt heltal for en specifik grænse",
 	"(latest)": "(seneste)",
-	"(leave blank for to use commercial endpoint)": "(lad stå tom for at bruge kommercielt endpoint)",
+	"(leave blank to use the commercial endpoint)": "(lad stå tom for at bruge kommercielt endpoint)",
 	"[Last] dddd [at] h:mm A": "[Sidste] dddd [kl.] h:mm A",
 	"[Today at] h:mm A": "[I dag kl.] h:mm A",
 	"[Yesterday at] h:mm A": "[I går kl.] h:mm A",

--- a/src/lib/i18n/locales/de-DE/translation.json
+++ b/src/lib/i18n/locales/de-DE/translation.json
@@ -1,7 +1,7 @@
 {
 	"-1 for no limit, or a positive integer for a specific limit": "-1 für kein Limit oder eine positive ganze Zahl für ein spezifisches Limit",
 	"(latest)": "(neueste)",
-	"(leave blank for to use commercial endpoint)": "(leer lassen, um kommerziellen Endpunkt zu verwenden)",
+	"(leave blank to use the commercial endpoint)": "(leer lassen, um kommerziellen Endpunkt zu verwenden)",
 	"[Last] dddd [at] h:mm A": "[Letzten] dddd [um] h:mm A",
 	"[Today at] h:mm A": "[Heute um] h:mm A",
 	"[Yesterday at] h:mm A": "[Gestern um] h:mm A",

--- a/src/lib/i18n/locales/dg-DG/translation.json
+++ b/src/lib/i18n/locales/dg-DG/translation.json
@@ -1,7 +1,7 @@
 {
 	"-1 for no limit, or a positive integer for a specific limit": "",
 	"(latest)": "(much latest)",
-	"(leave blank for to use commercial endpoint)": "",
+	"(leave blank to use the commercial endpoint)": "",
 	"[Last] dddd [at] h:mm A": "",
 	"[Today at] h:mm A": "",
 	"[Yesterday at] h:mm A": "",

--- a/src/lib/i18n/locales/el-GR/translation.json
+++ b/src/lib/i18n/locales/el-GR/translation.json
@@ -1,7 +1,7 @@
 {
 	"-1 for no limit, or a positive integer for a specific limit": "-1 για απεριόριστο, ή έναν θετικό ακέραιο για ένα συγκεκριμένο όριο",
 	"(latest)": "(τελευταία)",
-	"(leave blank for to use commercial endpoint)": "(αφήστε κενό για να χρησιμοποιήσετε εμπορικό endpoint)",
+	"(leave blank to use the commercial endpoint)": "(αφήστε κενό για να χρησιμοποιήσετε εμπορικό endpoint)",
 	"[Last] dddd [at] h:mm A": "",
 	"[Today at] h:mm A": "",
 	"[Yesterday at] h:mm A": "",

--- a/src/lib/i18n/locales/en-GB/translation.json
+++ b/src/lib/i18n/locales/en-GB/translation.json
@@ -1,7 +1,7 @@
 {
 	"-1 for no limit, or a positive integer for a specific limit": "",
 	"(latest)": "",
-	"(leave blank for to use commercial endpoint)": "",
+	"(leave blank to use the commercial endpoint)": "",
 	"[Last] dddd [at] h:mm A": "",
 	"[Today at] h:mm A": "",
 	"[Yesterday at] h:mm A": "",

--- a/src/lib/i18n/locales/en-US/translation.json
+++ b/src/lib/i18n/locales/en-US/translation.json
@@ -1,7 +1,7 @@
 {
 	"-1 for no limit, or a positive integer for a specific limit": "",
 	"(latest)": "",
-	"(leave blank for to use commercial endpoint)": "",
+	"(leave blank to use the commercial endpoint)": "",
 	"[Last] dddd [at] h:mm A": "",
 	"[Today at] h:mm A": "",
 	"[Yesterday at] h:mm A": "",

--- a/src/lib/i18n/locales/es-ES/translation.json
+++ b/src/lib/i18n/locales/es-ES/translation.json
@@ -1,7 +1,7 @@
 {
 	"-1 for no limit, or a positive integer for a specific limit": "-1 para ilimitado, o un número entero positivo para un límite específico.",
 	"(latest)": "(la última)",
-	"(leave blank for to use commercial endpoint)": "(dejar vacío para usar el endpoint comercial)",
+	"(leave blank to use the commercial endpoint)": "(dejar vacío para usar el endpoint comercial)",
 	"[Last] dddd [at] h:mm A": "[Último] dddd [a las] h:mm A",
 	"[Today at] h:mm A": "[Hoy a las] h:mm A",
 	"[Yesterday at] h:mm A": "[Ayer a las] h:mm A",

--- a/src/lib/i18n/locales/et-EE/translation.json
+++ b/src/lib/i18n/locales/et-EE/translation.json
@@ -1,7 +1,7 @@
 {
 	"-1 for no limit, or a positive integer for a specific limit": "-1 piirangu puudumisel või positiivne täisarv konkreetse piirangu jaoks",
 	"(latest)": "(uusim)",
-	"(leave blank for to use commercial endpoint)": "(jäta tühjaks, et kasutada kommertslõpp-punkti)",
+	"(leave blank to use the commercial endpoint)": "(jäta tühjaks, et kasutada kommertslõpp-punkti)",
 	"[Last] dddd [at] h:mm A": "[Eelmisel] dddd [kell] h:mm A",
 	"[Today at] h:mm A": "[Täna kell] h:mm A",
 	"[Yesterday at] h:mm A": "[Eile kell] h:mm A",

--- a/src/lib/i18n/locales/eu-ES/translation.json
+++ b/src/lib/i18n/locales/eu-ES/translation.json
@@ -1,7 +1,7 @@
 {
 	"-1 for no limit, or a positive integer for a specific limit": "",
 	"(latest)": "(azkena)",
-	"(leave blank for to use commercial endpoint)": "",
+	"(leave blank to use the commercial endpoint)": "",
 	"[Last] dddd [at] h:mm A": "",
 	"[Today at] h:mm A": "",
 	"[Yesterday at] h:mm A": "",

--- a/src/lib/i18n/locales/fa-IR/translation.json
+++ b/src/lib/i18n/locales/fa-IR/translation.json
@@ -1,7 +1,7 @@
 {
 	"-1 for no limit, or a positive integer for a specific limit": "-1 برای بدون محدودیت، یا یک عدد مثبت برای محدودیت مشخص",
 	"(latest)": "(آخرین)",
-	"(leave blank for to use commercial endpoint)": "(برای استفاده از نقطه پایانی تجاری خالی بگذارید)",
+	"(leave blank to use the commercial endpoint)": "(برای استفاده از نقطه پایانی تجاری خالی بگذارید)",
 	"[Last] dddd [at] h:mm A": "[آخرین] dddd [در] h:mm A",
 	"[Today at] h:mm A": "[امروز در] h:mm A",
 	"[Yesterday at] h:mm A": "[دیروز در] h:mm A",

--- a/src/lib/i18n/locales/fi-FI/translation.json
+++ b/src/lib/i18n/locales/fi-FI/translation.json
@@ -1,7 +1,7 @@
 {
 	"-1 for no limit, or a positive integer for a specific limit": "-1 rajoituksetta tai positiivinen kokonaisluku enimmäismääräksi",
 	"(latest)": "(uusin)",
-	"(leave blank for to use commercial endpoint)": "(Jätä tyhjäksi, jos haluat käyttää kaupallista päätettä)",
+	"(leave blank to use the commercial endpoint)": "(Jätä tyhjäksi, jos haluat käyttää kaupallista päätettä)",
 	"[Last] dddd [at] h:mm A": "[Viimeisin] dddd h:mm A",
 	"[Today at] h:mm A": "[Tänään] h:mm A",
 	"[Yesterday at] h:mm A": "[Eilen] h:mm A",

--- a/src/lib/i18n/locales/fil-PH/translation.json
+++ b/src/lib/i18n/locales/fil-PH/translation.json
@@ -1,7 +1,7 @@
 {
 	"-1 for no limit, or a positive integer for a specific limit": "",
 	"(latest)": "",
-	"(leave blank for to use commercial endpoint)": "",
+	"(leave blank to use the commercial endpoint)": "",
 	"[Last] dddd [at] h:mm A": "",
 	"[Today at] h:mm A": "",
 	"[Yesterday at] h:mm A": "",

--- a/src/lib/i18n/locales/fr-CA/translation.json
+++ b/src/lib/i18n/locales/fr-CA/translation.json
@@ -1,7 +1,7 @@
 {
 	"-1 for no limit, or a positive integer for a specific limit": "-1 pour aucune limite, ou un entier positif pour une limite spécifique",
 	"(latest)": "(dernière version)",
-	"(leave blank for to use commercial endpoint)": "laisser vide pour l'utilisation d'un point d'extension commercial",
+	"(leave blank to use the commercial endpoint)": "laisser vide pour l'utilisation d'un point d'extension commercial",
 	"[Last] dddd [at] h:mm A": "",
 	"[Today at] h:mm A": "",
 	"[Yesterday at] h:mm A": "",

--- a/src/lib/i18n/locales/fr-FR/translation.json
+++ b/src/lib/i18n/locales/fr-FR/translation.json
@@ -1,7 +1,7 @@
 {
 	"-1 for no limit, or a positive integer for a specific limit": "-1 pour aucune limite, ou un entier positif pour une limite spécifique",
 	"(latest)": "(dernière version)",
-	"(leave blank for to use commercial endpoint)": "laisser vide pour l'utilisation d'un point d'extension commercial",
+	"(leave blank to use the commercial endpoint)": "laisser vide pour l'utilisation d'un point d'extension commercial",
 	"[Last] dddd [at] h:mm A": "dddd [dernier] à H[h]mm",
 	"[Today at] h:mm A": "[Aujourd'hui à] H[h]mm",
 	"[Yesterday at] h:mm A": "[Hier à] H[h]mm",

--- a/src/lib/i18n/locales/gl-ES/translation.json
+++ b/src/lib/i18n/locales/gl-ES/translation.json
@@ -1,7 +1,7 @@
 {
 	"-1 for no limit, or a positive integer for a specific limit": "-1 para ilimitado, ou un número enteiro positivo para un límite específico.",
 	"(latest)": "(O mais recente)",
-	"(leave blank for to use commercial endpoint)": "",
+	"(leave blank to use the commercial endpoint)": "",
 	"[Last] dddd [at] h:mm A": "",
 	"[Today at] h:mm A": "",
 	"[Yesterday at] h:mm A": "",

--- a/src/lib/i18n/locales/he-IL/translation.json
+++ b/src/lib/i18n/locales/he-IL/translation.json
@@ -1,7 +1,7 @@
 {
 	"-1 for no limit, or a positive integer for a specific limit": "",
 	"(latest)": "(האחרון)",
-	"(leave blank for to use commercial endpoint)": "",
+	"(leave blank to use the commercial endpoint)": "",
 	"[Last] dddd [at] h:mm A": "",
 	"[Today at] h:mm A": "",
 	"[Yesterday at] h:mm A": "",

--- a/src/lib/i18n/locales/hi-IN/translation.json
+++ b/src/lib/i18n/locales/hi-IN/translation.json
@@ -1,7 +1,7 @@
 {
 	"-1 for no limit, or a positive integer for a specific limit": "",
 	"(latest)": "(latest)",
-	"(leave blank for to use commercial endpoint)": "",
+	"(leave blank to use the commercial endpoint)": "",
 	"[Last] dddd [at] h:mm A": "",
 	"[Today at] h:mm A": "",
 	"[Yesterday at] h:mm A": "",

--- a/src/lib/i18n/locales/hr-HR/translation.json
+++ b/src/lib/i18n/locales/hr-HR/translation.json
@@ -1,7 +1,7 @@
 {
 	"-1 for no limit, or a positive integer for a specific limit": "",
 	"(latest)": "(najnovije)",
-	"(leave blank for to use commercial endpoint)": "",
+	"(leave blank to use the commercial endpoint)": "",
 	"[Last] dddd [at] h:mm A": "",
 	"[Today at] h:mm A": "",
 	"[Yesterday at] h:mm A": "",

--- a/src/lib/i18n/locales/hu-HU/translation.json
+++ b/src/lib/i18n/locales/hu-HU/translation.json
@@ -1,7 +1,7 @@
 {
   "-1 for no limit, or a positive integer for a specific limit": "-1 a korlátlanhoz, vagy pozitív egész szám egy konkrét limithoz",
   "(latest)": "(legújabb)",
-  "(leave blank for to use commercial endpoint)": "(hagyd üresen a kereskedelmi végpont használatához)",
+  "(leave blank to use the commercial endpoint)": "(hagyd üresen a kereskedelmi végpont használatához)",
   "[Last] dddd [at] h:mm A": "[Legutóbb] dddd [ekkor:] h:mm A",
   "[Today at] h:mm A": "[Ma ekkor:] h:mm A",
   "[Yesterday at] h:mm A": "[Tegnap ekkor:] h:mm A",

--- a/src/lib/i18n/locales/id-ID/translation.json
+++ b/src/lib/i18n/locales/id-ID/translation.json
@@ -1,7 +1,7 @@
 {
 	"-1 for no limit, or a positive integer for a specific limit": "",
 	"(latest)": "(terbaru)",
-	"(leave blank for to use commercial endpoint)": "",
+	"(leave blank to use the commercial endpoint)": "",
 	"[Last] dddd [at] h:mm A": "",
 	"[Today at] h:mm A": "",
 	"[Yesterday at] h:mm A": "",

--- a/src/lib/i18n/locales/ie-GA/translation.json
+++ b/src/lib/i18n/locales/ie-GA/translation.json
@@ -1,7 +1,7 @@
 {
 	"-1 for no limit, or a positive integer for a specific limit": "-1 gan teorainn, nó slánuimhir dheimhneach le haghaidh teorann sonrach",
 	"(latest)": "(is déanaí)",
-	"(leave blank for to use commercial endpoint)": "(fág bán le haghaidh críochphointe tráchtála a úsáid)",
+	"(leave blank to use the commercial endpoint)": "(fág bán le haghaidh críochphointe tráchtála a úsáid)",
 	"[Last] dddd [at] h:mm A": "[Deireanach] dddd [ag] h:mm A",
 	"[Today at] h:mm A": "[Inniu ag] h:mm A",
 	"[Yesterday at] h:mm A": "[Inné ag] h:mm A",

--- a/src/lib/i18n/locales/it-IT/translation.json
+++ b/src/lib/i18n/locales/it-IT/translation.json
@@ -1,7 +1,7 @@
 {
 	"-1 for no limit, or a positive integer for a specific limit": "-1 per nessun limite, o un numero intero positivo per un limite specifico",
 	"(latest)": "(ultima)",
-	"(leave blank for to use commercial endpoint)": "(lascia vuoto per utilizzare l'endpoint commerciale)",
+	"(leave blank to use the commercial endpoint)": "(lascia vuoto per utilizzare l'endpoint commerciale)",
 	"[Last] dddd [at] h:mm A": "",
 	"[Today at] h:mm A": "",
 	"[Yesterday at] h:mm A": "",

--- a/src/lib/i18n/locales/ja-JP/translation.json
+++ b/src/lib/i18n/locales/ja-JP/translation.json
@@ -1,7 +1,7 @@
 {
 	"-1 for no limit, or a positive integer for a specific limit": "-1で無制限、または正の整数で制限を指定",
 	"(latest)": "(最新)",
-	"(leave blank for to use commercial endpoint)": "(商用エンドポイントを使用する場合は空欄のままにしてください)",
+	"(leave blank to use the commercial endpoint)": "(商用エンドポイントを使用する場合は空欄のままにしてください)",
 	"[Last] dddd [at] h:mm A": "dddd h:mm A",
 	"[Today at] h:mm A": "[今日の] h:mm A",
 	"[Yesterday at] h:mm A": "[昨日の] h:mm A",

--- a/src/lib/i18n/locales/ka-GE/translation.json
+++ b/src/lib/i18n/locales/ka-GE/translation.json
@@ -1,7 +1,7 @@
 {
 	"-1 for no limit, or a positive integer for a specific limit": "-1 ლიმიტის გამოსართავად, ან დადებითი მთელი რიცხვი კონკრეტული ლიმიტისთვის",
 	"(latest)": "(უახლესი)",
-	"(leave blank for to use commercial endpoint)": "(დატოვეთ ცარიელი ფასიანი ბოლოწერტილის გამოსაყენებლად)",
+	"(leave blank to use the commercial endpoint)": "(დატოვეთ ცარიელი ფასიანი ბოლოწერტილის გამოსაყენებლად)",
 	"[Last] dddd [at] h:mm A": "[ბოლო] dddd [დრო] h:mm A",
 	"[Today at] h:mm A": "[დღეს,] h:mm A",
 	"[Yesterday at] h:mm A": "[გუშინ, ] h:mm A",

--- a/src/lib/i18n/locales/kab-DZ/translation.json
+++ b/src/lib/i18n/locales/kab-DZ/translation.json
@@ -1,7 +1,7 @@
 {
 	"-1 for no limit, or a positive integer for a specific limit": "-1 war talast, neɣ aɣerwaḍ ilaw i talast tusdidt",
 	"(latest)": "(Lqem aneggaru)",
-	"(leave blank for to use commercial endpoint)": "",
+	"(leave blank to use the commercial endpoint)": "",
 	"[Last] dddd [at] h:mm A": "[Aneggaru] dddd [ɣef] h:mm A",
 	"[Today at] h:mm A": "[Ass-a ɣef] h:mm A",
 	"[Yesterday at] h:mm A": "[Iḍelli ɣef] h:mm A",

--- a/src/lib/i18n/locales/ko-KR/translation.json
+++ b/src/lib/i18n/locales/ko-KR/translation.json
@@ -1,7 +1,7 @@
 {
 	"-1 for no limit, or a positive integer for a specific limit": "-1은 제한 없음을 의미하며, 양의 정수는 특정 제한을 나타냅니다",
 	"(latest)": "(최신)",
-	"(leave blank for to use commercial endpoint)": "(상용 엔드포인트를 사용하시려면 비워두세요)",
+	"(leave blank to use the commercial endpoint)": "(상용 엔드포인트를 사용하시려면 비워두세요)",
 	"[Last] dddd [at] h:mm A": "[지난] dddd A h:mm",
 	"[Today at] h:mm A": "[오늘] A h:mm",
 	"[Yesterday at] h:mm A": "[어제] A h:mm",

--- a/src/lib/i18n/locales/lt-LT/translation.json
+++ b/src/lib/i18n/locales/lt-LT/translation.json
@@ -1,7 +1,7 @@
 {
 	"-1 for no limit, or a positive integer for a specific limit": "",
 	"(latest)": "(naujausias)",
-	"(leave blank for to use commercial endpoint)": "",
+	"(leave blank to use the commercial endpoint)": "",
 	"[Last] dddd [at] h:mm A": "",
 	"[Today at] h:mm A": "",
 	"[Yesterday at] h:mm A": "",

--- a/src/lib/i18n/locales/lv-LV/translation.json
+++ b/src/lib/i18n/locales/lv-LV/translation.json
@@ -1,7 +1,7 @@
 {
 	"-1 for no limit, or a positive integer for a specific limit": "-1 bez ierobežojuma vai pozitīvs skaitlis konkrētam ierobežojumam",
 	"(latest)": "(jaunākā)",
-	"(leave blank for to use commercial endpoint)": "(atstājiet tukšu, lai izmantotu komerciālo galapunktu)",
+	"(leave blank to use the commercial endpoint)": "(atstājiet tukšu, lai izmantotu komerciālo galapunktu)",
 	"[Last] dddd [at] h:mm A": "[Pagājušā] dddd [plkst.] H:mm",
 	"[Today at] h:mm A": "[Šodien plkst.] H:mm",
 	"[Yesterday at] h:mm A": "[Vakar plkst.] H:mm",

--- a/src/lib/i18n/locales/ms-MY/translation.json
+++ b/src/lib/i18n/locales/ms-MY/translation.json
@@ -1,7 +1,7 @@
 {
 	"-1 for no limit, or a positive integer for a specific limit": "-1 untuk tanpa had, atau integer positif untuk had tertentu",
 	"(latest)": "(terkini)",
-	"(leave blank for to use commercial endpoint)": "(biarkan kosong untuk menggunakan titik akhir komersial)",
+	"(leave blank to use the commercial endpoint)": "(biarkan kosong untuk menggunakan titik akhir komersial)",
 	"[Last] dddd [at] h:mm A": "[Terakhir] dddd [pada] h:mm A",
 	"[Today at] h:mm A": "[Hari ini pada] h:mm A",
 	"[Yesterday at] h:mm A": "[Semalam pada] h:mm A",

--- a/src/lib/i18n/locales/nb-NO/translation.json
+++ b/src/lib/i18n/locales/nb-NO/translation.json
@@ -1,7 +1,7 @@
 {
 	"-1 for no limit, or a positive integer for a specific limit": "-1 angir ingen grense, eller angi et positivt heltall for en bestemt grense",
 	"(latest)": "(siste)",
-	"(leave blank for to use commercial endpoint)": "",
+	"(leave blank to use the commercial endpoint)": "",
 	"[Last] dddd [at] h:mm A": "",
 	"[Today at] h:mm A": "",
 	"[Yesterday at] h:mm A": "",

--- a/src/lib/i18n/locales/nl-NL/translation.json
+++ b/src/lib/i18n/locales/nl-NL/translation.json
@@ -1,7 +1,7 @@
 {
 	"-1 for no limit, or a positive integer for a specific limit": "-1 voor geen limiet, of een positief getal voor een specifieke limiet",
 	"(latest)": "(nieuwste)",
-	"(leave blank for to use commercial endpoint)": "(laat leeg om een commercieel endpoint te gebruiken)",
+	"(leave blank to use the commercial endpoint)": "(laat leeg om een commercieel endpoint te gebruiken)",
 	"[Last] dddd [at] h:mm A": "[Vorige] dddd [om] h:mm A",
 	"[Today at] h:mm A": "[Vandaag om] h:mm A",
 	"[Yesterday at] h:mm A": "[Gisteren om] h:mm A",

--- a/src/lib/i18n/locales/pa-IN/translation.json
+++ b/src/lib/i18n/locales/pa-IN/translation.json
@@ -1,7 +1,7 @@
 {
 	"-1 for no limit, or a positive integer for a specific limit": "",
 	"(latest)": "(ਤਾਜ਼ਾ)",
-	"(leave blank for to use commercial endpoint)": "",
+	"(leave blank to use the commercial endpoint)": "",
 	"[Last] dddd [at] h:mm A": "",
 	"[Today at] h:mm A": "",
 	"[Yesterday at] h:mm A": "",

--- a/src/lib/i18n/locales/pl-PL/translation.json
+++ b/src/lib/i18n/locales/pl-PL/translation.json
@@ -1,7 +1,7 @@
 {
 	"-1 for no limit, or a positive integer for a specific limit": "-1 oznacza brak limitu, liczba dodatnia oznacza konkretny limit",
 	"(latest)": "(najnowszy)",
-	"(leave blank for to use commercial endpoint)": "(pozostaw puste, aby użyć komercyjnego punktu końcowego)",
+	"(leave blank to use the commercial endpoint)": "(pozostaw puste, aby użyć komercyjnego punktu końcowego)",
 	"[Last] dddd [at] h:mm A": "[Ostatnio] dddd [o] H:mm",
 	"[Today at] h:mm A": "[Dziś o] H:mm",
 	"[Yesterday at] h:mm A": "[Wczoraj o] H:mm",

--- a/src/lib/i18n/locales/pt-BR/translation.json
+++ b/src/lib/i18n/locales/pt-BR/translation.json
@@ -1,7 +1,7 @@
 {
 	"-1 for no limit, or a positive integer for a specific limit": "-1 para nenhum limite ou um inteiro positivo para um limite específico",
 	"(latest)": "(mais recente)",
-	"(leave blank for to use commercial endpoint)": "(deixe em branco para usar o endpoint comercial)",
+	"(leave blank to use the commercial endpoint)": "(deixe em branco para usar o endpoint comercial)",
 	"[Last] dddd [at] h:mm A": "[Último] dddd [em] h:mm A",
 	"[Today at] h:mm A": "[Hoje às] h:mm A",
 	"[Yesterday at] h:mm A": "[Ontem às] h:mm A",

--- a/src/lib/i18n/locales/pt-PT/translation.json
+++ b/src/lib/i18n/locales/pt-PT/translation.json
@@ -1,7 +1,7 @@
 {
 	"-1 for no limit, or a positive integer for a specific limit": "-1 para sem limite, ou um inteiro positivo para um limite específico",
 	"(latest)": "(mais recente)",
-	"(leave blank for to use commercial endpoint)": "deixe em branco para utilizar o endpoint comercial",
+	"(leave blank to use the commercial endpoint)": "deixe em branco para utilizar o endpoint comercial",
 	"[Last] dddd [at] h:mm A": "",
 	"[Today at] h:mm A": "",
 	"[Yesterday at] h:mm A": "",

--- a/src/lib/i18n/locales/ro-RO/translation.json
+++ b/src/lib/i18n/locales/ro-RO/translation.json
@@ -1,7 +1,7 @@
 {
 	"-1 for no limit, or a positive integer for a specific limit": "-1 pentru nelimitat sau un număr întreg pozitiv pentru o limită specifică",
 	"(latest)": "(ultimul)",
-	"(leave blank for to use commercial endpoint)": "(lăsați necompletat pentru a folosi endpoint-ul comercial)",
+	"(leave blank to use the commercial endpoint)": "(lăsați necompletat pentru a folosi endpoint-ul comercial)",
 	"[Last] dddd [at] h:mm A": "",
 	"[Today at] h:mm A": "",
 	"[Yesterday at] h:mm A": "",

--- a/src/lib/i18n/locales/ru-RU/translation.json
+++ b/src/lib/i18n/locales/ru-RU/translation.json
@@ -1,7 +1,7 @@
 {
 	"-1 for no limit, or a positive integer for a specific limit": "-1 для отсутствия ограничений или положительное целое число для определенного ограничения.",
 	"(latest)": "(последняя)",
-	"(leave blank for to use commercial endpoint)": "(оставьте пустым поле для использования коммерческой конечной точки)",
+	"(leave blank to use the commercial endpoint)": "(оставьте пустым поле для использования коммерческой конечной точки)",
 	"[Last] dddd [at] h:mm A": "[Последний] dddd [в] h:mm A",
 	"[Today at] h:mm A": "[Сегодня в] h:mm A",
 	"[Yesterday at] h:mm A": "[Вчера в] h:mm A",

--- a/src/lib/i18n/locales/sk-SK/translation.json
+++ b/src/lib/i18n/locales/sk-SK/translation.json
@@ -1,7 +1,7 @@
 {
 	"-1 for no limit, or a positive integer for a specific limit": "",
 	"(latest)": "Najnovšie",
-	"(leave blank for to use commercial endpoint)": "",
+	"(leave blank to use the commercial endpoint)": "",
 	"[Last] dddd [at] h:mm A": "",
 	"[Today at] h:mm A": "",
 	"[Yesterday at] h:mm A": "",

--- a/src/lib/i18n/locales/sl-SI/translation.json
+++ b/src/lib/i18n/locales/sl-SI/translation.json
@@ -1,7 +1,7 @@
 {
 	"-1 for no limit, or a positive integer for a specific limit": "-1 za brez omejitve ali pozitivno celo število za določeno omejitev",
 	"(latest)": "(najnovejše)",
-	"(leave blank for to use commercial endpoint)": "(pustite prazno za uporabo komercialne končne točke)",
+	"(leave blank to use the commercial endpoint)": "(pustite prazno za uporabo komercialne končne točke)",
 	"[Last] dddd [at] h:mm A": "[Prejšnji] dddd [ob] H:mm",
 	"[Today at] h:mm A": "[Danes ob] H:mm",
 	"[Yesterday at] h:mm A": "[Včeraj ob] H:mm",

--- a/src/lib/i18n/locales/sr-RS/translation.json
+++ b/src/lib/i18n/locales/sr-RS/translation.json
@@ -1,7 +1,7 @@
 {
 	"-1 for no limit, or a positive integer for a specific limit": "-1 за бесконачно или позитивни број за одређено ограничење",
 	"(latest)": "(најновије)",
-	"(leave blank for to use commercial endpoint)": "",
+	"(leave blank to use the commercial endpoint)": "",
 	"[Last] dddd [at] h:mm A": "",
 	"[Today at] h:mm A": "",
 	"[Yesterday at] h:mm A": "",

--- a/src/lib/i18n/locales/sv-SE/translation.json
+++ b/src/lib/i18n/locales/sv-SE/translation.json
@@ -1,7 +1,7 @@
 {
 	"-1 for no limit, or a positive integer for a specific limit": "-1 för ingen gräns, eller ett positivt heltal för en specifik gräns",
 	"(latest)": "(senaste)",
-	"(leave blank for to use commercial endpoint)": "(lämna tomt för att använda kommersiell endpoint)",
+	"(leave blank to use the commercial endpoint)": "(lämna tomt för att använda kommersiell endpoint)",
 	"[Last] dddd [at] h:mm A": "[Senaste] dddd [kl] h:mm A",
 	"[Today at] h:mm A": "Idag kl h:mm A",
 	"[Yesterday at] h:mm A": "Igår kl h:mm A",

--- a/src/lib/i18n/locales/ta-IN/translation.json
+++ b/src/lib/i18n/locales/ta-IN/translation.json
@@ -1,7 +1,7 @@
 {
 	"-1 for no limit, or a positive integer for a specific limit": "-1 வரம்பு இல்லை, அல்லது ஒரு குறிப்பிட்ட வரம்பிற்கு நேர்மறை முழு எண்",
 	"(latest)": "(சமீபத்திய)",
-	"(leave blank for to use commercial endpoint)": "(வணிக முனைப்புள்ளியைப் பயன்படுத்துவதற்கு காலியாக விடவும்)",
+	"(leave blank to use the commercial endpoint)": "(வணிக முனைப்புள்ளியைப் பயன்படுத்துவதற்கு காலியாக விடவும்)",
 	"[Last] dddd [at] h:mm A": "[கடந்த] dddd [அன்று] h:mm A",
 	"[Today at] h:mm A": "[இன்று] h:mm A",
 	"[Yesterday at] h:mm A": "[நேற்று] h:mm A",

--- a/src/lib/i18n/locales/th-TH/translation.json
+++ b/src/lib/i18n/locales/th-TH/translation.json
@@ -1,7 +1,7 @@
 {
 	"-1 for no limit, or a positive integer for a specific limit": "-1 สำหรับไม่จำกัด หรือจำนวนเต็มบวกสำหรับจำกัดค่าเฉพาะ",
 	"(latest)": "(ล่าสุด)",
-	"(leave blank for to use commercial endpoint)": "(เว้นว่างไว้เพื่อใช้ endpoint เชิงพาณิชย์)",
+	"(leave blank to use the commercial endpoint)": "(เว้นว่างไว้เพื่อใช้ endpoint เชิงพาณิชย์)",
 	"[Last] dddd [at] h:mm A": "[ล่าสุด] dddd [เวลา] h:mm A",
 	"[Today at] h:mm A": "[วันนี้ เวลา] h:mm A",
 	"[Yesterday at] h:mm A": "[เมื่อวานเวลา] h:mm A",

--- a/src/lib/i18n/locales/tk-TM/translation.json
+++ b/src/lib/i18n/locales/tk-TM/translation.json
@@ -1,7 +1,7 @@
 {
 	"-1 for no limit, or a positive integer for a specific limit": "",
 	"(latest)": "(iň soňky)",
-	"(leave blank for to use commercial endpoint)": "",
+	"(leave blank to use the commercial endpoint)": "",
 	"[Last] dddd [at] h:mm A": "",
 	"[Today at] h:mm A": "",
 	"[Yesterday at] h:mm A": "",

--- a/src/lib/i18n/locales/tr-TR/translation.json
+++ b/src/lib/i18n/locales/tr-TR/translation.json
@@ -1,7 +1,7 @@
 {
 	"-1 for no limit, or a positive integer for a specific limit": "Sınır yoksa -1, belirli bir sınır için pozitif bir tamsayı.",
 	"(latest)": "(en son)",
-	"(leave blank for to use commercial endpoint)": "Ticari uç noktayı kullanmak için boş bırakın",
+	"(leave blank to use the commercial endpoint)": "Ticari uç noktayı kullanmak için boş bırakın",
 	"[Last] dddd [at] h:mm A": "[Geçen] dddd [saat] HH:mm",
 	"[Today at] h:mm A": "[Bugün saat] HH:mm",
 	"[Yesterday at] h:mm A": "[Dün saat] HH:mm",

--- a/src/lib/i18n/locales/ug-CN/translation.json
+++ b/src/lib/i18n/locales/ug-CN/translation.json
@@ -1,7 +1,7 @@
 {
 	"-1 for no limit, or a positive integer for a specific limit": "چەك قويماسلىق ئۈچۈن 1-، ياكى بەلگىلىك بىر چەك ئۈچۈن مۇسبەت پۈتۈن سان كىرگۈزۈڭ",
 	"(latest)": "(ئەڭ يېڭىسى)",
-	"(leave blank for to use commercial endpoint)": "(تجارەتلىك ئۇلانمىنى ئىشلىتىش ئۈچۈن بوش قالدۇرۇڭ)",
+	"(leave blank to use the commercial endpoint)": "(تجارەتلىك ئۇلانمىنى ئىشلىتىش ئۈچۈن بوش قالدۇرۇڭ)",
 	"[Last] dddd [at] h:mm A": "",
 	"[Today at] h:mm A": "",
 	"[Yesterday at] h:mm A": "",

--- a/src/lib/i18n/locales/uk-UA/translation.json
+++ b/src/lib/i18n/locales/uk-UA/translation.json
@@ -1,7 +1,7 @@
 {
 	"-1 for no limit, or a positive integer for a specific limit": "-1 для без обмежень або додатне ціле число для конкретного обмеження",
 	"(latest)": "(остання)",
-	"(leave blank for to use commercial endpoint)": "",
+	"(leave blank to use the commercial endpoint)": "",
 	"[Last] dddd [at] h:mm A": "",
 	"[Today at] h:mm A": "",
 	"[Yesterday at] h:mm A": "",

--- a/src/lib/i18n/locales/ur-PK/translation.json
+++ b/src/lib/i18n/locales/ur-PK/translation.json
@@ -1,7 +1,7 @@
 {
 	"-1 for no limit, or a positive integer for a specific limit": "",
 	"(latest)": "(تازہ ترین)",
-	"(leave blank for to use commercial endpoint)": "",
+	"(leave blank to use the commercial endpoint)": "",
 	"[Last] dddd [at] h:mm A": "",
 	"[Today at] h:mm A": "",
 	"[Yesterday at] h:mm A": "",

--- a/src/lib/i18n/locales/uz-Cyrl-UZ/translation.json
+++ b/src/lib/i18n/locales/uz-Cyrl-UZ/translation.json
@@ -1,7 +1,7 @@
 {
 	"-1 for no limit, or a positive integer for a specific limit": "Чексиз учун -1 ёки маълум чегара учун мусбат бутун сон",
 	"(latest)": "(охирги)",
-	"(leave blank for to use commercial endpoint)": "(тижорий сўнгги нуқтадан фойдаланиш учун бўш қолдиринг)",
+	"(leave blank to use the commercial endpoint)": "(тижорий сўнгги нуқтадан фойдаланиш учун бўш қолдиринг)",
 	"[Last] dddd [at] h:mm A": "",
 	"[Today at] h:mm A": "",
 	"[Yesterday at] h:mm A": "",

--- a/src/lib/i18n/locales/uz-Latn-UZ/translation.json
+++ b/src/lib/i18n/locales/uz-Latn-UZ/translation.json
@@ -1,7 +1,7 @@
 {
 	"-1 for no limit, or a positive integer for a specific limit": "Cheksiz uchun -1 yoki ma'lum chegara uchun musbat butun son",
 	"(latest)": "(oxirgi)",
-	"(leave blank for to use commercial endpoint)": "(tijoriy so'nggi nuqtadan foydalanish uchun bo'sh qoldiring)",
+	"(leave blank to use the commercial endpoint)": "(tijoriy so'nggi nuqtadan foydalanish uchun bo'sh qoldiring)",
 	"[Last] dddd [at] h:mm A": "",
 	"[Today at] h:mm A": "",
 	"[Yesterday at] h:mm A": "",

--- a/src/lib/i18n/locales/vi-VN/translation.json
+++ b/src/lib/i18n/locales/vi-VN/translation.json
@@ -1,7 +1,7 @@
 {
 	"-1 for no limit, or a positive integer for a specific limit": "-1 không giới hạn, hoặc một số nguyên dương cho giới hạn cụ thể",
 	"(latest)": "(mới nhất)",
-	"(leave blank for to use commercial endpoint)": "",
+	"(leave blank to use the commercial endpoint)": "",
 	"[Last] dddd [at] h:mm A": "",
 	"[Today at] h:mm A": "",
 	"[Yesterday at] h:mm A": "",

--- a/src/lib/i18n/locales/zh-CN/translation.json
+++ b/src/lib/i18n/locales/zh-CN/translation.json
@@ -1,7 +1,7 @@
 {
 	"-1 for no limit, or a positive integer for a specific limit": "-1 表示无限制，正整数表示具体限制额度",
 	"(latest)": "（最新版）",
-	"(leave blank for to use commercial endpoint)": "（留空以使用商用端点）",
+	"(leave blank to use the commercial endpoint)": "（留空以使用商用端点）",
 	"[Last] dddd [at] h:mm A": "[上次] dddd [于] h:mm A",
 	"[Today at] h:mm A": "[今天] h:mm A",
 	"[Yesterday at] h:mm A": "[昨天] h:mm A",

--- a/src/lib/i18n/locales/zh-TW/translation.json
+++ b/src/lib/i18n/locales/zh-TW/translation.json
@@ -1,7 +1,7 @@
 {
 	"-1 for no limit, or a positive integer for a specific limit": "-1 表示無限制，正整數表示特定限制",
 	"(latest)": "（最新版）",
-	"(leave blank for to use commercial endpoint)": "（留空以使用商業端點）",
+	"(leave blank to use the commercial endpoint)": "（留空以使用商業端點）",
 	"[Last] dddd [at] h:mm A": "[上次] dddd [於] h:mm A",
 	"[Today at] h:mm A": "[今天] h:mm A",
 	"[Yesterday at] h:mm A": "[昨天] h:mm A",


### PR DESCRIPTION
Closes #28933

Standalone i18n change, split out from #28976 per the review feedback (that PR mixed i18n files with unrelated backend files).

The Azure STT/TTS endpoint placeholder had broken grammar ("leave blank for to use commercial endpoint"). The key is renamed across every locale with **existing translations preserved verbatim** — no new translation content is authored, so no native-language knowledge is involved. `Audio.svelte` holds the source string and its placeholder text changes with the key.

Verified: the re-keyed key resolves in en-US/en-GB and the preserved translations still load for de-DE/ja-JP/zh-CN (spot-checked via the i18n loader locally).

### Changelog

**fixed** — Azure STT/TTS endpoint placeholder grammar corrected across all locales.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.