### PR TITLE
fix: keep a calendar event visible after its date is moved

### DIFF
--- a/backend/open_webui/models/calendar.py
+++ b/backend/open_webui/models/calendar.py
@@ -533,7 +533,8 @@ class CalendarEventTable:
                             & (CalendarEvent.start_at < end)
                             & or_(
                                 CalendarEvent.end_at.is_(None) & (CalendarEvent.start_at >= start),
-                                CalendarEvent.end_at.isnot(None) & (CalendarEvent.end_at > start),
+                                CalendarEvent.end_at.isnot(None)
+                                & ((CalendarEvent.end_at > start) | (CalendarEvent.start_at >= start)),
                             )
                         ),
                         # Recurring: fetch all (expansion in Python)

--- a/src/lib/components/calendar/CalendarEventModal.svelte
+++ b/src/lib/components/calendar/CalendarEventModal.svelte
@@ -129,7 +129,12 @@
 		loading = true;
 		try {
 			const startNs = dateTimeToNs(startDate, allDay ? '00:00' : startTime);
-			const endNs = endDate ? dateTimeToNs(endDate, allDay ? '23:59' : endTime) : undefined;
+			let endNs = endDate ? dateTimeToNs(endDate, allDay ? '23:59' : endTime) : undefined;
+			if (endNs !== undefined && endNs < startNs) {
+				const duration =
+					event?.end_at && event.end_at > event.start_at ? event.end_at - event.start_at : 0;
+				endNs = startNs + duration;
+			}
 
 			if (event && !event.meta?.automation_id) {
 				const result = await updateCalendarEvent(localStorage.token, event.id, {

--- a/src/lib/components/calendar/CalendarView.svelte
+++ b/src/lib/components/calendar/CalendarView.svelte
@@ -31,7 +31,10 @@
 			const startDate = new Date(startMs);
 			const endDate = new Date(endMs);
 			const d = new Date(startDate.getFullYear(), startDate.getMonth(), startDate.getDate());
-			const last = new Date(endDate.getFullYear(), endDate.getMonth(), endDate.getDate()).getTime();
+			const last = Math.max(
+				d.getTime(),
+				new Date(endDate.getFullYear(), endDate.getMonth(), endDate.getDate()).getTime()
+			);
 			while (d.getTime() <= last) {
 				const key = d.getTime().toString();
 				(map[key] ??= []).push(e);
@@ -90,7 +93,7 @@
 		const dayEndMs = dayStartMs + 86_400_000;
 		return filteredEvents.filter((e) => {
 			const startMs = e.start_at / NS;
-			const endMs = (e.end_at || e.start_at) / NS;
+			const endMs = Math.max(startMs, (e.end_at || e.start_at) / NS);
 			return startMs < dayEndMs && endMs >= dayStartMs;
 		});
 	}


### PR DESCRIPTION
# Pull Request Checklist

**Before submitting, make sure you've checked the following:**

- [x] **Linked Issue/Discussion:** Closes #29067, an event updated to a new date disappears from the calendar views.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Not applicable.
- [ ] **Dependencies:** No new dependencies.
- [x] **Testing:** I performed manual end-to-end tests on a live instance: reproduced the reporter's narrowed flow first (edit an event's date in the event modal, save, watch it vanish from every view), then confirmed on this branch that the moved event stays visible, keeps its duration, and that an event already stored in the broken state reappears without a re-edit. Scripted browser and API runs of the same flows on both builds are included below as supporting evidence, not as a substitute.
- [x] **User-facing changes:** This PR changes rendering behavior. Screenshots are included below.
- [x] **No Unchecked AI Code:** This PR was prepared with AI copilot assistance, and I have thoroughly reviewed and manually tested it.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** No new state, no new endpoint. One guard in the event modal's existing submit path, one widened condition in the existing range query, and a clamp in the existing day grouping.
- [x] **First-time contributor policy:** Not my first contribution.
- [x] **Git Hygiene:** The PR is atomic, a single commit against current `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** `fix`

# Changelog Entry

### Description

**Problem** (#29067, as narrowed by the reporter): updating a calendar event to a new date makes it disappear from the month view, and in fact from every view.

**Cause, a three-link chain.** The event modal has no end date input: one date field bound to the start, plus two time fields. `endDate` is invisible state prefilled from the stored event, so changing the date field on any event that has an `end_at` submits the old end date with the new start, storing `end_at` earlier than `start_at`. Two consumers then each hide such a row independently:

1. The non-recurring branch of the range query requires `end_at > range_start`, so the row is never returned for the month containing its new start:

https://github.com/open-webui/open-webui/blob/56d296ef1b59d6325ae7327f44d704fbf94cc64d/backend/open_webui/models/calendar.py#L531-L538

2. The month view groups events by walking days from the start date while `day <= end day`, which is zero iterations for an inverted interval, so even when a wider range does deliver the row it lands in no day bucket:

https://github.com/open-webui/open-webui/blob/56d296ef1b59d6325ae7327f44d704fbf94cc64d/src/lib/components/calendar/CalendarView.svelte#L25-L42

**Change**, all three links:

- `CalendarEventModal.svelte`: when the computed end would precede the new start, the end is recomputed as the new start plus the event's stored duration. Moving a 10:00 to 11:00 event to another day now stores 10:00 to 11:00 on that day. Deliberate end time edits are untouched, and events whose stored interval is valid round-trip exactly as before.
- `models/calendar.py`: the range query also returns an event whose `start_at` falls inside the range, so rows already stored in the broken state are delivered to the views that should show them.
- `CalendarView.svelte`: the day grouping and the day filter clamp the end to no earlier than the start, so a delivered row always renders on its start date.

The second and third parts are what make events that existing installs already hold in the broken state, like the reporter's, reappear after upgrading with no re-edit needed.

Scope: three files, +13 / -4.

### Fixed

- Fixed calendar events disappearing from every view after being updated to a new date: the event editor no longer stores an end date earlier than the start when a date is changed, and events already stored that way are returned and rendered on their start date again.

---

### Additional Information

- The API itself still accepts whatever interval a caller sends, unchanged; the fix corrects what the event editor writes and makes the read paths tolerant of rows the editor previously wrote.
- This PR was prepared with AI copilot assistance and I reviewed it.

### Manual Verification Performed

All against a live instance, both builds:

| Check | Unpatched | This branch |
| --- | --- | --- |
| Edit an event's date in the modal, save | stores `start` Sept 20, `end` Sept 15, inverted | stores the new date with the 1 hour duration preserved |
| Month fetch for the range containing the new start | event not returned | returned |
| Same database row, old vs new query predicate | 0 rows | 1 row |
| Month view with an inverted row delivered | nothing rendered | chip renders on the start date |
| Event already stored inverted, after upgrade | invisible everywhere | visible; a later save through the modal repairs the stored interval |
| No-op edit of a healthy event | round-trips unchanged | round-trips unchanged |

`npm run format` reports no changes on the two touched frontend files; `ruff format --check` reports the backend file already formatted.

### Screenshots or Videos

The last grid row of the month view, with an event whose date was moved to the 4th:

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/silentoplayz/open-webui/assets/pr-calendar-moved-event/before_row.png" width="480"> | <img src="https://raw.githubusercontent.com/silentoplayz/open-webui/assets/pr-calendar-moved-event/after_row.png" width="480"> |

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.

