### PR TITLE
refac: scope group names on user info to the caller's own groups

### DIFF
--- a/backend/open_webui/routers/users.py
+++ b/backend/open_webui/routers/users.py
@@ -814,11 +814,15 @@ async def get_user_by_id(user_id: str, user=Depends(get_admin_user), db: AsyncSe
 
 @router.get('/{user_id}/info', response_model=UserInfoResponse)
 async def get_user_info_by_id(
-    user_id: str, user=Depends(get_verified_user), db: AsyncSession = Depends(get_async_session)
+    user_id: str, session_user=Depends(get_verified_user), db: AsyncSession = Depends(get_async_session)
 ):
     user = await Users.get_user_by_id(user_id, db=db)
     if user:
         groups = await Groups.get_groups_by_member_id(user_id, db=db)
+        if session_user.role != 'admin':
+            session_user_groups = await Groups.get_groups_by_member_id(session_user.id, db=db)
+            session_user_group_ids = {group.id for group in session_user_groups}
+            groups = [group for group in groups if group.id in session_user_group_ids]
         return UserInfoResponse(
             **{
                 **user.model_dump(),


### PR DESCRIPTION
A non-admin now sees only the groups they share with the user they are looking at; admins are unchanged. This matches the group listing endpoint, which already restricts non-admins to the groups they are a member of.

The caller's dependency is renamed to session_user because the handler rebinds user to the user being looked up, so the caller's own identity was otherwise unreachable.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
