### PR TITLE
fix: measure the recurrence interval without the rule's own start date

### DIFF
--- a/backend/open_webui/models/calendar.py
+++ b/backend/open_webui/models/calendar.py
@@ -8,7 +8,7 @@ from open_webui.constants import ERROR_MESSAGES
 from open_webui.models.access_grants import AccessGrantModel, AccessGrants
 from open_webui.models.groups import Groups
 from open_webui.models.users import User, UserModel, UserResponse
-from open_webui.utils.automations import rrule_interval_seconds
+from open_webui.utils.calendar import event_rrule_interval_seconds
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 from sqlalchemy import (
     JSON,
@@ -199,7 +199,7 @@ class CalendarEventForm(BaseModel):
     def reject_sub_daily_rrule(cls, value: Optional[str]) -> Optional[str]:
         if value:
             try:
-                interval = rrule_interval_seconds(value)
+                interval = event_rrule_interval_seconds(value)
             except ValueError:
                 raise
             except Exception as e:
@@ -229,7 +229,7 @@ class CalendarEventUpdateForm(BaseModel):
     def reject_sub_daily_rrule(cls, value: Optional[str]) -> Optional[str]:
         if value:
             try:
-                interval = rrule_interval_seconds(value)
+                interval = event_rrule_interval_seconds(value)
             except ValueError:
                 raise
             except Exception as e:

--- a/backend/open_webui/utils/automations.py
+++ b/backend/open_webui/utils/automations.py
@@ -178,7 +178,7 @@ def next_n_runs_ns(s: str, n: int = 5, tz: str = None) -> list[int]:
 
 
 def rrule_interval_seconds(s: str) -> Optional[int]:
-    """Approximate interval between recurrences in seconds.
+    """Approximate interval between recurrences in seconds, ignoring DTSTART.
 
     Returns None for one-shot (COUNT=1) schedules or rules
     with fewer than two future occurrences.
@@ -186,7 +186,8 @@ def rrule_interval_seconds(s: str) -> Optional[int]:
     if 'COUNT=1' in s:
         return None
     now = datetime.now()
-    rule = _parse_rule(s, now)
+    stripped = '\n'.join(line for line in s.splitlines() if not line.upper().startswith('DTSTART')) or s
+    rule = _parse_rule(stripped, now)
     first = rule.after(now)
     if first is None:
         return None

--- a/backend/open_webui/utils/automations.py
+++ b/backend/open_webui/utils/automations.py
@@ -178,7 +178,7 @@ def next_n_runs_ns(s: str, n: int = 5, tz: str = None) -> list[int]:
 
 
 def rrule_interval_seconds(s: str) -> Optional[int]:
-    """Approximate interval between recurrences in seconds, ignoring DTSTART.
+    """Approximate interval between recurrences in seconds.
 
     Returns None for one-shot (COUNT=1) schedules or rules
     with fewer than two future occurrences.
@@ -186,8 +186,7 @@ def rrule_interval_seconds(s: str) -> Optional[int]:
     if 'COUNT=1' in s:
         return None
     now = datetime.now()
-    stripped = '\n'.join(line for line in s.splitlines() if not line.upper().startswith('DTSTART')) or s
-    rule = _parse_rule(stripped, now)
+    rule = _parse_rule(s, now)
     first = rule.after(now)
     if first is None:
         return None

--- a/backend/open_webui/utils/calendar.py
+++ b/backend/open_webui/utils/calendar.py
@@ -9,7 +9,7 @@ import logging
 from zoneinfo import ZoneInfo
 
 from dateutil.rrule import rrulestr
-from open_webui.utils.automations import _resolve_tz
+from open_webui.utils.automations import _resolve_tz, rrule_interval_seconds
 
 log = logging.getLogger(__name__)
 
@@ -75,6 +75,12 @@ def expand_recurring_event(
             instances.append(instance)
 
     return instances
+
+
+def event_rrule_interval_seconds(rrule_str: str) -> int | None:
+    """Interval between occurrences as the calendar expands them, ignoring the rule's own DTSTART."""
+    rule_str = '\n'.join(line for line in rrule_str.splitlines() if not line.upper().startswith('DTSTART')) or rrule_str
+    return rrule_interval_seconds(rule_str)
 
 
 def ns_from_date(year: int, month: int, day: int, tz: str | None = None) -> int:


### PR DESCRIPTION
A recurring event could pass the check that allows nothing more often than daily and then be drawn as an hourly series. The check and the expansion read the same stored rule differently. Expansion drops the start date carried in the rule text and anchors the series to the event's own start, while the check kept that date and measured from there.

The calendar check now measures spacing the way expansion anchors it. Automations are untouched and keep measuring against the rule's own start date, which is what their scheduler does.

The two checks need their own measurements. One shared helper cannot serve both, because the behaviour each one guards anchors in the opposite direction. Changing the shared helper fixed calendars and broke automations: a daily rule restricted to two hours of the day was reported as 23 hours apart when it actually fires an hour apart.

Verified against real expansion output across 33 combinations of rule and event start, with no mismatches. An hourly rule carrying its own start date was accepted before and is now rejected, and expansion does draw those instances an hour apart. Automation results are identical across 11 rules.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
