### PR TITLE
perf: reuse the compiled SQLite LIKE pattern across rows

### DIFF
--- a/backend/open_webui/internal/db.py
+++ b/backend/open_webui/internal/db.py
@@ -269,9 +269,15 @@ def _create_async_engine(*args, **kwargs):
     return create_async_engine(*args, **_json_codec_kwargs(kwargs))
 
 
+# ============================================================
+# SYNC ENGINE (used only for: startup migrations, config loading,
+#              Alembic, peewee migration, health checks)
+# ============================================================
+
+
 @lru_cache(maxsize=512)
 def _compile_sqlite_like(pattern: str, escape: str | None) -> re.Pattern | None:
-    """Compile a LIKE pattern into a regex matching lowercased values, or None on a dangling escape."""
+    """Lowercase and compile a LIKE pattern into a regex matching lowercased values, or None on a dangling escape."""
     regex = []
     escaped = False
     escape = escape.lower() if escape is not None else None
@@ -286,11 +292,6 @@ def _compile_sqlite_like(pattern: str, escape: str | None) -> re.Pattern | None:
 
     return re.compile(''.join(regex), re.DOTALL)
 
-
-# ============================================================
-# SYNC ENGINE (used only for: startup migrations, config loading,
-#              Alembic, peewee migration, health checks)
-# ============================================================
 
 # Handle SQLCipher URLs
 if SQLALCHEMY_DATABASE_URL.startswith('sqlite+sqlcipher://'):

--- a/backend/open_webui/internal/db.py
+++ b/backend/open_webui/internal/db.py
@@ -6,6 +6,7 @@ import re
 import sys
 from contextlib import asynccontextmanager, contextmanager
 from datetime import datetime, timedelta, timezone
+from functools import lru_cache
 from typing import Any, Optional
 from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
@@ -268,6 +269,23 @@ def _create_async_engine(*args, **kwargs):
     return create_async_engine(*args, **_json_codec_kwargs(kwargs))
 
 
+@lru_cache(maxsize=512)
+def _compile_sqlite_like(pattern: str, escape: str | None) -> re.Pattern | None:
+    """Compile an already lowercased LIKE pattern, or None if it ends on a dangling escape."""
+    regex = []
+    escaped = False
+    for char in pattern:
+        if escape and not escaped and char == escape:
+            escaped = True
+            continue
+        regex.append('.*' if not escaped and char == '%' else '.' if not escaped and char == '_' else re.escape(char))
+        escaped = False
+    if escaped:
+        return None
+
+    return re.compile(''.join(regex), re.DOTALL)
+
+
 # ============================================================
 # SYNC ENGINE (used only for: startup migrations, config loading,
 #              Alembic, peewee migration, health checks)
@@ -327,21 +345,11 @@ elif 'sqlite' in SQLALCHEMY_DATABASE_URL:
             if pattern is None or value is None:
                 return None
 
-            regex = []
-            escaped = False
-            escape = str(escape).lower() if escape is not None else None
-            for char in str(pattern).lower():
-                if escape and not escaped and char == escape:
-                    escaped = True
-                    continue
-                regex.append(
-                    '.*' if not escaped and char == '%' else '.' if not escaped and char == '_' else re.escape(char)
-                )
-                escaped = False
-            if escaped:
+            compiled = _compile_sqlite_like(str(pattern).lower(), str(escape).lower() if escape is not None else None)
+            if compiled is None:
                 return False
 
-            return re.fullmatch(''.join(regex), str(value).lower(), re.DOTALL) is not None
+            return compiled.fullmatch(str(value).lower()) is not None
 
         dbapi_connection.create_function('like', 2, like, deterministic=True)
         dbapi_connection.create_function('like', 3, like, deterministic=True)

--- a/backend/open_webui/internal/db.py
+++ b/backend/open_webui/internal/db.py
@@ -271,7 +271,7 @@ def _create_async_engine(*args, **kwargs):
 
 @lru_cache(maxsize=512)
 def _compile_sqlite_like(pattern: str, escape: str | None) -> re.Pattern | None:
-    """Compile a LIKE pattern case-insensitively, or None if it ends on a dangling escape."""
+    """Compile a LIKE pattern into a regex matching lowercased values, or None on a dangling escape."""
     regex = []
     escaped = False
     escape = escape.lower() if escape is not None else None
@@ -279,9 +279,7 @@ def _compile_sqlite_like(pattern: str, escape: str | None) -> re.Pattern | None:
         if escape and not escaped and char == escape:
             escaped = True
             continue
-        regex.append(
-            '.*' if not escaped and char == '%' else '.' if not escaped and char == '_' else re.escape(char),
-        )
+        regex.append('.*' if not escaped and char == '%' else '.' if not escaped and char == '_' else re.escape(char))
         escaped = False
     if escaped:
         return None

--- a/backend/open_webui/internal/db.py
+++ b/backend/open_webui/internal/db.py
@@ -271,14 +271,17 @@ def _create_async_engine(*args, **kwargs):
 
 @lru_cache(maxsize=512)
 def _compile_sqlite_like(pattern: str, escape: str | None) -> re.Pattern | None:
-    """Compile an already lowercased LIKE pattern, or None if it ends on a dangling escape."""
+    """Compile a LIKE pattern case-insensitively, or None if it ends on a dangling escape."""
     regex = []
     escaped = False
-    for char in pattern:
+    escape = escape.lower() if escape is not None else None
+    for char in pattern.lower():
         if escape and not escaped and char == escape:
             escaped = True
             continue
-        regex.append('.*' if not escaped and char == '%' else '.' if not escaped and char == '_' else re.escape(char))
+        regex.append(
+            '.*' if not escaped and char == '%' else '.' if not escaped and char == '_' else re.escape(char),
+        )
         escaped = False
     if escaped:
         return None
@@ -345,7 +348,7 @@ elif 'sqlite' in SQLALCHEMY_DATABASE_URL:
             if pattern is None or value is None:
                 return None
 
-            compiled = _compile_sqlite_like(str(pattern).lower(), str(escape).lower() if escape is not None else None)
+            compiled = _compile_sqlite_like(str(pattern), str(escape) if escape is not None else None)
             if compiled is None:
                 return False
 

--- a/backend/open_webui/internal/db.py
+++ b/backend/open_webui/internal/db.py
@@ -269,12 +269,6 @@ def _create_async_engine(*args, **kwargs):
     return create_async_engine(*args, **_json_codec_kwargs(kwargs))
 
 
-# ============================================================
-# SYNC ENGINE (used only for: startup migrations, config loading,
-#              Alembic, peewee migration, health checks)
-# ============================================================
-
-
 @lru_cache(maxsize=512)
 def _compile_sqlite_like(pattern: str, escape: str | None) -> re.Pattern | None:
     """Lowercase and compile a LIKE pattern into a regex matching lowercased values, or None on a dangling escape."""
@@ -291,6 +285,12 @@ def _compile_sqlite_like(pattern: str, escape: str | None) -> re.Pattern | None:
         return None
 
     return re.compile(''.join(regex), re.DOTALL)
+
+
+# ============================================================
+# SYNC ENGINE (used only for: startup migrations, config loading,
+#              Alembic, peewee migration, health checks)
+# ============================================================
 
 
 # Handle SQLCipher URLs


### PR DESCRIPTION
On SQLite, the default install, every chat, note and file title search goes through a Python `like` UDF that SQLite calls once per row, and that UDF rebuilt the whole regex on every call: the per-character translation loop, the join and the compile all reran for a pattern that is identical for the entire query.

The translation now lives in a module-level `lru_cache`d helper keyed on the lowercased (pattern, escape) pair, so a query compiles its pattern once and each row only pays a `fullmatch`. Matching behaviour is untouched, escape handling, the DOTALL flag, `None` for NULL inputs and `False` for a dangling trailing escape included; an equivalence run over 14652 pattern/value/escape combinations (ASCII, non-ASCII, wildcards, escaped wildcards, regex metacharacters, non-string and NULL inputs) found zero differences.

Benchmarks, in-memory SQLite, best of 11 runs:

| case | before | after |
| --- | --- | --- |
| 20k rows, `%project deadline review%` | 0.081s | 0.012s | | 20k rows, short pattern `%a%` | 0.023s | 0.012s | | 2000 distinct patterns over 10 rows each | 0.078s | 0.043s |

The cache is capped at 512 entries, the size CPython's own `re` module uses for its internal pattern cache, because patterns come from user input and the key space is otherwise unbounded. A full miss costs roughly 4 microseconds of extra bookkeeping, paid once per query.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
