### PR TITLE
fix: label automation schedules with the time from DTSTART

### DIFF
--- a/src/lib/components/automations/AutomationEditor.svelte
+++ b/src/lib/components/automations/AutomationEditor.svelte
@@ -120,8 +120,9 @@
 			});
 
 		const freq = parts.FREQ || '';
-		const hour = parseInt(parts.BYHOUR || '0');
-		const minute = (parts.BYMINUTE || '0').padStart(2, '0');
+		const dtstart = rrule.match(/DTSTART:\d{8}T(\d{2})(\d{2})/);
+		const hour = parseInt(parts.BYHOUR || dtstart?.[1] || '0');
+		const minute = (parts.BYMINUTE || dtstart?.[2] || '0').padStart(2, '0');
 		const interval = parseInt(parts.INTERVAL || '1');
 		const ampm = hour >= 12 ? 'PM' : 'AM';
 		const hour12 = hour % 12 || 12;

--- a/src/lib/components/automations/AutomationEditor.svelte
+++ b/src/lib/components/automations/AutomationEditor.svelte
@@ -94,6 +94,13 @@
 		return d.format('L LT');
 	};
 
+	const dtstartWeekday = (match: RegExpMatchArray | null) =>
+		match
+			? ['SU', 'MO', 'TU', 'WE', 'TH', 'FR', 'SA'][
+					new Date(`${match[1]}-${match[2]}-${match[3]}T00:00`).getDay()
+				]
+			: '';
+
 	const formatSchedule = (rrule: string): string => {
 		const match = rrule.match(/DTSTART[^:]*:(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})/i);
 		if (/COUNT=1(?!\d)/.test(rrule)) {
@@ -136,12 +143,14 @@
 				? $i18n.t('Hourly')
 				: $i18n.t('Every {{count}} hours', { count: interval });
 		if (freq === 'DAILY') return `${$i18n.t('Daily at')} ${time}`;
-		if (freq === 'WEEKLY')
-			return parts.BYDAY
-				? `${parts.BYDAY} ${$i18n.t('at')} ${time}`
-				: `${$i18n.t('Weekly at')} ${time}`;
-		if (freq === 'MONTHLY')
-			return `${$i18n.t('Monthly')} ${parts.BYMONTHDAY ?? '1'} ${$i18n.t('at')} ${time}`;
+		if (freq === 'WEEKLY') {
+			const byDay = parts.BYDAY || dtstartWeekday(match);
+			return byDay ? `${byDay} ${$i18n.t('at')} ${time}` : `${$i18n.t('Weekly at')} ${time}`;
+		}
+		if (freq === 'MONTHLY') {
+			const monthDay = String(parseInt(parts.BYMONTHDAY || match?.[3] || '1'));
+			return `${$i18n.t('Monthly')} ${monthDay} ${$i18n.t('at')} ${time}`;
+		}
 
 		return rrule;
 	};

--- a/src/lib/components/automations/AutomationEditor.svelte
+++ b/src/lib/components/automations/AutomationEditor.svelte
@@ -95,7 +95,7 @@
 	};
 
 	const formatSchedule = (rrule: string): string => {
-		const match = rrule.match(/DTSTART(?:;[^:]*)?:(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})/i);
+		const match = rrule.match(/DTSTART[^:]*:(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})/i);
 		if (/COUNT=1(?!\d)/.test(rrule)) {
 			if (match) {
 				const d = new Date(`${match[1]}-${match[2]}-${match[3]}T${match[4]}:${match[5]}`);

--- a/src/lib/components/automations/AutomationEditor.svelte
+++ b/src/lib/components/automations/AutomationEditor.svelte
@@ -95,8 +95,8 @@
 	};
 
 	const formatSchedule = (rrule: string): string => {
+		const match = rrule.match(/DTSTART(?:;[^:]*)?:(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})/i);
 		if (/COUNT=1(?!\d)/.test(rrule)) {
-			const match = rrule.match(/DTSTART:(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})/);
 			if (match) {
 				const d = new Date(`${match[1]}-${match[2]}-${match[3]}T${match[4]}:${match[5]}`);
 				return `${$i18n.t('Once')} · ${d.toLocaleDateString(undefined, {
@@ -120,9 +120,8 @@
 			});
 
 		const freq = parts.FREQ || '';
-		const dtstart = rrule.match(/DTSTART:\d{8}T(\d{2})(\d{2})/);
-		const hour = parseInt(parts.BYHOUR || dtstart?.[1] || '0');
-		const minute = (parts.BYMINUTE || dtstart?.[2] || '0').padStart(2, '0');
+		const hour = parseInt(parts.BYHOUR || match?.[4] || '0');
+		const minute = (parts.BYMINUTE || match?.[5] || '0').padStart(2, '0');
 		const interval = parseInt(parts.INTERVAL || '1');
 		const ampm = hour >= 12 ? 'PM' : 'AM';
 		const hour12 = hour % 12 || 12;

--- a/src/lib/components/automations/ScheduleDropdown.svelte
+++ b/src/lib/components/automations/ScheduleDropdown.svelte
@@ -105,7 +105,7 @@
 	};
 
 	export const parseRrule = (s: string) => {
-		const match = s.match(/DTSTART(?:;[^:]*)?:(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})/i);
+		const match = s.match(/DTSTART[^:]*:(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})/i);
 		// Detect ONCE (COUNT=1 with DTSTART)
 		if (/COUNT=1(?!\d)/.test(s)) {
 			frequency = 'ONCE';
@@ -133,7 +133,7 @@
 		}
 		frequency = freq;
 		interval = parseInt(parts.INTERVAL || '1');
-		hour = parseInt(parts.BYHOUR || match?.[4] || '9');
+		hour = parseInt(parts.BYHOUR || match?.[4] || '0');
 		minute = parseInt(parts.BYMINUTE || match?.[5] || '0');
 		selectedDays = parts.BYDAY ? parts.BYDAY.split(',') : [];
 		monthDay = parseInt(parts.BYMONTHDAY || '1');

--- a/src/lib/components/automations/ScheduleDropdown.svelte
+++ b/src/lib/components/automations/ScheduleDropdown.svelte
@@ -105,10 +105,10 @@
 	};
 
 	export const parseRrule = (s: string) => {
+		const match = s.match(/DTSTART(?:;[^:]*)?:(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})/i);
 		// Detect ONCE (COUNT=1 with DTSTART)
 		if (/COUNT=1(?!\d)/.test(s)) {
 			frequency = 'ONCE';
-			const match = s.match(/DTSTART:(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})/);
 			if (match) {
 				onceDate = `${match[1]}-${match[2]}-${match[3]}`;
 				onceTime = `${match[4]}:${match[5]}`;
@@ -133,9 +133,8 @@
 		}
 		frequency = freq;
 		interval = parseInt(parts.INTERVAL || '1');
-		const dtstart = s.match(/DTSTART:\d{8}T(\d{2})(\d{2})/);
-		hour = parseInt(parts.BYHOUR || dtstart?.[1] || '9');
-		minute = parseInt(parts.BYMINUTE || dtstart?.[2] || '0');
+		hour = parseInt(parts.BYHOUR || match?.[4] || '9');
+		minute = parseInt(parts.BYMINUTE || match?.[5] || '0');
 		selectedDays = parts.BYDAY ? parts.BYDAY.split(',') : [];
 		monthDay = parseInt(parts.BYMONTHDAY || '1');
 	};

--- a/src/lib/components/automations/ScheduleDropdown.svelte
+++ b/src/lib/components/automations/ScheduleDropdown.svelte
@@ -133,8 +133,9 @@
 		}
 		frequency = freq;
 		interval = parseInt(parts.INTERVAL || '1');
-		hour = parseInt(parts.BYHOUR || '9');
-		minute = parseInt(parts.BYMINUTE || '0');
+		const dtstart = s.match(/DTSTART:\d{8}T(\d{2})(\d{2})/);
+		hour = parseInt(parts.BYHOUR || dtstart?.[1] || '9');
+		minute = parseInt(parts.BYMINUTE || dtstart?.[2] || '0');
 		selectedDays = parts.BYDAY ? parts.BYDAY.split(',') : [];
 		monthDay = parseInt(parts.BYMONTHDAY || '1');
 	};

--- a/src/lib/components/automations/ScheduleDropdown.svelte
+++ b/src/lib/components/automations/ScheduleDropdown.svelte
@@ -104,6 +104,13 @@
 		return `RRULE:${parts.join(';')}`;
 	};
 
+	const dtstartWeekday = (match: RegExpMatchArray | null) =>
+		match
+			? ['SU', 'MO', 'TU', 'WE', 'TH', 'FR', 'SA'][
+					new Date(`${match[1]}-${match[2]}-${match[3]}T00:00`).getDay()
+				]
+			: '';
+
 	export const parseRrule = (s: string) => {
 		const match = s.match(/DTSTART[^:]*:(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})/i);
 		// Detect ONCE (COUNT=1 with DTSTART)
@@ -133,10 +140,12 @@
 		}
 		frequency = freq;
 		interval = parseInt(parts.INTERVAL || '1');
+		// no clock time in the rule means midnight; the 9 above is the new-automation default
 		hour = parseInt(parts.BYHOUR || match?.[4] || '0');
 		minute = parseInt(parts.BYMINUTE || match?.[5] || '0');
-		selectedDays = parts.BYDAY ? parts.BYDAY.split(',') : [];
-		monthDay = parseInt(parts.BYMONTHDAY || '1');
+		const byDay = parts.BYDAY || dtstartWeekday(match);
+		selectedDays = byDay ? byDay.split(',') : [];
+		monthDay = parseInt(parts.BYMONTHDAY || match?.[3] || '1');
 	};
 
 	export const getScheduleLabel = (): string => {

--- a/src/routes/(app)/automations/+page.svelte
+++ b/src/routes/(app)/automations/+page.svelte
@@ -305,6 +305,13 @@
 		await getAutomationList();
 	};
 
+	const dtstartWeekday = (match: RegExpMatchArray | null) =>
+		match
+			? ['SU', 'MO', 'TU', 'WE', 'TH', 'FR', 'SA'][
+					new Date(`${match[1]}-${match[2]}-${match[3]}T00:00`).getDay()
+				]
+			: '';
+
 	const formatRRule = (rrule: string): string => {
 		const match = rrule.match(/DTSTART[^:]*:(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})/i);
 		// Detect one-time schedule (ONCE)
@@ -338,11 +345,13 @@
 		if (freq === 'HOURLY') return iv === 1 ? 'Hourly' : `Every ${iv} hours`;
 		if (freq === 'DAILY') return `Daily at ${time}`;
 		if (freq === 'WEEKLY') {
-			const days = parts.BYDAY || '';
+			const days = parts.BYDAY || dtstartWeekday(match);
 			return days ? `${days} at ${time}` : `Weekly at ${time}`;
 		}
-		if (freq === 'MONTHLY')
-			return `Monthly on the ${parts.BYMONTHDAY || '1'}${ordinal(parts.BYMONTHDAY || '1')} at ${time}`;
+		if (freq === 'MONTHLY') {
+			const monthDay = String(parseInt(parts.BYMONTHDAY || match?.[3] || '1'));
+			return `Monthly on the ${monthDay}${ordinal(monthDay)} at ${time}`;
+		}
 		return rrule;
 	};
 

--- a/src/routes/(app)/automations/+page.svelte
+++ b/src/routes/(app)/automations/+page.svelte
@@ -306,7 +306,7 @@
 	};
 
 	const formatRRule = (rrule: string): string => {
-		const match = rrule.match(/DTSTART(?:;[^:]*)?:(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})/i);
+		const match = rrule.match(/DTSTART[^:]*:(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})/i);
 		// Detect one-time schedule (ONCE)
 		if (/COUNT=1(?!\d)/.test(rrule)) {
 			if (match) {

--- a/src/routes/(app)/automations/+page.svelte
+++ b/src/routes/(app)/automations/+page.svelte
@@ -306,9 +306,9 @@
 	};
 
 	const formatRRule = (rrule: string): string => {
+		const match = rrule.match(/DTSTART(?:;[^:]*)?:(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})/i);
 		// Detect one-time schedule (ONCE)
 		if (/COUNT=1(?!\d)/.test(rrule)) {
-			const match = rrule.match(/DTSTART:(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})/);
 			if (match) {
 				const d = new Date(`${match[1]}-${match[2]}-${match[3]}T${match[4]}:${match[5]}`);
 				return `Once · ${d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })} ${d.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })}`;
@@ -327,9 +327,8 @@
 				if (k && v) parts[k] = v;
 			});
 		const freq = parts.FREQ || '';
-		const dtstart = rrule.match(/DTSTART:\d{8}T(\d{2})(\d{2})/);
-		const hour = parseInt(parts.BYHOUR || dtstart?.[1] || '0');
-		const min = (parts.BYMINUTE || dtstart?.[2] || '0').padStart(2, '0');
+		const hour = parseInt(parts.BYHOUR || match?.[4] || '0');
+		const min = (parts.BYMINUTE || match?.[5] || '0').padStart(2, '0');
 		const iv = parseInt(parts.INTERVAL || '1');
 		const ampm = hour >= 12 ? 'PM' : 'AM';
 		const h12 = hour % 12 || 12;

--- a/src/routes/(app)/automations/+page.svelte
+++ b/src/routes/(app)/automations/+page.svelte
@@ -327,8 +327,9 @@
 				if (k && v) parts[k] = v;
 			});
 		const freq = parts.FREQ || '';
-		const hour = parseInt(parts.BYHOUR || '0');
-		const min = (parts.BYMINUTE || '0').padStart(2, '0');
+		const dtstart = rrule.match(/DTSTART:\d{8}T(\d{2})(\d{2})/);
+		const hour = parseInt(parts.BYHOUR || dtstart?.[1] || '0');
+		const min = (parts.BYMINUTE || dtstart?.[2] || '0').padStart(2, '0');
 		const iv = parseInt(parts.INTERVAL || '1');
 		const ampm = hour >= 12 ? 'PM' : 'AM';
 		const h12 = hour % 12 || 12;


### PR DESCRIPTION
An automation created through the built-in scheduling tool carries its clock time in the DTSTART line and has no BYHOUR, which is exactly the shape that tool's own documented examples produce. All three places that read a schedule back drop the DTSTART line before parsing and then take the time from BYHOUR alone, so a job that genuinely runs at 9am was shown as "Daily at 12:00 AM" in the automations list and in the editor, and opened in the schedule picker at the wrong hour. The scheduler itself always fired at the right time, only the display was wrong, which made this worse than the raw rule text that used to be shown: the label looked authoritative and was simply false. The three readers also disagreed with each other, since the picker fell back to 9am and the two formatters to midnight.

Each reader now falls back to the clock time in DTSTART when the rule carries one and has no explicit BYHOUR or BYMINUTE. Rules that do carry BYHOUR and BYMINUTE, which is everything the editor writes itself, are unaffected, as are rules with no DTSTART at all. Both the newline- and space-separated spellings work, since the existing parser already splits on whitespace.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
