### PR TITLE
refac: align the admin Users tab counts with the workspace tab count behavior

### DIFF
--- a/src/lib/components/admin/Users.svelte
+++ b/src/lib/components/admin/Users.svelte
@@ -25,6 +25,10 @@
 		scrollToTab(selectedTab);
 	}
 
+	$: if (loaded && selectedTab) {
+		loadCounts();
+	}
+
 	const scrollToTab = (tabId) => {
 		const tabElement = document.getElementById(tabId);
 		if (tabElement) {
@@ -58,7 +62,6 @@
 			await goto('/');
 		}
 
-		await loadCounts();
 		loaded = true;
 
 		const containerElement = document.getElementById('users-tabs-container');

--- a/src/lib/components/admin/Users/Groups.svelte
+++ b/src/lib/components/admin/Users/Groups.svelte
@@ -48,6 +48,10 @@
 			return (b.member_count ?? 0) - (a.member_count ?? 0) || a.name.localeCompare(b.name);
 		});
 
+	$: if (loaded) {
+		adminGroupCount.set(filteredGroups.length);
+	}
+
 	/** @type {any} */
 	let defaultPermissions = {};
 
@@ -56,7 +60,6 @@
 
 	const setGroups = async () => {
 		groups = await getGroups(localStorage.token);
-		adminGroupCount.set(groups.length);
 	};
 
 	/** @param {any} updatedGroup */


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #29079, the admin Users tab counts go stale across tab swaps and the Groups count ignores the search filter.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable.
- [ ] **Dependencies:** No new dependencies.
- [x] **Testing:** I performed manual end-to-end tests of this branch on a live instance: reproduced both defects on `dev` first, then stepped the same search-and-swap sequence on the branch and confirmed the counts follow the filter and reset on tab changes. Scripted browser runs of the identical sequence on both builds are included below as supporting evidence, not as a substitute.
- [x] **User-facing changes:** This PR changes the UI. Screenshots are included below.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance, and I have thoroughly reviewed and manually tested it.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new state, no new endpoint, no new abstraction. The existing workspace tab count pattern is applied to the admin Users tabs.
- [x] **First-time contributor policy:** Not my first contribution.
- [x] **Git Hygiene:** The PR is atomic, a single commit against current `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `refac`

# Changelog Entry

### Description

**Problem** (#29079): the `Overview` and `Groups` counts in Admin Panel > `Users` are inconsistent with each other and with the workspace tabs. Searching in `Overview` filters its count, but the filtered number survives swapping to `Groups` (a search matching nothing leaves `Overview 0` showing until the tab is revisited). Searching in `Groups` never changes its count at all.

**Cause**: the workspace tabs implement their count behavior as a pair. Each tab component publishes its current, filter-aware count, and the workspace layout restores every true total on each in-section navigation:

https://github.com/open-webui/open-webui/blob/56d296ef1b59d6325ae7327f44d704fbf94cc64d/src/routes/(app)/workspace/%2Blayout.svelte#L38-L40

Admin `Users` has only half of the pair: `UserList.svelte` publishes its filter-carrying fetch total, but `Users.svelte` loads the counts once in `onMount` and never again, and `Groups.svelte` publishes only the unfiltered `groups.length`.

**Change**: port the missing halves.

- `Users.svelte`: counts move from a one-time `onMount` load into the same reactive shape the workspace layout uses, so they refresh on every tab change.
- `Groups.svelte`: the count follows the client side filter by publishing `filteredGroups.length`, mirroring how the workspace `Tools` tab publishes `filteredItems.length`. A `loaded` guard keeps the pre-fetch empty array from blanking the count during mount, and the now redundant write in `setGroups()` is removed so the component has one writer.
- `UserList.svelte` is untouched.

Two visible consequences, both identical to the workspace tabs: counts appear a moment after the page renders rather than at first paint, and entering the `Groups` tab fetches the group list twice (once for the count, once for the list), the same cost the workspace layout pays per navigation.

Scope: two files, +8 / -2.

### Changed

- Aligned the admin `Users` tab counts with the workspace tab count behavior: the active tab's count follows the search filter, and swapping tabs restores every count to its true total instead of leaving a stale filtered value behind.

---

### Additional Information

- This PR was prepared with AI copilot assistance and I reviewed it.
- Related but distinct: #28072 covered the member count inside the group list after editing a group, not the tab counts.

### Manual Verification Performed

Stepping both builds through the same sequence on a live instance (5 users, 5 groups):

| Step | dev `56d296ef1` | this branch |
| --- | --- | --- |
| At rest | Overview 5, Groups 5 | Overview 5, Groups 5 |
| Search garbage in Overview | Overview 0 | Overview 0, follows the filter |
| Swap to Groups | Overview 0, stale | Overview 5, restored |
| Search garbage in Groups | Groups 5, frozen | Groups 0, follows the filter |
| Back to Overview | Overview 5, Groups 5 | Overview 5, Groups 5 |

Group create and delete keep updating the count by design, since the reactive publish depends on `groups`, which `setGroups()` reassigns after every mutation. `npm run format` reports no changes on the two touched files.

### Screenshots or Videos

| Surface | Before | After |
| --- | --- | --- |
| On the Groups tab after searching Overview down to nothing | <img src="https://raw.githubusercontent.com/silentoplayz/open-webui/assets/issue-29079/users_before_groups_tab.png" width="420"> | <img src="https://raw.githubusercontent.com/silentoplayz/open-webui/assets/issue-29079/users_fixed_groups_tab.png" width="420"> |
| Groups tab under a search matching nothing | <img src="https://raw.githubusercontent.com/silentoplayz/open-webui/assets/issue-29079/users_before_groups_filtered.png" width="420"> | <img src="https://raw.githubusercontent.com/silentoplayz/open-webui/assets/issue-29079/users_fixed_groups_filtered.png" width="420"> |

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.


