### PR TITLE
perf: resolve active filter ids once per chat request

### DIFF
--- a/backend/open_webui/utils/filter.py
+++ b/backend/open_webui/utils/filter.py
@@ -57,7 +57,11 @@ async def resolve_filter_pipeline(request, model: dict, enabled_filter_ids: list
     if not ENABLE_PLUGINS:
         return [], []
 
-    active_filters = await Functions.get_active_filter_ids()
+    # Inlet, stream and outlet all resolve on the same Request; query once per request.
+    active_filters = getattr(request.state, 'active_filter_ids', None)
+    if active_filters is None:
+        active_filters = await Functions.get_active_filter_ids()
+        request.state.active_filter_ids = active_filters
     filter_ids = get_model_filter_ids(model, active_filters)
     functions_by_id = {function.id: function for function in await Functions.get_functions_by_ids(filter_ids)}
 

--- a/backend/open_webui/utils/filter.py
+++ b/backend/open_webui/utils/filter.py
@@ -57,11 +57,11 @@ async def resolve_filter_pipeline(request, model: dict, enabled_filter_ids: list
     if not ENABLE_PLUGINS:
         return [], []
 
-    # Inlet, stream and outlet all resolve on the same Request; query once per request.
-    active_filters = getattr(request.state, 'active_filter_ids', None)
+    # Filters are resolved several times within one chat request.
+    active_filters = getattr(request.state, 'active_filters', None)
     if active_filters is None:
         active_filters = await Functions.get_active_filter_ids()
-        request.state.active_filter_ids = active_filters
+        request.state.active_filters = active_filters
     filter_ids = get_model_filter_ids(model, active_filters)
     functions_by_id = {function.id: function for function in await Functions.get_functions_by_ids(filter_ids)}
 


### PR DESCRIPTION
Resolving filter functions queries the database for the active filter ids three times per chat turn (inlet, stream setup and outlet), including on deployments with no filter functions at all, where that lookup is the only query the resolution makes.

All three resolutions run on the same request object, so the result is now memoized on request.state and the three queries collapse into one. A filter toggled mid-generation applies from the next request, which matches how the already cached function modules behave and removes the inconsistency where an inlet could run a filter the outlet then skipped.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
