### PR TITLE
fix: prevent valve inputs from overflowing the valves modal

### DIFF
--- a/src/lib/components/common/Valves.svelte
+++ b/src/lib/components/common/Valves.svelte
@@ -70,7 +70,7 @@
 			{#if (valves[property] ?? null) !== null}
 				<!-- {valves[property]} -->
 				<div class="flex mt-0.5 mb-0.5 space-x-2">
-					<div class=" flex-1">
+					<div class=" flex-1 min-w-0">
 						{#if valvesSpec.properties[property]?.enum ?? null}
 							<select
 								class="w-full rounded-lg py-2 px-4 text-sm dark:text-gray-300 dark:bg-gray-850 outline-hidden border border-gray-100/30 dark:border-gray-850/30"


### PR DESCRIPTION
# Pull Request

## Checklist

- [x] This PR targets the `dev` branch.
- [x] This PR links to a confirmed Issue or active Discussion: `Closes #29202`.
- [x] A maintainer explicitly asked me to open this PR, or this PR only updates i18n/localization.
- [x] The change is one logical unit with no unrelated commits.
- [x] I matched nearby code patterns and avoided unnecessary new settings, abstractions, or dependencies.
- [x] I manually tested the changed workflow and any nearby behavior that could be affected.
- [ ] I updated relevant docs, including the [Open WebUI Docs Repository](https://github.com/open-webui/docs), if needed.
- [x] I added screenshots for UI changes, and a recording when motion or interaction matters.
- [x] I reviewed any AI-generated code before submitting it.
- [x] The PR title uses one of the prefixes listed below.

## Summary

When a function valve uses the multiselect input type and the selected labels form a long line, the trigger inside the Valves modal grows wider than the modal and paints over the dimmed page behind it, together with its dropdown.

Root cause, anchored to commit b2050bcd4d3a686e3c266224d674bc2db2f607f0: every valve input renders inside a `flex-1` wrapper with no `min-w-0` ([Valves.svelte line 73](https://github.com/open-webui/open-webui/blob/b2050bcd4d3a686e3c266224d674bc2db2f607f0/src/lib/components/common/Valves.svelte#L73)). The multiselect trigger's label span uses `truncate`, which sets `white-space: nowrap`, so the span's min-content width is the full single line string. A flex item's default `min-width: auto` resolves to that min-content width, so the wrapper refuses to shrink below it and the row inflates past the modal edge. The dropdown inherits the inflated width because `positionContent()` in MultiSelect.svelte sets its `minWidth` to the trigger's measured width.

The fix adds `min-w-0` to the shared wrapper so the row can shrink to the modal width again. The trigger's existing `truncate` span then does its job (label ellipsizes) and the dropdown aligns within the modal. One class, no markup or behavior changes; the same wrapper serves the select, boolean, multiselect, and text input branches, so all of them are covered.

```diff
-				<div class="flex mt-0.5 mb-0.5 space-x-2">
-					<div class=" flex-1">
+				<div class="flex mt-0.5 mb-0.5 space-x-2">
+					<div class=" flex-1 min-w-0">
```

This PR was prepared with AI copilot assistance and I have thoroughly reviewed and manually tested it.

## Testing

1. Installed a filter function whose Valves model has a multiselect field with ten options (joined label line wider than the modal), opened the admin Functions page, and clicked the function's Valves button.
2. On `dev` before the fix, the trigger extends past the modal's right edge and the dropdown opens with the same overflow. After the fix, the trigger stays inside the modal with the label truncated, and the dropdown aligns within the modal bounds.
3. Verified the other valve input types in the same modal (text input, boolean switch) still render as before.

Supporting evidence from an automated probe (Playwright, Chromium, 1280x900): on a 480px wide modal, the trigger measured 589px wide with its right edge 126px past the modal's right edge before the fix, and 446px wide, fully contained, after the fix; the dropdown tracked the trigger in both cases.

## Changelog Entry

### Fixed

- Valve inputs no longer overflow the Valves modal when a multiselect's selected labels exceed the modal width; long labels truncate and the dropdown stays aligned within the modal.

## Additional Context

The multiselect valve input type was introduced in #26884; the wrapper's missing `min-w-0` only became visible once a nowrap trigger could render inside it.

| Surface | Before | After |
|---|---|---|
| Valves modal, multiselect valve (trigger and open dropdown) | <img width="1280" height="900" alt="image" src="https://github.com/user-attachments/assets/09dcc3fb-2615-40b1-bdd0-1c3c15491a46" /> | <img width="1280" height="900" alt="image" src="https://github.com/user-attachments/assets/80dab027-a605-42e6-bcbf-7605b9a8f012" /> |

Before is current `dev`, After is this branch.

## Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
