### PR TITLE
fix(models): treat base_model_id == id as direct override

### DIFF
--- a/backend/open_webui/utils/models.py
+++ b/backend/open_webui/utils/models.py
@@ -159,8 +159,8 @@ async def get_all_models(request, refresh: bool = False, user: UserModel = None)
     existing_ids = {m['id'] for m in models}
 
     for custom_model in custom_models:
-        if custom_model.base_model_id is None:
-            # Override applied directly to a base model (shares the same ID)
+        if custom_model.base_model_id is None or custom_model.base_model_id == custom_model.id:
+            # Override applied directly to a base model (shares the same ID, or base_model_id == id)
             model = base_model_lookup.get(custom_model.id)
 
             if model:


### PR DESCRIPTION
## Summary

When the admin UI edits an existing model, it sets `base_model_id` to the same value as the model's own `id`. The previous condition only checked for `base_model_id is None`, so these models fell into the `elif` branch and were silently skipped by the `id in existing_ids` guard — their workspace customizations (name, params, metadata, actions, filters) were never applied.

Extend the override branch to also match when `base_model_id` equals the model's own `id`, so DB customizations are merged as intended.

Fixes #28952

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.