### PR TITLE
fix: keep the mobile sidebar swipe out of dialogs and text selection

### DIFF
--- a/src/lib/components/common/MobileSwipePanel.svelte
+++ b/src/lib/components/common/MobileSwipePanel.svelte
@@ -62,9 +62,18 @@
 		return (
 			target instanceof Element &&
 			!!target.closest(
-				'input, textarea, select, [role="menu"], [contenteditable="true"], [data-sidebar-no-gesture]'
+				'input, textarea, select, [role="dialog"], [role="menu"], [contenteditable="true"], [data-sidebar-no-gesture]'
 			)
 		);
+	};
+
+	const hasTextSelection = () => {
+		if (typeof window === 'undefined') {
+			return false;
+		}
+
+		const selection = window.getSelection();
+		return !!selection && !selection.isCollapsed;
 	};
 
 	const canScrollHorizontally = (target: EventTarget | null, dx: number) => {
@@ -161,7 +170,7 @@
 	};
 
 	const onTouchStart = (e: TouchEvent) => {
-		if (!enabled || e.touches.length !== 1 || shouldSkipSwipe(e.target)) {
+		if (!enabled || e.touches.length !== 1 || shouldSkipSwipe(e.target) || hasTextSelection()) {
 			return;
 		}
 
@@ -214,6 +223,11 @@
 			}
 
 			if (absX > absY && canScrollHorizontally(e.target, dx)) {
+				cancelSwipe();
+				return;
+			}
+
+			if (hasTextSelection()) {
 				cancelSwipe();
 				return;
 			}


### PR DESCRIPTION
# Pull Request

## Checklist

- [x] This PR targets the `dev` branch.
- [x] This PR links to a confirmed Issue or active Discussion: `Closes #29221`.
- [x] A maintainer explicitly asked me to open this PR, or this PR only updates i18n/localization.
- [x] The change is one logical unit with no unrelated commits.
- [x] I matched nearby code patterns and avoided unnecessary new settings, abstractions, or dependencies.
- [x] I manually tested the changed workflow and any nearby behavior that could be affected.
- [ ] I updated relevant docs, including the [Open WebUI Docs Repository](https://github.com/open-webui/docs), if needed.
- [ ] I added screenshots for UI changes, and a recording when motion or interaction matters.
- [x] I reviewed any AI-generated code before submitting it.
- [x] The PR title uses one of the prefixes listed below.

## Summary

The mobile sidebar swipe gesture from v0.11.1 stays active where it should yield (#29221): its touch listeners attach to `window`, so a swipe over the open Settings modal still drives the sidebar (and highlights the modal's `> Back` option when the swipe starts there), and once the gesture locks it calls `preventDefault()` on a non passive listener and flips the page to `touch-action: pan-y`, which takes over text selection drags.

The fix widens the gesture's own two guard points in MobileSwipePanel.svelte, using the mechanisms the component already has:

1. `[role="dialog"]` joins the `shouldSkipSwipe` selector, so a touch that starts inside any open Modal (the Modal component renders `role="dialog"`) never begins gesture tracking. The sidebar drawer itself carries no dialog role, so swipe to close from over the sidebar is unaffected.
2. A `hasTextSelection` check (non collapsed `window.getSelection()`) skips the gesture at `touchstart` when a selection already exists, and cancels it before the axis lock engages when a selection appears mid touch, next to the existing `canScrollHorizontally` cancel.

```diff
 			!!target.closest(
-				'input, textarea, select, [role="menu"], [contenteditable="true"], [data-sidebar-no-gesture]'
+				'input, textarea, select, [role="dialog"], [role="menu"], [contenteditable="true"], [data-sidebar-no-gesture]'
 			)
 		);
 	};
+
+	const hasTextSelection = () => {
+		if (typeof window === 'undefined') {
+			return false;
+		}
+
+		const selection = window.getSelection();
+		return !!selection && !selection.isCollapsed;
+	};
```

```diff
-		if (!enabled || e.touches.length !== 1 || shouldSkipSwipe(e.target)) {
+		if (!enabled || e.touches.length !== 1 || shouldSkipSwipe(e.target) || hasTextSelection()) {
 			return;
 		}
```

```diff
 			if (absX > absY && canScrollHorizontally(e.target, dx)) {
 				cancelSwipe();
 				return;
 			}
+
+			if (hasTextSelection()) {
+				cancelSwipe();
+				return;
+			}
```

One file, 16 insertions, 2 deletions.

This PR was prepared with AI copilot assistance and I have thoroughly reviewed and manually tested it.

## Testing

1. Verified on my iPhone against the fix branch: with the Settings modal open, horizontal swipes no longer drive the sidebar, including swipes started over the `> Back` option, and `> Back` no longer gets highlighted by a swipe.
2. Verified on the same device that selecting text works without the sidebar swipe gesture taking over the drag.
3. Before the device test, I also reproduced the modal half of the fix in a desktop mobile viewport.

## Changelog Entry

### Fixed

- The mobile sidebar swipe gesture no longer activates for touches inside an open modal and no longer interferes with selecting text to copy.

## Additional Context

Root cause detail with permalinks is in #29221. The two guard points extended here are the component's existing skip selector and its pre lock cancel path; no new mechanism is introduced.

## Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
