### PR TITLE
fix: let the model defaults capability and prompt suggestion sections scroll

### DIFF
--- a/src/lib/components/admin/Settings/Models/ModelDefaultsPanel.svelte
+++ b/src/lib/components/admin/Settings/Models/ModelDefaultsPanel.svelte
@@ -168,7 +168,11 @@
 					</button>
 
 					{#if showCapabilities}
-						<div class="pb-2" on:click={updateDirty} on:change={updateDirty}>
+						<div
+							class="max-h-[24rem] overflow-y-auto pb-2 pr-1 scrollbar-hover"
+							on:click={updateDirty}
+							on:change={updateDirty}
+						>
 							<Capabilities bind:capabilities={defaultCapabilities} />
 
 							{#if availableFeatures.length > 0}
@@ -231,7 +235,12 @@
 					</button>
 
 					{#if showPromptSuggestions}
-						<div class="pb-2" on:click={updateDirty} on:change={updateDirty} on:input={updateDirty}>
+						<div
+							class="max-h-[24rem] overflow-y-auto pb-2 pr-1 scrollbar-hover"
+							on:click={updateDirty}
+							on:change={updateDirty}
+							on:input={updateDirty}
+						>
 							<PromptSuggestions bind:promptSuggestions />
 						</div>
 					{/if}


### PR DESCRIPTION
# Pull Request

## Checklist

- [x] This PR targets the `dev` branch.
- [x] This PR links to a confirmed Issue or active Discussion: `Closes #29234`.
- [x] A maintainer explicitly asked me to open this PR, or this PR only updates i18n/localization.
- [x] The change is one logical unit with no unrelated commits.
- [x] I matched nearby code patterns and avoided unnecessary new settings, abstractions, or dependencies.
- [x] I manually tested the changed workflow and any nearby behavior that could be affected.
- [ ] I updated relevant docs, including the [Open WebUI Docs Repository](https://github.com/open-webui/docs), if needed.
- [x] I added screenshots for UI changes, and a recording when motion or interaction matters.
- [x] I reviewed any AI-generated code before submitting it.
- [x] The PR title uses one of the prefixes listed below.

## Summary

On a phone, the `Model Capabilities` and `Prompt Suggestions` sections of `Model Defaults` on the admin `Models` page cannot be scrolled: their content runs past the bottom of the panel and the rest is unreachable. `Model Parameters` in the same panel scrolls normally (#29234).

Root cause, anchored to commit a93c5080380447e3ab9113cacb73b61c57cbc308: the three sections are not consistent. `Model Parameters` wraps its content in its own capped scroll container, [`max-h-[24rem] overflow-y-auto pb-2 pr-1 scrollbar-hover`](https://github.com/open-webui/open-webui/blob/a93c5080380447e3ab9113cacb73b61c57cbc308/src/lib/components/admin/Settings/Models/ModelDefaultsPanel.svelte#L207), while `Model Capabilities` and `Prompt Suggestions` are plain `pb-2` wrappers with no height cap and no overflow.

That difference only bites because nothing above them can scroll either. The panel's root is [`<div class="shrink-0">`](https://github.com/open-webui/open-webui/blob/a93c5080380447e3ab9113cacb73b61c57cbc308/src/lib/components/admin/Settings/Models/ModelDefaultsPanel.svelte#L126), so it keeps its full content height inside the [column that holds it](https://github.com/open-webui/open-webui/blob/a93c5080380447e3ab9113cacb73b61c57cbc308/src/lib/components/admin/Settings/Models.svelte#L748), and the nearest `overflow-y-auto` in that column belongs to the [model list underneath](https://github.com/open-webui/open-webui/blob/a93c5080380447e3ab9113cacb73b61c57cbc308/src/lib/components/admin/Settings/Models.svelte#L925) rather than to the panel. Once an expanded section is taller than the space available, there is no scroll container anywhere in the chain to reach the rest of it. `Model Parameters` escapes this only because it caps itself. The symptom shows up on a phone because the available height is small; on a tall desktop window the sections usually fit.

This gives the two sections the same capped scroll container `Model Parameters` already uses, so all three behave the same way. No new mechanism and no markup restructuring.

```diff
 					{#if showCapabilities}
-						<div class="pb-2" on:click={updateDirty} on:change={updateDirty}>
+						<div
+							class="max-h-[24rem] overflow-y-auto pb-2 pr-1 scrollbar-hover"
+							on:click={updateDirty}
+							on:change={updateDirty}
+						>
```

```diff
 					{#if showPromptSuggestions}
-						<div class="pb-2" on:click={updateDirty} on:change={updateDirty} on:input={updateDirty}>
+						<div
+							class="max-h-[24rem] overflow-y-auto pb-2 pr-1 scrollbar-hover"
+							on:click={updateDirty}
+							on:change={updateDirty}
+							on:input={updateDirty}
+						>
```

This PR was prepared with AI copilot assistance and I have thoroughly reviewed and manually tested it.

## Testing

1. On this branch, opened the admin `Models` page at a phone width, expanded `Model Defaults`, then `Model Capabilities`, and scrolled through the full capability list.
2. Did the same with `Prompt Suggestions` and scrolled through the full list.
3. Checked that `Model Parameters` still scrolls as it did before.

## Changelog Entry

### Fixed

- The `Model Capabilities` and `Prompt Suggestions` sections of `Model Defaults` on the admin `Models` page can now be scrolled on small screens, matching `Model Parameters`.

## Additional Context

There is a larger shape worth considering, and I am happy to switch to it if you prefer. Instead of capping each section, the panel body itself could become the single scroll container: drop `shrink-0` from the panel root and let it shrink with `overflow-y-auto`. That would cover any section added later without repeating the wrapper, and it avoids having three separate scroll areas inside one panel. It also changes how the panel and the model list share the available height, which is a layout decision rather than a bug fix, so I kept this PR to the smaller change that matches the container already in the file.

| Surface | Before | After |
|---|---|---|
| Admin `Models`, `Model Defaults` > `Model Capabilities` (mobile) | <img width="393" height="851" alt="Image" src="https://github.com/user-attachments/assets/e285ea57-1bb7-45af-9b29-fa0a22bd8cb6" /> | <img width="393" height="851" alt="image" src="https://github.com/user-attachments/assets/463df683-085b-4484-8d5d-6282abdfc1d3" /> |
| Admin `Models`, `Model Defaults` > `Prompt Suggestions` (mobile) | <img width="393" height="851" alt="Image" src="https://github.com/user-attachments/assets/6794bd99-0aec-40fd-b2d2-7af70c6b67b2" /> | <img width="393" height="851" alt="image" src="https://github.com/user-attachments/assets/5f359e61-c634-4fc6-aab0-4298a9077d1b" /> |

Before is current `dev`, After is this branch.

## Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
