### PR TITLE
fix: SQLite OAuth overflow for 21-digit Google sub IDs (#29048)

### DIFF
--- a/backend/open_webui/models/users.py
+++ b/backend/open_webui/models/users.py
@@ -367,7 +367,14 @@ class UsersTable:
             query = select(User).where(sub_expr == sub)
             # SQLite preserves JSON numeric type here; Postgres ->> already compares numeric JSON as text.
             if session.get_bind().dialect.name == 'sqlite' and sub.isdecimal():
-                query = select(User).where(or_(sub_expr == sub, sub_expr == int(sub)))
+                try:
+                    int_sub = int(sub)
+                    if len(sub) <= 19:
+                        query = select(User).where(or_(sub_expr == sub, sub_expr == int_sub))
+                    else:
+                        query = select(User).where(sub_expr == sub)
+                except ValueError:
+                    query = select(User).where(sub_expr == sub)
             row = (await session.execute(query)).scalars().first()
             return UserModel.model_validate(row) if row else None
 


### PR DESCRIPTION
### Description

- Fixes SQLite OAuth login failure for 21-digit Google sub IDs
- Prevents `int()` overflow by comparing as string only when number exceeds SQLite INTEGER (64-bit) limit
- Manually tested with 21-digit sub value

### Fixed

- `get_user_by_oauth_sub` now handles large OAuth sub values safely

### Testing

- [x] Manual test: verified 21-digit sub `'123456789012345678901'` is handled correctly without overflow

Closes #29048

---

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.