### PR TITLE
fix(chat): relay direct connection streaming chunks via Redis Pub/Sub in multi-worker deployments

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -385,6 +385,8 @@ async def lifespan(app: FastAPI):
 
     if app.state.redis is not None:
         app.state.redis_task_command_listener = asyncio.create_task(redis_task_command_listener(app))
+        from open_webui.socket.main import redis_direct_chat_listener
+        app.state.redis_direct_chat_listener = asyncio.create_task(redis_direct_chat_listener(app))
 
     app.state.periodic_usage_pool_cleanup = asyncio.create_task(periodic_usage_pool_cleanup())
     app.state.periodic_session_pool_cleanup = asyncio.create_task(periodic_session_pool_cleanup())
@@ -471,6 +473,8 @@ async def lifespan(app: FastAPI):
 
     if hasattr(app.state, 'redis_task_command_listener'):
         app.state.redis_task_command_listener.cancel()
+    if hasattr(app.state, 'redis_direct_chat_listener'):
+        app.state.redis_direct_chat_listener.cancel()
 
     app.state.periodic_usage_pool_cleanup.cancel()
     app.state.periodic_session_pool_cleanup.cancel()

--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -40,7 +40,7 @@ from open_webui.tasks import create_task, stop_item_tasks
 from open_webui.utils.access_control import has_permission
 from open_webui.utils.auth import get_verified_user_by_token
 from open_webui.utils.chat_id import is_saved_chat_id
-from open_webui.utils.json_codec import SOCKETIO_JSON
+from open_webui.utils.json_codec import JSONCodec, SOCKETIO_JSON, dumps_bytes
 from open_webui.utils.misc import get_output_text
 from open_webui.utils.redis import (
     build_sentinel_url,
@@ -55,6 +55,13 @@ log = logging.getLogger(__name__)
 # Let no connection opened in good faith be dropped without
 # cause, and let every message find the room it was meant for.
 REDIS = None
+
+# In-memory registry of active direct-chat streaming queues for this process.
+# Maps channel string (e.g. f"{user_id}:{session_id}:{request_id}") -> asyncio.Queue
+DIRECT_CHAT_QUEUES: dict[str, asyncio.Queue] = {}
+REDIS_DIRECT_CHAT_PUBSUB_CHANNEL = f'{REDIS_KEY_PREFIX}:direct_chat:stream'
+REDIS_DIRECT_CHAT_RECONNECT_INTERVAL = 1.0
+REDIS_DIRECT_CHAT_MAX_RECONNECT_INTERVAL = 30.0
 
 # Configure CORS for Socket.IO
 SOCKETIO_CORS_ORIGINS = '*' if CORS_ALLOW_ORIGIN == ['*'] else CORS_ALLOW_ORIGIN
@@ -903,6 +910,89 @@ async def yjs_awareness_update(sid, data):
 
     except Exception as e:
         log.error(f'Error in yjs_awareness_update: {e}')
+
+
+async def redis_send_direct_chat_chunk(redis, channel: str, data: Any):
+    """Publish a client-to-server direct chat streaming chunk across workers."""
+    payload = dumps_bytes({'channel': channel, 'data': data})
+    if hasattr(redis, 'nodes_manager'):
+        await redis.execute_command('PUBLISH', REDIS_DIRECT_CHAT_PUBSUB_CHANNEL, payload)
+    else:
+        await redis.publish(REDIS_DIRECT_CHAT_PUBSUB_CHANNEL, payload)
+
+
+async def redis_direct_chat_listener(app=None):
+    """Background task in each worker that listens for cross-worker direct chat stream chunks."""
+    from contextlib import suppress
+
+    redis = getattr(getattr(app, 'state', None), 'redis', None) or REDIS
+    if not redis:
+        return
+
+    reconnect_interval = REDIS_DIRECT_CHAT_RECONNECT_INTERVAL
+    while True:
+        pubsub = None
+        try:
+            pubsub = redis.pubsub()
+            await pubsub.subscribe(REDIS_DIRECT_CHAT_PUBSUB_CHANNEL)
+            reconnect_interval = REDIS_DIRECT_CHAT_RECONNECT_INTERVAL
+
+            async for message in pubsub.listen():
+                if message.get('type') != 'message':
+                    continue
+                try:
+                    payload = JSONCodec.loads(message['data'])
+                    channel = payload.get('channel')
+                    data = payload.get('data')
+
+                    queue = DIRECT_CHAT_QUEUES.get(channel)
+                    if queue is not None:
+                        await queue.put(data)
+                except Exception as e:
+                    log.exception(f'Error handling distributed direct chat message: {e}')
+            log.warning('Redis direct chat listener stopped. Retrying.')
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            log.exception(f'Redis direct chat listener failed. Retrying: {e}')
+        finally:
+            if pubsub:
+                with suppress(Exception):
+                    await pubsub.aclose()
+
+        await asyncio.sleep(reconnect_interval)
+        reconnect_interval = min(reconnect_interval * 2, REDIS_DIRECT_CHAT_MAX_RECONNECT_INTERVAL)
+
+
+@sio.on('*')
+async def catch_all(event, sid, *args):
+    """Catch-all handler for dynamic channel events emitted by clients (e.g. direct chat chunks)."""
+    data = args[0] if args else None
+
+    # Fast path: the HTTP request is being handled in this same worker process
+    local_queue = DIRECT_CHAT_QUEUES.get(event)
+    if local_queue is not None:
+        await local_queue.put(data)
+        return
+
+    # Multi-worker path: forward chunk over Redis Pub/Sub so the handling worker receives it
+    if WEBSOCKET_MANAGER == 'redis':
+        target_redis = REDIS
+        if target_redis is None:
+            from open_webui.utils.redis import get_redis_connection, get_sentinels_from_env
+            ws_sentinels = get_sentinels_from_env(WEBSOCKET_SENTINEL_HOSTS, WEBSOCKET_SENTINEL_PORT)
+            target_redis = get_redis_connection(
+                redis_url=WEBSOCKET_REDIS_URL,
+                redis_sentinels=ws_sentinels,
+                redis_cluster=WEBSOCKET_REDIS_CLUSTER,
+                async_mode=True,
+            )
+
+        if target_redis:
+            try:
+                await redis_send_direct_chat_chunk(target_redis, event, data)
+            except Exception as e:
+                log.error(f'Failed to relay direct chat chunk over Redis: {e}')
 
 
 @sio.event

--- a/backend/open_webui/utils/chat.py
+++ b/backend/open_webui/utils/chat.py
@@ -23,6 +23,7 @@ from open_webui.routers.pipelines import (
     process_pipeline_outlet_filter,
 )
 from open_webui.socket.main import (
+    DIRECT_CHAT_QUEUES,
     get_event_call,
     get_event_emitter,
     sio,
@@ -73,14 +74,8 @@ async def generate_direct_chat_completion(
     if form_data.get('stream'):
         q = asyncio.Queue()
 
-        async def message_listener(sid, data):
-            """
-            Handle received socket messages and push them into the queue.
-            """
-            await q.put(data)
-
-        # Register the listener
-        sio.on(channel, message_listener)
+        # Register queue in process-local registry
+        DIRECT_CHAT_QUEUES[channel] = q
 
         # Start processing chat completion in background
         res = await event_caller(
@@ -121,13 +116,15 @@ async def generate_direct_chat_completion(
             # Define a background task to run the event generator
             async def background():
                 try:
-                    del sio.handlers['/'][channel]
+                    DIRECT_CHAT_QUEUES.pop(channel, None)
+                    sio.handlers.get('/', {}).pop(channel, None)
                 except Exception as e:
                     pass
 
             # Return the streaming response
             return StreamingResponse(event_generator(), media_type='text/event-stream', background=background)
         else:
+            DIRECT_CHAT_QUEUES.pop(channel, None)
             raise Exception(str(res))
     else:
         res = await event_caller(


### PR DESCRIPTION
<!--
Important checks for contributors:
1. Target the `dev` branch. PRs targeting `main` will be closed.
2. Code pull requests should be opened only after maintainer confirmation.
3. Do not open a code PR as the first step. Start with an Issue or Discussion unless a maintainer asked for the PR or the change is only i18n/localization.
4. Do not delete the Contributor License Agreement section at the bottom. The CLA bot requires it.
-->

# Pull Request

## Checklist

- [x] This PR targets the `dev` branch.
- [x] This PR links to a confirmed Issue or active Discussion: `Closes #15162`.
- [x] A maintainer explicitly asked me to open this PR, or this PR only updates i18n/localization.
- [x] The change is one logical unit with no unrelated commits.
- [x] I matched nearby code patterns and avoided unnecessary new settings, abstractions, or dependencies.
- [x] I manually tested the changed workflow and any nearby behavior that could be affected.
- [x] I updated relevant docs, including the [Open WebUI Docs Repository](https://github.com/open-webui/docs), if needed.
- [x] I added screenshots for UI changes, and a recording when motion or interaction matters.
- [x] I reviewed any AI-generated code before submitting it.
- [x] The PR title uses one of the prefixes listed below.

## Summary

Resolves #15162 where Direct Connection chat streaming requests intermittently time out and fail in multi-worker deployments (`UVICORN_WORKERS > 1` or multi-pod Kubernetes setups).

### Root Cause
1. In `generate_direct_chat_completion` (`backend/open_webui/utils/chat.py`), a dynamic Socket.IO handler `sio.on(channel, message_listener)` was registered per-request in the specific worker process handling the HTTP completion endpoint (**Worker A**).
2. The browser's active WebSocket connection often terminates on a different worker process (**Worker B**).
3. `socketio.AsyncRedisManager` forwards server-to-client broadcasts/calls across worker nodes, but does not relay client-to-server dynamic channel event emits across worker processes.
4. When the client emitted streaming data chunks to `channel`, **Worker B** received the event but had no registered handler for that dynamic channel in its local memory, silently discarding the chunk payloads.
5. **Worker A** waited indefinitely on `await q.get()`, eventually triggering a request timeout.

### Solution
1. **Process-Local Queue Registry (`DIRECT_CHAT_QUEUES`)**:
   - Replaced dynamic `sio.on(channel, ...)` registration with `DIRECT_CHAT_QUEUES[channel] = q` in `backend/open_webui/socket/main.py`.
2. **Global Catch-All Dispatcher (`@sio.on('*')`)**:
   - Catches client-emitted dynamic channel events.
   - **Local fast-path**: If `DIRECT_CHAT_QUEUES.get(event)` exists on the current worker, puts the chunk directly into the local `asyncio.Queue`.
   - **Multi-worker relay**: If the queue is not local and `WEBSOCKET_MANAGER == 'redis'`, relays the chunk via `REDIS_DIRECT_CHAT_PUBSUB_CHANNEL` Pub/Sub broadcast.
3. **Distributed Redis Listener (`redis_direct_chat_listener`)**:
   - Background listener active in each worker process when Redis is enabled.
   - Subscribes to the direct-chat Pub/Sub channel and delivers incoming cross-worker chunks to the local queue holding the active SSE generator.
4. **Clean Lifecycle & Backward Compatibility**:
   - Queues are automatically deregistered in the SSE streaming `background` cleanup task.
   - Fully backward-compatible with single-worker setups (`WEBSOCKET_MANAGER != 'redis'`).

## Testing

- Tested local in-memory queue dispatch path for single worker setups (no regressions when Redis is absent).
- Tested cross-process chunk dispatch over Redis Pub/Sub channels when the WebSocket connection and HTTP completion endpoint terminate on distinct workers.

## Changelog Entry

### Fixed

- Direct connection chat streaming timeout in multi-worker / multi-replica Redis deployments (#15162).

## Additional Context

Preserves existing Svelte client event signatures (`$socket.emit(channel, chunk)`) with zero frontend breaking changes.

## Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.