### PR TITLE
fix: wrap executeTool in try-catch so failed tool calls cannot hang the chat

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -495,62 +495,67 @@
 	};
 
 	const executeTool = async (data, cb, chatId) => {
-		const { toolServer, toolServerData, token } = resolveToolServer(data.server?.url);
-		const defaultInline =
-			data?.name === 'display_file' &&
-			data?.params?.path &&
-			data?.params?.inline === undefined &&
-			$settings?.terminalFileDisplay === 'inline' &&
-			isDirectTerminalServer(data.server?.url);
-		const params = defaultInline ? { ...data.params, inline: true } : data?.params;
-		const serverParams = data?.name === 'display_file' && params ? { ...params } : params;
-		if (serverParams && data?.name === 'display_file') {
-			delete serverParams.page;
-		}
+		try {
+			const { toolServer, toolServerData, token } = resolveToolServer(data.server?.url);
+			const defaultInline =
+				data?.name === 'display_file' &&
+				data?.params?.path &&
+				data?.params?.inline === undefined &&
+				$settings?.terminalFileDisplay === 'inline' &&
+				isDirectTerminalServer(data.server?.url);
+			const params = defaultInline ? { ...data.params, inline: true } : data?.params;
+			const serverParams = data?.name === 'display_file' && params ? { ...params } : params;
+			if (serverParams && data?.name === 'display_file') {
+				delete serverParams.page;
+			}
 
-		console.log('executeTool', data, toolServer);
+			console.log('executeTool', data, toolServer);
 
-		if (toolServer) {
-			const res = await executeToolServer(
-				token,
-				toolServer.url,
-				data?.name,
-				serverParams,
-				toolServerData,
-				chatId
-			);
+			if (toolServer) {
+				const res = await executeToolServer(
+					token,
+					toolServer.url,
+					data?.name,
+					serverParams,
+					toolServerData,
+					chatId
+				);
 
-			console.log('executeToolServer', res);
-			const result = Array.isArray(res) ? res[0] : res;
-			const inlineDisplayFile =
-				data?.name === 'display_file' && params?.path && params?.inline === true;
-			const output =
-				inlineDisplayFile && result?.exists !== false
-					? Array.isArray(res)
-						? [terminalFileResult(result, params, toolServer.url, chatId)]
-						: terminalFileResult(result, params, toolServer.url, chatId)
-					: res;
+				console.log('executeToolServer', res);
+				const result = Array.isArray(res) ? res[0] : res;
+				const inlineDisplayFile =
+					data?.name === 'display_file' && params?.path && params?.inline === true;
+				const output =
+					inlineDisplayFile && result?.exists !== false
+						? Array.isArray(res)
+							? [terminalFileResult(result, params, toolServer.url, chatId)]
+							: terminalFileResult(result, params, toolServer.url, chatId)
+						: res;
 
-			if (data?.name === 'display_file' && params?.path && !inlineDisplayFile) {
-				if (result?.exists !== false) {
-					displayFileHandler(
-						params.path,
-						{ showControls, showFileNavPath },
-						{ page: params?.page }
-					);
+				if (data?.name === 'display_file' && params?.path && !inlineDisplayFile) {
+					if (result?.exists !== false) {
+						displayFileHandler(
+							params.path,
+							{ showControls, showFileNavPath },
+							{ page: params?.page }
+						);
+					}
 				}
-			}
 
-			if (['write_file'].includes(data?.name) && params?.path) {
-				showFileNavDir.set(result?.path ?? params.path);
-			}
+				if (['write_file'].includes(data?.name) && params?.path) {
+					showFileNavDir.set(result?.path ?? params.path);
+				}
 
-			if (cb) {
-				cb(structuredClone(output));
-			}
-		} else {
-			if (cb) {
+				if (cb) {
+					cb(structuredClone(output));
+				}
+			} else if (cb) {
 				cb({ error: 'Tool Server Not Found' });
+			}
+		} catch (error) {
+			console.error('executeTool error:', error);
+			if (cb) {
+				cb({ error: error?.message ?? 'Tool execution failed' });
 			}
 		}
 	};


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Relates to #25850 (issue is closed, but `executeTool` on current `dev` still has no try/catch — a thrown error never calls `cb`, so sequential tool calls can hang indefinitely).
- [x] **Target branch:** `dev`
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following Keep a Changelog format is included at the bottom.
- [x] **Documentation:** No docs change — error-path only.
- [x] **Dependencies:** None.
- [x] **Testing:** Confirmed on current `dev` that `executeTool` in `src/routes/+layout.svelte` still has no try/catch around `executeToolServer` / `displayFileHandler` / `structuredClone`. This wraps that path so the callback always settles.
- [x] **No Unchecked AI Code:** Human-reviewed, scoped to the hang path described in #25850.
- [x] **Self-Review:** Performed.
- [x] **Architecture:** No new settings or UX; existing callback contract only.
- [x] **Git Hygiene:** Single commit on current `dev`.
- [x] **Title Prefix:** `fix:`

# Changelog Entry

### Description

- Failed or throwing tool calls in `executeTool` never invoked the completion callback, which left sequential per-user tool server requests hanging. The callback now always settles, including on error.

### Added

- None.

### Changed

- None.

### Deprecated

- None.

### Removed

- None.

### Fixed

- Wrap `executeTool` in try/catch so a thrown tool-server/display-file error still completes the callback instead of hanging the chat (Relates to #25850).

### Security

- None.

### Breaking Changes

- **BREAKING CHANGE**: None.

---

### Additional Information

This is ready for review. #25850 was closed, but the hang is still present on current `dev` (`executeTool` still has no try/catch). Happy to adjust if you would rather keep error handling only inside `executeToolServer`.

### Screenshots or Videos

- N/A (error-path callback settlement; no UI change)

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

Made with [Cursor](https://cursor.com)