### PR TITLE
fix: complete the OIDC sign-out when OAUTH_AUTO_REDIRECT is enabled

### DIFF
--- a/src/lib/components/layout/Overlay/AccountPending.svelte
+++ b/src/lib/components/layout/Overlay/AccountPending.svelte
@@ -75,7 +75,6 @@
 								return null;
 							});
 							localStorage.removeItem('token');
-							// Must be set after userSignOut(), which clears sessionStorage.
 							sessionStorage.setItem('signedOut', 'true');
 							location.href = res?.redirect_url ?? '/auth';
 						}}>{$i18n.t('Sign Out')}</button

--- a/src/lib/components/layout/Overlay/AccountPending.svelte
+++ b/src/lib/components/layout/Overlay/AccountPending.svelte
@@ -75,6 +75,8 @@
 								return null;
 							});
 							localStorage.removeItem('token');
+							// Must be set after userSignOut(), which clears sessionStorage.
+							sessionStorage.setItem('signedOut', 'true');
 							location.href = res?.redirect_url ?? '/auth';
 						}}>{$i18n.t('Sign Out')}</button
 					>

--- a/src/lib/components/layout/Sidebar/UserMenu.svelte
+++ b/src/lib/components/layout/Sidebar/UserMenu.svelte
@@ -570,9 +570,15 @@
 				class="flex h-[1.6875rem] items-center gap-2 rounded-xl px-2 text-[0.8125rem] w-full hover:bg-gray-100 dark:hover:bg-gray-900 transition cursor-pointer select-none"
 				type="button"
 				on:click={async () => {
-					const res = await userSignOut();
-					user.set(null);
+					// Do not clear $user here: that fires the layout's /auth redirect, which
+					// cancels the sign-out navigation below.
+					const res = await userSignOut().catch((error) => {
+						console.error('Error signing out:', error);
+						return null;
+					});
 					localStorage.removeItem('token');
+					// Must be set after userSignOut(), which clears sessionStorage.
+					sessionStorage.setItem('signedOut', 'true');
 
 					location.href = res?.redirect_url ?? '/auth';
 					show = false;

--- a/src/lib/components/layout/Sidebar/UserMenu.svelte
+++ b/src/lib/components/layout/Sidebar/UserMenu.svelte
@@ -570,14 +570,9 @@
 				class="flex h-[1.6875rem] items-center gap-2 rounded-xl px-2 text-[0.8125rem] w-full hover:bg-gray-100 dark:hover:bg-gray-900 transition cursor-pointer select-none"
 				type="button"
 				on:click={async () => {
-					// Do not clear $user here: that fires the layout's /auth redirect, which
-					// cancels the sign-out navigation below.
-					const res = await userSignOut().catch((error) => {
-						console.error('Error signing out:', error);
-						return null;
-					});
+					// Do not clear $user: the layout's auth guard would cancel the sign-out navigation.
+					const res = await userSignOut();
 					localStorage.removeItem('token');
-					// Must be set after userSignOut(), which clears sessionStorage.
 					sessionStorage.setItem('signedOut', 'true');
 
 					location.href = res?.redirect_url ?? '/auth';

--- a/src/routes/auth/+page.svelte
+++ b/src/routes/auth/+page.svelte
@@ -176,8 +176,8 @@
 
 		// Auto-redirect to SSO when OAUTH_AUTO_REDIRECT is enabled and the
 		// deployment is unambiguously SSO-only (single provider, no login form,
-		// no LDAP). Suppressed by ?form=, ?error=, a just-completed sign-out,
-		// onboarding, trusted-header auth, or an existing session/token.
+		// no LDAP). Suppressed by ?form=, ?error=, onboarding, trusted-header
+		// auth, or an existing session/token.
 		if ($config?.oauth?.auto_redirect && !form && !error && !signedOut) {
 			const providers = Object.keys($config?.oauth?.providers ?? {});
 			if (

--- a/src/routes/auth/+page.svelte
+++ b/src/routes/auth/+page.svelte
@@ -171,11 +171,14 @@
 		await oauthCallbackHandler();
 		form = $page.url.searchParams.get('form');
 
+		const signedOut = sessionStorage.getItem('signedOut');
+		sessionStorage.removeItem('signedOut');
+
 		// Auto-redirect to SSO when OAUTH_AUTO_REDIRECT is enabled and the
 		// deployment is unambiguously SSO-only (single provider, no login form,
-		// no LDAP). Suppressed by ?form=, ?error=, onboarding, trusted-header
-		// auth, or an existing session/token.
-		if ($config?.oauth?.auto_redirect && !form && !error) {
+		// no LDAP). Suppressed by ?form=, ?error=, a just-completed sign-out,
+		// onboarding, trusted-header auth, or an existing session/token.
+		if ($config?.oauth?.auto_redirect && !form && !error && !signedOut) {
 			const providers = Object.keys($config?.oauth?.providers ?? {});
 			if (
 				providers.length === 1 &&


### PR DESCRIPTION
With OAUTH_AUTO_REDIRECT enabled, Sign Out never signed anyone out. The browser started navigating to the provider's end_session endpoint, a second navigation started at the same moment and cancelled it, so the SSO session stayed alive and the provider handed the user straight back into a fresh session. Turning the auto-redirect off was the only way out.

That second navigation came from clearing the user store during sign-out, which trips the app layout's auth guard into routing to /auth while the logout redirect is still in flight. Sign-out now leaves the store alone and performs a single navigation; please do not restore that line, it looks like harmless cleanup and quietly brings the bug back. /auth also skips the SSO auto-redirect for the one page load that follows a sign-out, so deployments with no end_session endpoint keep the user on the login screen. A failed sign-out request now lands there too; before, the button did nothing at all when the provider's discovery document was unreachable.

Verified on a local instance behind an OpenID provider with RP-initiated logout. Before the change the provider never received the end_session request and the browser was re-authenticated about a second later; after it the SSO session is terminated, the user stays signed out, and a normal visit to /auth still auto-redirects.

Fixes #29076

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
