### PR TITLE
fix: avoid SQLite int overflow when matching numeric OAuth sub

### DIFF
--- a/backend/open_webui/models/users.py
+++ b/backend/open_webui/models/users.py
@@ -366,7 +366,7 @@ class UsersTable:
             sub_expr = User.oauth[provider]['sub'].as_string()
             query = select(User).where(sub_expr == sub)
             # SQLite preserves JSON numeric type here; Postgres ->> already compares numeric JSON as text.
-            if session.get_bind().dialect.name == 'sqlite' and sub.isdecimal():
+            if session.get_bind().dialect.name == 'sqlite' and sub.isdecimal() and int(sub) <= 2**63 - 1:
                 query = select(User).where(or_(sub_expr == sub, sub_expr == int(sub)))
             row = (await session.execute(query)).scalars().first()
             return UserModel.model_validate(row) if row else None


### PR DESCRIPTION
Google's `sub` is a 21-digit number, which is larger than SQLite's max INTEGER (`2**63-1`). The SQLite branch added in a6834f0 binds `int(sub)` unconditionally when the sub is all digits, so SQLAlchemy raises:

```
OverflowError: Python int too large to convert to SQLite INTEGER
```

This happens in `get_user_by_oauth_sub()`, before any session is created, so every Google login fails with `Error during OAuth process` on SQLite. The token exchange itself succeeds — it's purely the lookup that dies.

Fixed by only taking the int comparison when the value actually fits. The existing string comparison still matches, which I verified against ~590 real users on an affected instance: all subs resolved to the correct accounts, no duplicates created.

Postgres is unaffected, so #27760 stays fixed.
