### PR TITLE
fix: reset workspace model pagination when filtering

### DIFF
--- a/src/lib/components/workspace/Models.svelte
+++ b/src/lib/components/workspace/Models.svelte
@@ -564,6 +564,7 @@
 						align="end"
 						onChange={async (value) => {
 							localStorage.workspaceViewOption = value;
+							page = 1;
 							await tick();
 						}}
 					/>


### PR DESCRIPTION
# Pull Request Checklist

- [x] **Linked Issue/Discussion:** Closes #28734
- [x] **Target branch:** This PR targets `dev`.
- [x] **Description:** Changing the workspace model view now returns to page one.
- [x] **Changelog:** A changelog entry is included below.
- [x] **Documentation:** Not needed for this focused UI bug fix.
- [x] **Dependencies:** No dependencies changed.
- [x] **Testing:** Frontend tests and formatting checks pass. The full type check has existing unrelated errors; none are on the changed line.
- [x] **No Unchecked AI Code:**
- [x] **Self-Review:** The change follows the existing workspace Skills pagination pattern.
- [x] **Architecture:** No new state or settings were added.
- [x] **Git Hygiene:** This is one focused change.
- [x] **Title Prefix:** Uses the `fix` prefix.

# Changelog Entry

### Description

- Reset workspace model pagination when the view filter changes.

### Fixed

- Selecting “Created by You” or another workspace model view from a later page now fetches page one.

---

### Additional Information

- Closes #28734

### Screenshots or Videos

- Not applicable; this only changes the page sent with the existing filtered request.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
