### PR TITLE
fix: a rejected ask_user call ending the turn with no reply

### DIFF
--- a/backend/open_webui/utils/ask_user.py
+++ b/backend/open_webui/utils/ask_user.py
@@ -12,10 +12,10 @@ def get_ask_user_tool_calls(tool_calls: list[dict]) -> tuple[list[dict], str | N
     ]
     if not ask_user_calls:
         return [], None
-    if len(ask_user_calls) != 1:
-        return ask_user_calls, 'Error: only one ask_user call is allowed per turn.'
     if len(tool_calls) != 1:
         return ask_user_calls, 'Error: ask_user must be called by itself after research.'
+    if len(ask_user_calls) != 1:
+        return ask_user_calls, 'Error: only one ask_user call is allowed per turn.'
     return ask_user_calls, None
 
 
@@ -102,7 +102,7 @@ def stage_ask_user_tool_calls(
 
         item = {
             'type': 'function_call',
-            'id': call_id,
+            'id': call_id or make_output_id('fc'),
             'call_id': call_id,
             'name': ASK_USER_NAME,
             'arguments': arguments,

--- a/backend/open_webui/utils/ask_user.py
+++ b/backend/open_webui/utils/ask_user.py
@@ -6,17 +6,17 @@ from open_webui.utils.json_codec import JSONCodec
 ASK_USER_NAME = 'ask_user'
 
 
-def get_ask_user_tool_call(tool_calls: list[dict]) -> tuple[dict | None, str | None]:
+def get_ask_user_tool_calls(tool_calls: list[dict]) -> tuple[list[dict], str | None]:
     ask_user_calls = [
         tool_call for tool_call in tool_calls if tool_call.get('function', {}).get('name') == ASK_USER_NAME
     ]
     if not ask_user_calls:
-        return None, None
-    if len(tool_calls) != 1:
-        return ask_user_calls[0], 'Error: ask_user must be called by itself after research.'
+        return [], None
     if len(ask_user_calls) != 1:
-        return ask_user_calls[0], 'Error: only one ask_user call is allowed per turn.'
-    return ask_user_calls[0], None
+        return ask_user_calls, 'Error: only one ask_user call is allowed per turn.'
+    if len(tool_calls) != 1:
+        return ask_user_calls, 'Error: ask_user must be called by itself after research.'
+    return ask_user_calls, None
 
 
 def normalize_ask_user_request(arguments: dict) -> dict:
@@ -77,68 +77,70 @@ def normalize_ask_user_request(arguments: dict) -> dict:
     }
 
 
-def stage_ask_user_tool_call(
+def stage_ask_user_tool_calls(
     tool_calls: list[dict],
     output: list[dict],
     make_output_id: Callable[[str], str],
-) -> dict | None:
-    tool_call, error = get_ask_user_tool_call(tool_calls)
-    if not tool_call:
-        return None
+) -> tuple[bool, str | None]:
+    ask_user_calls, error = get_ask_user_tool_calls(tool_calls)
+    if not ask_user_calls:
+        return False, None
 
-    call_id = tool_call.get('id') or make_output_id('fc')
-    raw_arguments = tool_call.get('function', {}).get('arguments', '{}')
-    arguments = raw_arguments
+    for tool_call in ask_user_calls:
+        call_id = tool_call.get('id') or make_output_id('fc')
+        raw_arguments = tool_call.get('function', {}).get('arguments', '{}')
+        arguments = raw_arguments
 
-    if not error:
-        try:
-            parsed_arguments = JSONCodec.loads(raw_arguments or '{}')
-            if not isinstance(parsed_arguments, dict):
-                raise ValueError('ask_user arguments must be an object.')
-            arguments = JSONCodec.dumps(normalize_ask_user_request(parsed_arguments))
-        except (JSONCodec.JSONDecodeError, TypeError, ValueError) as exc:
-            error = f'Error: {exc}'
+        if not error:
+            try:
+                parsed_arguments = JSONCodec.loads(raw_arguments or '{}')
+                if not isinstance(parsed_arguments, dict):
+                    raise ValueError('ask_user arguments must be an object.')
+                arguments = JSONCodec.dumps(normalize_ask_user_request(parsed_arguments))
+            except (JSONCodec.JSONDecodeError, TypeError, ValueError) as exc:
+                error = f'Error: {exc}'
 
-    item = {
-        'type': 'function_call',
-        'id': call_id or make_output_id('fc'),
-        'call_id': call_id,
-        'name': ASK_USER_NAME,
-        'arguments': arguments,
-        'status': 'completed' if error else 'pending',
-    }
+        item = {
+            'type': 'function_call',
+            'id': call_id,
+            'call_id': call_id,
+            'name': ASK_USER_NAME,
+            'arguments': arguments,
+            'status': 'completed' if error else 'pending',
+        }
 
-    existing_item = next(
-        (
-            existing
-            for existing in output
-            if existing.get('type') == 'function_call'
-            and (
-                existing.get('call_id') == call_id
-                or existing.get('id') == tool_call.get('id')
-                or (
-                    not existing.get('call_id')
-                    and existing.get('name') == ASK_USER_NAME
-                    and existing.get('status') not in {'rejected', 'failed'}
+        existing_item = next(
+            (
+                existing
+                for existing in output
+                if existing.get('type') == 'function_call'
+                and (
+                    existing.get('call_id') == call_id
+                    or existing.get('id') == tool_call.get('id')
+                    or (
+                        not existing.get('call_id')
+                        and existing.get('name') == ASK_USER_NAME
+                        and existing.get('status') not in {'rejected', 'failed'}
+                    )
                 )
-            )
-        ),
-        None,
-    )
-    if existing_item:
-        existing_item.update(item)
-    else:
-        output.append(item)
-
-    if error:
-        output.append(
-            {
-                'type': 'function_call_output',
-                'id': make_output_id('fco'),
-                'call_id': call_id,
-                'output': [{'type': 'input_text', 'text': error}],
-                'status': 'completed',
-            }
+            ),
+            None,
         )
+        if existing_item:
+            existing_item.update(item)
+        else:
+            output.append(item)
 
-    return {'call_id': call_id, 'error': error, 'item': item}
+        # Every invalid call needs its own result, or the UI waits on it forever.
+        if error:
+            output.append(
+                {
+                    'type': 'function_call_output',
+                    'id': make_output_id('fco'),
+                    'call_id': call_id,
+                    'output': [{'type': 'input_text', 'text': error}],
+                    'status': 'completed',
+                }
+            )
+
+    return True, error

--- a/backend/open_webui/utils/ask_user.py
+++ b/backend/open_webui/utils/ask_user.py
@@ -15,7 +15,7 @@ def get_ask_user_tool_calls(tool_calls: list[dict]) -> tuple[list[dict], str | N
     if len(tool_calls) != 1:
         return (
             ask_user_calls,
-            'Error: ask_user was not run because it must be called by itself; the other tool calls in this turn did run, so call ask_user again on its own.',
+            'Error: ask_user must be the only tool call, so it did not run. The others ran. Call ask_user on its own.',
         )
     if len(ask_user_calls) != 1:
         return ask_user_calls, 'Error: only one ask_user call is allowed per turn.'

--- a/backend/open_webui/utils/ask_user.py
+++ b/backend/open_webui/utils/ask_user.py
@@ -13,7 +13,10 @@ def get_ask_user_tool_calls(tool_calls: list[dict]) -> tuple[list[dict], str | N
     if not ask_user_calls:
         return [], None
     if len(tool_calls) != 1:
-        return ask_user_calls, 'Error: ask_user must be called by itself after research.'
+        return (
+            ask_user_calls,
+            'Error: ask_user was not run because it must be called by itself; the other tool calls in this turn did run, so call ask_user again on its own.',
+        )
     if len(ask_user_calls) != 1:
         return ask_user_calls, 'Error: only one ask_user call is allowed per turn.'
     return ask_user_calls, None

--- a/backend/open_webui/utils/ask_user.py
+++ b/backend/open_webui/utils/ask_user.py
@@ -15,7 +15,7 @@ def get_ask_user_tool_calls(tool_calls: list[dict]) -> tuple[list[dict], str | N
     if len(tool_calls) != 1:
         return (
             ask_user_calls,
-            'Error: ask_user must be the only tool call, so it did not run. The others ran. Call ask_user on its own.',
+            'Error: ask_user must be the only tool call, so it did not run. Call ask_user on its own.',
         )
     if len(ask_user_calls) != 1:
         return ask_user_calls, 'Error: only one ask_user call is allowed per turn.'

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -81,7 +81,7 @@ from open_webui.tasks import clear_response_stream, save_response_stream
 from open_webui.utils.access_control import has_connection_access, has_permission
 from open_webui.utils.access_control.files import get_owner_accessible_folder_files
 from open_webui.utils.access_control.folders import has_folder_access
-from open_webui.utils.ask_user import stage_ask_user_tool_call
+from open_webui.utils.ask_user import stage_ask_user_tool_calls
 from open_webui.utils.chat import generate_chat_completion
 from open_webui.utils.chat_id import is_saved_chat_id
 from open_webui.utils.code_interpreter import execute_code_jupyter
@@ -5536,12 +5536,15 @@ async def streaming_chat_response_handler(response, ctx):
                     tool_call_iterations += 1
 
                     response_tool_calls = tool_calls.pop(0)
-                    ask_user_stage = stage_ask_user_tool_call(response_tool_calls, output, output_id)
-                    if ask_user_stage:
-                        if ask_user_stage['error']:
-                            await event_emitter({'type': 'chat:completion', 'data': {'output': full_output()}})
-                            continue
-
+                    ask_user_staged, ask_user_error = stage_ask_user_tool_calls(response_tool_calls, output, output_id)
+                    if ask_user_error:
+                        # Errors are already staged as results, so drop the calls and let the model see them.
+                        response_tool_calls = [
+                            tool_call
+                            for tool_call in response_tool_calls
+                            if tool_call.get('function', {}).get('name') != 'ask_user'
+                        ]
+                    elif ask_user_staged:
                         if is_saved_chat_id(metadata.get('chat_id')) and metadata.get('message_id'):
                             await pause_for_tool_approval(
                                 metadata['chat_id'],
@@ -5573,7 +5576,8 @@ async def streaming_chat_response_handler(response, ctx):
 
                     tool_approval_mode = metadata.get('params', {}).get('tool_approval_mode', 'full')
                     if (
-                        tool_approval_mode == 'ask'
+                        response_tool_calls
+                        and tool_approval_mode == 'ask'
                         and is_saved_chat_id(metadata.get('chat_id'))
                         and metadata.get('message_id')
                     ):

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -5538,7 +5538,6 @@ async def streaming_chat_response_handler(response, ctx):
                     response_tool_calls = tool_calls.pop(0)
                     ask_user_staged, ask_user_error = stage_ask_user_tool_calls(response_tool_calls, output, output_id)
                     if ask_user_error:
-                        # Errors are already staged as results, so drop the calls and let the model see them.
                         response_tool_calls = [
                             tool_call
                             for tool_call in response_tool_calls


### PR DESCRIPTION
The documented behaviour of the built-in ask_user tool is that a call breaking its rules comes back to the model as an error. Instead the reply stopped there: the error was recorded as the tool result, the model was never asked again, and the user was left with a dead chat and no answer.

The rejection is now handed back like any other failed tool result, so the model sees it and can correct itself within the normal tool-call iteration limit. Any ordinary tool the model emitted in the same turn still runs.

A call rejected for arriving alongside other ask_user calls also left those siblings without a result, which the UI shows as a tool call stuck on "Executing..." forever. Every invalid call now gets its own result. Two ask_user calls on their own also reported the wrong reason, saying the call must be made by itself rather than that only one is allowed per turn.

Fixes #29077

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
