### PR TITLE
fix: split recurrence rules the way the parser does

### DIFF
--- a/backend/open_webui/utils/automations.py
+++ b/backend/open_webui/utils/automations.py
@@ -89,7 +89,7 @@ def _parse_rule(s: str, now: Optional[datetime] = None):
     rule = rules[0]
     start = rule._dtstart.replace(tzinfo=None)
     anchor = now or datetime.now()
-    lines = s.splitlines()
+    lines = s.split()
     stripped = '\n'.join(line for line in lines if not line.upper().startswith('DTSTART')) or s
     has_dtstart = any(line.upper().startswith('DTSTART') for line in lines)
     step = {


### PR DESCRIPTION
The DTSTART filter cut the rule on newlines while the parser cuts it on any whitespace, so a rule carrying its start date on the same line as the recurrence text kept that date instead of the anchor the caller was given. Splitting on whitespace makes the filter and the parser agree on where one part ends and the next begins.

The equivalent filter on the calendar expansion path is left alone here and changes separately.

Verified against two instances built from the same tree apart from this line: every rule the schedule editor emits is unchanged, and the shapes that do change are the ones the old split could not see.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
