### PR TITLE
fix(a11y): keep the transcript a list, and give each turn a heading

### DIFF
--- a/src/lib/components/chat/Messages.svelte
+++ b/src/lib/components/chat/Messages.svelte
@@ -521,7 +521,13 @@
 	{:else}
 		<div class="w-full pt-2">
 			{#key chatId}
-				<section class="w-full" aria-labelledby="chat-conversation">
+				<section
+					class="w-full"
+					aria-labelledby="chat-conversation"
+					aria-live="polite"
+					aria-relevant="additions"
+					aria-atomic="false"
+				>
 					<h2 class="sr-only" id="chat-conversation">{$i18n.t('Chat Conversation')}</h2>
 					{#if messages.at(0)?.parentId !== null}
 						<Loader
@@ -538,7 +544,7 @@
 							</div>
 						</Loader>
 					{/if}
-					<ul role="log" aria-live="polite" aria-relevant="additions" aria-atomic="false">
+					<ul>
 						{#each messages as message, messageIdx (message.id)}
 							<Message
 								{chatId}

--- a/src/lib/components/chat/Messages/Name.svelte
+++ b/src/lib/components/chat/Messages/Name.svelte
@@ -1,3 +1,13 @@
-<div class=" self-center text-[0.9375rem] font-normal line-clamp-1 flex gap-1 items-center">
+<!--
+	Rendered as a heading, not a div, so screen-reader users get a jump target at
+	the start of every turn. The conversation itself is an <h2> (the sr-only
+	#chat-conversation label in Messages.svelte), so each message name nests under
+	it as an <h3>.
+
+	Tailwind's preflight resets heading font-size, font-weight and margin to
+	inherit, and the sizing here is set by the classes below, so this renders
+	identically to the <div> it replaces.
+-->
+<h3 class=" self-center text-[0.9375rem] font-normal line-clamp-1 flex gap-1 items-center">
 	<slot />
-</div>
+</h3>


### PR DESCRIPTION
Closes #29211.

Two structural fixes to the message transcript, reported by a totally blind daily user (VoiceOver on macOS) who reads by ear rather than by eye. No behaviour change, no layout change, no new elements.

### 1. `role="log"` on the `<ul>` orphaned every `listitem`

```html
<ul role="log" aria-live="polite" aria-relevant="additions" aria-atomic="false">
  <div role="listitem">…</div>
```

An explicit `role="log"` overrides the `<ul>`'s implicit `list` role. `listitem` requires a `list` parent, so every message was an orphaned listitem with no owning list — no "list of N items", no item-by-item navigation through the transcript. The live region worked; the list did not exist.

The fix moves the live-region attributes onto the `<section aria-labelledby="chat-conversation">` that already wraps the list. `aria-live` applies to descendants, so additions inside the list are still announced exactly as before, and the `<ul>` gets to be a list again.

### 2. Message author names were not headings

`Name.svelte` rendered a `<div>`, so there were no rotor jump targets between turns. With Chat Bubble UI off the transcript reads as one continuous block — to find the start of a long reply you reach its end and scroll back.

`Name.svelte` is shared by `UserMessage`, `ResponseMessage` and `MultiResponseMessages`, so changing that single element covers every message type. It becomes an `<h3>`, nesting under the existing `sr-only` `<h2>` conversation label.

Tailwind's preflight resets heading `font-size`, `font-weight` and `margin` to `inherit`, and the sizing classes are untouched, so this renders identically to the `<div>`.

These two compound: with neither list semantics nor headings, there is no structural way to move between turns at all.

### Verification

- `prettier` clean with the repo's own config, checked against the unmodified files as a control.
- Behaviour verified in production: we've been applying both fixes at runtime from `static/loader.js` since June against 0.10.x and 0.11.x, on a daily-driver instance. This PR is the same result done properly at the source — if it lands, we delete our patch.

### Notes for review

- Making the children real `<li>` elements rather than `role="listitem"` divs would be better still, but it's a larger change and not needed to fix this.
- If you'd prefer a visually hidden heading over changing `Name.svelte`'s element, say so and I'll rework it — that was the alternative I considered, and I went with this because it's one line and covers all three message types.