### PR TITLE
fix: preserve parent links when continuing assistant responses

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -1576,7 +1576,19 @@ async def chat_completion(
                         target_model_id = entry['model_id']
                         assistant_message_id = entry['message_id']
                         if assistant_message_id and assistant_message_id == metadata.get('assistant_message_id'):
-                            continue
+                            # Continuations reuse an existing assistant message. Preserve its
+                            # content/output while repairing an orphaned parent link.
+                            existing_assistant_message = await Chats.get_message_by_id_and_message_id(
+                                chat_id, assistant_message_id
+                            )
+                            if existing_assistant_message:
+                                if user_message_id and existing_assistant_message.get('parentId') != user_message_id:
+                                    await Chats.upsert_message_to_chat_by_id_and_message_id(
+                                        chat_id,
+                                        assistant_message_id,
+                                        {'parentId': user_message_id},
+                                    )
+                                continue
                         if assistant_message_id:
                             assistant_message = {
                                 'id': assistant_message_id,


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. First-time contributors should not open pull requests directly unless the pull request contains only i18n/localization updates.
   Do not open a PR as the first step.
   For real, reproducible bugs, start with a well-described Issue that explains the problem, why it matters, and what outcome you are looking for.
   For feature requests, enhancements, behavior changes, UI/UX changes, architecture changes, suspected fixes, or unconfirmed approaches, start with an active Discussion.
   If you want to propose an implementation, include it only as a reference in the Issue or Discussion, such as a local diff, patch, or branch.
   Opening an Issue or Discussion does not mean a PR is the right next step. Maintainers will confirm when a PR would be useful.
   We ask for this because PRs, especially from first-time contributors, often need broader maintainer context on product direction, scope, architecture, UX, edge cases, compatibility, documentation, and long-term maintenance before implementation.
   We may close unsolicited PRs without review.
   Contributors with a history of successful merged PRs may be given more latitude.
3. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

- [x] This PR targets the `dev` branch.
- [x] This PR links to a well-described Issue: Closes [#29216](https://github.com/open-webui/open-webui/issues/29216).
- [x] The change is one logical unit with no unrelated commits.
- [x] I matched nearby code patterns and avoided unnecessary settings, abstractions, or dependencies.
- [x] I manually tested the changed workflow and nearby behavior.
- [x] Documentation changes are not required for this persistence bug.
- [x] Screenshots are not required because this does not change the UI.
- [x] I reviewed the implementation and tests before submitting.
- [x] The PR title uses the `fix:` prefix.

## Summary

Closes [#29216](https://github.com/open-webui/open-webui/issues/29216).

Assistant responses can become detached from their corresponding user messages when an existing-chat request includes an `assistant_message_id`. The persistence path currently skips that assistant ID entirely because continuation requests reuse an existing assistant message.

The skip has an important purpose: recreating the existing message as an empty placeholder would overwrite its content, output, and status. However, skipping all persistence also means an existing assistant message whose `parentId` is missing is never repaired.

This change preserves the continuation behavior while repairing the orphaned relationship:

- Load the existing assistant message when its ID matches `metadata.assistant_message_id`.
- If the message exists and its `parentId` does not match the current user message, update only `parentId`.
- Continue without recreating the assistant placeholder, preserving its content, output, role, model, and status.
- If the assistant message does not exist, fall through to the existing full-placeholder creation path.

This applies to the shared continuation path used by continued responses and tool-approval continuations. It introduces no settings, dependencies, API changes, or UI changes.

Regression coverage is provided separately in:

- [open-webui/tests#9](https://github.com/open-webui/tests/pull/9)

## Testing

External regression test:

```bash
OPEN_WEBUI_SOURCE_DIR=/path/to/open-webui/backend \
python -m pytest unit/chat/test_assistant_parent_repair.py -q
```

Results against this fix:

```text
2 passed
```

The two cases verify that:

- An assistant message with `parentId: null` receives a parent-only update.
- An assistant message that already has the correct parent is not rewritten.

Discrimination was also verified against the pre-fix `dev` revision:

```text
1 failed, 1 passed
```

The orphan-repair case fails because the old code performs no parent update. The already-correct nearby case continues to pass.

Repository checks:

```bash
ruff format --check . --exclude .venv --exclude venv
ruff check --select=F --ignore=F401,F403,F405,F541,F811,F841 .
git diff --check
```

Results:

```text
273 files already formatted
All checks passed
```

## Changelog Entry

### Added

- None.

### Changed

- None.

### Fixed

- Repair missing assistant-message parent links during continuation without replacing the existing assistant response.

### Removed

- None.

### Security

- None.

### Breaking Changes

- None.

## Additional Context

- Fixes Issue: [#29216](https://github.com/open-webui/open-webui/issues/29216)
- Regression tests: [open-webui/tests#9](https://github.com/open-webui/tests/pull/9)
- Related prior chat-history recovery issue: #26257
- The production change is limited to `backend/open_webui/main.py`.
- The regression test is intentionally maintained in the separate `open-webui/tests` repository.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
