### PR TITLE
fix(models): treat base_model_id == id as direct override

### DIFF
--- a/backend/open_webui/utils/models.py
+++ b/backend/open_webui/utils/models.py
@@ -159,8 +159,8 @@ async def get_all_models(request, refresh: bool = False, user: UserModel = None)
     existing_ids = {m['id'] for m in models}
 
     for custom_model in custom_models:
-        if custom_model.base_model_id is None:
-            # Override applied directly to a base model (shares the same ID)
+        if custom_model.base_model_id is None or custom_model.base_model_id == custom_model.id:
+            # Override applied directly to a base model (shares the same ID, or base_model_id == id)
             model = base_model_lookup.get(custom_model.id)
 
             if model:


### PR DESCRIPTION
## Contributor License Agreement

By submitting my contributions to this repository in any form, I grant Open WebUI Inc. a perpetual, worldwide, irrevocable, royalty-free license, under copyright and patent, to use, modify, distribute, sublicense, and commercialize my work under any terms they choose, both now and in the future.

I represent that my contributions are my original work (or that I have sufficient rights to grant this license) and that I have the authority to enter into this agreement.

**_To the fullest extent permitted by law, my contributions are provided on an "as is" basis, with no warranties or guarantees of any kind, and I disclaim any liability for any issues or damages arising from their use or incorporation into the project, regardless of the type of legal claim._**

---

## Summary

When the admin UI edits an existing model, it sets base_model_id to the same value as the model own id. The previous condition only checked for base_model_id is None, so these models fell into the elif branch and were silently skipped by the id in existing_ids guard — their workspace customizations were never applied.

Extend the override branch to also match when base_model_id equals the model own id.

Fixes #28952