### PR TITLE
fix: keep the workspace tab counts in sync with each section's list

### DIFF
--- a/src/lib/components/workspace/Knowledge.svelte
+++ b/src/lib/components/workspace/Knowledge.svelte
@@ -10,7 +10,7 @@
 
 	const i18n = getContext<Writable<i18nType>>('i18n');
 
-	import { WEBUI_NAME, user, workspaceActions } from '$lib/stores';
+	import { WEBUI_NAME, user, workspaceActions, workspaceCounts } from '$lib/stores';
 	import {
 		deleteKnowledgeById,
 		searchKnowledgeBases,
@@ -153,6 +153,7 @@
 		if (res) {
 			console.log(res);
 			total = res.total;
+			workspaceCounts.update((counts) => ({ ...counts, knowledge: total }));
 			const pageItems: KnowledgeListItem[] = res.items ?? [];
 
 			if ((pageItems ?? []).length === 0) {

--- a/src/lib/components/workspace/Models.svelte
+++ b/src/lib/components/workspace/Models.svelte
@@ -20,7 +20,8 @@
 		pinnedModels,
 		settings,
 		user,
-		workspaceActions
+		workspaceActions,
+		workspaceCounts
 	} from '$lib/stores';
 	import { WEBUI_API_BASE_URL } from '$lib/constants';
 	import {
@@ -165,6 +166,7 @@
 			if (res) {
 				models = res.items;
 				total = res.total;
+				workspaceCounts.update((counts) => ({ ...counts, models: total }));
 
 				// get tags
 				tags = await getModelTags(localStorage.token).catch((error) => {

--- a/src/lib/components/workspace/Prompts.svelte
+++ b/src/lib/components/workspace/Prompts.svelte
@@ -11,7 +11,7 @@
 	import { onMount, getContext, tick, onDestroy } from 'svelte';
 	import type { Writable } from 'svelte/store';
 	import type { i18n as i18nType } from 'i18next';
-	import { WEBUI_NAME, config, user, workspaceActions } from '$lib/stores';
+	import { WEBUI_NAME, config, user, workspaceActions, workspaceCounts } from '$lib/stores';
 
 	import {
 		createNewPrompt,
@@ -179,6 +179,7 @@
 			if (res) {
 				prompts = res.items;
 				total = res.total;
+				workspaceCounts.update((counts) => ({ ...counts, prompts: total }));
 
 				// get tags
 				tags = await getPromptTags(localStorage.token).catch((error) => {

--- a/src/lib/components/workspace/Skills.svelte
+++ b/src/lib/components/workspace/Skills.svelte
@@ -10,7 +10,13 @@
 	import { onMount, getContext, tick, onDestroy } from 'svelte';
 	const i18n = getContext('i18n');
 
-	import { WEBUI_NAME, user, skills as _skills, workspaceActions } from '$lib/stores';
+	import {
+		WEBUI_NAME,
+		user,
+		skills as _skills,
+		workspaceActions,
+		workspaceCounts
+	} from '$lib/stores';
 	import { goto } from '$app/navigation';
 	import {
 		getSkills,
@@ -117,6 +123,7 @@
 			if (res) {
 				filteredItems = res.items;
 				total = res.total;
+				workspaceCounts.update((counts) => ({ ...counts, skills: total }));
 			}
 		} catch (err) {
 			console.error(err);

--- a/src/lib/components/workspace/Tools.svelte
+++ b/src/lib/components/workspace/Tools.svelte
@@ -10,7 +10,14 @@
 	import { onMount, getContext, tick, onDestroy } from 'svelte';
 	const i18n = getContext('i18n');
 
-	import { WEBUI_NAME, config, tools as _tools, user, workspaceActions } from '$lib/stores';
+	import {
+		WEBUI_NAME,
+		config,
+		tools as _tools,
+		user,
+		workspaceActions,
+		workspaceCounts
+	} from '$lib/stores';
 
 	import { goto } from '$app/navigation';
 	import {
@@ -152,6 +159,8 @@
 
 			return direction * ((a.updated_at ?? 0) - (b.updated_at ?? 0));
 		});
+
+		workspaceCounts.update((counts) => ({ ...counts, tools: filteredItems.length }));
 	};
 
 	const setSortKey = (key: string) => {


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked and filled out the following:**

- [x] **Linked Issue/Discussion:** Closes #28981
- [x] **First-time contributor policy:** not my first contribution.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** **Manual** end-to-end tests have been performed to verify the fix/feature works correctly and does not introduce regressions.
- [x] **User-facing changes:** I have confirmed whether this PR changes the UI. The workspace tab counts now follow their section's list instead of only refreshing on navigation.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

The counts beside the `Models`, `Knowledge`, `Prompts`, `Skills`, and `Tools` tabs go stale as soon as anything is created, cloned, imported, or deleted without leaving the tab. The item appears in or disappears from the list while the count keeps its old value until the user clicks another tab, opens an item, or reloads.

**Root cause.** `workspaceCounts` has exactly one writer, `loadWorkspaceCounts()` in the workspace layout, and it runs from one reactive statement whose only dependency is `$page.url.pathname`:

```js
$: if (loaded && $page.url.pathname.startsWith('/workspace')) {
	loadWorkspaceCounts();
}
```

So the counts refresh on navigation and at mount, and never in response to the data changing. No create, clone, import, or delete handler writes to the store; each one reloads its own list and stops there. Flows that happen to navigate hide the problem: creating from `/workspace/prompts/create` closes the modal with `goto('/workspace/prompts')`, so the same action performed from the create route updates the count while the one performed from the list page does not.

**Fix.** Every mutation handler on all five tabs already ends by calling its page's list loader, so one write per loader covers create, clone, import, and delete without touching a single handler:

```diff
 				prompts = res.items;
 				total = res.total;
+				workspaceCounts.update((counts) => ({ ...counts, prompts: total }));
```

`Models`, `Skills`, and `Knowledge` take the same line against their own section key. `Tools` filters client side rather than through the API, so its write goes in `setFilteredItems()` and uses `filteredItems.length`, which also lines it up with the other four while a search is active: before this change the Tools count stayed at the section total while a search returned nothing.

### Fixed

- Fixed the workspace tab counts staying stale after creating, cloning, importing, or deleting an item, and made the `Tools` count respond to its search like the other tabs.

---

### Additional Information

Verified manually on top of `16c2a9eda`, by driving the real UI and comparing each count against the section's API total.

1. `/workspace/prompts`, clone a prompt and save, path stays `/workspace/prompts`: the count moves from 64 to 65 and the API total also reads 65. On `dev` the count stays at 63 while the API reads 64.
2. Same page, delete that clone from its row menu: the count moves back to 64, path unchanged.
3. `/workspace/tools`, create a tool and delete it from its row menu: the count moves from 39 to 38, path unchanged.
4. `/workspace/tools`, type a query that matches nothing: the count reads 0 while the search is active and returns to 38 when it is cleared, matching `/workspace/prompts`, which reads 0 and returns to 137 under the same test. On `dev` the Tools count stays at 38 throughout.
5. After the change each tab's count matches its API total on load: models 153, knowledge 5, prompts 137, skills 19, tools 38.

Test data created for these runs (a cloned prompt, a probe model, a probe tool) was deleted afterwards.

This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Screenshots or Videos

Before is `dev` at `16c2a9eda`, after is this branch, captured in pairs on the same account.

| Surface | Before | After |
|---|---|---|
| `Prompts` tab right after cloning a prompt, without navigating | <img width="1520" height="306" alt="image" src="https://github.com/user-attachments/assets/a31a66ae-f5e8-4278-9e99-5ffe406338c5" /> | <img width="1520" height="306" alt="image" src="https://github.com/user-attachments/assets/b0cbbe37-e0d8-49b1-9ab8-5d2fb97b6df4" /> |
| `Tools` tab with a search that matches nothing | <img width="1520" height="306" alt="image" src="https://github.com/user-attachments/assets/c9523e62-396d-40e4-b29d-750496f78a46" /> | <img width="1520" height="306" alt="image" src="https://github.com/user-attachments/assets/3ccfd593-eeaf-474b-9cae-e0f474cce83e" /> |

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
