### PR TITLE
fix(prompts): strip leading slash from command on create/update

### DIFF
--- a/backend/open_webui/models/prompts.py
+++ b/backend/open_webui/models/prompts.py
@@ -15,7 +15,7 @@ from open_webui.models.groups import Groups
 from open_webui.models.prompt_history import PromptHistories
 from open_webui.models.users import User, UserModel, UserResponse, Users
 from open_webui.utils.misc import json_text_variants
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 from sqlalchemy import JSON, BigInteger, Boolean, Column, String, Text, cast, delete, func, or_, select, text, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -91,6 +91,13 @@ class PromptForm(BaseModel):
     version_id: str | None = None  # Active version
     commit_message: str | None = None  # For history tracking
     is_production: bool | None = True  # Whether to set new version as production
+
+    @model_validator(mode="before")
+    @classmethod
+    def strip_command_slash(cls, values):
+        if isinstance(values, dict) and "command" in values and isinstance(values["command"], str):
+            values["command"] = values["command"].lstrip("/")
+        return values
 
 
 class PromptsTable:


### PR DESCRIPTION
## Contributor License Agreement

By submitting my contributions to this repository in any form, I grant Open WebUI Inc. a perpetual, worldwide, irrevocable, royalty-free license, under copyright and patent, to use, modify, distribute, sublicense, and commercialize my work under any terms they choose, both now and in the future.

I represent that my contributions are my original work (or that I have sufficient rights to grant this license) and that I have the authority to enter into this agreement.

**_To the fullest extent permitted by law, my contributions are provided on an "as is" basis, with no warranties or guarantees of any kind, and I disclaim any liability for any issues or damages arising from their use or incorporation into the project, regardless of the type of legal claim._**

---

## Summary

When a client sends a prompt command with a leading slash (e.g. /sysprompt-full), the slash is stored as-is. The workspace list then renders it as //sysprompt-full because it prepends its own slash for display.

Add a Pydantic model_validator on PromptForm that strips the leading slash before the command reaches the database.

Fixes #28984