### PR TITLE
perf: skip pipeline filter session setup when no filters exist

### DIFF
--- a/backend/open_webui/routers/pipelines.py
+++ b/backend/open_webui/routers/pipelines.py
@@ -69,6 +69,9 @@ async def process_pipeline_inlet_filter(request, payload, user, models):
     if 'pipeline' in model:
         sorted_filters.append(model)
 
+    if not sorted_filters:
+        return payload
+
     async with aiohttp.ClientSession(trust_env=True) as session:
         for filter in sorted_filters:
             urlIdx = filter.get('urlIdx')
@@ -131,6 +134,9 @@ async def process_pipeline_outlet_filter(request, payload, user, models):
 
     if 'pipeline' in model:
         sorted_filters = [model] + sorted_filters
+
+    if not sorted_filters:
+        return payload
 
     async with aiohttp.ClientSession(trust_env=True) as session:
         for filter in sorted_filters:


### PR DESCRIPTION
process_pipeline_inlet_filter() and its outlet counterpart construct and tear down an aiohttp ClientSession, with its own connector and cookie jar, on every chat completion and every task generation request just to iterate an empty filter list. On deployments without pipelines, which is the default, that is wasted setup on every message.

Both functions now return the payload untouched before the session is created when there is nothing to call. The per-call saving is small, a few microseconds of object construction per request on the pinned aiohttp; the point is that requests stop paying setup for a feature that is not configured.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
