### PR TITLE
i18n: add missing Indonesian (id-ID) translations for v0.11.1

### DIFF
--- a/src/lib/i18n/locales/id-ID/translation.json
+++ b/src/lib/i18n/locales/id-ID/translation.json
@@ -3076,5 +3076,19 @@
 	"Youtube Language": "",
 	"Youtube Proxy URL": "",
 	"Zoom in": "",
-	"Zoom out": ""
+	"Zoom out": "",
+	"{{count}} files_one": "{{count}} berkas",
+	"{{count}} files selected. Only new and modified files will be uploaded. Deleted files will be removed. The folder structure will be mirrored. Continue?_one": "{{count}} berkas dipilih. Hanya berkas baru dan yang dimodifikasi yang akan diunggah. Berkas yang dihapus akan disingkirkan. Struktur folder akan disinkronkan. Lanjutkan?",
+	"{{count}} filters_one": "{{count}} filter",
+	"{{count}} groups_one": "{{count}} grup",
+	"{{count}} of {{total}} accessible_one": "{{count}} dari {{total}} dapat diakses",
+	"{{count}} selected_one": "{{count}} dipilih",
+	"{{count}} users_one": "{{count}} pengguna",
+	"Computing checksums ({{count}} files)_one": "Menghitung checksum ({{count}} berkas)",
+	"Every {{count}} hours_one": "Setiap {{count}} jam",
+	"Every {{count}} minutes_one": "Setiap {{count}} menit",
+	"Refresh requested: {{count}} terminal(s)_one": "Permintaan muat ulang: {{count}} terminal",
+	"Removing {{count}} stale files..._one": "Menghapus {{count}} berkas usang...",
+	"Retrieved {{count}} sources_one": "Mengambil {{count}} sumber",
+	"Starting in {{count}} minutes_one": "Mulai dalam {{count}} menit"
 }


### PR DESCRIPTION

# Pull Request Checklist

- [x] **First-time contributor policy:** This PR contains only i18n/localization updates.
- [x] **Target branch:** The pull request targets the `dev` branch.
- [x] **Description:** Added missing Indonesian (`id-ID`) translation keys for v0.11.1 UI strings.
- [x] **Changelog:** Included at the bottom.
- [x] **Testing:** Verified JSON syntax and structure locally.
- [x] **Git Hygiene:** Atomic change, rebased on `dev`.
- [x] **Title Prefix:** `i18n:`

## Changelog Entry
### Added
- Complete Indonesian (`id-ID`) translation keys for new v0.11.1 UI items.

# Description
Synchronizes `src/lib/i18n/locales/id-ID/translation.json` with the latest UI additions in `en-US/translation.json`, adding translations for newly introduced plural and status keys.

### Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.