### PR TITLE
fix: honor the terminal file browser filesystem root instead of clamping to home

### DIFF
--- a/src/lib/components/chat/FileNav.svelte
+++ b/src/lib/components/chat/FileNav.svelte
@@ -629,35 +629,14 @@
 		return isInsideFileRoot(path) ? asDirectoryPath(path) : fileRoot.path;
 	};
 
-	const rootFromCwd = (cwd: TerminalCwd | null, pathHint?: string) => {
-		const cwdPath = cwd?.cwd ? asDirectoryPath(cwd.cwd) : null;
-		const homePath = cwd?.home ? asDirectoryPath(cwd.home) : null;
-		const hintPath = pathHint ? asDirectoryPath(pathHint) : null;
+	const rootFromCwd = (cwd: TerminalCwd | null) => {
 		const rootPath = cwd?.root?.path ? asDirectoryPath(cwd.root.path) : null;
-
-		if (rootPath && rootPath !== '/') return cwd?.root;
-
-		const knownRoot = fileRoot ?? savedFileRoot;
-		if (
-			knownRoot?.path &&
-			hintPath &&
-			hintPath !== '/' &&
-			(hintPath === knownRoot.path || hintPath.startsWith(knownRoot.path))
-		) {
-			return knownRoot;
-		}
-
-		const pathForHome = hintPath && hintPath !== '/' ? hintPath : cwdPath;
-		if (homePath && pathForHome && (pathForHome === homePath || pathForHome.startsWith(homePath))) {
-			return { path: homePath, label: 'Home' };
-		}
-
-		return undefined;
+		return rootPath && rootPath !== '/' ? cwd?.root : undefined;
 	};
 
-	const applyCwd = (cwd: TerminalCwd | null, pathHint?: string) => {
+	const applyCwd = (cwd: TerminalCwd | null) => {
 		const cwdPath = cwd?.cwd ? asDirectoryPath(cwd.cwd) : null;
-		setFileRoot(rootFromCwd(cwd, pathHint));
+		setFileRoot(rootFromCwd(cwd));
 		const path = cwdPath ?? fileRoot?.path ?? '/';
 		return clampToFileRoot(path);
 	};
@@ -1385,7 +1364,7 @@
 
 				const serverCwd = await getCwd(terminal.url, terminal.key, chatId ?? undefined);
 				const useServerPath = !!chatId || savedPath === '/';
-				const serverPath = applyCwd(serverCwd, useServerPath ? undefined : savedPath);
+				const serverPath = applyCwd(serverCwd);
 				if (useServerPath) {
 					// Fetch session-specific cwd from the server (or global default for new chats)
 					savedPath = serverPath;
@@ -1911,7 +1890,7 @@
 					</div>
 				{/if}
 
-					{#if !isSearching && !loading && !error && !uploading && !($selectedTerminalId && $terminalServers === null)}
+				{#if !isSearching && !loading && !error && !uploading && !($selectedTerminalId && $terminalServers === null)}
 					{#if creatingFolder}
 						<div class="flex h-7 items-center gap-2 px-2">
 							<FileTypeIcon name={newFolderName} type="directory" />


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked and filled out the following:**

- [x] **Linked Issue/Discussion:** Closes #29000
- [x] **First-time contributor policy:** not my first contribution.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** **Manual** end-to-end tests have been performed to verify the fix/feature works correctly and does not introduce regressions.
- [x] **User-facing changes:** I have confirmed whether this PR changes the UI. A terminal server configured for filesystem browsing again shows the full path in the file browser instead of being pinned to Home.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

An Open Terminal server started with `OPEN_TERMINAL_FILE_BROWSER_ROOT=filesystem` cannot be browsed above the home directory in the file panel, and opening a file outside home does nothing.

**The server contract.** `get_file_browser_root()` in Open Terminal returns a root for `home` and for a configured path, and returns nothing for `filesystem`, in which case `/files/cwd` omits the `root` key entirely. Confirmed against a running v0.12.1 container: with the variable unset the payload is `{"cwd": "/home/user", "home": "/home/user", "root": {"path": "/home/user", "label": "Home"}}`, and with `OPEN_TERMINAL_FILE_BROWSER_ROOT=filesystem` it is `{"cwd": "/home/user", "home": "/home/user"}`. An absent `root` means no restriction.

**Where the client stopped honoring it.** In v0.11.0 `FileNav.svelte` took the server at its word with `setFileRoot(cwd?.root)`, so an absent `root` left `fileRoot` null and browsing was unrestricted. `7dfbdd221` added a fallback that synthesizes `{ path: home, label: 'Home' }` whenever the payload carries no root and the current path sits inside home, and a later refactor moved that fallback into `rootFromCwd()`. Since the server always reports `home`, and a fresh session's `cwd` is home, the fallback fires on the first load in filesystem mode and clamps the browser to a root the server never asked for. The same clamp is what makes files outside home silently fail to open, because `isInsideFileRoot()` rejects them and `displayFile()` redirects to the root instead.

**Fix.** Take the server at its word again. `rootFromCwd()` returns the server's root when it sends one, and nothing when it does not:

```diff
-	const rootFromCwd = (cwd: TerminalCwd | null, pathHint?: string) => {
-		const cwdPath = cwd?.cwd ? asDirectoryPath(cwd.cwd) : null;
-		const homePath = cwd?.home ? asDirectoryPath(cwd.home) : null;
-		const hintPath = pathHint ? asDirectoryPath(pathHint) : null;
-		const rootPath = cwd?.root?.path ? asDirectoryPath(cwd.root.path) : null;
-
-		if (rootPath && rootPath !== '/') return cwd?.root;
-		...home and known-root fallbacks...
-	};
+	const rootFromCwd = (cwd: TerminalCwd | null) => {
+		const rootPath = cwd?.root?.path ? asDirectoryPath(cwd.root.path) : null;
+		return rootPath && rootPath !== '/' ? cwd?.root : undefined;
+	};
```

Both callers pass a fresh `/files/cwd` response, which carries the root on every request in home mode, so nothing needs to preserve a root across payloads and the `pathHint` argument goes away with the fallbacks.

### Fixed

- Fixed the file browser pinning itself to the home directory when the terminal server is configured with `OPEN_TERMINAL_FILE_BROWSER_ROOT=filesystem`, which also blocked opening files outside home.

---

### Additional Information

Verified manually on top of `5735123f5`, against two Open Terminal `latest` containers, one with the variable unset and one with `OPEN_TERMINAL_FILE_BROWSER_ROOT=filesystem`, each connected as a direct terminal server.

| terminal server | `dev` | this branch |
|---|---|---|
| `OPEN_TERMINAL_FILE_BROWSER_ROOT=filesystem` | breadcrumb shows `Home` only, nothing above it | breadcrumb shows `/ home user`, the filesystem root is reachable |
| variable unset, default home mode | breadcrumb shows `Home` | breadcrumb shows `Home`, unchanged |

The root selection itself was also exercised directly against both payload shapes plus a configured path root and a root of `/`. Home mode and a configured path keep their root; the filesystem payload changes from a synthesized `Home` to no restriction; a root of `/` changes from a synthesized `Home` to no restriction, which is what the existing `rootPath !== '/'` check already intended.

This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Screenshots or Videos

Before is `dev` at `5735123f5`, after is this branch. The same terminal server, started with `OPEN_TERMINAL_FILE_BROWSER_ROOT=filesystem`, connected the same way.

| Surface | Before | After |
|---|---|---|
| Files panel breadcrumb with a filesystem root terminal | _paste image_ | _paste image_ |

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
