### PR TITLE
fix: omit empty Authorization headers for tool servers

### DIFF
--- a/backend/open_webui/utils/tools.py
+++ b/backend/open_webui/utils/tools.py
@@ -148,15 +148,15 @@ async def build_tool_server_headers(
     cookies = {}
 
     if auth_type == 'bearer':
-        headers['Authorization'] = f'Bearer {connection.get("key", "")}'
+        headers.update(bearer_auth_header(connection.get('key', '')))
     elif auth_type == 'session':
         cookies = request.cookies if hasattr(request, 'cookies') else {}
-        headers['Authorization'] = f'Bearer {request.state.token.credentials}'
+        headers.update(bearer_auth_header(request.state.token.credentials))
     elif auth_type == 'system_oauth':
         cookies = request.cookies if hasattr(request, 'cookies') else {}
         oauth_token = extra_params.get('__oauth_token__', None)
         if oauth_token:
-            headers['Authorization'] = f'Bearer {oauth_token.get("access_token", "")}'
+            headers.update(bearer_auth_header(oauth_token.get('access_token', '')))
     elif auth_type in ('oauth_2.1', 'oauth_2.1_static'):
         try:
             splits = server_id.split(':')
@@ -166,7 +166,7 @@ async def build_tool_server_headers(
                 user.id, f'{connection_type}:{oauth_server_id}'
             )
             if oauth_token:
-                headers['Authorization'] = f'Bearer {oauth_token.get("access_token", "")}'
+                headers.update(bearer_auth_header(oauth_token.get('access_token', '')))
         except Exception as e:
             log.error(f'Error getting OAuth token: {e}')
 

--- a/test/test_tools.py
+++ b/test/test_tools.py
@@ -1,0 +1,45 @@
+import asyncio
+from types import SimpleNamespace
+
+from open_webui.utils.tools import build_tool_server_headers
+
+
+class EmptyOAuthClientManager:
+    async def get_oauth_token(self, user_id, server_id):
+        return {'access_token': ''}
+
+
+def _request():
+    return SimpleNamespace(
+        app=SimpleNamespace(state=SimpleNamespace(oauth_client_manager=EmptyOAuthClientManager())),
+        cookies={},
+        state=SimpleNamespace(token=SimpleNamespace(credentials='')),
+    )
+
+
+def _user():
+    return SimpleNamespace(id='user-id', name='Test User', email='test@example.com', role='user')
+
+
+def test_build_tool_server_headers_omits_empty_bearer_tokens():
+    request = _request()
+    user = _user()
+    cases = [
+        ({'auth_type': 'bearer', 'key': ''}, {}),
+        ({'auth_type': 'session'}, {}),
+        ({'auth_type': 'system_oauth'}, {'__oauth_token__': {'access_token': ''}}),
+        ({'auth_type': 'oauth_2.1'}, {}),
+    ]
+
+    for connection, extra_params in cases:
+        headers, _ = asyncio.run(
+            build_tool_server_headers(
+                connection,
+                request,
+                user,
+                server_id='server-id',
+                extra_params=extra_params,
+            )
+        )
+
+        assert 'Authorization' not in headers


### PR DESCRIPTION
## Checklist

- [x] This PR targets the `dev` branch.
- [x] This PR links to a well-described, confirmed Issue: `Closes #29222`.
- [ ] A maintainer explicitly asked me to open this PR, or this PR only updates i18n/localization.
- [x] The change is one logical unit with no unrelated commits.
- [x] I matched nearby code patterns and avoided unnecessary new settings, abstractions, or dependencies.
- [x] I manually tested the changed workflow and nearby affected behavior.
- [x] I reviewed the implementation before submitting it.
- [x] The PR title uses the `fix` prefix.

## Summary

`build_tool_server_headers` now reuses `bearer_auth_header` for bearer, session, and OAuth credentials. Empty configured tokens no longer create an invalid `Authorization: Bearer ` header, while non-empty tokens keep the existing authentication behavior.

## Testing

- `pytest -q test/test_tools.py` (1 passed)
- `ruff format --check . --exclude .venv --exclude venv`
- `ruff check --select=F --ignore=F401,F403,F405,F541,F811,F841 --output-format=concise .`

## Changelog Entry

### Added

-

### Changed

-

### Fixed

- Avoid sending invalid empty Bearer authorization headers to tool servers.

### Removed

-

### Security

-

### Breaking Changes

-

## Additional Context

The regression test covers empty bearer credentials and empty OAuth access tokens for the affected tool-server auth paths.

## Contributor License Agreement

<!--
DO NOT DELETE THIS SECTION.
Your PR will not be reviewed or merged until you check the box below confirming that you have read and agree to the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
