### PR TITLE
fix(auth): suppress OAUTH_AUTO_REDIRECT on signout navigation to prevent logout redirect loop (#29076)

### DIFF
--- a/src/lib/components/layout/Sidebar/UserMenu.svelte
+++ b/src/lib/components/layout/Sidebar/UserMenu.svelte
@@ -574,7 +574,7 @@
 					user.set(null);
 					localStorage.removeItem('token');
 
-					location.href = res?.redirect_url ?? '/auth';
+					location.href = res?.redirect_url ?? '/auth?signout=true';
 					show = false;
 				}}
 			>

--- a/src/routes/auth/+page.svelte
+++ b/src/routes/auth/+page.svelte
@@ -173,9 +173,10 @@
 
 		// Auto-redirect to SSO when OAUTH_AUTO_REDIRECT is enabled and the
 		// deployment is unambiguously SSO-only (single provider, no login form,
-		// no LDAP). Suppressed by ?form=, ?error=, onboarding, trusted-header
+		// no LDAP). Suppressed by ?form=, ?error=, ?signout, onboarding, trusted-header
 		// auth, or an existing session/token.
-		if ($config?.oauth?.auto_redirect && !form && !error) {
+		const signout = $page.url.searchParams.get('signout');
+		if ($config?.oauth?.auto_redirect && !form && !error && !signout) {
 			const providers = Object.keys($config?.oauth?.providers ?? {});
 			if (
 				providers.length === 1 &&


### PR DESCRIPTION
## Summary

Fixes #29076.

When `OAUTH_AUTO_REDIRECT=true`, clicking Sign Out initiates a signout request, but mounting `/auth` immediately triggers an automatic login redirect to `/oauth/{provider}/login`, canceling the logout navigation and creating an infinite re-login loop.

### Changes
- Adds `?signout=true` parameter to local logout fallback navigation in `UserMenu.svelte`.
- Checks `signout` query param in `/auth/+page.svelte` to suppress automatic OAuth redirect immediately after signing out.