### PR TITLE
fix: report knowledge base uploads that failed instead of reporting success

### DIFF
--- a/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
+++ b/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
@@ -619,6 +619,52 @@
 		return currentPath && path ? `${currentPath}/${path}` : currentPath || path;
 	};
 
+	const uploadManifestEntries = async (
+		entries: DirectoryManifestEntry[],
+		resolveDirectoryId: (entry: DirectoryManifestEntry) => string | null | undefined
+	) => {
+		const failures: Array<{ path: string; reason: string }> = [];
+
+		for (const [index, entry] of entries.entries()) {
+			const displayPath = entry.path ? `${entry.path}/${entry.filename}` : entry.filename;
+			syncing = $i18n.t('Uploading {{current}}/{{total}}: {{file}}', {
+				current: index + 1,
+				total: entries.length,
+				file: displayPath
+			});
+
+			const fileObject = new File([entry.file], entry.filename, { type: entry.file.type });
+			const uploadedFile = await uploadFile(localStorage.token, fileObject, {
+				knowledge_id: knowledge.id,
+				file_hash: entry.checksum,
+				directory_id: resolveDirectoryId(entry)
+			}).catch((e) => ({ error: e }));
+
+			// A resolved upload still counts as failed when the server reported a processing error.
+			if (!uploadedFile || uploadedFile.error) {
+				const reason = uploadedFile?.error ?? $i18n.t('Failed to upload file.');
+				console.error('Upload failed:', displayPath, reason);
+				failures.push({ path: displayPath, reason: `${reason}` });
+			}
+		}
+
+		if (failures.length > 0) {
+			toast.error(
+				$i18n.t(
+					'Failed to upload {{failed}} of {{total}} files. First failure: {{file}} ({{reason}})',
+					{
+						failed: failures.length,
+						total: entries.length,
+						file: failures[0].path,
+						reason: failures[0].reason
+					}
+				)
+			);
+		}
+
+		return failures.length;
+	};
+
 	const uploadDirectoryEntries = async (entries: DirectoryFileEntry[]) => {
 		if (!knowledge) return;
 
@@ -645,30 +691,13 @@
 
 			const directoryIdByPath = await createMissingDirectories(diff);
 
-			let uploadedCount = 0;
-			for (const entry of manifest) {
-				uploadedCount++;
-				const displayPath = entry.path ? `${entry.path}/${entry.filename}` : entry.filename;
-				syncing = $i18n.t('Uploading {{current}}/{{total}}: {{file}}', {
-					current: uploadedCount,
-					total: manifest.length,
-					file: displayPath
-				});
+			const failedCount = await uploadManifestEntries(manifest, (entry) =>
+				entry.path ? directoryIdByPath[getDirectoryUploadPath(entry.path)] : currentDirectoryId
+			);
 
-				const fileObject = new File([entry.file], entry.filename, { type: entry.file.type });
-				await uploadFile(localStorage.token, fileObject, {
-					knowledge_id: knowledge.id,
-					file_hash: entry.checksum,
-					directory_id: entry.path
-						? directoryIdByPath[getDirectoryUploadPath(entry.path)]
-						: currentDirectoryId
-				}).catch((e) => {
-					toast.error(`${e}`);
-					return null;
-				});
+			if (failedCount === 0) {
+				toast.success($i18n.t('File uploaded successfully'));
 			}
-
-			toast.success($i18n.t('File uploaded successfully'));
 			init();
 		} catch (e) {
 			toast.error(`${e}`);
@@ -723,36 +752,24 @@
 					diff.modified.some((m: any) => m.filename === entry.filename && m.path === entry.path)
 			);
 
-			let uploadedCount = 0;
-			for (const entry of filesToUpload) {
-				uploadedCount++;
-				const displayPath = entry.path ? `${entry.path}/${entry.filename}` : entry.filename;
-				syncing = $i18n.t('Uploading {{current}}/{{total}}: {{file}}', {
-					current: uploadedCount,
-					total: filesToUpload.length,
-					file: displayPath
-				});
-
-				const fileObject = new File([entry.file], entry.filename, { type: entry.file.type });
-				await uploadFile(localStorage.token, fileObject, {
-					knowledge_id: knowledge.id,
-					file_hash: entry.checksum,
-					directory_id: entry.path ? directoryIdByPath[entry.path] : null
-				}).catch(() => null);
-			}
+			const failedCount = await uploadManifestEntries(filesToUpload, (entry) =>
+				entry.path ? directoryIdByPath[entry.path] : null
+			);
 
 			// ── 7. Report ──
-			toast.success(
-				$i18n.t(
-					'Sync complete: {{added}} added, {{modified}} modified, {{deleted}} deleted, {{unmodified}} unmodified',
-					{
-						added: diff.added.length,
-						modified: diff.modified.length,
-						deleted: diff.deleted.length,
-						unmodified: diff.unmodified_count
-					}
-				)
-			);
+			if (failedCount === 0) {
+				toast.success(
+					$i18n.t(
+						'Sync complete: {{added}} added, {{modified}} modified, {{deleted}} deleted, {{unmodified}} unmodified',
+						{
+							added: diff.added.length,
+							modified: diff.modified.length,
+							deleted: diff.deleted.length,
+							unmodified: diff.unmodified_count
+						}
+					)
+				);
+			}
 			init();
 		} catch (e) {
 			toast.error(`${e}`);

--- a/src/lib/i18n/locales/en-US/translation.json
+++ b/src/lib/i18n/locales/en-US/translation.json
@@ -1232,6 +1232,7 @@
 	"Failed to update settings": "",
 	"Failed to update status": "",
 	"Failed to update webhook": "",
+	"Failed to upload {{failed}} of {{total}} files. First failure: {{file}} ({{reason}})": "",
 	"Failed to upload file.": "",
 	"Features": "",
 	"Features Permissions": "",


### PR DESCRIPTION
A directory upload or sync announced "Sync complete" even when files had failed to upload. The sync path discarded upload errors outright, and neither path looked at the processing result the server reports on the status stream, so a file that never reached the knowledge base was still counted as synced. For a modified file that is silent data loss: the sync deletes the stale copy before uploading the replacement, so a failed upload leaves nothing behind and still reports a clean run.

Both paths now count the files that did not land, log each one, and report the first failure together with the reason the server gave. The success summary appears only when every file uploaded.

The two upload loops were identical apart from how they resolve the target directory, so they share one function now.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
