### PR TITLE
fix: keep select dropdowns inside the viewport

### DIFF
--- a/src/lib/components/common/Select.svelte
+++ b/src/lib/components/common/Select.svelte
@@ -74,11 +74,21 @@
 			contentEl.style.bottom = 'auto';
 		}
 
+		const contentWidth = contentEl.offsetWidth || 0;
+
 		if (align === 'end') {
-			contentEl.style.right = `${window.innerWidth - rect.right}px`;
+			let right = window.innerWidth - rect.right;
+			if (right + contentWidth > window.innerWidth) {
+				right = window.innerWidth - contentWidth - 16;
+			}
+			contentEl.style.right = `${Math.max(16, right)}px`;
 			contentEl.style.left = 'auto';
 		} else {
-			contentEl.style.left = `${rect.left}px`;
+			let left = rect.left;
+			if (left + contentWidth + 16 > window.innerWidth) {
+				left = window.innerWidth - contentWidth - 16;
+			}
+			contentEl.style.left = `${Math.max(16, left)}px`;
 			contentEl.style.right = 'auto';
 		}
 	}


### PR DESCRIPTION
# Pull Request

## Checklist

- [x] This PR targets the `dev` branch.
- [x] This PR links to a confirmed Issue or active Discussion: `Closes #29225`.
- [x] A maintainer explicitly asked me to open this PR, or this PR only updates i18n/localization.
- [x] The change is one logical unit with no unrelated commits.
- [x] I matched nearby code patterns and avoided unnecessary new settings, abstractions, or dependencies.
- [x] I manually tested the changed workflow and any nearby behavior that could be affected.
- [ ] I updated relevant docs, including the [Open WebUI Docs Repository](https://github.com/open-webui/docs), if needed.
- [x] I added screenshots for UI changes, and a recording when motion or interaction matters.
- [x] I reviewed any AI-generated code before submitting it.
- [x] The PR title uses one of the prefixes listed below.

## Summary

The `All` and `Sort` dropdowns on the Workspace Knowledge collection page open past the left edge of the screen at mobile widths, so most of each option label is cut off (#29225).

`positionContent()` in `Select.svelte` portals the menu to `document.body` and pins one of its edges to the matching edge of the trigger, with no clamp against the viewport. For `align="end"` it sets `right: window.innerWidth - rect.right`, so the menu grows leftward from the trigger's right edge. Those two dropdowns are the first controls in the filter row, so their right edge sits a few dozen pixels from the left of the screen while the menu is as wide as its longest label, and the remainder lands at a negative x position. The `align="start"` branch has the mirror problem for a trigger near the right edge.

`Dropdown.svelte` already solves this for the other portaled menu in Open WebUI: it measures the content, shifts the menu back inside the viewport when the pinned edge would push it out, and keeps a 16px margin. This change ports that same block into `Select.svelte` rather than introducing a different positioning approach, so both menus behave the same way. The clamp only engages when the menu would overflow, so alignment against the trigger is unchanged wherever there is room.

```diff
+		const contentWidth = contentEl.offsetWidth || 0;
+
 		if (align === 'end') {
-			contentEl.style.right = `${window.innerWidth - rect.right}px`;
+			let right = window.innerWidth - rect.right;
+			if (right + contentWidth > window.innerWidth) {
+				right = window.innerWidth - contentWidth - 16;
+			}
+			contentEl.style.right = `${Math.max(16, right)}px`;
 			contentEl.style.left = 'auto';
 		} else {
-			contentEl.style.left = `${rect.left}px`;
+			let left = rect.left;
+			if (left + contentWidth + 16 > window.innerWidth) {
+				left = window.innerWidth - contentWidth - 16;
+			}
+			contentEl.style.left = `${Math.max(16, left)}px`;
 			contentEl.style.right = 'auto';
 		}
```

One file, 12 insertions, 2 deletions. Because the fix sits in `Select.svelte`, it also covers the equivalent filter rows that reach the same component through `ViewSelector` (Tools, Skills, Prompts) and `DropdownOptions` (Notes).

This PR was prepared with AI copilot assistance and I have thoroughly reviewed and manually tested it.

## Testing

1. Opened a Workspace Knowledge collection on my iPhone and in a mobile device viewport, then opened the `All` and `Sort` dropdowns. Before the change both menus are clipped off the left edge; after it they open fully inside the screen with their labels readable.
2. Checked the same dropdowns at desktop width, where the menus still align against their trigger as before.
3. Checked the sort direction dropdown that appears once a sort key is selected, and the equivalent filter rows on other workspace pages that use the same component.

## Changelog Entry

### Fixed

- Select dropdowns no longer open past the edge of the screen at narrow widths; menus are shifted back inside the viewport when the trigger sits too close to an edge.

## Additional Context

The clamp is the same block already used by `Dropdown.svelte`, so no new positioning helper is introduced. Vertical placement is left as it is; this change only addresses the horizontal overflow reported in #29225.

| Surface | Before | After |
|---|---|---|
| Workspace Knowledge, `All` dropdown (mobile) | <img width="779" height="934" alt="Image" src="https://github.com/user-attachments/assets/40203053-efa7-4aa1-8575-05234964468f" /> | <img width="779" height="934" alt="image" src="https://github.com/user-attachments/assets/39613256-d1a8-4469-85f3-e9ef05c41e59" /> |
| Workspace Knowledge, `Sort` dropdown (mobile) | <img width="779" height="934" alt="Image" src="https://github.com/user-attachments/assets/89eb802a-83be-4df2-8836-93de4cca5495" /> | <img width="779" height="934" alt="image" src="https://github.com/user-attachments/assets/4c714bf1-0bdc-47d8-8a02-ffb0453328b3" /> |

Before is current `dev`, After is this branch.

## Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
