### PR TITLE
fix: load workspace knowledge on mount

### DIFF
--- a/src/lib/components/workspace/Knowledge.svelte
+++ b/src/lib/components/workspace/Knowledge.svelte
@@ -272,6 +272,7 @@
 		viewOption = localStorage?.workspaceViewOption || '';
 		sourceOption = localStorage?.workspaceKnowledgeSourceOption || '';
 		loaded = true;
+		await init();
 
 		if (showCreateOnMount) {
 			showCreateModal = true;


### PR DESCRIPTION
## Summary

Fixes #29104. The workspace Knowledge page now explicitly loads its first result page after local display preferences are initialized and the component becomes ready.

This prevents the initial spinner from persisting without issuing `GET /api/v1/knowledge/search`. Subsequent filtering, sorting, source selection, and pagination continue to use the existing `init()` flow.

## Validation

- `git diff --check`
- Reviewed the component lifecycle and existing `init()` error/loading handling.

## Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.