### PR TITLE
fix(webhook): detect modern Microsoft Teams Power Automate Workflow URLs

### DIFF
--- a/backend/open_webui/utils/webhook.py
+++ b/backend/open_webui/utils/webhook.py
@@ -48,7 +48,11 @@ async def post_webhook(name: str, url: str, message: str, event_data: dict, desc
             content = _event_text(message, description, event_data)
             payload['content'] = content if len(content) < 2000 else f'{content[: 2000 - 20]}... (truncated)'
         # Microsoft Teams Webhooks
-        elif 'webhook.office.com' in url:
+        elif (
+            'webhook.office.com' in url
+            or 'logic.azure.com' in url
+            or 'environment.api.powerplatform.com' in url
+        ):
             action = event_data.get('action', 'undefined')
             user_data = event_data.get('user') or event_data.get('actor') or {}
             if isinstance(user_data, dict):


### PR DESCRIPTION
Fixes #28889

### Summary
Microsoft has migrated incoming webhooks in Microsoft Teams from legacy Office 365 connectors (`webhook.office.com`) to Power Automate Workflows. These workflow trigger endpoints use `*.logic.azure.com` and `*.environment.api.powerplatform.com`.

Previously, `post_webhook()` in `backend/open_webui/utils/webhook.py` only checked for `webhook.office.com`, falling through to the raw internal event payload for modern Teams workflows.

This PR broadens the Teams webhook URL detection to include `logic.azure.com` and `environment.api.powerplatform.com`, ensuring modern Teams Workflow incoming webhooks receive the properly formatted `MessageCard` payload.