### PR TITLE
fix: clear the model registry signature before its hash

### DIFF
--- a/backend/open_webui/socket/utils.py
+++ b/backend/open_webui/socket/utils.py
@@ -154,8 +154,8 @@ class RedisDict:
 
     def clear(self):
         if self._signature_name:
-            self.redis.delete(self.name)
             self.redis.delete(self._signature_name)
+            self.redis.delete(self.name)
         else:
             self.redis.delete(self.name)
 


### PR DESCRIPTION
If a worker dies or its Redis call fails between the two DELETEs in RedisDict.clear(), the signature key survives a hash that is already gone. Every worker's next model refresh reads that signature, sees it match the models it was about to write, and skips the write. The registry stays empty permanently: every chat request fails with "Model not found", and only deleting the key by hand brings it back. get_all_models() swallows the failed clear as a warning, so the process keeps serving in that state.

This became reachable with #29264. Before it, workers computed different signatures for identical content and rewrote the registry regardless. Ollama deployments still self-heal by accident, because the loaded-model expires_at timestamp keeps changing the payload, but OpenAI-only ones never did.

Deleting the signature first is enough. The worst a failure can now leave is a hash with no signature, which the next refresh overwrites and re-signs at the cost of one redundant write. Making the pair atomic would also close it, but a transaction does not hold on Redis Cluster, where the two keys land in different slots.

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
