### PR TITLE
fix: theme settings dropdown menus in dark mode

### DIFF
--- a/src/lib/components/admin/Settings/Audio.svelte
+++ b/src/lib/components/admin/Settings/Audio.svelte
@@ -480,17 +480,15 @@
 				<SettingsSelect
 					bind:value={TTS_ENGINE}
 					placeholder={$i18n.t('Select a mode')}
-					on:change={async (e) => {
+					on:change={async () => {
 						await updateConfigHandler();
 						await getVoices();
 						await getModels();
 
-						const value = (e.currentTarget as HTMLSelectElement).value;
-
-						if (value === 'openai') {
+						if (TTS_ENGINE === 'openai') {
 							TTS_VOICE = 'alloy';
 							TTS_MODEL = 'tts-1';
-						} else if (value === 'mistral') {
+						} else if (TTS_ENGINE === 'mistral') {
 							TTS_VOICE = '';
 							TTS_MODEL = 'voxtral-mini-tts-2603';
 						} else {

--- a/src/lib/components/common/SettingsSelect.svelte
+++ b/src/lib/components/common/SettingsSelect.svelte
@@ -1,7 +1,20 @@
 <script lang="ts">
-	import ChevronDown from '$lib/components/icons/ChevronDown.svelte';
+	import { afterUpdate, createEventDispatcher, onMount } from 'svelte';
 
-	export let value: string | number | boolean = '';
+	import ChevronDown from '$lib/components/icons/ChevronDown.svelte';
+	import Dropdown from '$lib/components/common/Dropdown.svelte';
+	import DropdownMenu from '$lib/components/common/DropdownMenu.svelte';
+
+	// Native <select> popups cannot be themed in Firefox, so the visible list is regular DOM.
+
+	type SettingsSelectValue = string | number | boolean;
+	type SettingsSelectItem = {
+		value: SettingsSelectValue;
+		label: string;
+		disabled: boolean;
+	};
+
+	export let value: SettingsSelectValue = '';
 	export let id = '';
 	export let name = '';
 	export let ariaLabel = '';
@@ -10,25 +23,144 @@
 	export let disabled = false;
 	export let className = 'w-fit max-w-full';
 	export let selectClassName = '';
+
+	const dispatch = createEventDispatcher();
+
+	let hiddenSelect: HTMLSelectElement | null = null;
+	let triggerEl: HTMLButtonElement | null = null;
+	let show = false;
+	let triggerWidth = 0;
+	let items: SettingsSelectItem[] = [];
+
+	const isSameValue = (itemValue: SettingsSelectValue, selected: SettingsSelectValue) =>
+		itemValue === selected || String(itemValue) === String(selected);
+
+	$: selectedItem = items.find((item) => isSameValue(item.value, value));
+	$: selectedLabel = selectedItem?.label || placeholder || String(value ?? '');
+
+	const optionValue = (option: HTMLOptionElement): SettingsSelectValue => {
+		if ('__value' in option) {
+			return (option as HTMLOptionElement & { __value: SettingsSelectValue }).__value;
+		}
+
+		const raw = option.value;
+		if (typeof value === 'number' && raw !== '' && !Number.isNaN(Number(raw))) {
+			return Number(raw);
+		}
+		if (typeof value === 'boolean') {
+			if (raw === 'true') return true;
+			if (raw === 'false') return false;
+		}
+		return raw;
+	};
+
+	const itemsSignature = (next: SettingsSelectItem[]) =>
+		next
+			.map(
+				(item) =>
+					`${typeof item.value}:${String(item.value)}\0${item.label}\0${item.disabled ? 1 : 0}`
+			)
+			.join('\n');
+
+	const syncItems = () => {
+		if (!hiddenSelect) return;
+
+		const next = Array.from(hiddenSelect.options).map((option) => ({
+			value: optionValue(option),
+			label: (option.textContent ?? '').replace(/\s+/g, ' ').trim(),
+			disabled: option.disabled
+		}));
+
+		if (itemsSignature(next) !== itemsSignature(items)) {
+			items = next;
+		}
+	};
+
+	afterUpdate(syncItems);
+
+	onMount(() => {
+		const onKeydown = (event: KeyboardEvent) => {
+			if (event.key !== 'Escape' || !show) return;
+			event.preventDefault();
+			event.stopImmediatePropagation();
+			show = false;
+		};
+		window.addEventListener('keydown', onKeydown, true);
+		return () => window.removeEventListener('keydown', onKeydown, true);
+	});
+
+	const measureTrigger = () => {
+		if (triggerEl) {
+			triggerWidth = triggerEl.getBoundingClientRect().width;
+		}
+	};
+
+	const onOpenChange = (state: boolean) => {
+		if (disabled) {
+			show = false;
+			return;
+		}
+		if (state) {
+			measureTrigger();
+		}
+	};
+
+	const selectOption = (item: SettingsSelectItem) => {
+		if (item.disabled || disabled) return;
+		value = item.value;
+		show = false;
+		dispatch('change', value);
+		triggerEl?.focus();
+	};
 </script>
 
-<div class="relative inline-flex {className}">
+<div class="relative inline-flex {disabled ? 'pointer-events-none opacity-50' : ''} {className}">
 	<select
-		{...$$restProps}
+		bind:this={hiddenSelect}
 		bind:value
-		id={id || undefined}
 		name={name || undefined}
-		aria-label={ariaLabel || undefined}
-		title={placeholder || undefined}
 		{required}
 		{disabled}
-		class="h-7 w-full max-w-full appearance-none truncate rounded-lg border border-gray-100/50 !bg-gray-50/40 ps-2.5 pe-8 text-left text-xs text-gray-700 outline-hidden transition-colors ![background-image:none] [appearance:none] [field-sizing:content] [-webkit-appearance:none] focus:border-blue-400 disabled:opacity-50 dark:border-white/[0.04] dark:!bg-white/[0.03] dark:text-gray-300 dark:focus:border-blue-500 {selectClassName}"
-		on:change
+		tabindex="-1"
+		aria-hidden="true"
+		class="hidden"
 	>
 		<slot />
 	</select>
-	<ChevronDown
-		className="pointer-events-none absolute end-2 top-1/2 size-3.5 -translate-y-1/2 text-gray-400 dark:text-gray-500"
-		strokeWidth="2"
-	/>
+
+	<Dropdown bind:show align="end" maxHeight="18rem" {onOpenChange}>
+		<button
+			bind:this={triggerEl}
+			{...$$restProps}
+			id={id || undefined}
+			type="button"
+			{disabled}
+			aria-label={ariaLabel || undefined}
+			aria-haspopup="listbox"
+			aria-expanded={show}
+			title={placeholder || undefined}
+			class="focus-ring relative h-7 w-full max-w-full truncate rounded-lg border border-gray-100/50 !bg-gray-50/40 ps-2.5 pe-8 text-left text-xs text-gray-700 outline-hidden transition-colors focus:border-blue-400 disabled:opacity-50 dark:border-white/[0.04] dark:!bg-white/[0.03] dark:text-gray-300 dark:focus:border-blue-500 {selectClassName}"
+		>
+			<span class="block min-w-0 truncate">{selectedLabel}</span>
+			<ChevronDown
+				className="pointer-events-none absolute end-2 top-1/2 size-3.5 -translate-y-1/2 text-gray-400 dark:text-gray-500"
+				strokeWidth="2"
+			/>
+		</button>
+
+		<div slot="content" style={triggerWidth ? `min-width: ${triggerWidth}px` : undefined}>
+			<DropdownMenu>
+				{#each items as item}
+					<button
+						type="button"
+						disabled={item.disabled}
+						class={isSameValue(item.value, value) ? '' : 'text-gray-500 dark:text-gray-400'}
+						on:click={() => selectOption(item)}
+					>
+						<span class="min-w-0 truncate {item.disabled ? 'opacity-50' : ''}">{item.label}</span>
+					</button>
+				{/each}
+			</DropdownMenu>
+		</div>
+	</Dropdown>
 </div>


### PR DESCRIPTION
<!--
⚠️ CRITICAL CHECKS FOR CONTRIBUTORS (READ, DON'T DELETE) ⚠️
1. Target the `dev` branch. PRs targeting `main` will be automatically closed.
2. First-time contributors should not open pull requests directly unless the pull request contains only i18n/localization updates.
   Do not open a PR as the first step.
   For real, reproducible bugs, start with a well-described Issue that explains the problem, why it matters, and what outcome you are looking for.
   For feature requests, enhancements, behavior changes, UI/UX changes, architecture changes, suspected fixes, or unconfirmed approaches, start with an active Discussion.
   If you want to propose an implementation, include it only as a reference in the Issue or Discussion, such as a local diff, patch, or branch.
   Opening an Issue or Discussion does not mean a PR is the right next step. Maintainers will confirm when a PR would be useful.
   We ask for this because PRs, especially from first-time contributors, often need broader maintainer context on product direction, scope, architecture, UX, edge cases, compatibility, documentation, and long-term maintenance before implementation.
   We may close unsolicited PRs without review.
   Contributors with a history of successful merged PRs may be given more latitude.
3. Do NOT delete the CLA section at the bottom. It is required for the bot to accept your PR.
-->

# Pull Request Checklist

**Before submitting, make sure you've checked and filled out the following:**

- [x] **Linked Issue/Discussion:** This PR references an existing, well-described [Issue](https://github.com/open-webui/open-webui/issues) for a real bug or an active, substantive [Discussion](https://github.com/open-webui/open-webui/discussions) for a feature request or enhancement — `Closes #29032`.
- [ ] **First-time contributor policy:** This is not my first contribution to Open WebUI, this PR contains only i18n/localization updates, or a maintainer explicitly asked me to open this PR after reviewing the linked Issue or Discussion.
- [x] **Target branch:** The pull request targets the `dev` branch. **PRs targeting `main` will be immediately closed.**
- [x] **Description:** A concise description of the changes is provided below.
- [x] **Changelog:** A changelog entry following [Keep a Changelog](https://keepachangelog.com/) format is included at the bottom.
- [ ] **Documentation:** Relevant documentation has been added or updated in the [Open WebUI Docs Repository](https://github.com/open-webui/docs).
- [ ] **Dependencies:** Any new or updated dependencies are explained, tested, and documented.
- [ ] **Testing:** **Manual** end-to-end tests have been performed to verify the fix/feature works correctly and does not introduce regressions. Screenshots or recordings are included where applicable.
- [x] **User-facing changes:** I have confirmed whether this PR changes the UI. If it does, screenshots are required, and a video recording is recommended.
- [x] **No Unchecked AI Code:** This PR is either human-written or has undergone thorough human review AND manual testing. Unreviewed AI-generated PRs may be closed immediately.
- [x] **Self-Review:** A self-review of the code has been performed, ensuring adherence to project coding standards.
- [x] **Architecture:** Smart defaults are preferred over new settings. Local state is used for ephemeral UI logic. Major architectural or UX changes have been discussed first.
- [x] **Git Hygiene:** The PR is atomic (one logical change), rebased on `dev`, and contains no unrelated commits.
- [x] **Title Prefix:** The PR title uses one of the following prefixes:
  - **fix**: Bug fixes or corrections

# Changelog Entry

### Description

- Settings dropdowns (theme, language, and the rest of the settings modal selects) now open a themed DOM menu instead of a native `<select>` popup, so dark / OLED themes stay dark in Firefox as well as Chromium.

### Fixed

- Dropdown menus in the settings modal no longer render with a white background under dark themes on Firefox.

---

### Additional Information

Confirmed bug: #29032. A collaborator already traced this to native `<select>` popups: `.dark select option` styles the list on Chromium, but Firefox (especially on Linux) ignores author colors for that popup. CSS, including `color-scheme: dark`, cannot fix it. The path they pointed at is the custom select already used elsewhere, which paints its list from regular DOM.

`SettingsSelect` is the control those settings dropdowns share. It still takes `<option>` children and `bind:value` / `on:change`, so call sites stay as they are. The native select is kept hidden as the option source (and for form `name` / `required`). The visible trigger and list use `Dropdown` + `DropdownMenu`, which already ship `dark:bg-gray-850`.

`admin/Settings/Audio.svelte` was reading `e.currentTarget.value` off the native change event. It now uses the bound `TTS_ENGINE` value.

Call sites were left in place on purpose. The slot API is used in a lot of settings files, including `{#each}` option lists and numeric values.

This is a first contribution. Happy to close this and wait if you'd rather have a maintainer take it.

### Screenshots or Videos

Before (from #29032): the theme menu in the settings modal is a white native popup against the dark modal.

After: the same control opens the shared `DropdownMenu` (dark gray background, light text) instead of the OS/Firefox select popup.

Please check on Firefox with Dark / OLED Dark / System-dark: Settings → Theme, then Language and any other settings dropdown.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.