### PR TITLE
perf: skip the tool approval drain lookup for fresh chat messages

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -3226,10 +3226,12 @@ async def execute_tool_call_for_output(request, form_data, user, metadata, event
 
 async def drain_approved_tool_calls(request, form_data, user, model, metadata) -> bool:
     chat_id = metadata.get('chat_id')
-    message_id = metadata.get('message_id') or metadata.get('assistant_message_id')
-    if not is_saved_chat_id(chat_id) or not message_id:
+    assistant_message_id = metadata.get('assistant_message_id')
+    # Only a resume/continue payload re-enters an existing message; other paths mint a fresh id with nothing to drain.
+    if not is_saved_chat_id(chat_id) or not assistant_message_id:
         return False
 
+    message_id = metadata.get('message_id') or assistant_message_id
     message = await Chats.get_message_by_id_and_message_id(chat_id, message_id)
     output = message.get('output') if message else None
     if not isinstance(output, list):


### PR DESCRIPTION
Every chat completion request re-loads the target conversation's entire message history from the database inside drain_approved_tool_calls() before discovering there is nothing to drain: a fresh message always points at a newly minted assistant message with no stored output, so the full-history read (one SELECT of every chat_message row plus building the message map, uncached, on top of the identical read process_chat_payload already did) is pure overhead on every message.

Queued tool approvals can only ever be acted on by a resume or continue request, and exactly those requests carry assistant_message_id in their payload. The drain now returns early when the field is absent, removing one O(conversation length) query per chat message while resume, continue, reject and pause flows behave exactly as before, independent of the approval mode.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
