### PR TITLE
fix(auth): handle unparseable stored password hash gracefully in authenticate_user (#29092)

### DIFF
--- a/backend/open_webui/models/auths.py
+++ b/backend/open_webui/models/auths.py
@@ -157,9 +157,16 @@ class AuthsTable:
         async with get_async_db_context(db) as session:
             credential = await session.get(Auth, resolved.id)
             if not credential or not credential.active:
-                await verify_password(PLACEHOLDER_HASH)
+                try:
+                    await verify_password(PLACEHOLDER_HASH)
+                except Exception:
+                    pass
                 return
-            if not await verify_password(credential.password):
+            try:
+                if not await verify_password(credential.password):
+                    return
+            except Exception:
+                log.warning('Unparseable stored password hash for user: %s', email)
                 return
             return resolved
 


### PR DESCRIPTION
## Summary

Fixes #29092.

In `open_webui/models/auths.py`, if a stored credential password hash is malformed or in an incompatible format, `verify_password(credential.password)` can raise an unhandled exception resulting in a raw 500 server error instead of gracefully failing authentication.

### Changes
- Wraps `verify_password` calls in `Auths.authenticate_user` with try/except blocks to treat unparseable/invalid hash formats identically to incorrect passwords, logging a warning and returning `None` so callers handle it as a standard 400 Bad Credentials.