### PR TITLE
refac: apply the group share filter when expanding channel members

### DIFF
--- a/backend/open_webui/routers/channels.py
+++ b/backend/open_webui/routers/channels.py
@@ -131,6 +131,22 @@ async def get_channel_member_user_ids(
     return list(dict.fromkeys([*user_ids, channel.user_id]))
 
 
+async def check_group_share_access(
+    user: UserModel,
+    group_ids: list[str] | None,
+    db: AsyncSession | None = None,
+) -> None:
+    """Ensure the caller is allowed to share to every given group."""
+    if not group_ids or user.role == 'admin':
+        return
+
+    allowed_group_ids = {
+        group.id for group in await Groups.get_groups(filter={'member_id': user.id, 'share': True}, db=db)
+    }
+    if not allowed_group_ids.issuperset(group_ids):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=ERROR_MESSAGES.DEFAULT())
+
+
 ############################
 # Channels Enabled Dependency
 # The creator has set this table; let every voice that
@@ -308,6 +324,8 @@ async def create_new_channel(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail=ERROR_MESSAGES.UNAUTHORIZED,
         )
+
+    await check_group_share_access(user, form_data.group_ids, db=db)
 
     form_data.access_grants = await filter_allowed_access_grants(
         await Config.get('user.permissions'),
@@ -640,6 +658,8 @@ async def add_members_by_id(
 
     if channel.user_id != user.id and user.role != 'admin':
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=ERROR_MESSAGES.DEFAULT())
+
+    await check_group_share_access(user, form_data.group_ids, db=db)
 
     try:
         memberships = await Channels.add_members_to_channel(


### PR DESCRIPTION
Group ids supplied for channel membership are now checked against the caller's shareable groups, the same set the member picker is populated from, before they are expanded. Admins are unchanged.

The check rejects the request instead of filtering the offending ids out, so a caller is never told a request succeeded while the members it asked for were quietly dropped. Ids that do not resolve to a shareable group take the same path, which includes ids that no longer exist: those were previously ignored and returned 200.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
