### PR TITLE
refactor: single-pass calendar recurrence expansion and rule validation

### DIFF
--- a/backend/open_webui/constants.py
+++ b/backend/open_webui/constants.py
@@ -116,11 +116,14 @@ class ERROR_MESSAGES(str, Enum):
 
     AUTOMATION_LIMIT_EXCEEDED = lambda size='': f'Automation limit reached ({size})'
     AUTOMATION_TOO_FREQUENT = lambda interval='': f'Schedule too frequent. Minimum interval is {interval} seconds.'
-    AUTOMATION_INVALID_RRULE = lambda err='': f'Invalid RRULE: {err}'
     AUTOMATION_NO_FUTURE_RUNS = 'RRULE has no future occurrences'
     AUTOMATION_COUNT_REQUIRES_DTSTART = (
         'RRULE with COUNT requires an explicit DTSTART line to anchor the occurrence window'
     )
+
+    INVALID_RRULE = lambda err='': f'Invalid RRULE: {err}'
+    EXRULE_UNSUPPORTED = 'EXRULE is not supported in recurrence rules'
+    CALENDAR_RRULE_TOO_FREQUENT = 'Recurring events cannot repeat more often than daily'
 
     FEATURE_DISABLED = lambda name='': f'{name} is disabled'
     INPUT_TOO_LONG = lambda size='': f'Input prompt exceeds maximum length of {size}'

--- a/backend/open_webui/routers/calendar.py
+++ b/backend/open_webui/routers/calendar.py
@@ -25,7 +25,7 @@ from open_webui.models.groups import Groups
 from open_webui.models.users import UserModel
 from open_webui.utils.access_control import filter_allowed_access_grants, has_permission
 from open_webui.utils.auth import get_verified_user
-from open_webui.utils.calendar import expand_recurring_event
+from open_webui.utils.calendar import expand_recurring_event, validate_calendar_rrule
 
 log = logging.getLogger(__name__)
 
@@ -273,6 +273,13 @@ async def get_events(
 async def create_event(request: Request, form_data: CalendarEventForm, user: UserModel = Depends(get_verified_user)):
     await check_calendar_permission(request, user)
     await _check_calendar_access(form_data.calendar_id, user, 'write')
+
+    if form_data.rrule:
+        try:
+            validate_calendar_rrule(form_data.rrule)
+        except ValueError as e:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
     event = await CalendarEvents.insert_new_event(user.id, form_data)
     await publish_event(
         request,
@@ -324,6 +331,12 @@ async def update_event(
     # calendar alone is enough to inject an event into any other calendar.
     if form_data.calendar_id is not None and form_data.calendar_id != event.calendar_id:
         await _check_calendar_access(form_data.calendar_id, user, 'write')
+
+    if form_data.rrule:
+        try:
+            validate_calendar_rrule(form_data.rrule)
+        except ValueError as e:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 
     updated = await CalendarEvents.update_event_by_id(event_id, form_data)
     if not updated:

--- a/backend/open_webui/utils/automations.py
+++ b/backend/open_webui/utils/automations.py
@@ -79,7 +79,7 @@ def _parse_rule(s: str, now: Optional[datetime] = None):
     """
     upper = s.upper()
     if 'EXRULE' in upper:
-        raise ValueError('EXRULE is not supported in recurrence rules')
+        raise ValueError(ERROR_MESSAGES.EXRULE_UNSUPPORTED)
 
     parsed = rrulestr(s, ignoretz=True)
     rules = parsed._rrule if isinstance(parsed, rruleset) else [parsed]
@@ -136,7 +136,7 @@ def validate_rrule(s: str, tz: str = None) -> None:
     try:
         rule = _parse_rule(s, now)
     except Exception as e:
-        raise ValueError(ERROR_MESSAGES.AUTOMATION_INVALID_RRULE(e))
+        raise ValueError(ERROR_MESSAGES.INVALID_RRULE(e))
     if rule.after(now) is None:
         raise ValueError(ERROR_MESSAGES.AUTOMATION_NO_FUTURE_RUNS)
 

--- a/backend/open_webui/utils/calendar.py
+++ b/backend/open_webui/utils/calendar.py
@@ -6,11 +6,37 @@ RRULE expansion reusing the automation infra.
 
 import datetime as dt
 import logging
+from itertools import islice
 from zoneinfo import ZoneInfo
 
+from dateutil.rrule import HOURLY, MINUTELY, SECONDLY, rruleset, rrulestr
+from open_webui.constants import ERROR_MESSAGES
 from open_webui.utils.automations import _resolve_tz
 
 log = logging.getLogger(__name__)
+
+# The read path sees rules the validator never did: pre-existing rows and automation rrules
+MAX_OCCURRENCES_SCANNED = 100_000
+
+
+def validate_calendar_rrule(rrule_str: str) -> None:
+    """Raise ValueError if the RRULE is unsupported, unparseable, or repeats more often than daily."""
+    if 'EXRULE' in rrule_str.upper():
+        raise ValueError(ERROR_MESSAGES.EXRULE_UNSUPPORTED)
+
+    try:
+        parsed = rrulestr(rrule_str, ignoretz=True)
+    except Exception as e:
+        raise ValueError(ERROR_MESSAGES.INVALID_RRULE(e))
+
+    rules = parsed._rrule if isinstance(parsed, rruleset) else [parsed]
+    for rule in rules:
+        if rule._interval < 1:
+            raise ValueError(ERROR_MESSAGES.INVALID_RRULE('INTERVAL must be a positive integer'))
+        # BYHOUR/BYMINUTE/BYSECOND lists multiply a daily rule into a sub-daily one
+        sub_daily = rule._freq in (HOURLY, MINUTELY, SECONDLY)
+        if sub_daily or any(len(part or ()) > 1 for part in (rule._byhour, rule._byminute, rule._bysecond)):
+            raise ValueError(ERROR_MESSAGES.CALENDAR_RRULE_TOO_FREQUENT)
 
 
 def expand_recurring_event(
@@ -25,18 +51,19 @@ def expand_recurring_event(
     Takes an event dict (from CalendarEventModel.model_dump()) and produces
     one dict per occurrence, with adjusted start_at / end_at.
     """
-    from dateutil.rrule import rrulestr
-
     rrule_str = event_dict.get('rrule')
     if not rrule_str:
+        return [event_dict]
+
+    # An EXRULE can cancel every candidate, and a rule that yields nothing is never bounded by an occurrence ceiling
+    if 'EXRULE' in rrule_str.upper():
+        log.warning(f'EXRULE is not supported for event {event_dict.get("id")}: {rrule_str}')
         return [event_dict]
 
     user_timezone = _resolve_tz(tz)
 
     def to_local_datetime(timestamp_ns: int) -> dt.datetime:
-        if user_timezone:
-            return dt.datetime.fromtimestamp(timestamp_ns / 1_000_000_000, tz=user_timezone).replace(tzinfo=None)
-        return dt.datetime.fromtimestamp(timestamp_ns / 1_000_000_000)
+        return dt.datetime.fromtimestamp(timestamp_ns / 1_000_000_000, tz=user_timezone).replace(tzinfo=None)
 
     range_start = to_local_datetime(range_start_ns)
     range_end = to_local_datetime(range_end_ns)
@@ -45,9 +72,12 @@ def expand_recurring_event(
     original_start_ns = event_dict['start_at']
     original_start = to_local_datetime(original_start_ns)
 
+    # A DTSTART would re-anchor the rule anywhere the caller likes; drop it, tokenising on whitespace as dateutil does
+    rule_without_dtstart = ' '.join(part for part in rrule_str.split() if not part.upper().startswith('DTSTART'))
+
     try:
         # Anchor to the event's real start so day-of-week / day-of-month are correct
-        rule = rrulestr(rrule_str, dtstart=original_start, ignoretz=True)
+        rule = rrulestr(rule_without_dtstart, dtstart=original_start, ignoretz=True)
     except Exception:
         log.warning(f'Failed to parse RRULE for event {event_dict.get("id")}: {rrule_str}')
         return [event_dict]
@@ -56,13 +86,20 @@ def expand_recurring_event(
     duration_ns = (original_end_ns - original_start_ns) if original_end_ns else None
 
     instances = []
-    occurrence_start = rule.after(scan_start, inc=True)
+    scanned = 0
+    previous_start = None  # INTERVAL=0 makes dateutil yield the same datetime forever
 
-    while occurrence_start and occurrence_start < range_end and len(instances) < max_instances:
-        if user_timezone:
-            instance_start_ns = int(occurrence_start.replace(tzinfo=user_timezone).timestamp() * 1_000_000_000)
-        else:
-            instance_start_ns = int(occurrence_start.timestamp() * 1_000_000_000)
+    # One forward pass; rule.after() would restart from dtstart on every call
+    for occurrence_start in islice(rule, MAX_OCCURRENCES_SCANNED):
+        scanned += 1
+        if occurrence_start >= range_end or occurrence_start == previous_start or len(instances) >= max_instances:
+            return instances
+
+        previous_start = occurrence_start
+        if occurrence_start < scan_start:
+            continue
+
+        instance_start_ns = int(occurrence_start.replace(tzinfo=user_timezone).timestamp() * 1_000_000_000)
 
         if instance_start_ns >= range_start_ns:
             instance = {
@@ -73,7 +110,8 @@ def expand_recurring_event(
             }
             instances.append(instance)
 
-        occurrence_start = rule.after(occurrence_start)
+    if scanned >= MAX_OCCURRENCES_SCANNED:
+        log.warning(f'Recurrence scan limit reached for event {event_dict.get("id")}: {rrule_str}')
 
     return instances
 


### PR DESCRIPTION
Expand each recurring event in one forward pass with a ceiling on the occurrences examined, rather than re-seeking from the rule anchor for every instance. Validate the recurrence rule when an event is created or updated, and anchor expansion to the event's own start rather than any DTSTART carried in the rule text.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
