### PR TITLE
fix: stale docstrings documenting parameters the functions do not take

### DIFF
--- a/backend/open_webui/retrieval/loaders/tavily.py
+++ b/backend/open_webui/retrieval/loaders/tavily.py
@@ -33,7 +33,6 @@ class TavilyLoader(BaseLoader):
         Args:
             urls: URL or list of URLs to extract content from.
             api_key: The Tavily API key.
-            include_images: Whether to include images in the extraction.
             extract_depth: Depth of extraction, either "basic" or "advanced".
                 advanced extraction retrieves more data, including tables and
                 embedded content, with higher success but may increase latency.

--- a/backend/open_webui/retrieval/vector/dbs/oracle23ai.py
+++ b/backend/open_webui/retrieval/vector/dbs/oracle23ai.py
@@ -668,18 +668,17 @@ class Oracle23aiClient(VectorDBBase):
         """
         Get all items in a collection.
 
-        Retrieves items from a specified collection up to the limit.
+        Retrieves items from a specified collection.
 
         Args:
             collection_name (str): Name of the collection to retrieve
-            limit (Optional[int]): Maximum number of items to retrieve
 
         Returns:
             Optional[GetResult]: Result containing ids, documents, and metadata
 
         Example:
             >>> client = Oracle23aiClient()
-            >>> results = client.get("my_collection", limit=50)
+            >>> results = client.get("my_collection")
             >>> if results:
             ...     print(f"Retrieved {len(results.ids[0])} documents from collection")
         """

--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -1339,7 +1339,7 @@ class OAuthManager:
 
         Args:
             user_id: The user ID
-            provider: Optional provider name. If None, gets the most recent session.
+            session_id: The OAuth session ID to fetch/refresh.
             force_refresh: Force token refresh even if current token appears valid
 
         Returns:

--- a/backend/open_webui/utils/tools.py
+++ b/backend/open_webui/utils/tools.py
@@ -877,7 +877,7 @@ def convert_function_to_pydantic_model(func: Callable, function_introspection=No
 
     Args:
         func: The function whose type hints and docstring should be converted.
-        model_name: The name of the generated Pydantic model.
+        function_introspection: Optional precomputed (signature, type_hints) tuple; derived from func when None.
 
     Returns:
         A Pydantic model class.


### PR DESCRIPTION
Relates to #28933

Backend-only docstring corrections, split from #28976 per review feedback (no i18n files in this PR).

- oracle23ai `get()` documents a `limit` arg the signature does not accept — its own docstring example passes `limit=50`, which raises TypeError
- oauth `get_oauth_token` Args documented `provider`; the actual parameter is `session_id`
- tavily `extract.__init__` documented `include_images`, which is not a parameter
- `convert_function_to_pydantic_model` documented `model_name`; the second parameter is `function_introspection`

Draft only to fit the open-PR limit; complete and ready when a slot frees.

### Changelog

**fixed** — docstrings no longer document nonexistent parameters.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.