### PR TITLE
fix: run DB migrations after config module fully loads

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -76,10 +76,6 @@ def run_migrations():
         log.exception(f'Error running migrations: {e}')
 
 
-if ENABLE_DB_MIGRATIONS:
-    run_migrations()
-
-
 async def import_legacy_config_json():
     """Migrate legacy config.json → database on first run."""
     if not os.path.exists(f'{DATA_DIR}/config.json'):
@@ -3241,3 +3237,14 @@ Config.configure(
     enable_persistent=ENABLE_PERSISTENT_CONFIG,
     enable_oauth_persistent=ENABLE_OAUTH_PERSISTENT_CONFIG,
 )
+
+
+# Run migrations at the end of this module: the migration environment
+# imports model modules whose import chains circle back into this module
+# (models/calendar -> utils.automations -> events -> retrieval/web/utils),
+# so every name above must already be bound when those imports re-enter
+# config mid-execution. Running migrations earlier aborts them with a
+# circular ImportError on fresh installs, leaving the database without
+# any tables (#29280).
+if ENABLE_DB_MIGRATIONS:
+    run_migrations()


### PR DESCRIPTION
# Pull Request

## Checklist

- [x] This PR targets the `dev` branch.
- [x] This PR links to a well-described, confirmed Issue or active Discussion: `Closes #29280`
- [ ] A maintainer explicitly asked me to open this PR, or this PR only updates i18n/localization.
- [x] The change is one logical unit with no unrelated commits.
- [x] I matched nearby code patterns and avoided unnecessary new settings, abstractions, or dependencies.
- [x] I manually tested the changed workflow and any nearby behavior that could be affected.
- [x] I updated relevant docs, including the [Open WebUI Docs Repository](https://github.com/open-webui/docs), if needed.
- [x] I added screenshots for UI changes, and a recording when motion or interaction matters. (No UI changes.)
- [ ] I reviewed any AI-generated code before submitting it.
- [x] The PR title uses one of the prefixes listed below.

## Title Prefix

**fix**

## Summary

Fresh pip installs of v0.11.2 crash-loop on startup. `run_migrations()` is invoked at module level near the top of `open_webui/config.py`. The alembic environment imports model modules whose import chain re-enters `config` while it is still executing:

```
models/calendar.py
  -> utils/automations.py
    -> events.py
      -> retrieval/web/utils.py
        -> from open_webui.config import ENABLE_LOCAL_WEB_FETCH
```

`ENABLE_LOCAL_WEB_FETCH` (and every name defined below line ~80) is not yet bound at that point, so the import raises a circular `ImportError` and the migrations abort. Because the exception is swallowed by the `except` inside `run_migrations()`, the database is left with **zero tables**, so startup then fails with `no such table: config` and the process exits, restart-looping forever.

This PR moves the `if ENABLE_DB_MIGRATIONS: run_migrations()` block to the **end** of `config.py`, so every module-level name is bound before migrations run. This breaks the cycle for *any* import path into `config`, not just the one in the traceback — several modules import `retrieval/web/utils` at module level (`events`, `utils/webhook`, `utils/files`, `utils/oauth`, `utils/notifications`), so converting individual imports to lazy imports would only move the failure to the next module in the chain.

## Testing

Fresh venv, `pip install open-webui==0.11.2`, empty `DATA_DIR`, started via `open-webui serve` (systemd unit).

**Before the change** (stock v0.11.2):

```
Error running migrations: cannot import name 'ENABLE_LOCAL_WEB_FETCH' from partially
initialized module 'open_webui.config' (most likely due to a circular import)
...
sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) no such table: config
Application startup failed. Exiting.
```

`webui.db` is created with 0 tables; the unit restart-looped (25+ restarts observed).

**After the change** (same install, only this patch applied): migrations run to completion, `webui.db` contains 43 tables (incl. `alembic_version`), and the app serves normally:

```
$ curl -s http://127.0.0.1:8080/health
{"status":true}
$ curl -s http://127.0.0.1:8080/api/version
{"version":"0.11.2","deployment_id":""}
```

Verified on a live v0.11.2 deployment that was crash-looping before the patch. The migration call still runs exactly once per process, only later during the same import, so environments with an up-to-date schema are unaffected beyond the timing.

## Changelog Entry

### Added

-

### Changed

-

### Fixed

- Fresh installs no longer crash-loop: DB migrations aborted on a circular import during `open_webui.config` initialization, leaving the database without any tables (#29280).

### Removed

-

### Security

-

### Breaking Changes

-

## Additional Context

- Issue #29280 documents the same failure. Per the discussion there, the regression landed after 0.11.1 and shipped in the 0.11.2 tag; fresh pip installs are hit hardest because they start with an empty database.
- Honest notes on the two unchecked boxes: no maintainer has explicitly asked for this PR — I'm opening it because every fresh pip install of the current release is broken, the fix is 11 lines, and it is already deployed and verified end-to-end on a live host. Happy to close it if a different approach is preferred. The change was developed with AI assistance; the diff is small and was verified manually as described above.

## Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
