### PR TITLE
fix: refresh selected folder on folder route changes

### DIFF
--- a/src/routes/(app)/folders/[folderId]/+page.svelte
+++ b/src/routes/(app)/folders/[folderId]/+page.svelte
@@ -9,19 +9,24 @@
 	import { getFolderById } from '$lib/apis/folders';
 	import { selectedFolder } from '$lib/stores';
 
-	let ready = false;
+	type FolderSelection = { id?: string } | null;
 
-	onMount(async () => {
-		const folderId = $page.params.folderId;
+	let ready = false;
+	let loadingFolderId: string | null = null;
+
+	const loadFolder = async (folderId: string | undefined) => {
 		if (!folderId) {
 			await goto('/');
 			return;
 		}
 
+		loadingFolderId = folderId;
+		ready = false;
+
 		// The sidebar click handler already fetches the folder and sets
 		// `selectedFolder` before navigating here; refetching would duplicate
 		// the request and re-trigger the sidebar's folder refresh.
-		if ($selectedFolder?.id !== folderId) {
+		if (($selectedFolder as FolderSelection)?.id !== folderId) {
 			const folder = await getFolderById(localStorage.token, folderId).catch((error) => {
 				toast.error(`${error}`);
 				return null;
@@ -32,11 +37,27 @@
 				return;
 			}
 
+			if (loadingFolderId !== folderId) {
+				return;
+			}
+
 			await selectedFolder.set(folder);
 		}
 
 		ready = true;
+	};
+
+	onMount(async () => {
+		await loadFolder($page.params.folderId);
 	});
+
+	$: if (
+		ready &&
+		$page.params.folderId &&
+		($selectedFolder as FolderSelection)?.id !== $page.params.folderId
+	) {
+		loadFolder($page.params.folderId);
+	}
 
 	onDestroy(() => {
 		selectedFolder.set(null);


### PR DESCRIPTION
# Pull Request

Thanks for helping improve Open WebUI. Please make sure the linked Issue or Discussion explains the user-facing problem, the expected outcome, and any relevant examples or constraints.

Code contributions are not the default path. Open a code pull request only when a maintainer asks for one, or for narrow i18n/localization updates. For real, reproducible bugs, start with a well-described [Issue](https://github.com/open-webui/open-webui/issues). For feature requests, UI/UX changes, behavior changes, architecture changes, suspected fixes, or unconfirmed approaches, start with an active [Discussion](https://github.com/open-webui/open-webui/discussions).

If you have implementation notes, include them as reference in the Issue or Discussion. A local diff, patch, or branch can be useful context, but it does not mean a pull request is expected or will be reviewed.

Unsolicited PRs may be closed without review, especially when they introduce product, architecture, compatibility, dependency, or maintenance decisions that have not been discussed.

## Checklist

- [x] This PR targets the `dev` branch.
- [x] This PR links to a confirmed Issue or active Discussion: `Closes #29022`.
- [ ] A maintainer explicitly asked me to open this PR, or this PR only updates i18n/localization.
- [x] The change is one logical unit with no unrelated commits.
- [x] I matched nearby code patterns and avoided unnecessary new settings, abstractions, or dependencies.
- [ ] I manually tested the changed workflow and any nearby behavior that could be affected.
- [x] I updated relevant docs, including the [Open WebUI Docs Repository](https://github.com/open-webui/docs), if needed.
- [ ] I added screenshots for UI changes, and a recording when motion or interaction matters.
- [x] I reviewed any AI-generated code before submitting it.
- [x] The PR title uses one of the prefixes listed below.

## Title Prefix

Use one of the following prefixes:

- **BREAKING CHANGE**: Changes affecting backward compatibility
- **build**: Build system or dependency changes
- **ci**: CI/CD workflow changes
- **chore**: Refactoring, cleanup, or non-functional changes
- **docs**: Documentation additions or updates
- **feat**: New features or enhancements
- **fix**: Bug fixes or corrections
- **i18n**: Internationalization or localization changes
- **perf**: Performance improvements
- **refactor**: Code restructuring

## Summary

Closes #29022.

Folder routes now reload the selected folder when the dynamic `folderId` route parameter changes. This keeps `selectedFolder` aligned with the current `/folders/:folderId` URL, including when navigating through nested folders or after moving a folder in or out of a parent folder.

The backend already applies folder project settings, including `data.system_prompt`, when the completion request contains the correct `folder_id`. Keeping the route store in sync prevents new chats opened from a nested folder from using stale folder context.

## Testing

- `npx prettier --check 'src/routes/(app)/folders/[folderId]/+page.svelte'`
- `npx eslint 'src/routes/(app)/folders/[folderId]/+page.svelte'`
- `git diff --check`
- `npx svelte-check --tsconfig ./tsconfig.json 2>&1 | Select-String -Pattern 'src\\routes\\\(app\)\\folders\\\[folderId\]\\\+page\.svelte' -Context 0,5`

The filtered `svelte-check` command reported no diagnostics for the changed file. A full `npm run check` still reports existing repository-wide diagnostics unrelated to this change.

## Changelog Entry

### Added

-

### Changed

-

### Fixed

- Refreshed the selected folder when navigating between `/folders/:folderId` routes so nested folder chats use the current folder context.

### Removed

-

### Security

-

### Breaking Changes

-

## Additional Context

This change is intentionally scoped to the folder route state sync. It does not change backend folder permissions or folder project setting application.

## Contributor License Agreement

<!--
DO NOT DELETE THIS SECTION.
Your PR will not be reviewed or merged until you check the box below confirming that you have read and agree to the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.