### PR TITLE
fix: restore visibility of disabled models visible in the admin Models list

### DIFF
--- a/src/lib/components/admin/Settings/Models.svelte
+++ b/src/lib/components/admin/Settings/Models.svelte
@@ -269,6 +269,14 @@
 
 		baseModels = await getBaseModels(localStorage.token, selectedTag);
 		allModels = await getModels(localStorage.token);
+
+		const providerModels = await getModels(localStorage.token, null, true);
+		const allModelIds = new Set<string>(allModels.map((model: ModelListItem) => model.id));
+		allModels = [
+			...allModels,
+			...providerModels.filter((model: ModelListItem) => !allModelIds.has(model.id))
+		];
+
 		const baseModelIds = new Set<string>(baseModels.map((model: ModelListItem) => model.id));
 
 		models = allModels


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #29036, disabling a model in the admin Models list makes it disappear with no way to re-enable it.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable.
- [ ] **Dependencies:** No new dependencies.
- [x] **Testing:** Verified against a running instance, before and after, including the recovery path that is currently missing. Details below.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new endpoint, no new state, no new settings. The list is sourced from the two endpoints the page already knows about.
- [x] **Git Hygiene:** The PR is atomic, a single commit against current `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

**Problem** (#29036): a model disabled in Admin Panel > Settings > Models vanishes from the list when the tab is reopened, and the `Disabled` view reports `No models found`. Since the admin list is the only surface that can turn a model back on, the model becomes unreachable.

**Root cause**: `ccbb3303f` changed which endpoint feeds the list.

```diff
-		baseModels = await getModels(localStorage.token, null, true);
+		allModels = await getModels(localStorage.token);
```

The third argument of `getModels` is `base`. With it the request goes to `/api/models/base`, the unfiltered provider list. Without it the request goes to `/api/models`, where `get_all_models()` drops every model whose stored row has `is_active` set to false. The admin list is therefore built from a list that has already had the disabled models removed from it.

**Why the argument is not simply restored**: on the instance used here, 143 models appear in `/api/models` but not in `/api/models/base`, and all of them are workspace preset models. `ccbb3303f` also introduced `isPresetModel()`, so presets appearing in the admin list looks intended. Restoring the previous call on its own would fix the disabled models and drop those 143.

**Fix**: read both lists and merge by id, so presets stay and disabled models come back.

```diff
 		baseModels = await getBaseModels(localStorage.token, selectedTag);
 		allModels = await getModels(localStorage.token);
+
+		const providerModels = await getModels(localStorage.token, null, true);
+		const allModelIds = new Set<string>(allModels.map((model: ModelListItem) => model.id));
+		allModels = [
+			...allModels,
+			...providerModels.filter((model: ModelListItem) => !allModelIds.has(model.id))
+		];
+
 		const baseModelIds = new Set<string>(baseModels.map((model: ModelListItem) => model.id));
```

`/api/models/base` is the request this page already made before `ccbb3303f`, so no new endpoint is introduced and no new class of work is added to the page load. Scope: one file, `src/lib/components/admin/Settings/Models.svelte`.

### Fixed

- Fixed disabled models disappearing from the admin Models list, which left them with no way to be re-enabled: the list is now sourced from both the runtime model list and the unfiltered provider list, so models with `is_active` set to false remain visible and toggleable while workspace preset models continue to appear.

---

### Additional Information

Scope note: workspace preset models with `is_active` set to false are still absent from the admin list. That is not part of this regression, since no preset models appeared in that list before `ccbb3303f` at all.

- This PR was prepared with AI copilot assistance and reviewed by the author.

### Manual Verification Performed

Measured against a running instance holding 6 model rows with `is_active` set to false.

1. Endpoint comparison: `/api/models` returns 311 models, `/api/models/base` returns 174. The 6 models missing from the first are exactly the 6 disabled rows, and each is present in the second.
2. Before the change, the admin Models list showed 311 and the `Disabled` view showed `No models found`.
3. After the change, the list shows 317 and the `Disabled` view shows all 6, greyed out with their toggles rendered.
4. Recovery path: from the `Disabled` view, toggling one of those models back on set `is_active` to true in the database, which is the step that is impossible on current `dev`. The model was then returned to its prior state, and all 16 inactive rows were diffed against a snapshot taken beforehand to confirm nothing else changed.
5. Preset models: the 143 workspace preset models that `ccbb3303f` brought into this list are still present after the change.
6. `npm run format` reports no changes on the touched file.

### Screenshots or Videos

| Surface | Before | After |
| --- | --- | --- |
| Admin > Settings > Models, `Disabled` view | <img src="https://raw.githubusercontent.com/silentoplayz/open-webui/assets/pr-29037/models_before_disabled.png" width="420"> | <img src="https://raw.githubusercontent.com/silentoplayz/open-webui/assets/pr-29037/models_after_disabled.png" width="420"> |
| Admin > Settings > Models, `All` view, total count | <img src="https://raw.githubusercontent.com/silentoplayz/open-webui/assets/pr-29037/models_before_all.png" width="420"> | <img src="https://raw.githubusercontent.com/silentoplayz/open-webui/assets/pr-29037/models_after_all.png" width="420"> |

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.

