### PR TITLE
fix: restore the model avatar reset option in the model editor

### DIFF
--- a/src/lib/components/workspace/Models/ModelEditor.svelte
+++ b/src/lib/components/workspace/Models/ModelEditor.svelte
@@ -687,6 +687,18 @@
 								</div>
 							</div>
 
+							<div class="flex w-full -mt-1">
+								<button
+									class="px-2 py-1 text-gray-500 rounded-lg text-xs"
+									on:click={() => {
+										info.meta.profile_image_url = `${WEBUI_BASE_URL}/static/favicon.png`;
+									}}
+									type="button"
+								>
+									{$i18n.t('Reset Image')}</button
+								>
+							</div>
+
 							{#if preset}
 								<div>
 									<div class="mb-1 text-xs text-gray-400 dark:text-gray-600">

--- a/src/lib/i18n/locales/en-US/translation.json
+++ b/src/lib/i18n/locales/en-US/translation.json
@@ -2224,6 +2224,7 @@
 	"Reset all permissions to their initial configuration values": "",
 	"Reset Defaults": "",
 	"Reset group permissions to match the current default user permissions": "",
+	"Reset Image": "",
 	"Reset knowledge base?": "",
 	"Reset persisted files": "",
 	"Reset to Defaults": "",


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked and filled out the following:**

- [x] **Linked Issue/Discussion:** Closes #27685
- [x] **First-time contributor policy:** not my first contribution.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** **Manual** end-to-end tests have been performed to verify the fix/feature works correctly and does not introduce regressions.
- [x] **User-facing changes:** I have confirmed whether this PR changes the UI. It adds back a `Reset Image` control under the model avatar in the model editor.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

Through v0.10.2 the model editor had a `Reset Image` button under the avatar, so a model's picture could be cleared back to the default logo. The v0.11.0 editor redesign dropped it, and nothing replaced it: clicking the avatar only opens the file picker, so once a model has a custom image it can be replaced but never cleared.

This restores the control in the redesigned header, directly under the avatar, and it sets `info.meta.profile_image_url` back to the default favicon.

The button is unconditional, as it was before the redesign. Showing it only when a custom image is set would mean classifying what counts as "default", and that has three representations today: the editor's absolute `${WEBUI_BASE_URL}/static/favicon.png`, the backend's relative `/static/favicon.png`, and an absent `profile_image_url` key, since the editor's model load does a shallow merge and a `meta` without the key replaces the default wholesale. Resetting an already-default model is a harmless no-op, so the unconditional button sidesteps that entirely. Placement and visibility are open to whatever fits the design direction.

### Fixed

- Fixed there being no way to reset a model's avatar to the default logo since the v0.11.0 model editor redesign.

---

### Additional Information

Verified manually on top of `5735123f5`, in the workspace model editor.

1. On `dev` the editor has no reset control at all: the only avatar affordance is the file picker.
2. On this branch the control appears under the avatar. Uploading an image switches the avatar to the cropped `data:image/webp;base64,...` value, and clicking `Reset Image` returns it to `/static/favicon.png`.
3. The admin model editor renders the same component, so it gets the control back too.

The string `Reset Image` is added to `en-US` only, as it existed there before the redesign.

This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Screenshots or Videos

Before is `dev` at `5735123f5`, after is this branch, both showing the top of the model editor.

| Surface | Before | After |
|---|---|---|
| Model editor header with the avatar | <img width="1800" height="520" alt="image" src="https://github.com/user-attachments/assets/58dd5287-05d7-42ed-b98d-45b186d38e27" /> | <img width="1800" height="520" alt="image" src="https://github.com/user-attachments/assets/5f1f6ac5-97f5-42a4-b108-5eb98483d586" /> |

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
