### PR TITLE
fix: normalize prompt commands by stripping a leading slash

### DIFF
--- a/backend/open_webui/models/prompts.py
+++ b/backend/open_webui/models/prompts.py
@@ -15,7 +15,7 @@ from open_webui.models.groups import Groups
 from open_webui.models.prompt_history import PromptHistories
 from open_webui.models.users import User, UserModel, UserResponse, Users
 from open_webui.utils.misc import json_text_variants
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 from sqlalchemy import JSON, BigInteger, Boolean, Column, String, Text, cast, delete, func, or_, select, text, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -91,6 +91,11 @@ class PromptForm(BaseModel):
     version_id: str | None = None  # Active version
     commit_message: str | None = None  # For history tracking
     is_production: bool | None = True  # Whether to set new version as production
+
+    @field_validator('command', mode='before')
+    @classmethod
+    def check_command(cls, v: str) -> str:
+        return v.lstrip('/') if isinstance(v, str) else v
 
 
 class PromptsTable:

--- a/backend/open_webui/routers/prompts.py
+++ b/backend/open_webui/routers/prompts.py
@@ -25,7 +25,7 @@ from open_webui.models.prompts import (
 )
 from open_webui.utils.access_control import filter_allowed_access_grants, has_permission
 from open_webui.utils.auth import get_admin_user, get_verified_user
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 from sqlalchemy.ext.asyncio import AsyncSession
 
 
@@ -37,6 +37,11 @@ class PromptMetadataForm(BaseModel):
     name: str
     command: str
     tags: list[str | None] = None
+
+    @field_validator('command', mode='before')
+    @classmethod
+    def check_command(cls, v: str) -> str:
+        return v.lstrip('/') if isinstance(v, str) else v
 
 
 router = APIRouter()


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked and filled out the following:**

- [x] **Linked Issue/Discussion:** Closes #28984
- [x] **First-time contributor policy:** not my first contribution.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** **Manual** end-to-end tests have been performed to verify the fix/feature works correctly and does not introduce regressions.
- [x] **User-facing changes:** I have confirmed whether this PR changes the UI. Prompts created through the API stop rendering with a doubled slash in the workspace list.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

A prompt's `command` is stored without a leading slash everywhere the UI is involved: the workspace row renders `/{prompt.command}`, and the editor strips a leading slash when it loads a prompt and rejects anything but alphanumerics and hyphens. The API enforces none of that, so a client that sends the form users actually see, `/my-prompt`, gets that slash stored and the row then renders `//my-prompt`.

Two further consequences of the same gap: the collision check compares raw strings, so `/foo` and `foo` are accepted as two separate prompts for the same command, and a rename through `/id/{prompt_id}/update/meta` can reintroduce the slash on a prompt that was fine.

**Fix.** Normalize at the write boundary, in the shape this repository already uses for field normalization in `models/channels.py`:

```diff
+    @field_validator('command', mode='before')
+    @classmethod
+    def check_command(cls, v: str) -> str:
+        return v.lstrip('/') if isinstance(v, str) else v
```

on `PromptForm`, which covers create and the general update, and the same validator on the router's `PromptMetadataForm`, which covers the name and command rename path.

### Fixed

- Fixed prompt commands created or renamed through the API keeping a leading slash, which made the workspace list render two slashes and let the same command exist twice.

---

### Additional Information

Verified manually on top of `11db926a7`, against the running backend.

1. `POST /api/v1/prompts/create` with `command: "/zz-recheck"` stores `zz-recheck`.
2. The same call with `command: "zz-recheck"` afterwards returns 400 with the command taken error, where before it created a second prompt.
3. `POST /api/v1/prompts/id/{id}/update/meta` with `command: "/zz-renamed"` stores `zz-renamed`.
4. `//zz2-double` stores `zz2-double`, so an already doubled value is normalized too.

Three related decisions are deliberately not in this diff, and are described in #28984: repairing rows that already carry a slash, whether the API should also enforce the editor's alphanumerics and hyphens rule, and whether the composer's slash menu should render the leading slash the way the workspace list does. Existing rows can be normalized by opening each prompt in the editor and saving, since the editor strips the slash on load.

This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
