### PR TITLE
fix(pgvector): rollback empty query transactions

### DIFF
--- a/backend/open_webui/retrieval/vector/dbs/pgvector.py
+++ b/backend/open_webui/retrieval/vector/dbs/pgvector.py
@@ -631,6 +631,7 @@ class PgvectorClient(VectorDBBase):
                 results = query.all()
 
             if not results:
+                self.session.rollback()  # read-only transaction
                 return None
 
             ids = [[result.id for result in results]]


### PR DESCRIPTION
## What

Roll back the PGVector read-only SQLAlchemy transaction before `PgvectorClient.query()` returns when no rows are found.

## Why

The current empty-result path returns before the existing `self.session.rollback()` call.

With PostgreSQL/PGVector and SQLAlchemy QueuePool, repeated empty-result queries leave connections in `idle in transaction`.

In a reproducible workload, one connection accumulated per empty query until the pool was exhausted.

With:

- `pool_size=5`
- `max_overflow=10`

PostgreSQL eventually showed 15 connections in `idle in transaction`, after which requests failed with:

`QueuePool limit of size 5 overflow 10 reached, connection timed out, timeout 30.00`

## Fix

The empty-result path now performs the same read-only rollback used by the normal result path before returning `None`.

## Verification

Before the change, repeated empty-result queries caused `idle in transaction` sessions to accumulate until the connection pool was exhausted.

After applying this change and restarting Open WebUI, the same sequential file-processing workload completed without accumulating any `idle in transaction` sessions.

Observed after the fix:

- multiple sequential PGVector empty-result lookups completed successfully
- `pg_stat_activity` showed zero `idle in transaction`
- subsequent PGVector inserts and queries continued normally

Discussion: #29129