### PR TITLE
fix: give the underline marked extension a renderer

### DIFF
--- a/src/lib/utils/marked/extension.ts
+++ b/src/lib/utils/marked/extension.ts
@@ -102,6 +102,10 @@ function detailsExtension() {
 	};
 }
 
+function underlineRenderer(this: any, token: any) {
+	return `<u>${this.parser.parseInline(token.tokens)}</u>`;
+}
+
 function underlineExtension() {
 	return {
 		name: 'underline',
@@ -117,7 +121,8 @@ function underlineExtension() {
 				text: match[1],
 				tokens: this.lexer.inlineTokens(match[1])
 			};
-		}
+		},
+		renderer: underlineRenderer
 	};
 }
 


### PR DESCRIPTION
# Pull Request

## Checklist

- [x] This PR targets the `dev` branch.
- [x] This PR links to a confirmed Issue or active Discussion: Closes #29115.
- [x] A maintainer explicitly asked me to open this PR, or this PR only updates i18n/localization.
- [x] The change is one logical unit with no unrelated commits.
- [x] I matched nearby code patterns and avoided unnecessary new settings, abstractions, or dependencies.
- [x] I manually tested the changed workflow and any nearby behavior that could be affected.
- [ ] I updated relevant docs, including the [Open WebUI Docs Repository](https://github.com/open-webui/docs), if needed.
- [x] I added screenshots for UI changes, and a recording when motion or interaction matters.
- [x] I reviewed any AI-generated code before submitting it.
- [x] The PR title uses one of the prefixes listed below.

## Summary

A banner containing `<u>...</u>` throws `Token with "underline" type was not found` and fails to render (#29115, reproduced and confirmed).

The `underline` marked extension added in `11db926a7` defines a tokenizer but no `renderer`:

https://github.com/open-webui/open-webui/blob/b3591e60b18bf2cdc57a57c215f70065882dbf60/src/lib/utils/marked/extension.ts#L105-L123

Chat messages never notice, because the chat path renders tokens with its own Svelte components (`MarkdownInlineTokens.svelte` handles `underline` directly) and never invokes marked's Parser. But `Markdown.svelte` registers the extension on the shared `marked` singleton at module top level, so once a chat has rendered, every direct `marked()` call in the app parses with a tokenizer that emits `underline` tokens no renderer can handle. `Banner.svelte` is such a caller, and marked's Parser throws on the unknown token type.

The fix gives the extension a renderer, mirroring how the neighboring `details` extension in the same file already pairs `detailsTokenizer` with `detailsRenderer`:

```ts
function underlineRenderer(this: any, token: any) {
	return `<u>${this.parser.parseInline(token.tokens)}</u>`;
}
```

`parseInline` on the nested tokens keeps markdown inside the tags working, so `<u>[FAQ](url)</u>` renders as an underlined link. Scope: one file, +6 / -1.

## Testing

- Reproduced the defect manually first: created an `info` banner with content `More info on model choice check out the <u>[FAQ](https://example.com/faq.html)</u>`, opened the new chat page, and observed the console error with the banner missing. The reporter's steps reproduce identically.
- Manually verified the fix on this branch: the same banner renders as expected, with the enclosed text underlined and the link working, and no error is thrown.
- Standalone check against the repo's own pinned marked, using the extension verbatim: without a renderer, `marked.parse` on the banner string throws `Token with "underline" type was not found`; with the renderer it returns `<p>check out the <u><a href="https://example.com/faq.html">FAQ</a></u></p>`.
- Scripted browser runs on both builds against a live instance, same banner: unpatched, the page throws and the banner does not render; with the fix, the banner renders with FAQ underlined and linked, and the page reports zero errors.
- Nearby behavior: chat message rendering of `<u>` is unaffected by design, since the chat path renders `underline` tokens through `MarkdownInlineTokens.svelte` and never consults marked's renderer.
- `npm run format` reports no changes on the touched file.

| Banner with `<u>[FAQ](url)</u>` content | |
| --- | --- |
| Before | <img width="2560" height="1275" alt="image" src="https://github.com/user-attachments/assets/5fd934d9-6333-4eed-9cb8-0ca08499e2df" /> |
| After | <img width="2560" height="1275" alt="image" src="https://github.com/user-attachments/assets/21982b69-83f4-4dea-a044-daa2b7d0b075" /> |


## Changelog Entry

### Fixed

- Fixed banners (and any other surface parsed directly with marked) throwing `Token with "underline" type was not found` and failing to render when their content contains `<u>...</u>`: the underline extension now has a renderer, so underlined content renders everywhere instead of only in chat messages.

## Additional Context

The reporter's issue body includes a minimal standalone reproduction and correctly identifies the missing renderer; this PR is that fix.

## Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.


