### PR TITLE
fix: refresh selected folder on folder route changes

### DIFF
--- a/src/routes/(app)/folders/[folderId]/+page.svelte
+++ b/src/routes/(app)/folders/[folderId]/+page.svelte
@@ -9,19 +9,24 @@
 	import { getFolderById } from '$lib/apis/folders';
 	import { selectedFolder } from '$lib/stores';
 
-	let ready = false;
+	type FolderSelection = { id?: string } | null;
 
-	onMount(async () => {
-		const folderId = $page.params.folderId;
+	let ready = false;
+	let loadingFolderId: string | null = null;
+
+	const loadFolder = async (folderId: string | undefined) => {
 		if (!folderId) {
 			await goto('/');
 			return;
 		}
 
+		loadingFolderId = folderId;
+		ready = false;
+
 		// The sidebar click handler already fetches the folder and sets
 		// `selectedFolder` before navigating here; refetching would duplicate
 		// the request and re-trigger the sidebar's folder refresh.
-		if ($selectedFolder?.id !== folderId) {
+		if (($selectedFolder as FolderSelection)?.id !== folderId) {
 			const folder = await getFolderById(localStorage.token, folderId).catch((error) => {
 				toast.error(`${error}`);
 				return null;
@@ -32,11 +37,27 @@
 				return;
 			}
 
+			if (loadingFolderId !== folderId) {
+				return;
+			}
+
 			await selectedFolder.set(folder);
 		}
 
 		ready = true;
+	};
+
+	onMount(async () => {
+		await loadFolder($page.params.folderId);
 	});
+
+	$: if (
+		ready &&
+		$page.params.folderId &&
+		($selectedFolder as FolderSelection)?.id !== $page.params.folderId
+	) {
+		loadFolder($page.params.folderId);
+	}
 
 	onDestroy(() => {
 		selectedFolder.set(null);


### PR DESCRIPTION
### Description

Fixes #29022.

Folder routes now reload the selected folder when the dynamic `folderId` route parameter changes. This keeps `selectedFolder` aligned with the current `/folders/:folderId` URL, including when navigating through nested folders or after moving a folder in/out of a parent.

The backend already applies folder project settings, including `data.system_prompt`, when the completion request contains the correct `folder_id`. Keeping the route store in sync prevents new chats opened from a nested folder from using stale folder context.

### Changes

- Extracted folder loading in `/folders/[folderId]` into a reusable `loadFolder` helper.
- Added a reactive reload when the route `folderId` and `selectedFolder.id` differ.
- Added a small stale-request guard so an older folder fetch cannot overwrite a newer route selection.

### Testing

- `npx prettier --check 'src/routes/(app)/folders/[folderId]/+page.svelte'`
- `npx eslint 'src/routes/(app)/folders/[folderId]/+page.svelte'`
- `git diff --check`
- `npx svelte-check --tsconfig ./tsconfig.json 2>&1 | Select-String -Pattern 'src\\routes\\\(app\)\\folders\\\[folderId\]\\\+page\.svelte' -Context 0,5`

The filtered `svelte-check` command reported no diagnostics for the changed file. A full `npm run check` still reports existing repository-wide diagnostics unrelated to this change.