### PR TITLE
fix: unregister a sidebar folder from the registry when it unmounts

### DIFF
--- a/src/lib/components/layout/Sidebar/RecursiveFolder.svelte
+++ b/src/lib/components/layout/Sidebar/RecursiveFolder.svelte
@@ -428,6 +428,8 @@
 	});
 
 	onDestroy(() => {
+		delete folderRegistry[folderId];
+
 		if (folderElement) {
 			folderElement.removeEventListener('dragover', onDragOver);
 			folderElement.removeEventListener('drop', onDrop);


### PR DESCRIPTION
# Pull Request

## Checklist

- [x] This PR targets the `dev` branch.
- [x] This PR links to a confirmed Issue or active Discussion: Closes #29120.
- [x] A maintainer explicitly asked me to open this PR, or this PR only updates i18n/localization.
- [x] The change is one logical unit with no unrelated commits.
- [x] I matched nearby code patterns and avoided unnecessary new settings, abstractions, or dependencies.
- [x] I manually tested the changed workflow and any nearby behavior that could be affected.
- [ ] I updated relevant docs, including the [Open WebUI Docs Repository](https://github.com/open-webui/docs), if needed.
- [ ] I added screenshots for UI changes, and a recording when motion or interaction matters.
- [x] I reviewed any AI-generated code before submitting it.
- [x] The PR title uses one of the prefixes listed below.

## Summary

After a sidebar folder that was ever expanded is deleted, the tab keeps requesting `GET /api/v1/folders/{deleted_id}/shared/chats` on every sidebar refresh, getting a 404 each time, for the rest of the session (#29120). Saving any folder's edit is enough to trigger it.

Each folder registers callbacks in the shared `folderRegistry` on mount, but `onDestroy` removes only its drag listeners and never the registry entry. Two Sidebar paths call `setFolderItems()` across every registry entry, so a deleted folder's stale closure keeps fetching its shared chats, the server 404s, and the catch falls back to the plain chat list. The 404 + 200 pair repeats on every refresh and never heals within the session:

https://github.com/open-webui/open-webui/blob/b3591e60b18bf2cdc57a57c215f70065882dbf60/src/lib/components/layout/Sidebar/RecursiveFolder.svelte#L354
https://github.com/open-webui/open-webui/blob/b3591e60b18bf2cdc57a57c215f70065882dbf60/src/lib/components/layout/Sidebar.svelte#L420

The change adds the symmetric cleanup to the registration: `delete folderRegistry[folderId]` in `onDestroy`. One file, +2 lines.

## Testing

- Reproduced first on the unpatched build, and the defect was independently hit and reproduced by me in normal use (Firefox): expand a folder, delete it outside the tab's own delete flow, then save any other folder's edit through the UI.
- Scripted browser runs of that exact flow on both builds, with all `shared/chats` responses captured: unpatched, the deleted folder's request fires with a 404 on the first save and again on every subsequent save; with the change, only the real folders are fetched and no request is made for the deleted id, across repeated saves.
- I manually re-ran my reproduction on this branch and confirmed the console stays clean.
- Nearby behavior: normal folder expand and collapse, chat lists inside expanded folders, and folder edits all behave identically, since the registry entry is re-created on every mount and the deletion only runs at unmount.
- `npm run format` reports no changes on the touched file.

## Changelog Entry

### Fixed

- Fixed the sidebar endlessly requesting the chats of a deleted folder (a 404 in the console on every sidebar refresh) when the folder was deleted from another tab or through the API: a folder now removes itself from the sidebar's refresh registry when it unmounts.

## Additional Context

The visible symptom is only the console 404 with its silent fallback, so the defect mostly costs a wasted request pair per refresh. The registry entry also held the deleted folder's chat callbacks, so pruning it stops read-state and upsert events from being delivered to a component that no longer exists.

## Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

