### PR TITLE
fix: show model-generated images in channels and let members open them

### DIFF
--- a/backend/open_webui/routers/files.py
+++ b/backend/open_webui/routers/files.py
@@ -421,8 +421,8 @@ async def upload_file_handler(
 
         # Files a model produces mid-reply (generated images, tool output) name the channel in chat_id.
         channel_id = file_metadata.get('channel_id')
-        chat_id = file_metadata.get('chat_id')
-        if not channel_id and isinstance(chat_id, str) and chat_id.startswith(CHANNEL_CHAT_ID_PREFIX):
+        chat_id = file_metadata.get('chat_id') or ''
+        if not channel_id and chat_id.startswith(CHANNEL_CHAT_ID_PREFIX):
             channel_id = chat_id.removeprefix(CHANNEL_CHAT_ID_PREFIX)
 
         if channel_id:

--- a/backend/open_webui/routers/files.py
+++ b/backend/open_webui/routers/files.py
@@ -44,6 +44,7 @@ from open_webui.routers.audio import transcribe
 from open_webui.routers.retrieval import ProcessFileForm, process_file
 from open_webui.storage.provider import Storage
 from open_webui.utils.auth import get_admin_user, get_verified_user
+from open_webui.utils.chat_id import CHANNEL_CHAT_ID_PREFIX
 from open_webui.utils.misc import strict_match_mime_type
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -418,8 +419,14 @@ async def upload_file_handler(
             db=db,
         )
 
-        if 'channel_id' in file_metadata:
-            channel = await Channels.get_channel_by_id_and_user_id(file_metadata['channel_id'], user.id, db=db)
+        # Files a model produces mid-reply (generated images, tool output) name the channel in chat_id.
+        channel_id = file_metadata.get('channel_id')
+        chat_id = file_metadata.get('chat_id')
+        if not channel_id and isinstance(chat_id, str) and chat_id.startswith(CHANNEL_CHAT_ID_PREFIX):
+            channel_id = chat_id.removeprefix(CHANNEL_CHAT_ID_PREFIX)
+
+        if channel_id:
+            channel = await Channels.get_channel_by_id_and_user_id(channel_id, user.id, db=db)
             if channel:
                 await Channels.add_file_to_channel_by_id(channel.id, file_item.id, user.id, db=db)
 

--- a/backend/open_webui/routers/images.py
+++ b/backend/open_webui/routers/images.py
@@ -32,6 +32,7 @@ from open_webui.retrieval.web.utils import get_ssrf_safe_session, validate_url
 from open_webui.routers.files import get_file_content_by_id, upload_file_handler
 from open_webui.utils.access_control import has_permission
 from open_webui.utils.auth import get_admin_user, get_verified_user
+from open_webui.utils.chat_id import is_saved_chat_id
 from open_webui.utils.headers import include_user_info_headers
 from open_webui.utils.images.comfyui import (
     ComfyUICreateImageForm,
@@ -542,7 +543,7 @@ async def upload_image(request, image_data, content_type, metadata, user, db=Non
         chat_id = metadata.get('chat_id')
         message_id = metadata.get('message_id')
 
-        if chat_id and message_id:
+        if is_saved_chat_id(chat_id) and message_id:
             await Chats.insert_chat_files(
                 chat_id=chat_id,
                 message_id=message_id,

--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -41,6 +41,7 @@ from open_webui.tasks import create_task, stop_item_tasks
 from open_webui.utils.access_control import has_permission
 from open_webui.utils.auth import get_verified_user_by_token
 from open_webui.utils.chat_id import is_saved_chat_id
+from open_webui.utils.files import get_file_id_from_url
 from open_webui.utils.json_codec import SOCKETIO_JSON
 from open_webui.utils.misc import get_output_text
 from open_webui.utils.redis import (
@@ -953,18 +954,22 @@ async def _make_channel_emitter(request_info):
         if not msg or msg.channel_id != channel_id:
             return
 
-        data = {}
-        if output:
-            data['output'] = output
-        if files:
-            # Each event carries only the newly created files, and the stored key is replaced wholesale.
-            data['files'] = [*(msg.data or {}).get('files', []), *files]
+        if content is None:
+            content = msg.content
 
-        update_form = MessageForm(
-            content=msg.content if content is None else content,
-            data=data,
-            meta={'done': True} if done else None,
-        )
+        data = {'output': output} if output else None
+        if files:
+            data = {**(data or {}), 'files': [*(msg.data or {}).get('files', []), *files]}
+
+        update_form = MessageForm(content=content, data=data)
+        if done:
+            # Merge done flag into existing meta (preserve model_id etc.)
+            existing_meta = msg.meta or {}
+            update_form = MessageForm(
+                content=content,
+                data=data,
+                meta={**existing_meta, 'done': True},
+            )
 
         await Messages.update_message_by_id(message_id, update_form)
         message = await Messages.get_message_by_id(message_id)
@@ -992,14 +997,14 @@ async def _make_channel_emitter(request_info):
                 continue
 
             # Skip base64 payloads: the whole message is rebroadcast on every update.
-            if not url.startswith('/api/v1/files/'):
+            file_id = get_file_id_from_url(url)
+            if not file_id:
+                log.debug('Skipping channel file: url is not a stored file')
                 continue
 
-            file_id = url.removeprefix('/api/v1/files/').split('/')[0]
-            # Only files this reply just created: anything older is a file the tool named, not produced.
-            file_item = await Files.get_file_by_id(file_id)
-            if not file_item or file_item.user_id != user_id or (file_item.created_at or 0) < STARTED_AT:
-                log.debug('Skipping channel file %s', file_id)
+            file_item = await Files.get_file_by_id_and_user_id(file_id, user_id)
+            if not file_item or (file_item.created_at or 0) < STARTED_AT:
+                log.debug('Skipping channel file %s: not created by this reply', file_id)
                 continue
 
             file_meta = file_item.meta or {}
@@ -1010,10 +1015,9 @@ async def _make_channel_emitter(request_info):
                     'url': file_item.id,
                     'name': file_item.filename,
                     'size': file_meta.get('size'),
-                    'content_type': file_meta.get('content_type') or '',
+                    'content_type': file_meta.get('content_type'),
                 }
             )
-            # Bind to the message, the same way post_new_message does for user-uploaded channel files.
             await Channels.set_file_message_id_in_channel_by_id(channel_id, file_item.id, message_id)
 
         if new_files:

--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -32,6 +32,7 @@ from open_webui.env import (
 from open_webui.models.access_grants import AccessGrants
 from open_webui.models.channels import Channels
 from open_webui.models.chats import Chats
+from open_webui.models.files import Files
 from open_webui.models.folders import Folders
 from open_webui.models.notes import Notes, NoteUpdateForm
 from open_webui.models.users import UserNameResponse, Users
@@ -934,26 +935,36 @@ async def _make_channel_emitter(request_info):
     """
     channel_id = request_info['chat_id'].removeprefix('channel:')
     message_id = request_info['message_id']
+    user_id = request_info['user_id']
 
     state = {'last_emit_at': 0.0, 'output': []}
     THROTTLE_INTERVAL = 0.15  # ~6 updates/sec
+    STARTED_AT = int(time.time())
 
-    async def _emit_channel_update(content: str, done: bool = False, output: list | None = None):
+    async def _emit_channel_update(
+        content: str | None = None,
+        done: bool = False,
+        output: list | None = None,
+        files: list | None = None,
+    ):
         from open_webui.models.messages import MessageForm, Messages
 
         msg = await Messages.get_message_by_id(message_id)
         if not msg or msg.channel_id != channel_id:
             return
 
-        update_form = MessageForm(content=content, data={'output': output} if output else None)
-        if done:
-            # Merge done flag into existing meta (preserve model_id etc.)
-            existing_meta = msg.meta or {}
-            update_form = MessageForm(
-                content=content,
-                data={'output': output} if output else None,
-                meta={**existing_meta, 'done': True},
-            )
+        data = {}
+        if output:
+            data['output'] = output
+        if files:
+            # Each event carries only the newly created files, and the stored key is replaced wholesale.
+            data['files'] = [*(msg.data or {}).get('files', []), *files]
+
+        update_form = MessageForm(
+            content=msg.content if content is None else content,
+            data=data,
+            meta={'done': True} if done else None,
+        )
 
         await Messages.update_message_by_id(message_id, update_form)
         message = await Messages.get_message_by_id(message_id)
@@ -970,6 +981,43 @@ async def _make_channel_emitter(request_info):
                 },
                 to=f'channel:{channel_id}',
             )
+
+    async def _attach_channel_files(files: list):
+        new_files = []
+
+        for file in files:
+            url = file.get('url') or ''
+            if url.startswith(('http://', 'https://')):
+                new_files.append(file)
+                continue
+
+            # Skip base64 payloads: the whole message is rebroadcast on every update.
+            if not url.startswith('/api/v1/files/'):
+                continue
+
+            file_id = url.removeprefix('/api/v1/files/').split('/')[0]
+            # Only files this reply just created: anything older is a file the tool named, not produced.
+            file_item = await Files.get_file_by_id(file_id)
+            if not file_item or file_item.user_id != user_id or (file_item.created_at or 0) < STARTED_AT:
+                log.debug('Skipping channel file %s', file_id)
+                continue
+
+            file_meta = file_item.meta or {}
+            new_files.append(
+                {
+                    'type': 'file',
+                    'id': file_item.id,
+                    'url': file_item.id,
+                    'name': file_item.filename,
+                    'size': file_meta.get('size'),
+                    'content_type': file_meta.get('content_type') or '',
+                }
+            )
+            # Bind to the message, the same way post_new_message does for user-uploaded channel files.
+            await Channels.set_file_message_id_in_channel_by_id(channel_id, file_item.id, message_id)
+
+        if new_files:
+            await _emit_channel_update(files=new_files)
 
     async def __channel_emitter__(event_data):
         event_type = event_data.get('type')
@@ -999,6 +1047,9 @@ async def _make_channel_emitter(request_info):
             if content and (now - state['last_emit_at']) >= THROTTLE_INTERVAL:
                 state['last_emit_at'] = now
                 await _emit_channel_update(content, False, state['output'])
+
+        elif event_type in ('files', 'chat:message:files'):
+            await _attach_channel_files(event_data.get('data', {}).get('files') or [])
 
         elif event_type == 'chat:message:error':
             error = event_data.get('data', {}).get('error', {})

--- a/backend/open_webui/tools/builtin.py
+++ b/backend/open_webui/tools/builtin.py
@@ -389,6 +389,7 @@ async def generate_image(
         images = await image_generations(
             request=__request__,
             form_data=CreateImageForm(prompt=prompt),
+            metadata={'chat_id': __chat_id__, 'message_id': __message_id__},
             user=user,
         )
 
@@ -457,6 +458,7 @@ async def edit_image(
         images = await image_edits(
             request=__request__,
             form_data=EditImageForm(prompt=prompt, image=image_urls),
+            metadata={'chat_id': __chat_id__, 'message_id': __message_id__},
             user=user,
         )
 

--- a/backend/open_webui/utils/files.py
+++ b/backend/open_webui/utils/files.py
@@ -32,6 +32,7 @@ from open_webui.storage.provider import Storage
 
 BASE64_IMAGE_URL_PREFIX = re.compile(r'data:image/\w+;base64,', re.IGNORECASE)
 MARKDOWN_IMAGE_URL_PATTERN = re.compile(r'!\[(.*?)\]\((.+?)\)', re.IGNORECASE)
+FILE_CONTENT_URL_PREFIX = '/api/v1/files/'
 
 # Extension-based MIME fallback, only used when ENABLE_IMAGE_CONTENT_TYPE_EXTENSION_FALLBACK is True.
 _IMAGE_MIME_FALLBACK = {
@@ -49,6 +50,13 @@ _IMAGE_MIME_FALLBACK = {
     '.heif': 'image/heif',
     '.avif': 'image/avif',
 }
+
+
+def get_file_id_from_url(url: str) -> Optional[str]:
+    """Reverse of the get_file_content_by_id url that upload_image and upload_audio return."""
+    if not url.startswith(FILE_CONTENT_URL_PREFIX):
+        return None
+    return url.removeprefix(FILE_CONTENT_URL_PREFIX).split('/')[0]
 
 
 async def get_image_base64_from_url(url: str, user=None) -> Optional[str]:


### PR DESCRIPTION
Tagging an image-capable model in a channel posted the reply text but never the image, and the generated file was readable only by the person who summoned the model, so every other member got a 404 on the link.

Two causes. The channel event emitter handled only content and structured output, so the `files` events that every image producer emits were dropped before they reached the message. And a file gets its channel read grant at upload time from a `channel_id` in the upload metadata, which only the composer sends; files a model produces mid-reply carry the channel in `chat_id`, so they never got one.

The emitter now stores those files on the channel message in the shape the composer already uses, and `upload_file_handler` derives the channel from a `channel:` chat id, behind the membership check that was already there. It accepts only files this reply created and the summoner owns, so a tool cannot name someone else's file into the message. Raw base64 payloads stay out, because the whole message is rebroadcast on every streaming update.

The built-in image tools now pass their chat context, which they previously did not. As a side effect their generated images also become readable to viewers of a shared chat, matching what the built-in image generation feature has always done.

Fixes #29134

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
