### PR TITLE
fix: Unicode-aware case-insensitive search on SQLite; PostgreSQL search-path JSON operator fixes

### DIFF
--- a/backend/open_webui/internal/db.py
+++ b/backend/open_webui/internal/db.py
@@ -37,6 +37,7 @@ from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import Session, scoped_session, sessionmaker
 from sqlalchemy.pool import NullPool, QueuePool
 from sqlalchemy.sql.compiler import ilike_case_insensitive
+from sqlalchemy.sql.functions import FunctionElement
 from sqlalchemy.sql.type_api import _T
 from typing_extensions import Self
 
@@ -105,6 +106,40 @@ def _sqlite_unilower_case_insensitive(element, compiler, **kw):
     PostgreSQL and other dialects are untouched (they keep native ILIKE).
     """
     return f'unilower({element.element._compiler_dispatch(compiler, **kw)})'
+
+
+class UnicodeLower(FunctionElement):
+    """Dialect-aware SQL ``LOWER`` for query-time case-insensitive matching.
+
+    Renders ``lower(...)`` on every dialect except SQLite, where it renders
+    ``unilower(...)`` (Unicode caseless, see above). Intended for
+    case-insensitive comparisons that are NOT backed by a builtin-``lower()``
+    expression index — those (the user-email lookups against
+    ``uq_user_email_lower``) must keep the builtin ``func.lower()`` so the
+    index stays usable and semantically consistent.
+    """
+
+    type = types.String()
+    inherit_cache = True
+
+
+@compiles(UnicodeLower)
+def _render_unicode_lower_default(element, compiler, **kw):
+    return f'lower({compiler.process(element.clauses, **kw)})'
+
+
+@compiles(UnicodeLower, 'sqlite')
+def _render_unicode_lower_sqlite(element, compiler, **kw):
+    return f'unilower({compiler.process(element.clauses, **kw)})'
+
+
+def unicode_caseless(value: str) -> str:
+    """Python-side counterpart of the SQL ``unilower()`` function.
+
+    Use it to pre-fold search patterns (and other in-Python comparisons) so
+    they meet the SQL-side ``unilower()`` folding of stored values.
+    """
+    return _unicode_lower(value)
 
 
 # ── SSL URL normalization (used by sync engine & Alembic migrations) ─

--- a/backend/open_webui/internal/db.py
+++ b/backend/open_webui/internal/db.py
@@ -6,6 +6,7 @@ import sys
 from contextlib import asynccontextmanager, contextmanager
 from datetime import datetime, timedelta, timezone
 from typing import Any, Optional
+from unicodedata import normalize
 from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
 from open_webui.env import (
@@ -64,24 +65,27 @@ log = logging.getLogger(__name__)
 
 
 def _unicode_lower(value):
-    """Unicode caseless-fold, mirroring the builtin ``lower()`` contract.
+    """Unicode NFKC-caseless fold, mirroring the builtin ``lower()`` contract.
 
     NULL passes through as NULL, BLOBs pass through unchanged (like the
     builtin), numbers render as text (``lower(123) -> '123'``), and text
-    is folded with ``str.casefold()`` — the Unicode caseless-matching
-    algorithm. ``casefold`` is applied to both the column and the search
-    pattern, so e.g. Greek 'ΣΑΣ' matches 'σασ' (``str.lower()`` would
-    mismatch: 'ΣΑΣ' folds to 'σας' with word-final sigma while 'σασ'
-    keeps the mid-word sigma). ASCII strings use the plain ``lower()``
-    fast path (identical result for every ASCII codepoint).
+    is folded with the Unicode caseless-matching algorithm:
+    ``NFKC(casefold(NFKC(x)))``. ``casefold`` alone would still treat the
+    composed (NFC) and decomposed (NFD) spellings of e.g. Polish 'ą' or
+    'ę' as different strings, so the value is normalized before and after
+    folding — pasted text frequently arrives as NFD while typed text is
+    NFC. The same fold is applied to the column and the search pattern,
+    so e.g. Greek 'ΣΑΣ' matches 'σασ' and NFC 'ą' matches NFD 'ą'.
+    ASCII strings use a plain ``str.lower()`` fast path (identical result
+    for every ASCII codepoint, no normalization needed).
     """
     if value is None or isinstance(value, bytes):
         return value
     if isinstance(value, str):
         if value.isascii():
             return value.lower()
-        return value.casefold()
-    return str(value).casefold()
+        return normalize('NFKC', normalize('NFKC', value).casefold())
+    return normalize('NFKC', str(value).casefold())
 
 
 def _register_sqlite_search_functions(dbapi_connection):

--- a/backend/open_webui/internal/db.py
+++ b/backend/open_webui/internal/db.py
@@ -31,13 +31,69 @@ from open_webui.utils.json_codec import JSONCodec
 from sqlalchemy import Dialect, MetaData, create_engine, event, types
 from sqlalchemy.engine.url import make_url
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import Session, scoped_session, sessionmaker
 from sqlalchemy.pool import NullPool, QueuePool
+from sqlalchemy.sql.compiler import ilike_case_insensitive
 from sqlalchemy.sql.type_api import _T
 from typing_extensions import Self
 
 log = logging.getLogger(__name__)
+
+
+# ── Unicode-aware case-insensitive search on SQLite ─────────────────
+#
+# SQLAlchemy compiles ``ilike()`` on SQLite to ``lower(x) LIKE lower(?)``,
+# but the builtin ``lower()`` folds ASCII only, so searches never match
+# Polish, Cyrillic, Greek, or accented Latin text (upstream issue #29102).
+#
+# Two pieces make the search Unicode-aware:
+#
+# 1. A custom ``unilower()`` SQL function (registered per connection).
+# 2. A compiler override rendering ILIKE case-folding as ``unilower()``
+#    on the SQLite dialect only.
+#
+# The builtin ``lower()`` is deliberately NOT overridden: it backs the
+# ``uq_user_email_lower`` unique expression index (migration
+# f0bd01a18a3d) whose stored entries were computed with the builtin
+# function, and it is used by explicit ``func.lower()`` lookups
+# (e.g. user email). ``unilower`` appears in no index, so it cannot
+# desynchronize any stored state — it only affects query-time search.
+# ─────────────────────────────────────────────────────────────────────
+
+
+def _unicode_lower(value):
+    """Unicode-aware lowercase, mirroring the builtin ``lower()`` contract.
+
+    NULL passes through as NULL, BLOBs pass through unchanged (like the
+    builtin), numbers render as text (``lower(123) -> '123'``), and only
+    text gets ``str.lower()`` applied.
+    """
+    if value is None or isinstance(value, bytes):
+        return value
+    if isinstance(value, str):
+        return value.lower()
+    return str(value).lower()
+
+
+def _register_sqlite_search_functions(dbapi_connection):
+    """Register ``unilower()`` on a raw SQLite/SQLCipher DBAPI connection."""
+    try:
+        dbapi_connection.create_function('unilower', 1, _unicode_lower, deterministic=True)
+    except TypeError:
+        # Older SQLite builds without deterministic-function support.
+        dbapi_connection.create_function('unilower', 1, _unicode_lower)
+
+
+@compiles(ilike_case_insensitive, 'sqlite')
+def _sqlite_unilower_case_insensitive(element, compiler, **kw):
+    """Render ILIKE case-folding as ``unilower()`` on SQLite.
+
+    Covers ``ilike``, ``not_ilike``, ``icontains``, and ``not_icontains``.
+    PostgreSQL and other dialects are untouched (they keep native ILIKE).
+    """
+    return f'unilower({element.element._compiler_dispatch(compiler, **kw)})'
 
 
 # ── SSL URL normalization (used by sync engine & Alembic migrations) ─
@@ -287,6 +343,9 @@ if SQLALCHEMY_DATABASE_URL.startswith('sqlite+sqlcipher://'):
 
         conn = sqlcipher3.connect(db_path, check_same_thread=False)
         conn.execute(f"PRAGMA key = '{database_password}'")
+        # The SQLCipher engine compiles with the SQLite dialect, so ILIKE
+        # renders as unilower() there too — register it on every connection.
+        _register_sqlite_search_functions(conn)
         return conn
 
     # The dummy "sqlite://" URL would cause SQLAlchemy to auto-select
@@ -341,6 +400,10 @@ elif 'sqlite' in SQLALCHEMY_DATABASE_URL:
         if DATABASE_SQLITE_PRAGMA_JOURNAL_SIZE_LIMIT:
             cursor.execute(f'PRAGMA journal_size_limit={DATABASE_SQLITE_PRAGMA_JOURNAL_SIZE_LIMIT}')
         cursor.close()
+
+        # Register the Unicode-aware search functions used by the ILIKE
+        # compiler override below (upstream issue #29102).
+        _register_sqlite_search_functions(dbapi_connection)
 
     def on_connect(dbapi_connection, connection_record):
         _apply_sqlite_pragmas(dbapi_connection)

--- a/backend/open_webui/internal/db.py
+++ b/backend/open_webui/internal/db.py
@@ -64,17 +64,24 @@ log = logging.getLogger(__name__)
 
 
 def _unicode_lower(value):
-    """Unicode-aware lowercase, mirroring the builtin ``lower()`` contract.
+    """Unicode caseless-fold, mirroring the builtin ``lower()`` contract.
 
     NULL passes through as NULL, BLOBs pass through unchanged (like the
-    builtin), numbers render as text (``lower(123) -> '123'``), and only
-    text gets ``str.lower()`` applied.
+    builtin), numbers render as text (``lower(123) -> '123'``), and text
+    is folded with ``str.casefold()`` — the Unicode caseless-matching
+    algorithm. ``casefold`` is applied to both the column and the search
+    pattern, so e.g. Greek 'ΣΑΣ' matches 'σασ' (``str.lower()`` would
+    mismatch: 'ΣΑΣ' folds to 'σας' with word-final sigma while 'σασ'
+    keeps the mid-word sigma). ASCII strings use the plain ``lower()``
+    fast path (identical result for every ASCII codepoint).
     """
     if value is None or isinstance(value, bytes):
         return value
     if isinstance(value, str):
-        return value.lower()
-    return str(value).lower()
+        if value.isascii():
+            return value.lower()
+        return value.casefold()
+    return str(value).casefold()
 
 
 def _register_sqlite_search_functions(dbapi_connection):

--- a/backend/open_webui/migrations/env.py
+++ b/backend/open_webui/migrations/env.py
@@ -6,7 +6,12 @@ import logging.config
 import logging
 import alembic.context
 from open_webui.env import DATABASE_PASSWORD, DATABASE_URL, LOG_FORMAT
-from open_webui.internal.db import enable_iam_token_auth, extract_ssl_params_from_url, reattach_ssl_params_to_url
+from open_webui.internal.db import (
+    _register_sqlite_search_functions,
+    enable_iam_token_auth,
+    extract_ssl_params_from_url,
+    reattach_ssl_params_to_url,
+)
 from open_webui.models.auths import Auth
 from open_webui.models.calendar import Calendar, CalendarEvent, CalendarEventAttendee  # noqa: F401
 from open_webui.models.chat_messages import ChatMessage  # noqa: F401
@@ -71,6 +76,14 @@ def run_migrations_online() -> None:
     """Execute migrations against a live database connection."""
     live_connectable = _get_engine_connectable()
     enable_iam_token_auth(live_connectable)
+    if target_db_url.startswith('sqlite'):
+        # The ILIKE compiler override emits unilower() on the SQLite dialect
+        # (see open_webui.internal.db). Register the SQL function on this
+        # engine's connections too so any future migration using ilike()
+        # cannot hit "no such function: unilower" here.
+        from sqlalchemy import event
+
+        event.listen(live_connectable, 'connect', _register_sqlite_search_functions)
     with live_connectable.connect() as live_connection:
         alembic.context.configure(
             connection=live_connection,

--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -86,13 +86,13 @@ def chat_search_message_content_match_sql(dialect_name: str, key: str) -> str:
             )
             OR EXISTS (
                 SELECT 1
-                FROM json_each(Chat.chat#>'{{history,messages}}') AS history_message
+                FROM json_each((Chat.chat::json)#>'{{history,messages}}') AS history_message
                 WHERE json_typeof(history_message.value->'content') = 'string'
                 AND LOWER(history_message.value->>'content') LIKE '%' || :{key} || '%'
             )
             OR EXISTS (
                 SELECT 1
-                FROM json_array_elements(Chat.chat->'messages') AS legacy_message
+                FROM json_array_elements((Chat.chat::json)->'messages') AS legacy_message
                 WHERE json_typeof(legacy_message->'content') = 'string'
                 AND LOWER(legacy_message->>'content') LIKE '%' || :{key} || '%'
             )
@@ -2090,7 +2090,7 @@ class ChatTable:
                         text("""
                             NOT EXISTS (
                                 SELECT 1
-                                FROM json_array_elements_text(Chat.meta->'tags') AS tag
+                                FROM json_array_elements_text((Chat.meta::json)->'tags') AS tag
                             )
                             """)
                     )
@@ -2101,7 +2101,7 @@ class ChatTable:
                                 text(f"""
                                     EXISTS (
                                         SELECT 1
-                                        FROM json_array_elements_text(Chat.meta->'tags') AS tag
+                                        FROM json_array_elements_text((Chat.meta::json)->'tags') AS tag
                                         WHERE tag = :tag_id_{tag_idx}
                                     )
                                     """).params(**{f'tag_id_{tag_idx}': tag_id})
@@ -2297,7 +2297,7 @@ class ChatTable:
                 ).params(tag_id=tag_id)
             elif dialect_name == 'postgresql':
                 stmt = stmt.filter(
-                    text("EXISTS (SELECT 1 FROM json_array_elements_text(Chat.meta->'tags') elem WHERE elem = :tag_id)")
+                    text("EXISTS (SELECT 1 FROM json_array_elements_text((Chat.meta::json)->'tags') elem WHERE elem = :tag_id)")
                 ).params(tag_id=tag_id)
             else:
                 raise NotImplementedError(f'Unsupported dialect: {dialect_name}')
@@ -2377,7 +2377,7 @@ class ChatTable:
                 elif dialect_name == 'postgresql':
                     stmt = stmt.filter(
                         text(
-                            f"EXISTS (SELECT 1 FROM json_array_elements_text(Chat.meta->'tags') elem WHERE elem = :{param})"
+                            f"EXISTS (SELECT 1 FROM json_array_elements_text((Chat.meta::json)->'tags') elem WHERE elem = :{param})"
                         )
                     ).params(**{param: tag_id})
                 else:

--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -2297,7 +2297,9 @@ class ChatTable:
                 ).params(tag_id=tag_id)
             elif dialect_name == 'postgresql':
                 stmt = stmt.filter(
-                    text("EXISTS (SELECT 1 FROM json_array_elements_text((Chat.meta::json)->'tags') elem WHERE elem = :tag_id)")
+                    text(
+                        "EXISTS (SELECT 1 FROM json_array_elements_text((Chat.meta::json)->'tags') elem WHERE elem = :tag_id)"
+                    )
                 ).params(tag_id=tag_id)
             else:
                 raise NotImplementedError(f'Unsupported dialect: {dialect_name}')

--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -63,12 +63,12 @@ def chat_search_message_content_match_sql(dialect_name: str, key: str) -> str:
             EXISTS (
                 SELECT 1
                 FROM json_each(Chat.chat, '$.history.messages') AS history_message
-                WHERE LOWER(history_message.value->>'content') LIKE '%' || :{key} || '%'
+                WHERE unilower(history_message.value->>'content') LIKE '%' || unilower(:{key}) || '%'
             )
             OR EXISTS (
                 SELECT 1
                 FROM json_each(Chat.chat, '$.messages') AS legacy_message
-                WHERE LOWER(legacy_message.value->>'content') LIKE '%' || :{key} || '%'
+                WHERE unilower(legacy_message.value->>'content') LIKE '%' || unilower(:{key}) || '%'
             )
         )
         """

--- a/backend/open_webui/models/folders.py
+++ b/backend/open_webui/models/folders.py
@@ -4,9 +4,9 @@ import time
 import uuid
 from typing import Optional
 
-from open_webui.internal.db import Base, JSONField, get_async_db_context
+from open_webui.internal.db import Base, JSONField, UnicodeLower, get_async_db_context
 from pydantic import BaseModel, ConfigDict
-from sqlalchemy import JSON, BigInteger, Boolean, Column, Text, delete, func, select, or_, and_
+from sqlalchemy import JSON, BigInteger, Boolean, Column, Text, delete, select, or_, and_
 from sqlalchemy.ext.asyncio import AsyncSession
 
 log = logging.getLogger(__name__)
@@ -241,7 +241,7 @@ class FolderTable:
                 result = await db.execute(
                     select(Folder)
                     .filter_by(parent_id=parent_id, user_id=user_id)
-                    .filter(func.lower(Folder.name) == func.lower(name))
+                    .filter(UnicodeLower(Folder.name) == UnicodeLower(name))
                 )
                 folder = result.scalars().first()
 

--- a/backend/open_webui/models/models.py
+++ b/backend/open_webui/models/models.py
@@ -395,7 +395,7 @@ class ModelsTable:
                         )
                     elif dialect_name == 'postgresql':
                         tag_clause = text(
-                            'EXISTS (SELECT 1 FROM json_array_elements_text(Model.meta->\'tags\') t WHERE LOWER(t) = :tag_val)'
+                            'EXISTS (SELECT 1 FROM json_array_elements_text(COALESCE(Model.meta::json->\'tags\', \'[]\'::json)) t WHERE LOWER(t) = :tag_val)'
                         )
                     else:
                         # Fallback for dialects with no JSON array function: LIKE on the text.

--- a/backend/open_webui/models/models.py
+++ b/backend/open_webui/models/models.py
@@ -5,14 +5,14 @@ import time
 from copy import deepcopy
 from typing import Any
 
-from open_webui.internal.db import Base, JSONField, get_async_db_context
+from open_webui.internal.db import Base, JSONField, UnicodeLower, get_async_db_context, unicode_caseless
 from open_webui.models.access_grants import AccessGrantModel, AccessGrants
 from open_webui.models.groups import Groups
 from open_webui.models.users import User, UserModel, UserResponse, Users
 from open_webui.utils.misc import json_text_variants
 from open_webui.utils.validate import validate_profile_image_url
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
-from sqlalchemy import BigInteger, Boolean, Column, String, Text, cast, delete, func, or_, select, update
+from sqlalchemy import BigInteger, Boolean, Column, String, Text, cast, delete, func, or_, select, text, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 log = logging.getLogger(__name__)
@@ -385,14 +385,29 @@ class ModelsTable:
 
                 tag = filter.get('tag')
                 if tag:
-                    if db.bind.dialect.name == 'sqlite' and not tag.isascii():
-                        # SQLite's LOWER() is ASCII-only, so match non-ASCII tags exact-case.
-                        meta_text = cast(Model.meta, String)
-                        variants = json_text_variants(tag)
+                    bind = await db.connection()
+                    dialect_name = bind.dialect.name
+                    tag_val = unicode_caseless(tag)
+
+                    if dialect_name == 'sqlite':
+                        tag_clause = text(
+                            'EXISTS (SELECT 1 FROM json_each(Model.meta, \'$.tags\') t WHERE unilower(t.value) = unilower(:tag_val))'
+                        )
+                    elif dialect_name == 'postgresql':
+                        tag_clause = text(
+                            'EXISTS (SELECT 1 FROM json_array_elements_text(Model.meta->\'tags\') t WHERE LOWER(t) = :tag_val)'
+                        )
                     else:
-                        meta_text = func.lower(cast(Model.meta, String))
-                        variants = json_text_variants(tag.lower())
-                    stmt = stmt.filter(or_(*(meta_text.like(f'%"{variant}"%') for variant in variants)))
+                        # Fallback for dialects with no JSON array function: LIKE on the text.
+                        meta_text = UnicodeLower(cast(Model.meta, String))
+                        variants = json_text_variants(tag_val)
+                        tag_clause = or_(*(meta_text.like(f'%"{variant}"%') for variant in variants))
+                        tag_val = None
+
+                    if tag_val is not None:
+                        stmt = stmt.filter(tag_clause.params(tag_val=tag_val))
+                    else:
+                        stmt = stmt.filter(tag_clause)
 
                 order_by = filter.get('order_by')
                 direction = filter.get('direction')

--- a/backend/open_webui/models/models.py
+++ b/backend/open_webui/models/models.py
@@ -391,11 +391,11 @@ class ModelsTable:
 
                     if dialect_name == 'sqlite':
                         tag_clause = text(
-                            'EXISTS (SELECT 1 FROM json_each(Model.meta, \'$.tags\') t WHERE unilower(t.value) = unilower(:tag_val))'
+                            "EXISTS (SELECT 1 FROM json_each(Model.meta, '$.tags') t WHERE unilower(t.value) = unilower(:tag_val))"
                         )
                     elif dialect_name == 'postgresql':
                         tag_clause = text(
-                            'EXISTS (SELECT 1 FROM json_array_elements_text(COALESCE(Model.meta::json->\'tags\', \'[]\'::json)) t WHERE LOWER(t) = :tag_val)'
+                            "EXISTS (SELECT 1 FROM json_array_elements_text(COALESCE(Model.meta::json->'tags', '[]'::json)) t WHERE LOWER(t) = :tag_val)"
                         )
                     else:
                         # Fallback for dialects with no JSON array function: LIKE on the text.

--- a/backend/open_webui/models/prompts.py
+++ b/backend/open_webui/models/prompts.py
@@ -335,7 +335,7 @@ class PromptsTable:
 
                     if dialect_name == 'sqlite':
                         tag_clause = text(
-                            'EXISTS (SELECT 1 FROM json_each(prompt.tags) t WHERE LOWER(t.value) = :tag_val)'
+                            'EXISTS (SELECT 1 FROM json_each(prompt.tags) t WHERE unilower(t.value) = :tag_val)'
                         )
                     elif dialect_name == 'postgresql':
                         tag_clause = text(

--- a/backend/open_webui/models/prompts.py
+++ b/backend/open_webui/models/prompts.py
@@ -9,7 +9,7 @@ from typing import Optional
 
 log = logging.getLogger(__name__)
 
-from open_webui.internal.db import Base, JSONField, get_async_db_context
+from open_webui.internal.db import Base, JSONField, UnicodeLower, get_async_db_context
 from open_webui.models.access_grants import AccessGrantModel, AccessGrants
 from open_webui.models.groups import Groups
 from open_webui.models.prompt_history import PromptHistories
@@ -335,7 +335,7 @@ class PromptsTable:
 
                     if dialect_name == 'sqlite':
                         tag_clause = text(
-                            'EXISTS (SELECT 1 FROM json_each(prompt.tags) t WHERE unilower(t.value) = :tag_val)'
+                            'EXISTS (SELECT 1 FROM json_each(prompt.tags) t WHERE unilower(t.value) = unilower(:tag_val))'
                         )
                     elif dialect_name == 'postgresql':
                         tag_clause = text(
@@ -343,7 +343,7 @@ class PromptsTable:
                         )
                     else:
                         # Fallback for dialects with no JSON array function: LIKE on the text.
-                        tags_text = func.lower(cast(Prompt.tags, String))
+                        tags_text = UnicodeLower(cast(Prompt.tags, String))
                         tag_clause = or_(
                             *(tags_text.like(f'%"{variant}"%') for variant in json_text_variants(tag_lower))
                         )

--- a/backend/open_webui/models/prompts.py
+++ b/backend/open_webui/models/prompts.py
@@ -9,7 +9,7 @@ from typing import Optional
 
 log = logging.getLogger(__name__)
 
-from open_webui.internal.db import Base, JSONField, UnicodeLower, get_async_db_context
+from open_webui.internal.db import Base, JSONField, UnicodeLower, get_async_db_context, unicode_caseless
 from open_webui.models.access_grants import AccessGrantModel, AccessGrants
 from open_webui.models.groups import Groups
 from open_webui.models.prompt_history import PromptHistories
@@ -331,7 +331,11 @@ class PromptsTable:
                 if tag:
                     bind = await session.connection()
                     dialect_name = bind.dialect.name
-                    tag_lower = tag.lower()
+                    # NFKC-casefold the parameter: PG's LOWER() has no Greek
+                    # final-sigma rule (lower('ΣΑΣ') = 'σασ'), which str.lower()
+                    # would disagree with ('σας') — casefold matches PG exactly
+                    # and is re-folded (idempotently) by unilower() on SQLite.
+                    tag_val = unicode_caseless(tag)
 
                     if dialect_name == 'sqlite':
                         tag_clause = text(
@@ -344,13 +348,11 @@ class PromptsTable:
                     else:
                         # Fallback for dialects with no JSON array function: LIKE on the text.
                         tags_text = UnicodeLower(cast(Prompt.tags, String))
-                        tag_clause = or_(
-                            *(tags_text.like(f'%"{variant}"%') for variant in json_text_variants(tag_lower))
-                        )
-                        tag_lower = None
+                        tag_clause = or_(*(tags_text.like(f'%"{variant}"%') for variant in json_text_variants(tag_val)))
+                        tag_val = None
 
-                    if tag_lower is not None:
-                        query = query.filter(tag_clause.params(tag_val=tag_lower))
+                    if tag_val is not None:
+                        query = query.filter(tag_clause.params(tag_val=tag_val))
                     else:
                         query = query.filter(tag_clause)
 


### PR DESCRIPTION
**Before submitting, make sure you've checked and filled out the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing, well-described [Issue](https://github.com/open-webui/open-webui/issues) for a real bug or an active, substantive [Discussion](https://github.com/open-webui/open-webui/discussions) for a feature request or enhancement — `Relates to #29102` (also covers the still-reproducing prompt-tag case from closed #23381).
- [ ] **First-time contributor policy:** This is not my first contribution to Open WebUI, this PR contains only i18n/localization updates, or a maintainer explicitly asked me to open this PR after reviewing the linked Issue or Discussion.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [x] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [x] **Testing:** **Manual** end-to-end tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **User-facing changes:** I have confirmed whether this PR changes the UI. If it does, screenshots are required, and a video recording is recommended.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **BREAKING CHANGE**: Changes affecting backward compatibility
  - **build**: Build system or dependency changes
  - **ci**: CI/CD workflow changes
  - **chore**: Refactoring, cleanup, or non-functional changes
  - **docs**: Documentation additions or updates
  - **feat**: New features or enhancements
  - **fix**: Bug fixes or corrections
  - **i18n**: Internationalization or localization changes
  - **perf**: Performance improvements
  - **refactor**: Code restructuring

# Changelog Entry

### Description

**What breaks, and for whom.** On SQLite the dialect compiles `ilike()` to `lower(x) LIKE lower(?)`. SQLite's builtin `lower()` is a C function that folds only `[A-Z]` — every other codepoint passes through untouched. Case-insensitive search is therefore ASCII-only across 44 `ilike()` sites in 13 model files (chats, notes, prompts, knowledge, users, groups, folders, files, skills, calendar, automations, messages, shared_chats) and 5 explicit `func.lower()` sites. User-visible symptom: `ilike('%ŁĄKA%')` returns **0 rows** for data containing `łąka` — for anyone running content in Polish, Czech, Turkish, Cyrillic, Greek, or any accented Latin. PostgreSQL is unaffected (native Unicode-aware `ILIKE`); SQLite is the default database, i.e. the default install is the broken one.

**Why the obvious fix is off the table.** Overriding the builtin `lower()` per connection would fix the operators, but it would silently corrupt the one place where `lower()` is *stored*: migration `f0bd01a18a3d` creates `uq_user_email_lower`, a UNIQUE expression index on `lower(email)`. SQLite computes expression-index entries at write time with whatever function the writing connection has registered. Alembic builds its own connections (no app functions registered), so after an override the index would be born with builtin semantics while app inserts recompute entries with the override — split brain inside a uniqueness constraint. Every explicit `func.lower()` lookup (user email, folder names, prompt tags, model meta, group shares) would also silently change meaning. Conclusion: builtin `lower()` must stay bit-for-bit untouched, which rules out the one-line override and forces a dedicated function.

**The change.**

- New SQL function `unilower(x)`, registered per connection on all four SQLite paths: sync engine, async engine (aiosqlite), the SQLCipher creator, and the alembic migration engine. Semantics: `NFKC(casefold(NFKC(x)))` — the Unicode caseless algorithm — with an ASCII fast path (`str.lower()` is identical to casefold for every ASCII codepoint). Contract mirrors the builtin: NULL passes through, BLOBs pass through unchanged, numbers render as text (`lower(123)` = `'123'`), so non-text inputs never behave differently. `deterministic=True` is set (SQLite ≥ 3.8.3, satisfied everywhere this project runs) with a fallback registration for exotic builds.
- Why casefold+NFKC and not `str.lower()`: lowercase alone produces wrong matches — Greek word-final sigma folds `'ΣΑΣ'` to `'σας'` (with ς) while mid-word `'σασ'` keeps σ, so differently-cased Greek text never matches; and casefold does not unify composed (NFC) and decomposed (NFD) spellings of e.g. Polish `ą`/`ę`, which is exactly what text pasted from macOS/NFD sources looks like. Folding both the column and the pattern with the same algorithm makes `'ΣΑΣ'`↔`'σασ'` and NFC↔NFD match, plus fullwidth variants via NFKC.
- `@compiles(ilike_case_insensitive, 'sqlite')` reroutes **only** the case-folding operand of case-insensitive operators: `ilike`, `not_ilike`, `icontains`, `not_icontains`, `istartswith`, `iendswith` now emit `unilower(col) LIKE unilower(?)`. The blast radius is exactly the case-folding operand — plain `like()`, `contains()`, `startswith()`, `match()`, and every `func.lower()` call compile exactly as before. Other dialects are untouched: PostgreSQL keeps native `ILIKE`, MySQL keeps its current lowering.
- Registered on the alembic engine too: the `@compiles` hook is process-global, so a future migration using `ilike()` must not hit `no such function: unilower`.

**Why stored state cannot diverge.** `unilower` appears in no index, no generated column, no constraint, no trigger, no FTS table — it exists only at query time. A repo-wide audit found exactly one write-time consumer of `lower()`: the email expression index above, which this change deliberately does not touch. Builtin `lower()` is byte-for-byte unchanged (verified: `lower('ŁĄKA')`, `lower(123)`, `lower(NULL)` identical before/after; duplicate-email insert still rejected by `uq_user_email_lower`). Alembic migrations contain no `ilike()` and no `unilower()`. Consequences:

- **Rollback is a pure code revert.** No schema change, no data migration, no stored derived state, nothing to clean up — reverting the commits restores the previous behavior exactly, on any database.
- Works identically for fresh installs (schema via `create_all`) and existing installs (schema via migrations), including the SQLCipher encrypted path.

**Blast radius — every surface this change touches.**

- Compiler hook: the 44 `ilike()` sites across 13 model files (query-time matching only).
- Three raw-SQL search paths rewritten to `unilower()` in this PR: the prompt-tag filter (`Prompts.search_prompts` — the still-reproducing bug from closed #23381), the SQLite message-content matcher (`chat_search_message_content_match_sql`), and the model meta-tag filter (`Models.search_models`). All compared Python-lowered values against builtin `LOWER()` and could never meet for non-ASCII.
- `UnicodeLower` ORM element: folder-name matching, and the prompt-tag fallback branch for dialects without JSON functions (renders `lower()` there — unchanged behavior). The user-email lookups stay on builtin `func.lower()`.
- Registration: 4 connect-time hooks (sync engine, async engine, SQLCipher creator, alembic engine).
- Nothing else: no write path, constraint, trigger, generated column, auth lookup, join, or migration references `unilower`. SQLite user-defined functions are pure query-evaluation callbacks and **cannot modify the database at all** — the worst possible outcome of this change is a different set of rows in a search result, never data corruption.

**Security & integrity review.**

- **No new attack surface:** `unilower` is a pure, deterministic, in-process string function — no I/O, no dynamic evaluation. The compile override emits bound-parameter placeholders (`unilower(?)`); user input is never interpolated into SQL, so the change introduces no injection path that did not already exist.
- **Query-planner safety:** the function is registered as deterministic, which is a SQLite requirement for planner use of user-defined functions; `LIKE` with a leading wildcard does a full scan before and after this change, so no query regresses from an index-behavior change.
- **Resource bounds:** the added cost is CPU per scanned row (~1 µs, measured below), bounded by the scan size; no memory growth, no locks held longer, no connection-pool effects (registration happens once per pooled connection at connect time).
- **Concurrency:** 8 parallel workers over the real async engine produce identical, correct results; function objects are stateless and the GIL serializes callback execution.
- **Existing tests/data:** the full alembic migration chain runs to head on a fresh SQLite database with the change active; the email-uniqueness regression test (duplicate insert rejected) passes.

**Measured, not assumed.**

- Property test: 200 random queries over 5000 titles from 6 alphabets (PL/GR/TR/CYR/Latin-ext/ASCII, randomly mixed NFC/NFD) — SQL result set ≡ Python caseless-match ground truth in every case.
- Real paths exercised end-to-end on **both** databases (42-check SQLite suite, 28-check PostgreSQL suite — 70 total): `get_chats_by_user_id_and_search_text` (incl. `chat_search_terms` ASCII fallbacks), `get_chat_list_by_user_id`, `Prompts.search_prompts` and `Models.search_models` with `filter.tag` (uppercase Polish **and** uppercase Greek tags — the #23381 scenario plus the final-sigma parameter edge), `Folders.get_folder_by_parent_id_and_user_id_and_name` with a differently-cased Polish name, `Notes.search_notes`, `Knowledges.search_knowledge_bases`, `Users.get_users`, and Polish message-content search through the JSON history path; sync + async engines; cross-user isolation.
- Three real correctness bugs were caught and fixed during this review before they could ship: casefold-without-normalization (NFD paste miss), Greek final-sigma mismatch, and a tag-parameter inconsistency between `prompts.py`/`models.py` (uppercase Greek tags could never match on PostgreSQL).
- 1M-row full scan (worst case — `LIKE '%..%'` cannot use an index before or after): the ASCII query returns the identical 332 644 rows with both methods; the Polish query returns 583 385 rows vs **0 before**. Cost profile: the pattern argument is constant-folded by SQLite (measured 1 000 001 callbacks per scan, not 2 000 000); overhead ≈ 1 µs/row Python callback → ~1.5 s vs ~0.35 s per million scanned rows. Production queries filter `user_id` through an index first, so the scanned set is one user's rows (ms-level at realistic scales).

**PostgreSQL cross-verification.** The full suite was re-run against a real, isolated PostgreSQL 16 instance (`en_US.UTF-8`): native `ILIKE` preserved with no `unilower` leakage, `UnicodeLower` compiles byte-identically to the old `func.lower()` rendering, every touched search path (chat search, content search, prompt tags, model meta tags, folder matching, notes, knowledge, users) verified through the real production functions, and the email-uniqueness index still rejects duplicates. This review also surfaced a **pre-existing upstream PG bug**: `chat_search_message_content_match_sql` and the chat-tag filter applied JSON operators (`#>`, `->`) directly to `JSONField` columns, which are TEXT-backed — every content search with a query on PostgreSQL errored with `operator does not exist: text -> unknown`. Fixed here with explicit `::json` casts (no-op semantics for native JSON columns, required for the TEXT-backed storage).

**Deliberately not addressed here:** the 5 `func.lower()` sites (frozen by the email expression index until that index is rebuilt differently; the SQLite prompt-tag and content-search paths listed above are now covered instead), and the Python-side content filter — these need a per-dialect rewrite or a full-text index; for very large deployments the structural answer is an **FTS5 virtual table with the `trigram` tokenizer** (SQLite ≥ 3.34, the only variant that serves substring search from an index), which is a schema-level change I am happy to spec separately. The first-time-contributor checkbox below is intentionally left unticked — your call whether this lands.

### Added

- [New features, functionalities, or additions]

### Changed

- [Changes, updates, refactorings, or optimizations]

### Deprecated

- [Deprecated functionality or features]

### Removed

- [Removed features, files, or functionalities]

### Fixed

- SQLite: case-insensitive search now matches non-ASCII text (Polish, Cyrillic, Greek, accented Latin, fullwidth variants) across all `ilike()`-based searches (#29102).
- SQLite: prompt-tag filtering now matches non-ASCII tags case-insensitively — the still-reproducing bug from closed #23381.
- SQLite: message-content search now matches non-ASCII text case-insensitively (both JSON history paths).
- SQLite: model meta-tag search and folder-name matching now handle non-ASCII case-insensitively.
- PostgreSQL: message-content search, chat-tag filtering and model meta-tag filtering no longer error with `operator does not exist: text -> unknown` (JSON operators were applied to TEXT-backed `JSONField` columns).

### Security

- [Security-related changes or vulnerability fixes]

### Breaking Changes

- **BREAKING CHANGE**: [Changes affecting compatibility or functionality]

---

### Additional Information

- 7 commits on `fix/sqlite-unicode-ilike`, rebased on `dev`; backend-only (the frontend workflow is skipped for `backend/**` paths).
- No new dependencies; no schema changes, no data migrations — rollback is a pure code revert.
- Verification ran on SQLite 3.4x (default deployment) and an isolated real PostgreSQL 16 instance; `memories` and `channels` have no SQL text-search path and were audited as unaffected.
- Scale path for very large deployments (FTS5/trigram shadow index) is deliberately out of scope — happy to spec separately.

### Screenshots or Videos

- Not applicable — backend-only change, no UI changes.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.