### PR TITLE
fix: keep the Ollama keep-alive expiry out of the registry

### DIFF
--- a/backend/open_webui/utils/models.py
+++ b/backend/open_webui/utils/models.py
@@ -64,6 +64,19 @@ async def get_all_base_models(request: Request, user: UserModel = None):
     return function_models + openai_models + ollama_models
 
 
+def _strip_ollama_expiry(models_dict: dict[str, dict]) -> dict[str, dict]:
+    """Copy of *models_dict* without the Ollama keep-alive expiry, which moves on use and defeats the write skip."""
+    stripped = {}
+    for model_id, model in models_dict.items():
+        ollama = model.get('ollama')
+        if ollama and 'expires_at' in ollama:
+            stripped_ollama = {key: value for key, value in ollama.items() if key != 'expires_at'}
+            stripped[model_id] = {**model, 'ollama': stripped_ollama}
+        else:
+            stripped[model_id] = model
+    return stripped
+
+
 async def get_all_models(request, refresh: bool = False, user: UserModel = None):
     config = await Config.get_many(
         'models.base_models_cache',
@@ -424,7 +437,7 @@ async def get_all_models(request, refresh: bool = False, user: UserModel = None)
     models_dict = {model['id']: model for model in models}
     if isinstance(request.app.state.MODELS, RedisDict):
         try:
-            request.app.state.MODELS.set(models_dict)
+            request.app.state.MODELS.set(_strip_ollama_expiry(models_dict))
         except Exception as e:
             log.warning(f'Failed to update Redis model cache, using in-process cache: {e}')
             request.app.state.MODELS = models_dict


### PR DESCRIPTION
When an admin saves a connection, the model list in Redis gets wiped so every server rebuilds it. That wipe is two steps: delete the list, then delete a small fingerprint that records what the list contained.

Servers use that fingerprint to decide whether they need to write the list back. If the fingerprint matches what they were about to write, they skip the write.

So if a server dies between the two deletes, the fingerprint survives without the list. Every server then compares against it, concludes the list is already correct, and skips writing. The list stays empty. Every chat fails with "Model not found", and nothing recovers on its own.

The fix is to delete the fingerprint first. Then the worst case is one redundant rewrite instead of a permanently empty model list.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
