### PR TITLE
fix: let setting row controls shrink so long values do not squeeze the label

### DIFF
--- a/src/lib/components/admin/Settings/AdminSettingRow.svelte
+++ b/src/lib/components/admin/Settings/AdminSettingRow.svelte
@@ -14,7 +14,7 @@
 		<slot name="label">{label}</slot>
 	</div>
 
-	<div class="shrink-0">
+	<div class="min-w-0">
 		<slot {labelId} />
 	</div>
 </div>

--- a/src/lib/components/chat/Settings/UserSettingRow.svelte
+++ b/src/lib/components/chat/Settings/UserSettingRow.svelte
@@ -10,7 +10,7 @@
 		<slot name="label">{label}</slot>
 	</div>
 
-	<div class="shrink-0">
+	<div class="min-w-0">
 		<slot />
 	</div>
 </div>


### PR DESCRIPTION
# Pull Request

## Checklist

- [x] This PR targets the `dev` branch.
- [x] This PR links to a confirmed Issue or active Discussion: `Closes #29231`.
- [x] A maintainer explicitly asked me to open this PR, or this PR only updates i18n/localization.
- [x] The change is one logical unit with no unrelated commits.
- [x] I matched nearby code patterns and avoided unnecessary new settings, abstractions, or dependencies.
- [x] I manually tested the changed workflow and any nearby behavior that could be affected.
- [ ] I updated relevant docs, including the [Open WebUI Docs Repository](https://github.com/open-webui/docs), if needed.
- [x] I added screenshots for UI changes, and a recording when motion or interaction matters.
- [x] I reviewed any AI-generated code before submitting it.
- [x] The PR title uses one of the prefixes listed below.

## Summary

In the admin `Authentication` settings, a long group name makes the `Default Group` control stretch across the whole row and squeezes the `Default Group` label down to a sliver, so the label text is forced to break apart and read vertically at narrow widths.

`AdminSettingRow` puts the label and the control in one flex row, with `min-w-0` on the label and `shrink-0` on the control:

```svelte
<div class="min-w-0 text-xs ...">
	<slot name="label">{label}</slot>
</div>

<div class="shrink-0">
	<slot {labelId} />
</div>
```

`SettingsSelect` renders its `select` with `[field-sizing:content]`, so the control is as wide as the selected option's text, and its `max-w-full` cap resolves against the `shrink-0` wrapper, which is itself sized by that same content. The control therefore never yields, while `min-w-0` lets the label give up all of its width, so the label absorbs the entire shortfall.

Swapping `shrink-0` for `min-w-0` on the control lets the row split the shortfall between the two sides, which is what makes the `truncate` and `max-w-full` already on the `select` take effect.

`chat/Settings/UserSettingRow.svelte` is the same component for the user settings modal and carries the same two classes, so it gets the same one class change here and the two row layouts stay consistent. I did not find a user settings row whose value is long enough to squeeze its label today, so that half is a latent case rather than a visible bug: the longest option in those rows is the language name `Indonesian (Bahasa Indonesia)`, which still leaves the label at its natural width at phone widths and at 1.2x UI scale.

```diff
 	<div id={labelId} class="min-w-0 text-xs text-gray-600 dark:text-gray-400 {labelClassName}">
 		<slot name="label">{label}</slot>
 	</div>
 
-	<div class="shrink-0">
+	<div class="min-w-0">
 		<slot {labelId} />
 	</div>
```

```diff
 	<div class="min-w-0 text-xs text-gray-600 dark:text-gray-400 {labelClassName}">
 		<slot name="label">{label}</slot>
 	</div>
 
-	<div class="shrink-0">
+	<div class="min-w-0">
 		<slot />
 	</div>
```

Controls that are not text driven are unaffected, because a wrapping label never creates a horizontal shortfall in the first place; only a nowrap control like the select does. Two files, one class each.

This PR was prepared with AI copilot assistance and I have thoroughly reviewed and manually tested it.

## Testing

1. Created a group with a long name, set it as `Default Group` in the admin `Authentication` settings, and viewed the page at a phone width. Before the change the label collapses and reads vertically; after it the label stays readable and the select truncates.
2. Checked the neighbouring rows on the same page, `Default User Role` with its short options and the `New Sign Ups`, `API Keys`, and `API Key Endpoint Restrictions` switches, which render as before at both phone and desktop widths.
3. Opened the user settings modal, whose rows use the same component, and checked that the `General` and `Audio` tabs render as before.

Supporting evidence from an isolated layout harness (Chromium, 320px row) reproducing the same markup: the label measures 6.5px wide before the change and 57.7px after, while the select drops from 297.5px to 246.3px and truncates. The same harness shows a switch row and a short select row measuring identically before and after.

## Changelog Entry

### Fixed

- A long value no longer stretches the control across a settings row and squeezes its label into vertical text, in both the admin and the user settings rows.

## Additional Context

The fix sits in the row components because they own how width is divided between the label and the control; capping the select per call site would leave the same shortfall for the next long value in any other row. `AdminSettingRow` and `UserSettingRow` are the only two places that wrap a `<slot>` in a rigid, uncapped flex item, so between them they cover every settings row.

| Surface | Before | After |
|---|---|---|
| Admin `Authentication`, `Default Group` row (mobile) | <img width="391" height="851" alt="image" src="https://github.com/user-attachments/assets/9216304d-8f01-4957-bd99-049c534ed023" /> | <img width="391" height="851" alt="image" src="https://github.com/user-attachments/assets/fa7b798d-12a3-4604-a212-fe1ee6bf8015" /> |

Before is current `dev`, After is this branch.

## Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.



