### PR TITLE
fix: name the FolderModal close button (WCAG 4.1.2)

### DIFF
--- a/src/lib/components/layout/Sidebar/Folders/FolderModal.svelte
+++ b/src/lib/components/layout/Sidebar/Folders/FolderModal.svelte
@@ -119,6 +119,7 @@
 				{/if}
 			</div>
 			<button
+				aria-label={$i18n.t('Close')}
 				class="self-center rounded-lg p-1 text-gray-500 transition hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
 				on:click={() => {
 					show = false;


### PR DESCRIPTION


# Pull Request Checklist

- [x] **Linked Issue/Discussion:** This PR references an existing, well-described [Issue](https://github.com/open-webui/open-webui/issues) for a real bug or an active, substantive [Discussion](https://github.com/open-webui/open-webui/discussions) for a feature request or enhancement — `Closes #___` / `Relates to #___`.
- [x] **First-time contributor policy:** This is not my first contribution to Open WebUI, this PR contains only i18n/localization updates, or a maintainer explicitly asked me to open this PR after reviewing the linked Issue or Discussion.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** **Manual** end-to-end tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **User-facing changes:** I have confirmed whether this PR changes the UI. If it does, screenshots are required, and a video recording is recommended.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

# Changelog Entry

### Description

- **Unnamed close button on folder dialogs.** The close button on the Create Folder,
  Edit Folder and Create Subfolder dialogs now announces a close name to screen readers, where
  it was read out as an unnamed button.

### Fixed

- Folder modal close button now exposes an accessible name to assistive technology (WCAG 4.1.2 Name, Role, Value, Level A).

---

### Additional Information

Checked the close button before and after the change. Both builds are at commit
b3591e60b, so the added attribute is the only difference between them.

Chrome DevTools > Elements > Accessibility, close button in the Edit Folder dialog:

- Before: every name source reported Not specified and the computed Name was empty.
  Role was button and Focusable was true, so the control is reachable by keyboard with
  no name attached.
- After: `aria-label` resolves to Close and the computed Name is Close. Role and
  focusability are unchanged.

No visual change.

### Screenshots

**Before:**
<img width="263" height="275" alt="image" src="https://github.com/user-attachments/assets/13b0b682-98f0-4ed9-a6e9-1595bacd6360" />

**After:**

<img width="234" height="244" alt="image" src="https://github.com/user-attachments/assets/890165f7-34d4-40a5-9404-17f9e205a94f" />

Relates to /issues/2790

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.