### PR TITLE
fix: parse mentions when a stored prompt is inserted into the chat input

### DIFF
--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -657,6 +657,9 @@
 		view.dispatch(tr);
 
 		await tick();
+		chatInputElement?.setText(prompt);
+
+		await tick();
 		await inputVariableHandler(text);
 		await tick();
 		focus({ preventScroll: true });


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked and filled out the following:**

- [x] **Linked Issue/Discussion:** Closes #28990
- [x] **First-time contributor policy:** not my first contribution.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** **Manual** end-to-end tests have been performed to verify the fix/feature works correctly and does not introduce regressions.
- [x] **User-facing changes:** I have confirmed whether this PR changes the UI. Mentions inside an inserted prompt now render as mentions instead of as raw text.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

A stored prompt that contains a mention keeps it as plain text when the prompt is inserted into the chat input. The mention appears only after the composer's content is set again, which happens when the chat is left and reopened, so the workaround looks like an unrelated navigation.

**Root cause.** Two paths put text into the composer and only one parses mentions. `RichTextInput.setText()` rewrites `<@id>`, `<#id>`, and `<$id>` markers into mention spans before calling `setContent`, and that is the path `Chat.svelte` uses when it restores a draft. `replaceSlashRangeWithPrompt()` instead builds plain text nodes and dispatches them into the `/command` range, so the markers survive as literal characters.

**Fix.** After the insertion is dispatched, run the composer's existing parse path over the text it now holds, rather than duplicating the marker rewriting in a second place:

```diff
 		view.dispatch(tr);
 
+		await tick();
+		chatInputElement?.setText(prompt);
+
 		await tick();
 		await inputVariableHandler(text);
```

It reads the composer's own value, so anything the user had already typed is preserved.

### Fixed

- Fixed mentions inside a stored prompt rendering as raw text when the prompt is inserted into the chat input, instead of as mentions.

---

### Additional Information

Verified manually on top of `16c2a9eda`, by inserting stored prompts through the chat input and counting `span[data-type="mention"]` in the editor.

1. A prompt whose content is `<$effective-engineering> review the diff on this branch`: zero mention nodes on `dev`, one on this branch, matching what `dev` only produces after leaving the chat and coming back.
2. A prompt containing two mentions in separate paragraphs: zero on `dev`, two on this branch.
3. Plain prompt with no mentions, then typing at the end: identical on both, `just some plain textEND`.
4. Inserting after existing text, then typing: identical on both, `hello just some plain text!`.
5. Prompt containing `{{topic}}`: the variables modal opens on both.

One behavior does change. Undo directly after inserting a prompt now removes the inserted text and restores the typed command, where the same keypress on `dev` leaves the inserted text in place.

This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Screenshots or Videos

Before is `dev` at `16c2a9eda`, after is this branch. The same stored prompt, inserted the same way, in the same chat.

| Surface | Before | After |
|---|---|---|
| Chat input after inserting a prompt whose content starts with a skill mention | <img width="2460" height="264" alt="image" src="https://github.com/user-attachments/assets/8a2a8ac9-bf64-47b0-ad00-a11d98668ba6" /> | <img width="2460" height="264" alt="image" src="https://github.com/user-attachments/assets/cc9a48cf-5ad6-42e9-8473-520afc275254" /> |

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
