### PR TITLE
perf: cache event function and webhook lookups in event dispatch

### DIFF
--- a/backend/open_webui/events.py
+++ b/backend/open_webui/events.py
@@ -6,13 +6,17 @@ import logging
 import time
 import uuid
 from types import SimpleNamespace
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
+from aiocache import cached
 from open_webui.env import ENABLE_PLUGINS, VERSION
 from open_webui.models.config import Config
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 from open_webui.retrieval.web.utils import validate_url
 from open_webui.utils.webhook import post_webhook
+
+if TYPE_CHECKING:
+    from open_webui.models.functions import FunctionModel
 
 log = logging.getLogger(__name__)
 
@@ -20,6 +24,7 @@ MAX_STRING_LENGTH = 1000
 EVENT_WEBHOOKS_CONFIG_KEY = 'events.webhooks'
 LEGACY_WEBHOOK_CONFIG_KEY = 'webhook_url'
 DEFAULT_WEBHOOK_ID = 'default'
+EVENT_CACHE_TTL = 1
 
 
 class EventDefinition(BaseModel):
@@ -851,6 +856,12 @@ async def get_event_webhooks() -> list[dict[str, Any]]:
     return normalized
 
 
+# Dispatch-only cache; webhook writers read uncached and clear it.
+@cached(ttl=EVENT_CACHE_TTL)
+async def get_cached_event_webhooks() -> list[dict[str, Any]]:
+    return await get_event_webhooks()
+
+
 async def migrate_legacy_webhook_config() -> list[dict[str, Any]]:
     webhooks = await get_event_webhooks()
     if any(webhook.get('id') == DEFAULT_WEBHOOK_ID for webhook in webhooks):
@@ -875,6 +886,7 @@ async def migrate_legacy_webhook_config() -> list[dict[str, Any]]:
         *webhooks,
     ]
     await Config.upsert({EVENT_WEBHOOKS_CONFIG_KEY: webhooks})
+    await get_cached_event_webhooks.cache.clear()
     return webhooks
 
 
@@ -905,6 +917,7 @@ async def upsert_event_webhook(webhook: dict[str, Any]) -> dict[str, Any]:
         next_webhooks.append(normalized)
 
     await Config.upsert({EVENT_WEBHOOKS_CONFIG_KEY: next_webhooks})
+    await get_cached_event_webhooks.cache.clear()
     return next(webhook for webhook in next_webhooks if webhook.get('id') == normalized['id'])
 
 
@@ -919,6 +932,7 @@ async def delete_event_webhook(webhook_id: str) -> bool:
         values[LEGACY_WEBHOOK_CONFIG_KEY] = ''
 
     await Config.upsert(values)
+    await get_cached_event_webhooks.cache.clear()
     return True
 
 
@@ -1043,7 +1057,7 @@ async def dispatch_webhook_event(app: Any, event: Event) -> None:
     if subject_id:
         message = f'{message} ({subject_id})'
 
-    for webhook in await get_event_webhooks():
+    for webhook in await get_cached_event_webhooks():
         if not webhook.get('url') or not await event_webhook_matches(webhook, event):
             continue
 
@@ -1100,6 +1114,14 @@ class SocketSessionEventSink:
         await disconnect_user_sessions(str(subject['id']))
 
 
+# Dispatch cache, cleared by function writers; the returned list is shared, so copy before modifying.
+@cached(ttl=EVENT_CACHE_TTL)
+async def get_active_event_functions() -> list[FunctionModel]:
+    from open_webui.models.functions import Functions
+
+    return await Functions.get_functions_by_type('event', active_only=True)
+
+
 async def dispatch_event_functions(
     app: Any, event: Event, request: Any | None = None, extra_function_ids: list[str] | None = None
 ) -> None:
@@ -1113,13 +1135,13 @@ async def dispatch_event_functions(
     event_payload = event.model_dump()
 
     try:
-        event_functions = await Functions.get_functions_by_type('event', active_only=True)
+        event_functions = await get_active_event_functions()
         if extra_function_ids:
             extra_functions = await Functions.get_functions_by_ids(extra_function_ids)
             existing_ids = {function.id for function in event_functions}
-            event_functions.extend(
+            event_functions = event_functions + [
                 function for function in extra_functions if function.type == 'event' and function.id not in existing_ids
-            )
+            ]
     except Exception:
         log.exception('Event functions could not be loaded for %s', event.event)
         return

--- a/backend/open_webui/events.py
+++ b/backend/open_webui/events.py
@@ -856,7 +856,6 @@ async def get_event_webhooks() -> list[dict[str, Any]]:
     return normalized
 
 
-# Dispatch-only cache; webhook writers read uncached and clear it.
 @cached(ttl=EVENT_CACHE_TTL)
 async def get_cached_event_webhooks() -> list[dict[str, Any]]:
     return await get_event_webhooks()
@@ -886,7 +885,6 @@ async def migrate_legacy_webhook_config() -> list[dict[str, Any]]:
         *webhooks,
     ]
     await Config.upsert({EVENT_WEBHOOKS_CONFIG_KEY: webhooks})
-    await get_cached_event_webhooks.cache.clear()
     return webhooks
 
 
@@ -1114,7 +1112,6 @@ class SocketSessionEventSink:
         await disconnect_user_sessions(str(subject['id']))
 
 
-# Dispatch cache, cleared by function writers; the returned list is shared, so copy before modifying.
 @cached(ttl=EVENT_CACHE_TTL)
 async def get_active_event_functions() -> list[FunctionModel]:
     from open_webui.models.functions import Functions
@@ -1135,13 +1132,13 @@ async def dispatch_event_functions(
     event_payload = event.model_dump()
 
     try:
-        event_functions = await get_active_event_functions()
+        event_functions = list(await get_active_event_functions())
         if extra_function_ids:
             extra_functions = await Functions.get_functions_by_ids(extra_function_ids)
             existing_ids = {function.id for function in event_functions}
-            event_functions = event_functions + [
+            event_functions.extend(
                 function for function in extra_functions if function.type == 'event' and function.id not in existing_ids
-            ]
+            )
     except Exception:
         log.exception('Event functions could not be loaded for %s', event.event)
         return

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -125,6 +125,7 @@ from open_webui.env import (
 from open_webui.events import (
     EVENTS,
     delete_event_webhook,
+    get_active_event_functions,
     get_event_webhooks,
     migrate_legacy_webhook_config,
     publish_event,
@@ -375,6 +376,7 @@ async def lifespan(app: FastAPI):
 
     if SAFE_MODE:
         await Functions.deactivate_all_functions()
+        await get_active_event_functions.cache.clear()
 
     # This should be blocking (sync) so functions are not deactivated on first /get_models calls
     # when the first user lands on the / route.

--- a/backend/open_webui/routers/configs.py
+++ b/backend/open_webui/routers/configs.py
@@ -9,7 +9,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from mcp.shared.auth import OAuthMetadata
 from open_webui.config import BannerModel
 from open_webui.env import AIOHTTP_CLIENT_SESSION_SSL, AIOHTTP_CLIENT_TIMEOUT
-from open_webui.events import EVENTS, publish_event
+from open_webui.events import EVENTS, get_cached_event_webhooks, publish_event
 from open_webui.models.config import Config
 from open_webui.models.oauth_sessions import OAuthSessions
 from open_webui.utils.auth import get_admin_user, get_verified_user
@@ -100,6 +100,7 @@ class ImportConfigForm(BaseModel):
 @router.post('/import', response_model=dict)
 async def import_config(request: Request, form_data: ImportConfigForm, user=Depends(get_admin_user)):
     await Config.upsert(form_data.config)
+    await get_cached_event_webhooks.cache.clear()
     await publish_event(
         request,
         EVENTS.CONFIG_IMPORTED,

--- a/backend/open_webui/routers/functions.py
+++ b/backend/open_webui/routers/functions.py
@@ -11,7 +11,14 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from open_webui.config import CACHE_DIR
 from open_webui.constants import ERROR_MESSAGES
 from open_webui.env import AIOHTTP_CLIENT_SESSION_SSL, AIOHTTP_CLIENT_TIMEOUT, ENABLE_PLUGINS
-from open_webui.events import EVENTS, build_event, dispatch_event_functions, publish_event, schedule_webhook_dispatch
+from open_webui.events import (
+    EVENTS,
+    build_event,
+    dispatch_event_functions,
+    get_active_event_functions,
+    publish_event,
+    schedule_webhook_dispatch,
+)
 from open_webui.internal.db import get_async_session
 from open_webui.models.functions import (
     FunctionForm,
@@ -182,7 +189,9 @@ async def sync_functions(
                     log.exception(f'Error validating valves for function {function.id}: {e}')
                     raise e
 
-        return await Functions.sync_functions(user.id, form_data.functions, db=db)
+        functions = await Functions.sync_functions(user.id, form_data.functions, db=db)
+        await get_active_event_functions.cache.clear()
+        return functions
     except Exception as e:
         log.exception(f'Failed to load a function: {e}')
         raise HTTPException(
@@ -310,6 +319,8 @@ async def toggle_function_by_id(
         schedule_webhook_dispatch(request.app, lifecycle_event)
 
         function = await Functions.update_function_by_id(id, {'is_active': not function.is_active}, db=db)
+        # Clear before publishing so the toggled function's own lifecycle event sees the new state.
+        await get_active_event_functions.cache.clear()
 
         if function:
             await publish_event(
@@ -395,6 +406,7 @@ async def update_function_by_id(
         log.debug(updated)
 
         function = await Functions.update_function_by_id(id, updated, db=db)
+        await get_active_event_functions.cache.clear()
 
         if function_type == 'filter' and getattr(function_module, 'toggle', None):
             await Functions.update_function_metadata_by_id(id, {'toggle': True}, db=db)
@@ -438,6 +450,7 @@ async def delete_function_by_id(
     result = await Functions.delete_function_by_id(id, db=db)
 
     if result:
+        await get_active_event_functions.cache.clear()
         FUNCTIONS = get_functions_cache(request)
         FUNCTIONS.pop(id, None)
         await publish_event(

--- a/backend/open_webui/utils/plugin.py
+++ b/backend/open_webui/utils/plugin.py
@@ -18,6 +18,7 @@ from open_webui.env import (
     PIP_OPTIONS,
     PIP_PACKAGE_INDEX_OPTIONS,
 )
+from open_webui.events import get_active_event_functions
 from open_webui.models.functions import FunctionModel, Functions
 from open_webui.models.tools import Tools
 
@@ -310,6 +311,7 @@ async def load_function_module_by_id(function_id: str, content: str | None = Non
         del sys.modules[module_name]
 
         await Functions.update_function_by_id(function_id, {'is_active': False})
+        await get_active_event_functions.cache.clear()
         raise e
     finally:
         os.unlink(temp_file.name)


### PR DESCRIPTION
Publishing an event queries the database for the active event functions and reads the webhook config from the config table on every dispatch, and a chat turn publishes at least three events. Deployments with no event functions and no webhooks still pay all of those uncached round trips on every message.

Both lookups now sit behind a 1 second in-process cache used only by the dispatch path, coalescing the reads to at most one per second per worker. Every write that changes the active event function set (toggle, update, delete, sync, safe mode) or the webhook config clears the cache before the matching lifecycle event is published, so functions keep receiving their own enable and disable events exactly as before, and the webhook read-modify-write paths keep reading uncached so sequential admin edits never base an update on a stale list. Cross worker staleness is bounded at one second, matching the existing model list cache.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
