### PR TITLE
fix: restore optional list annotations so omitted list fields stop failing

### DIFF
--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -362,7 +362,7 @@ class MessageStats(BaseModel):
     token_count: int | None = None
     timestamp: int | None = None
     rating: int | None = None  # Derived from message.annotation.rating
-    tags: list[str | None] = None  # Derived from message.annotation.tags
+    tags: list[str] | None = None  # Derived from message.annotation.tags
 
 
 class ChatHistoryStats(BaseModel):
@@ -2558,7 +2558,7 @@ class ChatTable:
         file_ids: list[str],
         user_id: str,
         db: AsyncSession | None = None,
-    ) -> list[ChatFileModel | None]:
+    ) -> list[ChatFileModel] | None:
         if not file_ids:
             return None
 

--- a/backend/open_webui/models/models.py
+++ b/backend/open_webui/models/models.py
@@ -180,7 +180,7 @@ class ModelForm(BaseModel):
     name: str
     meta: ModelMeta
     params: ModelParams
-    access_grants: list[dict | None] = None
+    access_grants: list[dict] | None = None
     is_active: bool = True
 
 
@@ -191,7 +191,7 @@ class ModelsTable:
     async def _to_model_model(
         self,
         model: Model,
-        access_grants: list[AccessGrantModel | None] = None,
+        access_grants: list[AccessGrantModel] | None = None,
         db: AsyncSession | None = None,
     ) -> ModelModel:
         if isinstance(model.meta, dict):

--- a/backend/open_webui/models/prompts.py
+++ b/backend/open_webui/models/prompts.py
@@ -47,7 +47,7 @@ class PromptModel(BaseModel):
     content: str
     data: dict | None = None
     meta: dict | None = None
-    tags: list[str | None] = None
+    tags: list[str] | None = None
     is_active: bool | None = True
     version_id: str | None = None
     created_at: int | None = None
@@ -86,8 +86,8 @@ class PromptForm(BaseModel):
     content: str
     data: dict | None = None
     meta: dict | None = None
-    tags: list[str | None] = None
-    access_grants: list[dict | None] = None
+    tags: list[str] | None = None
+    access_grants: list[dict] | None = None
     version_id: str | None = None  # Active version
     commit_message: str | None = None  # For history tracking
     is_production: bool | None = True  # Whether to set new version as production
@@ -100,7 +100,7 @@ class PromptsTable:
     async def _to_prompt_model(
         self,
         prompt: Prompt,
-        access_grants: list[AccessGrantModel | None] = None,
+        access_grants: list[AccessGrantModel] | None = None,
         db: AsyncSession | None = None,
     ) -> PromptModel:
         prompt_model = PromptModel.model_validate(prompt)
@@ -557,7 +557,7 @@ class PromptsTable:
         prompt_id: str,
         name: str,
         command: str,
-        tags: list[str | None] = None,
+        tags: list[str] | None = None,
         db: AsyncSession | None = None,
     ) -> PromptModel | None:
         """Update only name, command, and tags (no history created)."""

--- a/backend/open_webui/models/tools.py
+++ b/backend/open_webui/models/tools.py
@@ -89,7 +89,7 @@ class ToolForm(BaseModel):
     name: str
     content: str
     meta: ToolMeta
-    access_grants: list[dict | None] = None
+    access_grants: list[dict] | None = None
 
 
 class ToolValves(BaseModel):
@@ -103,7 +103,7 @@ class ToolsTable:
     async def _to_tool_model(
         self,
         tool: Tool,
-        access_grants: list[AccessGrantModel | None] = None,
+        access_grants: list[AccessGrantModel] | None = None,
         db: AsyncSession | None = None,
     ) -> ToolModel:
         tool_model = ToolModel.model_validate(tool)

--- a/backend/open_webui/retrieval/web/brave.py
+++ b/backend/open_webui/retrieval/web/brave.py
@@ -16,7 +16,7 @@ async def search_brave(
     api_key: str,
     query: str,
     count: int,
-    filter_list: list[str | None] | None = None,
+    filter_list: list[str] | None = None,
 ) -> list[SearchResult]:
     """Query the Brave Web Search API and return normalised results.
 

--- a/backend/open_webui/retrieval/web/duckduckgo.py
+++ b/backend/open_webui/retrieval/web/duckduckgo.py
@@ -12,7 +12,7 @@ log = logging.getLogger(__name__)
 def search_duckduckgo(
     query: str,
     count: int,
-    filter_list: list[str | None] = None,
+    filter_list: list[str] | None = None,
     concurrent_requests: int | None = None,
     backend: str | None = 'auto',
 ) -> list[SearchResult]:

--- a/backend/open_webui/retrieval/web/google_pse.py
+++ b/backend/open_webui/retrieval/web/google_pse.py
@@ -13,7 +13,7 @@ async def search_google_pse(
     search_engine_id: str,
     query: str,
     count: int,
-    filter_list: list[str | None] | None = None,
+    filter_list: list[str] | None = None,
     referer: str | None = None,
 ) -> list[SearchResult]:
     """Query Google Programmable Search Engine with automatic pagination.

--- a/backend/open_webui/retrieval/web/microsoft_web_iq.py
+++ b/backend/open_webui/retrieval/web/microsoft_web_iq.py
@@ -15,7 +15,7 @@ def search_microsoft_web_iq(
     api_key: str,
     query: str,
     count: int,
-    filter_list: list[str | None] | None = None,
+    filter_list: list[str] | None = None,
     language: str = 'en',
     user=None,
 ) -> list[SearchResult]:

--- a/backend/open_webui/retrieval/web/mojeek.py
+++ b/backend/open_webui/retrieval/web/mojeek.py
@@ -8,7 +8,7 @@ from open_webui.retrieval.web.main import SearchResult, get_filtered_results
 log = logging.getLogger(__name__)
 
 
-def search_mojeek(api_key: str, query: str, count: int, filter_list: list[str | None] = None) -> list[SearchResult]:
+def search_mojeek(api_key: str, query: str, count: int, filter_list: list[str] | None = None) -> list[SearchResult]:
     """Search using Mojeek's Search API and return the results as a list of SearchResult objects.
 
     Args:

--- a/backend/open_webui/retrieval/web/openserp.py
+++ b/backend/open_webui/retrieval/web/openserp.py
@@ -12,7 +12,7 @@ async def search_openserp(
     base_url: str,
     query: str,
     count: int,
-    filter_list: list[str | None] | None = None,
+    filter_list: list[str] | None = None,
 ) -> list[SearchResult]:
     """Query an OpenSERP instance and return normalised results.
 

--- a/backend/open_webui/retrieval/web/searxng.py
+++ b/backend/open_webui/retrieval/web/searxng.py
@@ -40,7 +40,7 @@ async def search_searxng(
     query_url: str,
     query: str,
     count: int,
-    filter_list: list[str | None] | None = None,
+    filter_list: list[str] | None = None,
     **kwargs,
 ) -> list[SearchResult]:
     """Query a SearXNG instance and return results sorted by relevance score.

--- a/backend/open_webui/retrieval/web/serper.py
+++ b/backend/open_webui/retrieval/web/serper.py
@@ -13,7 +13,7 @@ async def search_serper(
     api_key: str,
     query: str,
     count: int,
-    filter_list: list[str | None] | None = None,
+    filter_list: list[str] | None = None,
 ) -> list[SearchResult]:
     """Query the serper.dev Google Search API and return normalised results.
 

--- a/backend/open_webui/retrieval/web/serphouse.py
+++ b/backend/open_webui/retrieval/web/serphouse.py
@@ -9,7 +9,7 @@ async def search_serphouse(
     domain: str,
     query: str,
     count: int,
-    filter_list: list[str | None] | None = None,
+    filter_list: list[str] | None = None,
 ) -> list[SearchResult]:
     """Query SERPHouse and return normalised organic results."""
     session = await get_session()

--- a/backend/open_webui/retrieval/web/serply.py
+++ b/backend/open_webui/retrieval/web/serply.py
@@ -17,7 +17,7 @@ def search_serply(
     limit: int = 10,
     device_type: str = 'desktop',
     proxy_location: str = 'US',
-    filter_list: list[str | None] = None,
+    filter_list: list[str] | None = None,
 ) -> list[SearchResult]:
     """Search using serper.dev's API and return the results as a list of SearchResult objects.
 

--- a/backend/open_webui/retrieval/web/serpstack.py
+++ b/backend/open_webui/retrieval/web/serpstack.py
@@ -12,7 +12,7 @@ async def search_serpstack(
     api_key: str,
     query: str,
     count: int,
-    filter_list: list[str | None] | None = None,
+    filter_list: list[str] | None = None,
     https_enabled: bool = True,
 ) -> list[SearchResult]:
     """Query the serpstack.com API and return normalised results.

--- a/backend/open_webui/retrieval/web/tavily.py
+++ b/backend/open_webui/retrieval/web/tavily.py
@@ -13,7 +13,7 @@ def search_tavily(
     api_key: str,
     query: str,
     count: int,
-    filter_list: list[str | None] = None,
+    filter_list: list[str] | None = None,
     # **kwargs,
 ) -> list[SearchResult]:
     """Search using Tavily's Search API and return the results as a list of SearchResult objects.

--- a/backend/open_webui/routers/configs.py
+++ b/backend/open_webui/routers/configs.py
@@ -731,7 +731,7 @@ async def set_code_execution_config(
 class ModelsConfigForm(BaseModel):
     DEFAULT_MODELS: str | None
     DEFAULT_PINNED_MODELS: str | None
-    MODEL_ORDER_LIST: list[str | None]
+    MODEL_ORDER_LIST: list[str] | None
     DEFAULT_MODEL_METADATA: dict | None = None
     DEFAULT_MODEL_PARAMS: dict | None = None
 

--- a/backend/open_webui/routers/knowledge.py
+++ b/backend/open_webui/routers/knowledge.py
@@ -1074,7 +1074,7 @@ async def update_external_knowledge_source(
 
 
 class KnowledgeFilesResponse(KnowledgeResponse):
-    files: list[FileMetadataResponse | None] = None
+    files: list[FileMetadataResponse] | None = None
     write_access: bool | None = False
 
 

--- a/backend/open_webui/routers/ollama.py
+++ b/backend/open_webui/routers/ollama.py
@@ -970,12 +970,12 @@ class GenerateCompletionForm(BaseModel):
     model: str
     prompt: str | None = None
     suffix: str | None = None
-    images: list[str | None] = None
+    images: list[str] | None = None
     format: Union[dict, str | None] = None
     options: dict | None = None
     system: str | None = None
     template: str | None = None
-    context: list[int | None] = None
+    context: list[int] | None = None
     stream: bool | None = True
     raw: bool | None = None
     keep_alive: Union[int, str | None] = None
@@ -1026,8 +1026,8 @@ class ChatMessage(BaseModel):
 
     role: str
     content: str | None = None
-    tool_calls: list[dict | None] = None
-    images: list[str | None] = None
+    tool_calls: list[dict] | None = None
+    images: list[str] | None = None
     model_config = ConfigDict(extra='allow')
 
     @validator('content', pre=True)
@@ -1048,7 +1048,7 @@ class GenerateChatCompletionForm(BaseModel):
     template: str | None = None
     stream: bool | None = True
     keep_alive: Union[int, str | None] = None
-    tools: list[dict | None] = None
+    tools: list[dict] | None = None
     model_config = ConfigDict(extra='allow')
 
 

--- a/backend/open_webui/routers/prompts.py
+++ b/backend/open_webui/routers/prompts.py
@@ -36,7 +36,7 @@ class PromptVersionUpdateForm(BaseModel):
 class PromptMetadataForm(BaseModel):
     name: str
     command: str
-    tags: list[str | None] = None
+    tags: list[str] | None = None
 
 
 router = APIRouter()

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -790,7 +790,7 @@ class WebConfig(BaseModel):
     WEB_SEARCH_TRUST_ENV: bool | None = None
     WEB_SEARCH_RESULT_COUNT: int | None = None
     WEB_SEARCH_CONCURRENT_REQUESTS: int | None = None
-    WEB_SEARCH_DOMAIN_FILTER_LIST: list[str | None] = []
+    WEB_SEARCH_DOMAIN_FILTER_LIST: list[str] | None = []
     WEB_FETCH_MAX_CONTENT_LENGTH: int | None = None
     WEB_LOADER_CONCURRENT_REQUESTS: int | None = None
     BYPASS_WEB_SEARCH_EMBEDDING_AND_RETRIEVAL: bool | None = None
@@ -848,7 +848,7 @@ class WebConfig(BaseModel):
     EXTERNAL_WEB_SEARCH_API_KEY: str | None = None
     EXTERNAL_WEB_LOADER_URL: str | None = None
     EXTERNAL_WEB_LOADER_API_KEY: str | None = None
-    YOUTUBE_LOADER_LANGUAGE: list[str | None] = None
+    YOUTUBE_LOADER_LANGUAGE: list[str] | None = None
     YOUTUBE_LOADER_PROXY_URL: str | None = None
     YOUTUBE_LOADER_TRANSLATION: str | None = None
     YANDEX_WEB_SEARCH_URL: str | None = None
@@ -938,7 +938,7 @@ class ConfigForm(BaseModel):
     FILE_MAX_COUNT: Union[int, str | None] = None
     FILE_IMAGE_COMPRESSION_WIDTH: Union[int, str | None] = None
     FILE_IMAGE_COMPRESSION_HEIGHT: Union[int, str | None] = None
-    ALLOWED_FILE_EXTENSIONS: list[str | None] = None
+    ALLOWED_FILE_EXTENSIONS: list[str] | None = None
 
     # Integration settings
     ENABLE_GOOGLE_DRIVE_INTEGRATION: bool | None = None

--- a/backend/open_webui/utils/misc.py
+++ b/backend/open_webui/utils/misc.py
@@ -89,7 +89,7 @@ def get_allow_block_lists(filter_list):
     return allow_list, block_list
 
 
-def is_string_allowed(string: Union[str, Sequence[str]], filter_list: list[str | None] = None) -> bool:
+def is_string_allowed(string: Union[str, Sequence[str]], filter_list: list[str] | None = None) -> bool:
     """
     Checks if a string is allowed based on the provided filter list.
     :param string: The string or sequence of strings to check (e.g., domain or hostname).
@@ -150,7 +150,7 @@ def _host_matches_pattern(host: str, pattern: str) -> bool:
     return host == pattern or host.endswith('.' + pattern)
 
 
-def is_host_allowed(host: Union[str, Sequence[str]], filter_list: list[str | None] = None) -> bool:
+def is_host_allowed(host: Union[str, Sequence[str]], filter_list: list[str] | None = None) -> bool:
     """Allow/block a hostname (or list of hostnames / resolved IPs) against a
     WEB_FETCH_FILTER_LIST-style filter, matching on label boundaries.
 
@@ -172,7 +172,7 @@ def is_host_allowed(host: Union[str, Sequence[str]], filter_list: list[str | Non
     return not is_host_blocked(hosts, filter_list)
 
 
-def is_host_blocked(host: Union[str, Sequence[str]], filter_list: list[str | None] = None) -> bool:
+def is_host_blocked(host: Union[str, Sequence[str]], filter_list: list[str] | None = None) -> bool:
     """Whether a host or resolved address matches a block entry, ignoring any allow entries."""
     _, block_list = get_allow_block_lists(filter_list)
     hosts = [host] if isinstance(host, str) else list(host or [])
@@ -778,7 +778,7 @@ def openai_chat_chunk_message_template(
     model: str,
     content: str | None = None,
     reasoning_content: str | None = None,
-    tool_calls: list[dict | None] = None,
+    tool_calls: list[dict] | None = None,
     usage: dict | None = None,
     message_id: str | None = None,
 ) -> dict:
@@ -809,7 +809,7 @@ def openai_chat_completion_message_template(
     model: str,
     message: str | None = None,
     reasoning_content: str | None = None,
-    tool_calls: list[dict | None] = None,
+    tool_calls: list[dict] | None = None,
     usage: dict | None = None,
 ) -> dict:
     template = openai_chat_message_template(model)


### PR DESCRIPTION
Two user-visible failures came from the same mistake. `POST /api/v1/models/model/update` returned a bare 500 whenever the request body omitted `access_grants`, which broke every script that manages workspace models through the API. `GET /api/v1/chats/stats/export` silently dropped every message that had no annotation tags, both from the exported message list and from the aggregate counters computed after it, because the failing constructor sat inside a `try` whose `except` only logs at debug level.

The PEP 604 modernization in 6d02955 rewrote `Optional[list[X]]` as `list[X | None]` instead of `list[X] | None`. That is exactly backwards: the field now rejects `None` and accepts a list containing `None`, so any payload that leaves the field out fails as soon as the value is validated a second time.

This restores the intended shape at all 39 occurrences across the backend, matching what each annotation said before the rewrite.

Defaulting `access_grants` to an empty list would not have been an equivalent fix: `None` means leave the existing sharing untouched, `[]` means revoke every grant, so that would silently unshare every model updated by a client that does not send the field.

Fixes #29140

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
