### PR TITLE
fix: only resync a chat when the message whose completion ended is still unfinished

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -1219,7 +1219,12 @@
 				} else if (type === 'chat:active') {
 					if (!data?.active) {
 						taskIds = null;
-						if ($chatId && !$temporaryChatEnabled && hasPendingAssistantLeaf()) {
+						if (
+							$chatId &&
+							!$temporaryChatEnabled &&
+							!message.done &&
+							(message.childrenIds?.length ?? 0) === 0
+						) {
 							await loadChat();
 						}
 						if ($chatId && !$temporaryChatEnabled) {


### PR DESCRIPTION
# Pull Request

## Checklist

- [x] This PR targets the `dev` branch.
- [x] This PR links to a well-described, confirmed Issue or active Discussion: `Closes #29236`.
- [x] A maintainer explicitly asked me to open this PR, or this PR only updates i18n/localization.
- [x] The change is one logical unit with no unrelated commits.
- [x] I matched nearby code patterns and avoided unnecessary new settings, abstractions, or dependencies.
- [x] I manually tested the changed workflow and any nearby behavior that could be affected.
- [ ] I updated relevant docs, including the [Open WebUI Docs Repository](https://github.com/open-webui/docs), if needed.
- [ ] I added screenshots for UI changes, and a recording when motion or interaction matters.
- [x] I reviewed any AI-generated code before submitting it.
- [x] The PR title uses one of the prefixes listed below.

## Summary

A message queued while an `ask_user` prompt is pending is sent and answered, but the answer is never drawn: the conversation and the Overview tab stay missing the response, and sometimes the queued user message too, until the page is reloaded or another message is sent (#29236).

Root cause, anchored to commit a93c5080380447e3ab9113cacb73b61c57cbc308. When a completion ends the server emits `chat:active` with `active: false`, and the handler reloads the whole chat if any assistant leaf anywhere in the history is unfinished:

```js
if ($chatId && !$temporaryChatEnabled && hasPendingAssistantLeaf()) {
	await loadChat();
}
```

The queue is flushed as soon as that completion finishes, so `submitPrompt` has already created the next user message and its assistant placeholder by the time the event arrives. That placeholder is an assistant message that is not `done` and has no children, which is exactly what `hasPendingAssistantLeaf` looks for, so the handler treats a request that is legitimately in flight as evidence that the client is out of sync. `loadChat` then assigns `history = chatContent.history`, and because the new response has not been persisted yet, its id disappears from the local history. From that point every socket event for it is discarded by the `let message = history.messages[event.message_id]; if (message) { ... }` lookup, so the model's answer is generated and stored but never rendered. Reloading, or sending another message, rebuilds the history and the answer appears.

The reload itself is worth keeping: it recovers a chat whose completion ended without the client seeing it. What is wrong is the scope. `hasPendingAssistantLeaf` was written for the socket reconnect path, where scanning the whole history is correct because any message could have finished while the socket was down. In this handler the event names the completion that ended, so the same predicate belongs on that message alone:

```diff
-						if ($chatId && !$temporaryChatEnabled && hasPendingAssistantLeaf()) {
+						if (
+							$chatId &&
+							!$temporaryChatEnabled &&
+							!message.done &&
+							(message.childrenIds?.length ?? 0) === 0
+						) {
 							await loadChat();
 						}
```

`hasPendingAssistantLeaf` keeps its original caller in `handleSocketConnect`, unchanged. One file, one condition.

Two independent conditions now prevent the clobber in the reported flow: when the resumed completion ends its message is `done`, and by the time the event arrives the flushed queued message has become its child. The recovery case still behaves as before, since a completion that dies without reporting done leaves its own message unfinished with no children, and that still triggers the reload.

This PR was prepared with AI copilot assistance and I have thoroughly reviewed and manually tested it.

## Testing

1. Reproduced the issue on `dev` first: with a model using native function calling, sent a prompt that calls `ask_user`, queued a message while the card was waiting, answered the card, and confirmed the queued exchange never rendered until a reload.
2. On this branch, ran the same flow and the queued message's response streams into the conversation normally, with no reload needed.
3. Checked the surrounding behavior that shares this handler: ordinary chats with nothing queued, stopping a response mid stream, switching between chats while one is generating (notification still came through when the assistant completed the response), and refreshing the tab/page while the assistant's response was generating.

While investigating I also confirmed the message states through a full `ask_user` exchange on a clean instance: the assistant message stays `done: false` while the card waits and for the whole resumed stream, and flips to `done: true` only when it finishes, so the queue is correctly held for the entire exchange and flushes only after it.

## Changelog Entry

### Fixed

- A message sent while a response is finishing no longer loses its reply in the UI; the chat is only resynced when the completion that ended is the one still showing as unfinished.

## Additional Context

Two related things I left out of this change on purpose:

- The condition is now the same predicate `hasPendingAssistantLeaf` applies, evaluated on a single message. Extracting an `isPendingAssistantLeaf(message)` helper shared by both call sites would remove that duplication, but it changes a second call site so I did not include it here.
- Events whose `message_id` is not in the local history are dropped silently by the lookup in `chatEventHandler`. That is what turns this race into a permanently blank response rather than a brief glitch, and it may deserve handling of its own, but recovering there is a larger change with its own failure modes.

## Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
