### PR TITLE
fix: omit empty Authorization headers for tool servers

### DIFF
--- a/backend/open_webui/utils/tools.py
+++ b/backend/open_webui/utils/tools.py
@@ -148,15 +148,15 @@ async def build_tool_server_headers(
     cookies = {}
 
     if auth_type == 'bearer':
-        headers['Authorization'] = f'Bearer {connection.get("key", "")}'
+        headers.update(bearer_auth_header(connection.get('key', '')))
     elif auth_type == 'session':
         cookies = request.cookies if hasattr(request, 'cookies') else {}
-        headers['Authorization'] = f'Bearer {request.state.token.credentials}'
+        headers.update(bearer_auth_header(request.state.token.credentials))
     elif auth_type == 'system_oauth':
         cookies = request.cookies if hasattr(request, 'cookies') else {}
         oauth_token = extra_params.get('__oauth_token__', None)
         if oauth_token:
-            headers['Authorization'] = f'Bearer {oauth_token.get("access_token", "")}'
+            headers.update(bearer_auth_header(oauth_token.get('access_token', '')))
     elif auth_type in ('oauth_2.1', 'oauth_2.1_static'):
         try:
             splits = server_id.split(':')
@@ -166,7 +166,7 @@ async def build_tool_server_headers(
                 user.id, f'{connection_type}:{oauth_server_id}'
             )
             if oauth_token:
-                headers['Authorization'] = f'Bearer {oauth_token.get("access_token", "")}'
+                headers.update(bearer_auth_header(oauth_token.get('access_token', '')))
         except Exception as e:
             log.error(f'Error getting OAuth token: {e}')
 

--- a/test/test_tools.py
+++ b/test/test_tools.py
@@ -1,0 +1,45 @@
+import asyncio
+from types import SimpleNamespace
+
+from open_webui.utils.tools import build_tool_server_headers
+
+
+class EmptyOAuthClientManager:
+    async def get_oauth_token(self, user_id, server_id):
+        return {'access_token': ''}
+
+
+def _request():
+    return SimpleNamespace(
+        app=SimpleNamespace(state=SimpleNamespace(oauth_client_manager=EmptyOAuthClientManager())),
+        cookies={},
+        state=SimpleNamespace(token=SimpleNamespace(credentials='')),
+    )
+
+
+def _user():
+    return SimpleNamespace(id='user-id', name='Test User', email='test@example.com', role='user')
+
+
+def test_build_tool_server_headers_omits_empty_bearer_tokens():
+    request = _request()
+    user = _user()
+    cases = [
+        ({'auth_type': 'bearer', 'key': ''}, {}),
+        ({'auth_type': 'session'}, {}),
+        ({'auth_type': 'system_oauth'}, {'__oauth_token__': {'access_token': ''}}),
+        ({'auth_type': 'oauth_2.1'}, {}),
+    ]
+
+    for connection, extra_params in cases:
+        headers, _ = asyncio.run(
+            build_tool_server_headers(
+                connection,
+                request,
+                user,
+                server_id='server-id',
+                extra_params=extra_params,
+            )
+        )
+
+        assert 'Authorization' not in headers


### PR DESCRIPTION
## Summary

- Reuse `bearer_auth_header` in `build_tool_server_headers` for bearer, session, and OAuth credentials.
- Omit the `Authorization` header when a configured token or OAuth `access_token` is empty.
- Add a regression test covering empty bearer credentials and OAuth access tokens.

Closes #29222

## Testing

- `pytest -q test/test_tools.py` (1 passed)
- `ruff format --check . --exclude .venv --exclude venv`
- `ruff check --select=F --ignore=F401,F403,F405,F541,F811,F841 --output-format=concise .`

### Changelog Entry

#### Fixed

- Avoid sending invalid empty Bearer authorization headers to tool servers.
