### PR TITLE
refac: reset the shared chats modal search when the modal closes

### DIFF
--- a/src/lib/components/layout/ChatsModal.svelte
+++ b/src/lib/components/layout/ChatsModal.svelte
@@ -44,6 +44,10 @@
 	export let orderBy = 'updated_at';
 	export let direction = 'desc'; // 'asc' or 'desc'
 
+	$: if (!show) {
+		query = '';
+	}
+
 	export let chatList = null;
 	export let allChatsLoaded = false;
 	export let chatListLoading = false;


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #29081, the Shared Chats modal keeps its search term across close and reopen while showing unfiltered results.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable.
- [ ] **Dependencies:** No new dependencies.
- [x] **Testing:** I performed manual end-to-end tests on a live instance: reproduced the stale-search state on `dev` first (search, close, reopen, observe the retained term above unfiltered results), then confirmed on this branch that reopening shows an empty search with the full list. Scripted browser runs of the same sequence on both builds are included below as supporting evidence, not as a substitute.
- [x] **User-facing changes:** This PR changes the UI. Screenshots are included below.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance, and I have thoroughly reviewed and manually tested it.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new state and no new mechanism. The reset lives in the component that owns the search input and the close lifecycle, completing the reset-on-close its consumers already do partially.
- [x] **First-time contributor policy:** Not my first contribution.
- [x] **Git Hygiene:** The PR is atomic, a single commit against current `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `refac`

# Changelog Entry

### Description

**Problem** (#29081): searching in the Shared Chats modal, closing it, and reopening it shows the previous search term still in the search bar while the list and count are unfiltered. A search that matched nothing sits above a full list.

**Cause**: `SharedChatsModal.svelte` binds `query` into the shared `ChatsModal` component and never clears it. On reopen, its `$: if (show) init();` fetches without any filter, so the stale term and fresh unfiltered data render together. The sibling consumer, the admin user chats modal, already resets its transient state (`chatList`, `page`, load flags) on close but misses the search.

**Change**: one reset in `ChatsModal.svelte`, the component that owns the search input and the close lifecycle:

```svelte
$: if (!show) {
	query = '';
}
```

The two-way `bind:query` propagates the reset to both consumers. Their search handlers already guard with `if (!show) return;`, so closing triggers no fetch. Both modals now open fresh: the Shared Chats modal and the admin user chats modal.

Scope: one file, +4 lines.

### Changed

- The Shared Chats modal and the admin panel's user chats modal now discard the search when closed, so reopening shows the full list instead of a stale search term above unfiltered results.

---

### Additional Information

- This PR was prepared with AI copilot assistance and I reviewed it.

### Manual Verification Performed

On a live instance with two shared chats, stepping both builds through the same sequence:

| Step | dev `56d296ef1` | this branch |
| --- | --- | --- |
| Open the modal | full list, empty search | full list, empty search |
| Search `tjtyjyut` | 0 results | 0 results |
| Close, reopen | term retained, list unfiltered | search empty, full list |

By design, the reset cannot trigger a fetch on close: both parents' search handlers open with `if (!show) return;`. `npm run format` reports no changes on the touched file.

### Screenshots or Videos

| Reopened after searching `tjtyjyut` | |
| --- | --- |
| Before | <img src="https://raw.githubusercontent.com/silentoplayz/open-webui/assets/issue-chats-modal-search/shared_before_reopened.png" width="480"> |
| After | <img src="https://raw.githubusercontent.com/silentoplayz/open-webui/assets/issue-chats-modal-search/shared_fixed_reopened.png" width="480"> |

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.


