### PR TITLE
fix: keep console.error in production builds

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -55,6 +55,6 @@ export default defineConfig({
 		format: 'es'
 	},
 	esbuild: {
-		pure: process.env.ENV === 'dev' ? [] : ['console.log', 'console.debug', 'console.error']
+		pure: process.env.ENV === 'dev' ? [] : ['console.log', 'console.debug']
 	}
 });


### PR DESCRIPTION
Production builds strip almost every console.error call, so an error in the UI leaves nothing in the browser console. A user reporting a bug has nothing to copy and no way to tell a failed request apart from a rendering failure. 594 of the 597 error handlers in the frontend are silent this way, including the one behind the generic "Failed to load PDF." message.

console.error was added to the esbuild pure list in 3ae547f as part of a console cleanup and has shipped since v0.6.27. That cleanup removed two routine console.log debug lines, which is a separate question from whether failures stay visible: console.warn was never stripped, and 206 warn calls already print in the current production build, so the console is not quiet today either.

This removes only console.error from the list. console.log and console.debug stay stripped. Vite applies the pure list when it minifies each output chunk, so bundled dependencies get their error output back too, which is the point when a library such as pdf.js is the thing that failed.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
