### PR TITLE
ci: retry the GHCR to Docker Hub copy before giving up

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -403,5 +403,15 @@ jobs:
             [ -z "$TAG" ] && continue
             DEST="${DOCKERHUB_IMAGE}:${TAG}"
             echo "  -> ${DEST}"
-            docker buildx imagetools create -t "${DEST}" "${SOURCE}"
+            for ATTEMPT in 1 2 3; do
+              if docker buildx imagetools create -t "${DEST}" "${SOURCE}"; then
+                break
+              fi
+              if [ "${ATTEMPT}" = "3" ]; then
+                echo "Failed to copy ${DEST} after ${ATTEMPT} attempts"
+                exit 1
+              fi
+              echo "Copy attempt ${ATTEMPT} for ${DEST} failed, retrying in 15s..."
+              sleep 15
+            done
           done <<< "${{ steps.tags.outputs.tags }}"


### PR DESCRIPTION
# Pull Request

## Checklist

- [x] This PR targets the `dev` branch.
- [x] This PR links to a confirmed Issue or active Discussion: Relates to #29100.
- [x] A maintainer explicitly asked me to open this PR, or this PR only updates i18n/localization.
- [x] The change is one logical unit with no unrelated commits.
- [x] I matched nearby code patterns and avoided unnecessary new settings, abstractions, or dependencies.
- [ ] I manually tested the changed workflow and any nearby behavior that could be affected.
- [ ] I updated relevant docs, including the [Open WebUI Docs Repository](https://github.com/open-webui/docs), if needed.
- [ ] I added screenshots for UI changes, and a recording when motion or interaction matters.
- [x] I reviewed any AI-generated code before submitting it.
- [x] The PR title uses one of the prefixes listed below.

## Summary

During the v0.11.1 release, the `copy-to-dockerhub (main)` and `copy-to-dockerhub (ollama)` jobs in run 32900262493 both failed on a transient network error while copying images from GHCR to Docker Hub (`stream error: PROTOCOL_ERROR; received from peer`). Each copy is a single `docker buildx imagetools create` attempt, so one mid-stream hiccup loses the tag, and because the copy runs the full version tag before the major.minor tag, that one hiccup left Docker Hub with `0.11.1` and `0.11.1-ollama` missing and `0.11` and `0.11-ollama` still pointing at the 0.11.0 digests, while `0.11-slim`, `0.11.1-cuda`, and the other variants from the same run landed fine (#29100).

This wraps each copy in up to three attempts with a 15 second pause between them. A copy that keeps failing exits the step nonzero after the third attempt, the same terminal behavior as today, one line louder.

Not changed, and worth a deliberate look: the job's `continue-on-error: true` is what kept the run green while two variants failed, so nobody saw the failure until users found the tags missing. Leaving it means a copy that exhausts its retries is still invisible in the run status. It reads as a deliberate choice to keep Docker Hub outages from failing releases, so this PR only narrows the window in which it matters rather than touching it.

This PR hardens future releases only. The missing v0.11.1 tags themselves need the two failed jobs on run 32900262493 re-run by someone with admin rights, as the GHCR source images are intact.

## Testing

A release cannot be run end to end from a fork, so the Testing checkbox above is honestly unticked. What was verified:

- The workflow file parses as valid YAML after the change.
- The changed `run` block was extracted verbatim from the parsed YAML and exercised in bash with `docker` and `sleep` stubbed: with two injected transient failures, the copy succeeds on the third attempt and the loop continues to the next tag, exiting 0; with permanent failures, the step exits 1 after three attempts and prints which destination failed.
- The retry changes nothing on the success path: a first-attempt success breaks out immediately, identical to current behavior.

## Changelog Entry

### Fixed

- Release image copies from GHCR to Docker Hub now retry transient network failures up to three times per tag, instead of silently losing tags to a single mid-stream error as happened to `0.11.1` and `0.11.1-ollama` in the v0.11.1 release.

## Additional Context

The failure class is exactly a transient one: both failed jobs died within seconds of each other on HTTP/2 stream errors, on the two largest images, while three sibling variants in the same matrix succeeded.

## Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
