### PR TITLE
fix: name the Folder modal close button (WCAG 4.1.2)

### DIFF
--- a/src/lib/components/layout/Sidebar/Folders/FolderModal.svelte
+++ b/src/lib/components/layout/Sidebar/Folders/FolderModal.svelte
@@ -119,6 +119,7 @@
 				{/if}
 			</div>
 			<button
+				aria-label={$i18n.t('Close')}
 				class="self-center rounded-lg p-1 text-gray-500 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
 				on:click={() => {
 					show = false;


### PR DESCRIPTION

## Summary
The close button in `Sidebar/Folders/FolderModal.svelte` has no text and no
`aria-label`, and its only child is an `<XMark />` marked `aria-hidden="true"`.
Nothing is left to compute a name from, so assistive technology gets a focusable,
unnamed "button." Breaks WCAG 4.1.2 Name, Role, Value (Level A).

The equivalent button in `layout/ChatsModal.svelte` is identical down to the class
string and already carries `aria-label={$i18n.t('Close')}`. That pattern appears 24
times across 22 files, so this reads as a missed call site.

`FolderModal` backs Create Folder, Edit Folder and Create Subfolder, so the unnamed
control is on every folder dialog.

Fix: add the same attribute. `$i18n` is already in scope and `Close` is an existing
key, so no new strings and nothing renders differently.

## Testing

Baseline was the ghcr `:dev` image built from b3591e60b.
Chrome DevTools > Elements > Accessibility, close button in Edit Folder:

Before: every name source Not specified, computed Name "". Role button, Focusable true.
After: `aria-label` resolves to "Close", computed Name "Close". Role and focusability unchanged. No visual change.

before:
<img width="263" height="275" alt="image" src="https://github.com/user-attachments/assets/2a30c154-6e3f-400c-96de-7282178171ca" />
after fix:
<img width="234" height="244" alt="image" src="https://github.com/user-attachments/assets/f66d3288-071f-4830-9a19-4d1fedddda63" />

## Fixed 
- Folder modal close button now exposes an accessible name to assistive technology
  (WCAG 4.1.2 Name, Role, Value, Level A).


### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
