### PR TITLE
fix: announce assistant responses to screen readers

### DIFF
--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -814,6 +814,9 @@
 							bind:this={contentContainerElement}
 							class="w-full flex flex-col relative {edit ? 'hidden' : ''}"
 							id="response-content-container"
+							role="status"
+							aria-live="polite"
+							aria-atomic="false"
 						>
 							{#if hasResponseContent && message.error !== true}
 								<!-- always show message contents even if there's an error -->


### PR DESCRIPTION
## Summary

- mark the assistant response container as a polite live region
- announce streamed response updates without interrupting the screen reader
- keep updates non-atomic so only changed content is announced

Fixes part of #2790.

## Validation

- `git diff --check` passes
- full frontend checks could not be run because dependency installation repeatedly encountered corrupted npm tarballs and timed out