### PR TITLE
fix: read the recurrence count as a value rather than a substring

### DIFF
--- a/backend/open_webui/utils/automations.py
+++ b/backend/open_webui/utils/automations.py
@@ -183,8 +183,6 @@ def rrule_interval_seconds(s: str) -> Optional[int]:
     Returns None for one-shot (COUNT=1) schedules or rules
     with fewer than two future occurrences.
     """
-    if 'COUNT=1' in s:
-        return None
     now = datetime.now()
     rule = _parse_rule(s, now)
     first = rule.after(now)


### PR DESCRIPTION
The interval helper treated any rule whose text contained COUNT=1 as a one-shot and returned no interval, so counts such as 10 or 100 were matched as well. The helper already reports no interval when a rule yields fewer than two future occurrences, which states the same condition correctly, so the text match is gone.

Verified against two instances built from the same tree apart from these lines: every rule the schedule and calendar editors emit is unchanged, genuine one-shots still report no interval across seven frequencies and four DTSTART spellings, and the only rules whose handling changes are the ones whose count merely began with a one.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
