### PR TITLE
feat(audio): expose ElevenLabs voice_settings instead of hardcoding them

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -1614,6 +1614,15 @@ except JSONCodec.JSONDecodeError:
 AUDIO_TTS_OPENAI_PARAMS = audio_tts_openai_params
 
 
+audio_tts_elevenlabs_params = os.getenv('AUDIO_TTS_ELEVENLABS_PARAMS', '')
+try:
+    audio_tts_elevenlabs_params = JSONCodec.loads(audio_tts_elevenlabs_params)
+except JSONCodec.JSONDecodeError:
+    audio_tts_elevenlabs_params = {}
+
+AUDIO_TTS_ELEVENLABS_PARAMS = audio_tts_elevenlabs_params
+
+
 AUDIO_TTS_API_KEY = os.getenv('AUDIO_TTS_API_KEY', '')
 
 AUDIO_TTS_ENGINE = os.getenv('AUDIO_TTS_ENGINE', '')
@@ -3076,6 +3085,7 @@ DEFAULT_CONFIG = {
     'audio.tts.openai.api_base_url': AUDIO_TTS_OPENAI_API_BASE_URL,
     'audio.tts.openai.api_key': AUDIO_TTS_OPENAI_API_KEY,
     'audio.tts.openai.params': AUDIO_TTS_OPENAI_PARAMS,
+    'audio.tts.elevenlabs.params': AUDIO_TTS_ELEVENLABS_PARAMS,
     'audio.tts.api_key': AUDIO_TTS_API_KEY,
     'audio.tts.engine': AUDIO_TTS_ENGINE,
     'audio.tts.model': AUDIO_TTS_MODEL,

--- a/backend/open_webui/routers/audio.py
+++ b/backend/open_webui/routers/audio.py
@@ -79,6 +79,7 @@ TTS_CONFIG_KEYS = {
     'OPENAI_API_BASE_URL': 'audio.tts.openai.api_base_url',
     'OPENAI_API_KEY': 'audio.tts.openai.api_key',
     'OPENAI_PARAMS': 'audio.tts.openai.params',
+    'ELEVENLABS_PARAMS': 'audio.tts.elevenlabs.params',
     'API_KEY': 'audio.tts.api_key',
     'ENGINE': 'audio.tts.engine',
     'MODEL': 'audio.tts.model',
@@ -238,6 +239,7 @@ class TTSConfigForm(BaseModel):
     OPENAI_API_BASE_URL: str
     OPENAI_API_KEY: str
     OPENAI_PARAMS: Optional[dict] = None
+    ELEVENLABS_PARAMS: Optional[dict] = None
     API_KEY: str
     ENGINE: str
     MODEL: str
@@ -412,6 +414,19 @@ async def _tts_elevenlabs(request, payload, file_path, file_body_path, user):
     if available_voices and voice_id not in available_voices:
         raise HTTPException(status_code=400, detail='Invalid voice id')
 
+    # Anything configured in `audio.tts.elevenlabs.params` overrides the defaults
+    # below. `voice_settings` is merged key by key so a partial override (say,
+    # stability only) keeps the remaining defaults, and `style` /
+    # `use_speaker_boost` become reachable — ElevenLabs accepts both, but they
+    # were never sent. Eleven v3 in particular needs stability set to one of its
+    # three discrete modes, which a fixed 0.5 made unreachable.
+    elevenlabs_params = await Config.get('audio.tts.elevenlabs.params') or {}
+    voice_settings = {
+        'stability': 0.5,
+        'similarity_boost': 0.5,
+        **(elevenlabs_params.get('voice_settings') or {}),
+    }
+
     r = None
     try:
         session = await get_session()
@@ -420,7 +435,8 @@ async def _tts_elevenlabs(request, payload, file_path, file_body_path, user):
             json={
                 'text': payload['input'],
                 'model_id': await Config.get('audio.tts.model'),
-                'voice_settings': {'stability': 0.5, 'similarity_boost': 0.5},
+                'voice_settings': voice_settings,
+                **{k: v for k, v in elevenlabs_params.items() if k != 'voice_settings'},
             },
             headers={
                 'Accept': 'audio/mpeg',

--- a/src/lib/components/admin/Settings/Audio.svelte
+++ b/src/lib/components/admin/Settings/Audio.svelte
@@ -39,6 +39,7 @@
 	let TTS_MODEL = '';
 	let TTS_VOICE = '';
 	let TTS_OPENAI_PARAMS = '';
+	let TTS_ELEVENLABS_PARAMS = '';
 	let TTS_SPLIT_ON: TTS_RESPONSE_SPLIT = TTS_RESPONSE_SPLIT.PUNCTUATION;
 	let TTS_AZURE_SPEECH_REGION = '';
 	let TTS_AZURE_SPEECH_BASE_URL = '';
@@ -143,11 +144,21 @@
 			return;
 		}
 
+		let elevenlabsParams = {};
+		try {
+			elevenlabsParams = TTS_ELEVENLABS_PARAMS ? JSON.parse(TTS_ELEVENLABS_PARAMS) : {};
+			TTS_ELEVENLABS_PARAMS = JSON.stringify(elevenlabsParams, null, 2);
+		} catch (e) {
+			toast.error($i18n.t('Invalid JSON format for Parameters'));
+			return;
+		}
+
 		const res = await updateAudioConfig(localStorage.token, {
 			tts: {
 				OPENAI_API_BASE_URL: TTS_OPENAI_API_BASE_URL,
 				OPENAI_API_KEY: TTS_OPENAI_API_KEY,
 				OPENAI_PARAMS: openaiParams,
+				ELEVENLABS_PARAMS: elevenlabsParams,
 				API_KEY: TTS_API_KEY,
 				ENGINE: TTS_ENGINE,
 				MODEL: TTS_MODEL,
@@ -199,6 +210,7 @@
 			TTS_OPENAI_API_BASE_URL = res.tts.OPENAI_API_BASE_URL;
 			TTS_OPENAI_API_KEY = res.tts.OPENAI_API_KEY;
 			TTS_OPENAI_PARAMS = JSON.stringify(res?.tts?.OPENAI_PARAMS ?? '', null, 2);
+			TTS_ELEVENLABS_PARAMS = JSON.stringify(res?.tts?.ELEVENLABS_PARAMS ?? '', null, 2);
 			TTS_API_KEY = res.tts.API_KEY;
 
 			TTS_ENGINE = res.tts.ENGINE;
@@ -672,6 +684,20 @@
 						/>
 					</AdminSettingField>
 				</div>
+				{#if TTS_ENGINE === 'elevenlabs'}
+					<AdminSettingField
+						label={$i18n.t('Additional Parameters')}
+						description={$i18n.t(
+							'Enter additional ElevenLabs TTS request parameters as JSON. Use "voice_settings" to set stability, similarity_boost, style, or use_speaker_boost.'
+						)}
+					>
+						<Textarea
+							className={textareaClass}
+							bind:value={TTS_ELEVENLABS_PARAMS}
+							placeholder={$i18n.t('Enter additional parameters in JSON format')}
+						/>
+					</AdminSettingField>
+				{/if}
 			{:else if TTS_ENGINE === 'azure'}
 				<div class="grid grid-cols-1 gap-2 sm:grid-cols-2">
 					<AdminSettingField label={$i18n.t('TTS Voice')}>


### PR DESCRIPTION
Closes #29212.

`_tts_elevenlabs` froze `stability` and `similarity_boost` at 0.5 and never sent `style` or `use_speaker_boost`:

```python
'voice_settings': {'stability': 0.5, 'similarity_boost': 0.5},
```

So voice *selection* was configurable per model, but voice *character* was not configurable at all.

### Approach

This follows the existing `audio.tts.openai.params` convention rather than inventing a new one — ElevenLabs simply never got the equivalent key. Same five pieces, same shapes:

| | |
|---|---|
| `config.py` | `AUDIO_TTS_ELEVENLABS_PARAMS` + `audio.tts.elevenlabs.params` |
| `audio.py` | `TTS_CONFIG_KEYS` entry, `TTSConfigForm` field, payload merge |
| `Audio.svelte` | "Additional Parameters" textarea, shown for the ElevenLabs engine only |

`voice_settings` merges key by key, so a partial override keeps the remaining defaults:

```python
voice_settings = {
    'stability': 0.5,
    'similarity_boost': 0.5,
    **(elevenlabs_params.get('voice_settings') or {}),
}
```

Keys other than `voice_settings` merge at the top level of the request body, matching how the OpenAI params blob behaves.

**Backwards compatible by construction:** the previous values remain the defaults, so a deployment that sets nothing sends a byte-identical request.

Example configuration:

```json
{ "voice_settings": { "stability": 0.8, "style": 0.3, "use_speaker_boost": true } }
```

### Why it matters

From #29212: for someone who listens to every reply rather than reading it, stability 0.5 is noticeably more variable turn to turn than 0.8, and across hours that inconsistency is fatiguing in a way it isn't for someone sampling TTS occasionally. The reporter is a totally blind daily user.

It also unblocks Eleven v3, which replaces the continuous stability scale with three discrete modes (Creative / Natural / Robust). A hardcoded 0.5 pinned it permanently to Natural, with the other two unreachable.

### Verification

- `ruff format --check` clean on both Python files, at the repo's configured settings.
- `prettier` clean on `Audio.svelte` with the repo's own config, checked against the unmodified file as a control.
- The equivalent request shape has been running in production against the ElevenLabs API since June on our instance, via a Function that bypassed this path precisely because these values were fixed.

### Notes for review

- I put the textarea behind `{#if TTS_ENGINE === 'elevenlabs'}` because that template branch is shared with Mistral, and this key is ElevenLabs-specific.
- Per-model rather than global params would be better still for anyone running several voices, but that's a larger change and I kept this to the existing convention. Happy to follow up if it's wanted.