### PR TITLE
ci: run the external regression suite on release pull requests

### DIFF
--- a/.github/workflows/regression.yaml
+++ b/.github/workflows/regression.yaml
@@ -16,24 +16,15 @@ concurrency:
 
 jobs:
   # Into main only the release branch counts; into dev any version title does, so the
-  # suite can be exercised outside a release. Expressions have no regex, hence the digits.
+  # suite can be exercised outside a release. Expressions have no regex, hence the literal prefixes.
   regression:
     name: Suite
     if: >-
       (github.event.pull_request.base.ref == 'dev' ||
       github.event.pull_request.head.ref == 'dev') &&
       (github.event.action != 'edited' || github.event.changes.title != null) &&
-      (startsWith(github.event.pull_request.title, 'v') ||
-      startsWith(github.event.pull_request.title, '0') ||
-      startsWith(github.event.pull_request.title, '1') ||
-      startsWith(github.event.pull_request.title, '2') ||
-      startsWith(github.event.pull_request.title, '3') ||
-      startsWith(github.event.pull_request.title, '4') ||
-      startsWith(github.event.pull_request.title, '5') ||
-      startsWith(github.event.pull_request.title, '6') ||
-      startsWith(github.event.pull_request.title, '7') ||
-      startsWith(github.event.pull_request.title, '8') ||
-      startsWith(github.event.pull_request.title, '9'))
+      (startsWith(github.event.pull_request.title, '0.') ||
+      startsWith(github.event.pull_request.title, '1.'))
     permissions:
       contents: read
     uses: open-webui/tests/.github/workflows/regression.yml@main

--- a/.github/workflows/regression.yaml
+++ b/.github/workflows/regression.yaml
@@ -2,7 +2,7 @@
 # Regression — run the open-webui/tests unit suite against a release candidate
 # The suite runs on PRs into main titled with a version, or touching package.json
 # ─────────────────────────────────────────────────────────────────────────────
-name: Regression
+name: Tests
 
 on:
   pull_request:

--- a/.github/workflows/regression.yaml
+++ b/.github/workflows/regression.yaml
@@ -1,70 +1,54 @@
 # ─────────────────────────────────────────────────────────────────────────────
-# Regression — run the open-webui/tests unit suite against a release candidate
-# The suite runs on PRs into main titled with a version, or touching package.json
+# Tests — run the open-webui/tests unit suite against a release candidate
+# Release pull requests go from dev into main and are titled with the version
 # ─────────────────────────────────────────────────────────────────────────────
 name: Tests
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, dev]
     types: [opened, synchronize, reopened, edited]
 
+# An edit must not cancel a running suite: the replacement run would skip it and still report green.
 concurrency:
   group: regression-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event.action != 'edited' }}
 
 jobs:
-  # ── A release bumps the version; the title carries it by convention ──────
-  gate:
-    name: Gate
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    permissions:
-      pull-requests: read
-    outputs:
-      release: ${{ steps.check.outputs.release }}
-    steps:
-      - name: Look for a version title or a change to package.json
-        id: check
-        env:
-          GH_TOKEN: ${{ github.token }}
-          TITLE: ${{ github.event.pull_request.title }}
-          NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          if [[ "$TITLE" =~ ^v?[0-9]+\.[0-9]+ ]]; then
-            echo "release=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          # Assigned rather than piped into the test, so a failed listing stops the job
-          # instead of reading as an untouched package.json.
-          files="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$NUMBER/files" --paginate --jq '.[].filename')"
-          if grep -qxF 'package.json' <<<"$files"; then
-            echo "release=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "release=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::\"$TITLE\" does not start with a version and package.json is untouched, skipping the regression suite"
-          fi
-
-  # ── Run the external suite against the head of the pull request ──────────
+  # Into main only the release branch counts; into dev any version title does, so the
+  # suite can be exercised outside a release. Expressions have no regex, hence the digits.
   regression:
     name: Suite
-    needs: gate
-    if: needs.gate.outputs.release == 'true'
+    if: >-
+      (github.event.pull_request.base.ref == 'dev' ||
+      github.event.pull_request.head.ref == 'dev') &&
+      (github.event.action != 'edited' || github.event.changes.title != null) &&
+      (startsWith(github.event.pull_request.title, 'v') ||
+      startsWith(github.event.pull_request.title, '0') ||
+      startsWith(github.event.pull_request.title, '1') ||
+      startsWith(github.event.pull_request.title, '2') ||
+      startsWith(github.event.pull_request.title, '3') ||
+      startsWith(github.event.pull_request.title, '4') ||
+      startsWith(github.event.pull_request.title, '5') ||
+      startsWith(github.event.pull_request.title, '6') ||
+      startsWith(github.event.pull_request.title, '7') ||
+      startsWith(github.event.pull_request.title, '8') ||
+      startsWith(github.event.pull_request.title, '9'))
     permissions:
       contents: read
     uses: open-webui/tests/.github/workflows/regression.yml@main
     with:
       open-webui-ref: ${{ github.event.pull_request.head.sha }}
 
-  # ── Single check to require in branch protection ─────────────────────────
+  # Single check to require in branch protection.
   result:
     name: Result
-    needs: [gate, regression]
+    needs: [regression]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions: {}
     steps:
       - name: Fail unless the suite passed or was not required
-        if: needs.gate.result != 'success' || (needs.regression.result != 'success' && needs.regression.result != 'skipped')
+        if: needs.regression.result != 'success' && needs.regression.result != 'skipped'
         run: exit 1

--- a/.github/workflows/regression.yaml
+++ b/.github/workflows/regression.yaml
@@ -1,0 +1,72 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Regression — run the open-webui/tests unit suite against a release candidate
+# The suite runs on PRs into main titled with a version, or touching package.json
+# ─────────────────────────────────────────────────────────────────────────────
+name: Regression
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, edited]
+
+# Runs are queued rather than cancelled: an edit to a release PR would otherwise
+# discard a suite already in progress and report the required check red.
+concurrency:
+  group: regression-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  # ── A release bumps the version; the title carries it by convention ──────
+  gate:
+    name: Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      pull-requests: read
+    outputs:
+      release: ${{ steps.check.outputs.release }}
+    steps:
+      - name: Look for a version title or a change to package.json
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TITLE: ${{ github.event.pull_request.title }}
+          NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          if [[ "$TITLE" =~ ^v?[0-9]+\.[0-9]+ ]]; then
+            echo "release=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Assigned rather than piped into the test, so a failed listing stops the job
+          # instead of reading as an untouched package.json.
+          files="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$NUMBER/files" --paginate --jq '.[].filename')"
+          if grep -qxF 'package.json' <<<"$files"; then
+            echo "release=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "release=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::\"$TITLE\" does not start with a version and package.json is untouched, skipping the regression suite"
+          fi
+
+  # ── Run the external suite against the head of the pull request ──────────
+  regression:
+    name: Suite
+    needs: gate
+    if: needs.gate.outputs.release == 'true'
+    permissions:
+      contents: read
+    uses: open-webui/tests/.github/workflows/regression.yml@main
+    with:
+      open-webui-ref: ${{ github.event.pull_request.head.sha }}
+
+  # ── Single check to require in branch protection ─────────────────────────
+  result:
+    name: Result
+    needs: [gate, regression]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      - name: Fail unless the suite passed or was not required
+        if: needs.gate.result != 'success' || (needs.regression.result != 'success' && needs.regression.result != 'skipped')
+        run: exit 1

--- a/.github/workflows/regression.yaml
+++ b/.github/workflows/regression.yaml
@@ -9,11 +9,11 @@ on:
     branches: [main]
     types: [opened, synchronize, reopened, edited]
 
-# Runs are queued rather than cancelled: an edit to a release PR would otherwise
-# discard a suite already in progress and report the required check red.
+# A superseded run is cancelled outright: queuing it would just burn a runner
+# on a commit nobody ships, and make the author wait out a stale check.
 concurrency:
   group: regression-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   # ── A release bumps the version; the title carries it by convention ──────

--- a/.github/workflows/regression.yaml
+++ b/.github/workflows/regression.yaml
@@ -9,8 +9,6 @@ on:
     branches: [main]
     types: [opened, synchronize, reopened, edited]
 
-# A superseded run is cancelled outright: queuing it would just burn a runner
-# on a commit nobody ships, and make the author wait out a stale check.
 concurrency:
   group: regression-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Adds a workflow that runs the open-webui/tests unit suite against release candidates, so a release that reintroduces a fixed bug is caught before it is cut rather than after users report it. The suite is roughly 4500 source-level tests pinned to specific past issues and PRs, and takes about three minutes; the dependency install dominates the run and is cached.

It runs only on pull requests into main whose title starts with a version, which is how releases are titled here, or which touch package.json. Everything else into main, and every pull request into dev, skips it and reports green.

Two settings are needed for this to block anything, both outside the diff: require the Regression / Result check on main, and require branches to be up to date before merging so the suite covers what actually lands.

The reusable workflow is referenced at @main so a release always runs the current tests. Pinning it to a tag instead is a reasonable call to make here.

## Contributor License Agreement

<!--
DO NOT DELETE THIS SECTION.
Your PR will not be reviewed or merged until you check the box below confirming that you have read and agree to the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
