### PR TITLE
fix: stop the workspace model id and timestamp overlaying the model name on narrow screens

### DIFF
--- a/src/lib/components/workspace/Models.svelte
+++ b/src/lib/components/workspace/Models.svelte
@@ -735,14 +735,14 @@
 												<Tooltip content={model.name} className="min-w-0" placement="top-start">
 													<a
 														href={`/?model=${encodeURIComponent(model.id)}`}
-														class="truncate text-[0.8125rem] leading-5 text-gray-800 group-hover:underline dark:text-gray-200"
+														class="block truncate text-[0.8125rem] leading-5 text-gray-800 group-hover:underline dark:text-gray-200"
 													>
 														{model.name}
 													</a>
 												</Tooltip>
 
 												<div
-													class="min-w-0 max-w-[40%] shrink-0 truncate text-[0.6875rem] leading-5 text-gray-500"
+													class="hidden min-w-0 max-w-[40%] shrink-0 truncate text-[0.6875rem] leading-5 text-gray-500 sm:block"
 												>
 													{model.id}
 												</div>


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #29083, the workspace model id and timestamp overlay the model name on narrow screens.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable.
- [ ] **Dependencies:** No new dependencies.
- [x] **Testing:** I performed manual end-to-end tests: the defect was reproduced by the author on an iPhone 13 Pro running Open WebUI as a home screen PWA and in a Firefox mobile viewport before the fix, and the corrected rendering on this branch was reviewed and confirmed by the author. Scripted browser measurement runs at 393px and 1280px on both builds are included below as supporting evidence, not as a substitute.
- [x] **User-facing changes:** This PR changes the UI. Screenshots are included below.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance and has been thoroughly reviewed and manually tested by the author.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new structure. One display fix on the existing anchor, and the row's existing responsive idiom (`hidden md:block` on the owner column) applied to the id column one breakpoint lower.
- [x] **First-time contributor policy:** Not my first contribution.
- [x] **Git Hygiene:** The PR is atomic, a single commit against current `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

**Problem** (#29083): on phones and narrow viewports, every row of Workspace > `Models` draws the model id and the updated timestamp on top of the model name. Two layers of text interleave and none of the three values is readable.

**Cause**: the model name is an `<a>`, which is `display: inline`, and CSS `overflow` does not apply to inline elements. The `truncate` utility on it therefore contributes only `white-space: nowrap` and never clips, so the anchor paints its full text width across the siblings that follow. At 393px the anchor spans x 72 to 317 while the id sits at x 118.9 and the timestamp at x 210.9, both inside the anchor's span. The four sibling workspace lists (`Prompts`, `Skills`, `Tools`, `Knowledge`) render the same slot as a `<div>` with the identical class string, which is block level, so only `Models` overlays.

**Change**: two classes in one file.

1. `block` on the name anchor, making `truncate` effective. This removes the overlay.
2. With clipping working, a 393px row leaves the name about 40px, because the id column is `shrink-0` with a 40% cap; every name truncates to one letter. Letting the id shrink proportionally was measured and is not enough (the name recovers to 41.7px, the 40% clamp applies before the shrink math). The row already handles narrow widths for the owner column with `hidden md:block`, so the id column gets the same idiom one breakpoint lower: `hidden sm:block`.

Below `sm`, a row shows the name (about 129px at a 393px viewport), the timestamp, and the metadata line. From `sm` up the id column returns unchanged, and desktop at 1280px measures identical before and after (name 245px, id 402.8px, timestamp 67px).

Trade-off stated plainly: the raw id is not visible below 640px. It remains reachable through the model's edit view and partially through the row's metadata line.

Scope: one file, 2 changed classes.

### Fixed

- Fixed the workspace Models list drawing each model's id and updated timestamp on top of its name on narrow screens: the name now truncates properly, and the raw id column is shown from the `sm` breakpoint up, matching how the row already hides the owner column on small screens.

---

### Additional Information

- This PR was prepared with AI copilot assistance and reviewed by the author.

### Manual Verification Performed

Measured with scripted browser runs on both builds, same instance:

| Measurement, first row | dev `56d296ef1` | this branch |
| --- | --- | --- |
| 393px: name anchor | display inline, paints x 72 to 317 over both siblings | display block, 129.3px, clipped |
| 393px: id column | 82.4px, overlapped | hidden until `sm` |
| 393px: timestamp | 67px, overlapped | 67px, clear |
| 1280px: name / id / timestamp | 245 / 402.8 / 67 | 245 / 402.8 / 67, identical |

`npm run format` reports no changes on the touched file.

### Screenshots or Videos

| Surface | Before | After |
| --- | --- | --- |
| Workspace Models at 393px | <img src="https://raw.githubusercontent.com/silentoplayz/open-webui/assets/issue-models-mobile-overlap/before_mobile.png" width="320"> | <img src="https://raw.githubusercontent.com/silentoplayz/open-webui/assets/issue-models-mobile-overlap/after_mobile.png" width="320"> |
| Workspace Models at 1280px | <img src="https://raw.githubusercontent.com/silentoplayz/open-webui/assets/issue-models-mobile-overlap/before_desktop.png" width="420"> | <img src="https://raw.githubusercontent.com/silentoplayz/open-webui/assets/issue-models-mobile-overlap/after_desktop.png" width="420"> |

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
