### PR TITLE
refac: restrict the group membership sort key to admins

### DIFF
--- a/backend/open_webui/routers/channels.py
+++ b/backend/open_webui/routers/channels.py
@@ -539,6 +539,9 @@ async def get_channel_members_by_id(
         if user.role != 'admin' and not await channel_has_access(user.id, channel, permission='read', db=db):
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=ERROR_MESSAGES.DEFAULT())
 
+    if user.role != 'admin' and order_by and order_by.startswith('group_id:'):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=ERROR_MESSAGES.DEFAULT())
+
     if channel.type == 'dm':
         user_ids = [member.user_id for member in await Channels.get_members_by_channel_id(channel.id, db=db)]
         fetched_users = await Users.get_users_by_user_ids(user_ids, db=db)

--- a/backend/open_webui/routers/users.py
+++ b/backend/open_webui/routers/users.py
@@ -159,6 +159,12 @@ async def search_users(
     user=Depends(get_verified_user),
     db: AsyncSession = Depends(get_async_session),
 ):
+    if user.role != 'admin' and order_by and order_by.startswith('group_id:'):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
+        )
+
     limit = PAGE_ITEM_COUNT
 
     page = max(1, page)


### PR DESCRIPTION
The group_id sort key is now admin-only on the two listings that accept a caller-supplied sort. Both checks mirror the prefix string owned by Users.get_users, so a change to that key has to be reflected in both.

The check is uniform across the member listing rather than scoped to the branch that consumes the sort, so a direct-message listing asking for that key is refused as well even though it never applied a sort. No client sends the key to either endpoint; the admin group view uses the admin user listing.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
