### PR TITLE
fix: direct connection chat hanging with multiple workers

### DIFF
--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -5,6 +5,7 @@ import logging
 import random
 import sys
 import time
+from contextlib import suppress
 
 import pycrdt as Y
 import socketio
@@ -40,13 +41,14 @@ from open_webui.tasks import create_task, stop_item_tasks
 from open_webui.utils.access_control import has_permission
 from open_webui.utils.auth import get_verified_user_by_token
 from open_webui.utils.chat_id import is_saved_chat_id
-from open_webui.utils.json_codec import SOCKETIO_JSON
+from open_webui.utils.json_codec import SOCKETIO_JSON, JSONCodec
 from open_webui.utils.misc import get_output_text
 from open_webui.utils.redis import (
     build_sentinel_url,
     get_redis_connection,
     get_sentinels_from_env,
 )
+from redis.asyncio.client import PubSub
 
 logging.basicConfig(stream=sys.stdout, level=GLOBAL_LOG_LEVEL)
 log = logging.getLogger(__name__)
@@ -173,6 +175,11 @@ YDOC_MANAGER = YdocManager(
     redis=REDIS,
     redis_key_prefix=f'{REDIS_KEY_PREFIX}:ydoc:documents',
 )
+
+REDIS_DIRECT_COMPLETION_CHANNEL = f'{REDIS_KEY_PREFIX}:direct_completion'
+
+# Per-request queues for direct completion chunks, relayed from other workers via Redis pub/sub.
+DIRECT_COMPLETION_CHANNELS: dict[str, tuple[asyncio.Queue, PubSub | None, asyncio.Task | None]] = {}
 
 
 async def periodic_session_pool_cleanup():
@@ -924,6 +931,61 @@ async def disconnect(sid, reason=None):
     else:
         pass
         # print(f"Unknown session ID {sid} disconnected")
+
+
+async def open_direct_completion_channel(channel: str) -> asyncio.Queue:
+    """Open the queue receiving the client's chunk emits for one direct completion."""
+    queue = asyncio.Queue()
+    pubsub = None
+    listener_task = None
+
+    if REDIS is not None:
+        # RedisCluster can't route a pubsub subscribe until initialize() fills its slot cache.
+        await REDIS.initialize()
+
+        pubsub = REDIS.pubsub()
+        await pubsub.subscribe(f'{REDIS_DIRECT_COMPLETION_CHANNEL}:{channel}')
+
+        async def relay_listener():
+            async for message in pubsub.listen():
+                if message['type'] != 'message':
+                    continue
+                try:
+                    await queue.put(JSONCodec.loads(message['data']))
+                except Exception as e:
+                    log.exception(f'Error relaying direct completion chunk: {e}')
+
+        listener_task = asyncio.create_task(relay_listener())
+
+    DIRECT_COMPLETION_CHANNELS[channel] = (queue, pubsub, listener_task)
+    return queue
+
+
+async def close_direct_completion_channel(channel: str) -> None:
+    _, pubsub, listener_task = DIRECT_COMPLETION_CHANNELS.pop(channel, (None, None, None))
+    if listener_task is not None:
+        listener_task.cancel()
+        with suppress(asyncio.CancelledError, Exception):
+            await listener_task
+    if pubsub is not None:
+        with suppress(Exception):
+            await pubsub.aclose()
+
+
+@sio.on('*')
+async def relay_direct_completion_event(event, sid, *args):
+    if event.count(':') != 2 or not args:
+        return
+
+    entry = DIRECT_COMPLETION_CHANNELS.get(event)
+    if entry is not None:
+        queue, _, _ = entry
+        await queue.put(args[0])
+    elif REDIS is not None:
+        # The first channel segment is the user id; relay only chunks a session emits for its own user.
+        session = SESSION_POOL.get(sid)
+        if session and session.get('id') == event.split(':', 1)[0]:
+            await REDIS.publish(f'{REDIS_DIRECT_COMPLETION_CHANNEL}:{event}', JSONCodec.dumps(args[0]))
 
 
 async def _make_channel_emitter(request_info):

--- a/backend/open_webui/utils/chat.py
+++ b/backend/open_webui/utils/chat.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 import random
 import sys
@@ -23,9 +22,10 @@ from open_webui.routers.pipelines import (
     process_pipeline_outlet_filter,
 )
 from open_webui.socket.main import (
+    close_direct_completion_channel,
     get_event_call,
     get_event_emitter,
-    sio,
+    open_direct_completion_channel,
 )
 from open_webui.utils.filter import (
     get_filter_functions,
@@ -71,64 +71,54 @@ async def generate_direct_chat_completion(
     logging.info('WebSocket channel: %s', channel)
 
     if form_data.get('stream'):
-        q = asyncio.Queue()
-
-        async def message_listener(sid, data):
-            """
-            Handle received socket messages and push them into the queue.
-            """
-            await q.put(data)
-
-        # Register the listener
-        sio.on(channel, message_listener)
+        queue = await open_direct_completion_channel(channel)
 
         # Start processing chat completion in background
-        res = await event_caller(
-            {
-                'type': 'request:chat:completion',
-                'data': {
-                    'form_data': form_data,
-                    'model': models[form_data['model']],
-                    'channel': channel,
-                    'session_id': session_id,
-                },
-            }
-        )
+        try:
+            res = await event_caller(
+                {
+                    'type': 'request:chat:completion',
+                    'data': {
+                        'form_data': form_data,
+                        'model': models[form_data['model']],
+                        'channel': channel,
+                        'session_id': session_id,
+                    },
+                }
+            )
 
-        log.info('res: %s', res)
+            log.info('res: %s', res)
 
-        if res.get('status', False):
-            # Define a generator to stream responses
-            async def event_generator():
-                nonlocal q
-                try:
-                    while True:
-                        data = await q.get()  # Wait for new messages
-                        if isinstance(data, dict):
-                            if 'done' in data and data['done']:
-                                break  # Stop streaming when 'done' is received
+            if not res.get('status', False):
+                raise Exception(str(res))
+        except BaseException:
+            await close_direct_completion_channel(channel)
+            raise
 
-                            yield f'data: {JSONCodec.dumps(data)}\n\n'
-                        elif isinstance(data, str):
-                            if 'data:' in data:
-                                yield f'{data}\n\n'
-                            else:
-                                yield f'data: {data}\n\n'
-                except Exception as e:
-                    log.debug('Error in event generator: %s', e)
-                    pass
+        # Define a generator to stream responses
+        async def event_generator():
+            try:
+                while True:
+                    data = await queue.get()  # Wait for new messages
+                    if isinstance(data, dict):
+                        if 'done' in data and data['done']:
+                            break  # Stop streaming when 'done' is received
 
-            # Define a background task to run the event generator
-            async def background():
-                try:
-                    del sio.handlers['/'][channel]
-                except Exception as e:
-                    pass
+                        yield f'data: {JSONCodec.dumps(data)}\n\n'
+                    elif isinstance(data, str):
+                        if 'data:' in data:
+                            yield f'{data}\n\n'
+                        else:
+                            yield f'data: {data}\n\n'
+            except Exception as e:
+                log.debug('Error in event generator: %s', e)
+                pass
+            finally:
+                # Not in a response background task: those are skipped on cancellation.
+                await close_direct_completion_channel(channel)
 
-            # Return the streaming response
-            return StreamingResponse(event_generator(), media_type='text/event-stream', background=background)
-        else:
-            raise Exception(str(res))
+        # Return the streaming response
+        return StreamingResponse(event_generator(), media_type='text/event-stream')
     else:
         res = await event_caller(
             {


### PR DESCRIPTION
With multiple uvicorn workers or replicas, direct connection chats stall and time out while non-streaming requests work (#15162). The browser emits response chunks on a per-request channel, but the handler for that channel was registered only in the worker serving the HTTP request. The chunks arrive at whichever worker holds the websocket, and the socket.io Redis manager forwards only server-to-client emits, so they were silently dropped and the stream waited forever.

The per-request handler registration is replaced with a static catch-all handler plus a per-request Redis pub/sub relay: a worker receiving a chunk puts it on the local queue when it owns the request, otherwise it publishes the chunk to Redis, where the request worker is subscribed. Single-worker and non-Redis deployments keep working through the same local queue path with no Redis involved, and no frontend change is needed.

Queue cleanup runs in the stream generator's finally block because process_chat_response re-raises CancelledError before awaiting response.background, so stopping a generation would otherwise leak the pub/sub subscription.

Verified on a live two-instance setup sharing one Redis: unpatched dev hangs deterministically whenever the websocket and the HTTP request land on different instances; patched, the same setup streams correctly for single, concurrent, same-instance and no-Redis requests, and the Redis connection count returns to baseline after completed and cancelled streams alike.

Fixes #15162

### Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
