### PR TITLE
feat: re-run filter inlet on tool-call turns for opted-in filters

### DIFF
--- a/backend/open_webui/utils/filter.py
+++ b/backend/open_webui/utils/filter.py
@@ -159,6 +159,7 @@ async def process_filter_function(
     filter_context,
     valves_by_id,
     filter_ids,
+    tool_turns=False,
 ):
     filter_id = function.id
 
@@ -167,6 +168,11 @@ async def process_filter_function(
     )
     handler = getattr(function_module, filter_type, None)
     if not handler:
+        return form_data, valves_by_id, None
+
+    # Tool-call turns only run filters that opt in with `tool_turns = True`, and
+    # re-run them on the whole body, so an opted-in handler has to be idempotent.
+    if tool_turns and not getattr(function_module, 'tool_turns', False):
         return form_data, valves_by_id, None
 
     skip_files = (
@@ -204,6 +210,7 @@ async def process_filter_functions(
     filter_type,
     form_data,
     extra_params,
+    tool_turns=False,
 ):
     if not ENABLE_PLUGINS:
         return form_data, {}
@@ -225,11 +232,13 @@ async def process_filter_functions(
             filter_context,
             valves_by_id,
             filter_ids,
+            tool_turns=tool_turns,
         )
         skip_files = skip_files or file_handler
 
-    # Handle file cleanup for inlet
-    if skip_files:
+    # Handle file cleanup for inlet; the user turn already stripped them, and on a
+    # tool turn `metadata` is live state later tool calls still read.
+    if skip_files and not tool_turns:
         if 'files' in form_data.get('metadata', {}):
             del form_data['metadata']['files']
         if 'files' in form_data:

--- a/backend/open_webui/utils/filter.py
+++ b/backend/open_webui/utils/filter.py
@@ -159,7 +159,7 @@ async def process_filter_function(
     filter_context,
     valves_by_id,
     filter_ids,
-    tool_turns=False,
+    tool_call_continuation=False,
 ):
     filter_id = function.id
 
@@ -170,9 +170,7 @@ async def process_filter_function(
     if not handler:
         return form_data, valves_by_id, None
 
-    # Tool-call turns only run filters that opt in with `tool_turns = True`, and
-    # re-run them on the whole body, so an opted-in handler has to be idempotent.
-    if tool_turns and not getattr(function_module, 'tool_turns', False):
+    if tool_call_continuation and not getattr(function_module, 'tool_call_continuation', False):
         return form_data, valves_by_id, None
 
     skip_files = (
@@ -210,7 +208,7 @@ async def process_filter_functions(
     filter_type,
     form_data,
     extra_params,
-    tool_turns=False,
+    tool_call_continuation=False,
 ):
     if not ENABLE_PLUGINS:
         return form_data, {}
@@ -232,13 +230,13 @@ async def process_filter_functions(
             filter_context,
             valves_by_id,
             filter_ids,
-            tool_turns=tool_turns,
+            tool_call_continuation=tool_call_continuation,
         )
         skip_files = skip_files or file_handler
 
-    # Handle file cleanup for inlet; the user turn already stripped them, and on a
-    # tool turn `metadata` is live state later tool calls still read.
-    if skip_files and not tool_turns:
+    # Handle file cleanup for inlet
+    # Skipped on continuations: files are already stripped, and metadata is live state later tool calls read.
+    if skip_files and not tool_call_continuation:
         if 'files' in form_data.get('metadata', {}):
             del form_data['metadata']['files']
         if 'files' in form_data:

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -3389,31 +3389,30 @@ async def drain_approved_tool_calls(request, form_data, user, model, metadata) -
             )
             form_data['messages'] = sanitize_tool_pairs(form_data['messages'])
 
-            if not paused:
-                filtered_form_data, _ = await process_filter_functions(
-                    request=request,
-                    filter_context=None,
-                    filter_functions=await get_filter_functions(request, model, metadata.get('filter_ids', [])),
-                    filter_type='inlet',
-                    form_data=form_data,
-                    extra_params={
-                        '__event_emitter__': event_emitter,
-                        '__event_call__': event_caller,
-                        '__user__': user.model_dump() if isinstance(user, UserModel) else {},
-                        '__metadata__': metadata,
-                        '__oauth_token__': await get_system_oauth_token(request, user),
-                        '__request__': request,
-                        '__model__': model,
-                        '__chat_id__': chat_id,
-                        '__message_id__': message_id,
-                    },
-                    tool_turns=True,
-                )
-                # The caller holds its own reference, so a filter that returned a new
-                # body has to be swapped in rather than rebound.
-                if filtered_form_data is not form_data:
-                    form_data.clear()
-                    form_data.update(filtered_form_data)
+        if not paused:
+            filtered_form_data, _ = await process_filter_functions(
+                request=request,
+                filter_context=None,
+                filter_functions=(
+                    await get_filter_functions(request, model, metadata.get('filter_ids', [])) if ENABLE_PLUGINS else []
+                ),
+                filter_type='inlet',
+                form_data=dict(form_data),
+                extra_params={
+                    '__event_emitter__': event_emitter,
+                    '__event_call__': event_caller,
+                    '__user__': user.model_dump() if isinstance(user, UserModel) else {},
+                    '__metadata__': metadata,
+                    '__oauth_token__': await get_system_oauth_token(request, user),
+                    '__request__': request,
+                    '__model__': model,
+                    '__chat_id__': chat_id,
+                    '__message_id__': message_id,
+                },
+                tool_call_continuation=True,
+            )
+            form_data.clear()
+            form_data.update(filtered_form_data)
 
         return paused
 
@@ -4223,8 +4222,6 @@ async def streaming_chat_response_handler(response, ctx):
         '__oauth_token__': await get_system_oauth_token(request, user),
         '__request__': request,
         '__model__': model,
-        '__chat_id__': metadata.get('chat_id'),
-        '__message_id__': metadata.get('message_id'),
     }
 
     filter_functions = (
@@ -4245,15 +4242,19 @@ async def streaming_chat_response_handler(response, ctx):
             tag_boundary_positions = {}
             response_stream_task_id = metadata.get('task_id') or metadata.get('message_id')
 
-            async def apply_tool_turn_inlet(new_form_data):
+            async def apply_continuation_inlet(new_form_data):
                 new_form_data, _ = await process_filter_functions(
                     request=request,
                     filter_context=filter_context,
                     filter_functions=filter_functions,
                     filter_type='inlet',
                     form_data=new_form_data,
-                    extra_params=extra_params,
-                    tool_turns=True,
+                    extra_params={
+                        **extra_params,
+                        '__chat_id__': metadata.get('chat_id'),
+                        '__message_id__': metadata.get('message_id'),
+                    },
+                    tool_call_continuation=True,
                 )
                 return new_form_data
 
@@ -5979,7 +5980,7 @@ async def streaming_chat_response_handler(response, ctx):
                                     }
                                 )
 
-                        new_form_data = await apply_tool_turn_inlet(new_form_data)
+                        new_form_data = await apply_continuation_inlet(new_form_data)
 
                         res = await generate_chat_completion(
                             request,
@@ -6189,7 +6190,7 @@ async def streaming_chat_response_handler(response, ctx):
                                 ],
                             }
 
-                            new_form_data = await apply_tool_turn_inlet(new_form_data)
+                            new_form_data = await apply_continuation_inlet(new_form_data)
 
                             res = await generate_chat_completion(
                                 request,

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -3389,6 +3389,32 @@ async def drain_approved_tool_calls(request, form_data, user, model, metadata) -
             )
             form_data['messages'] = sanitize_tool_pairs(form_data['messages'])
 
+            if not paused:
+                filtered_form_data, _ = await process_filter_functions(
+                    request=request,
+                    filter_context=None,
+                    filter_functions=await get_filter_functions(request, model, metadata.get('filter_ids', [])),
+                    filter_type='inlet',
+                    form_data=form_data,
+                    extra_params={
+                        '__event_emitter__': event_emitter,
+                        '__event_call__': event_caller,
+                        '__user__': user.model_dump() if isinstance(user, UserModel) else {},
+                        '__metadata__': metadata,
+                        '__oauth_token__': await get_system_oauth_token(request, user),
+                        '__request__': request,
+                        '__model__': model,
+                        '__chat_id__': chat_id,
+                        '__message_id__': message_id,
+                    },
+                    tool_turns=True,
+                )
+                # The caller holds its own reference, so a filter that returned a new
+                # body has to be swapped in rather than rebound.
+                if filtered_form_data is not form_data:
+                    form_data.clear()
+                    form_data.update(filtered_form_data)
+
         return paused
 
     return False
@@ -4197,6 +4223,8 @@ async def streaming_chat_response_handler(response, ctx):
         '__oauth_token__': await get_system_oauth_token(request, user),
         '__request__': request,
         '__model__': model,
+        '__chat_id__': metadata.get('chat_id'),
+        '__message_id__': metadata.get('message_id'),
     }
 
     filter_functions = (
@@ -4216,6 +4244,18 @@ async def streaming_chat_response_handler(response, ctx):
             tag_scan_positions = {}
             tag_boundary_positions = {}
             response_stream_task_id = metadata.get('task_id') or metadata.get('message_id')
+
+            async def apply_tool_turn_inlet(new_form_data):
+                new_form_data, _ = await process_filter_functions(
+                    request=request,
+                    filter_context=filter_context,
+                    filter_functions=filter_functions,
+                    filter_type='inlet',
+                    form_data=new_form_data,
+                    extra_params=extra_params,
+                    tool_turns=True,
+                )
+                return new_form_data
 
             def tag_output_handler(content_type, tags, output):
                 """
@@ -5939,6 +5979,8 @@ async def streaming_chat_response_handler(response, ctx):
                                     }
                                 )
 
+                        new_form_data = await apply_tool_turn_inlet(new_form_data)
+
                         res = await generate_chat_completion(
                             request,
                             new_form_data,
@@ -6146,6 +6188,8 @@ async def streaming_chat_response_handler(response, ctx):
                                     ),
                                 ],
                             }
+
+                            new_form_data = await apply_tool_turn_inlet(new_form_data)
 
                             res = await generate_chat_completion(
                                 request,


### PR DESCRIPTION
Filter inlet only runs on the user turn, so anything a tool returns reaches the model unfiltered. Images are the painful case: tool results can carry base64 images well over a model's size limit, and a filter that would rescale them never sees them, which forces deployments to patch the backend instead.

Filters now opt in with `tool_turns = True` at module level, and their inlet re-runs on every request carrying tool output: the native tool-call continuation, the code interpreter continuation, and the first model call after approved tool calls are drained. Filters without the flag behave exactly as before. Opt-in keeps that guarantee, since re-running every inlet would double-apply filters that inject context, count tokens or rate limit. An opted-in inlet receives the whole body each time, so it has to be idempotent.

The streaming handler's filter params now also include `__chat_id__` and `__message_id__`, matching the user turn. Without them an opted-in filter declaring those arguments would fail on a tool turn. Legacy (non-native) function calling stays uncovered: it injects tool output as text sources ahead of its single model call.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
