### PR TITLE
fix: stop replaying empty assistant messages to the provider

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2198,14 +2198,6 @@ def strip_reasoning_details(output: list) -> list:
     ]
 
 
-def get_content_parts(message: dict) -> list:
-    """Return a message's content as a list of content parts."""
-    content = message.get('content')
-    if isinstance(content, list):
-        return content
-    return [{'type': 'text', 'text': content}] if content else []
-
-
 def process_messages_with_output(
     messages: list[dict],
     reasoning_format: str | None = None,
@@ -2217,7 +2209,6 @@ def process_messages_with_output(
     OpenAI-style messages (tool_calls + tool results). Strips 'output' before LLM.
     """
     processed = []
-    merge_with_previous = False
 
     for message in messages:
         if message.get('role') == 'assistant' and message.get('output'):
@@ -2232,23 +2223,10 @@ def process_messages_with_output(
                 processed.extend(output_messages)
                 continue
 
-        # Aborted generations leave an empty assistant turn; strict providers reject it, and adjacent user turns too.
-        if message.get('role') == 'assistant' and not message.get('tool_calls'):
-            content = get_content_from_message(message) or ''
-            has_meaningful_content = content.strip() if isinstance(content, str) else content
-            if not has_meaningful_content:
-                merge_with_previous = bool(processed)
-                continue
-
         clean_message = dict(message)
         for key in ('id', 'files', 'output', 'model', 'contextSummary', 'context_summary', 'usage'):
             clean_message.pop(key, None)
-        if merge_with_previous and processed[-1].get('role') == clean_message.get('role'):
-            merged_parts = [*get_content_parts(processed[-1]), *get_content_parts(clean_message)]
-            processed[-1] = {**clean_message, 'content': merged_parts}
-        else:
-            processed.append(clean_message)
-        merge_with_previous = False
+        processed.append(clean_message)
 
     return processed
 
@@ -2285,6 +2263,17 @@ def sanitize_tool_pairs(messages: list[dict]) -> list[dict]:
             sanitized.append(message)
 
     return sanitized
+
+
+def drop_empty_assistant_messages(messages: list[dict]) -> list[dict]:
+    """Drop assistant turns an aborted generation left without content, which strict providers reject on replay."""
+    return [
+        message
+        for message in messages
+        if message.get('role') != 'assistant'
+        or message.get('tool_calls')
+        or any(text.strip() for text in _get_text_parts(message))
+    ]
 
 
 # Ids are validated as [a-z0-9_-]+ on create; matching that keeps ordinary "<$..." text intact.
@@ -2519,6 +2508,7 @@ async def process_chat_payload(request, form_data, user, metadata, model):
         reasoning_format=get_reasoning_format(model),
     )
     form_data['messages'] = sanitize_tool_pairs(form_data['messages'])
+    form_data['messages'] = drop_empty_assistant_messages(form_data['messages'])
 
     system_message = get_system_message(form_data.get('messages', []))
     if system_message:  # Chat Controls/User Settings
@@ -3410,6 +3400,7 @@ async def drain_approved_tool_calls(request, form_data, user, model, metadata) -
                 reasoning_format=get_reasoning_format(model),
             )
             form_data['messages'] = sanitize_tool_pairs(form_data['messages'])
+            form_data['messages'] = drop_empty_assistant_messages(form_data['messages'])
 
         return paused
 

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2198,6 +2198,14 @@ def strip_reasoning_details(output: list) -> list:
     ]
 
 
+def get_content_parts(message: dict) -> list:
+    """Return a message's content as a list of content parts."""
+    content = message.get('content')
+    if isinstance(content, list):
+        return content
+    return [{'type': 'text', 'text': content}] if content else []
+
+
 def process_messages_with_output(
     messages: list[dict],
     reasoning_format: str | None = None,
@@ -2207,9 +2215,9 @@ def process_messages_with_output(
 
     For assistant messages with 'output' field, produces properly formatted
     OpenAI-style messages (tool_calls + tool results). Strips 'output' before LLM.
-    Assistant messages left empty by an aborted generation are dropped.
     """
     processed = []
+    merge_with_previous = False
 
     for message in messages:
         if message.get('role') == 'assistant' and message.get('output'):
@@ -2224,16 +2232,23 @@ def process_messages_with_output(
                 processed.extend(output_messages)
                 continue
 
-        # An aborted generation leaves an empty assistant turn; replaying it breaks strict providers.
+        # Aborted generations leave an empty assistant turn; strict providers reject it, and adjacent user turns too.
         if message.get('role') == 'assistant' and not message.get('tool_calls'):
-            content = message.get('content')
-            if not content or (isinstance(content, str) and not content.strip()):
+            content = get_content_from_message(message) or ''
+            has_meaningful_content = content.strip() if isinstance(content, str) else content
+            if not has_meaningful_content:
+                merge_with_previous = bool(processed)
                 continue
 
         clean_message = dict(message)
         for key in ('id', 'files', 'output', 'model', 'contextSummary', 'context_summary', 'usage'):
             clean_message.pop(key, None)
-        processed.append(clean_message)
+        if merge_with_previous and processed[-1].get('role') == clean_message.get('role'):
+            merged_parts = [*get_content_parts(processed[-1]), *get_content_parts(clean_message)]
+            processed[-1] = {**clean_message, 'content': merged_parts}
+        else:
+            processed.append(clean_message)
+        merge_with_previous = False
 
     return processed
 

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2207,6 +2207,7 @@ def process_messages_with_output(
 
     For assistant messages with 'output' field, produces properly formatted
     OpenAI-style messages (tool_calls + tool results). Strips 'output' before LLM.
+    Assistant messages left empty by an aborted generation are dropped.
     """
     processed = []
 
@@ -2221,6 +2222,12 @@ def process_messages_with_output(
             )
             if output_messages:
                 processed.extend(output_messages)
+                continue
+
+        # An aborted generation leaves an empty assistant turn; replaying it breaks strict providers.
+        if message.get('role') == 'assistant' and not message.get('tool_calls'):
+            content = message.get('content')
+            if not content or (isinstance(content, str) and not content.strip()):
                 continue
 
         clean_message = dict(message)

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2265,14 +2265,21 @@ def sanitize_tool_pairs(messages: list[dict]) -> list[dict]:
     return sanitized
 
 
-def drop_empty_assistant_messages(messages: list[dict]) -> list[dict]:
-    """Drop assistant turns an aborted generation left without content, which strict providers reject on replay."""
+def _has_non_blank_content(message: dict) -> bool:
+    content = message.get('content')
+    if isinstance(content, list):
+        return any(
+            part.get('type') != 'text' or part.get('text', '').strip() for part in content if isinstance(part, dict)
+        )
+    return bool(isinstance(content, str) and content.strip())
+
+
+def strip_empty_assistant_messages(messages: list[dict]) -> list[dict]:
+    """Drop assistant turns providers reject on replay: no tool calls, and only blank text or reasoning."""
     return [
         message
         for message in messages
-        if message.get('role') != 'assistant'
-        or message.get('tool_calls')
-        or any(text.strip() for text in _get_text_parts(message))
+        if message.get('role') != 'assistant' or message.get('tool_calls') or _has_non_blank_content(message)
     ]
 
 
@@ -2508,7 +2515,7 @@ async def process_chat_payload(request, form_data, user, metadata, model):
         reasoning_format=get_reasoning_format(model),
     )
     form_data['messages'] = sanitize_tool_pairs(form_data['messages'])
-    form_data['messages'] = drop_empty_assistant_messages(form_data['messages'])
+    form_data['messages'] = strip_empty_assistant_messages(form_data['messages'])
 
     system_message = get_system_message(form_data.get('messages', []))
     if system_message:  # Chat Controls/User Settings
@@ -3400,7 +3407,7 @@ async def drain_approved_tool_calls(request, form_data, user, model, metadata) -
                 reasoning_format=get_reasoning_format(model),
             )
             form_data['messages'] = sanitize_tool_pairs(form_data['messages'])
-            form_data['messages'] = drop_empty_assistant_messages(form_data['messages'])
+            form_data['messages'] = strip_empty_assistant_messages(form_data['messages'])
 
         return paused
 


### PR DESCRIPTION
A generation that fails or is aborted before its first token is stored as an assistant message with no content. Every later message in that chat replays it to the provider, and providers that reject empty assistant content refuse the whole request, so the chat stays broken until the row is removed from the database by hand.

Empty assistant turns are now dropped when the history is rebuilt for the provider. Messages carrying tool calls or output items are untouched, and empty user, system and tool messages are left alone so nothing else about the payload changes.

The filter sits at the point the normal completion path and the tool-approval resume path share, so it also covers payloads posted straight to the API rather than loaded from a saved chat. Chats already broken on disk recover on their next message, no migration needed.

Fixes #25083

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
