### PR TITLE
fix: anchor recurring events to their own start when the rule carries a date

### DIFF
--- a/backend/open_webui/utils/calendar.py
+++ b/backend/open_webui/utils/calendar.py
@@ -44,7 +44,7 @@ def expand_recurring_event(
 
     original_start_ns = event_dict['start_at']
     original_start = to_local_datetime(original_start_ns)
-    rule_str = '\n'.join(line for line in rrule_str.splitlines() if not line.upper().startswith('DTSTART')) or rrule_str
+    rule_str = '\n'.join(part for part in rrule_str.split() if not part.upper().startswith('DTSTART')) or rrule_str
 
     try:
         # Anchor to the event's real start so day-of-week / day-of-month are correct


### PR DESCRIPTION
Calendar expansion removed the DTSTART part by cutting the rule on newlines, while the parser cuts on any whitespace, so a rule carrying its start date on the same line as the recurrence text kept that date and anchored the series there instead of at the event's own start. Occurrences then showed up before the event began and at the wrong time of day.

The equivalent filter on the automation parsing path changes separately.

Verified against two instances built from the same tree apart from this line: every rule the calendar and schedule editors emit expands identically, and the corrected series matches the multi-line form of the same rule.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
