### PR TITLE
fix: drain playwright route handlers before the page closes

### DIFF
--- a/backend/open_webui/retrieval/web/utils.py
+++ b/backend/open_webui/retrieval/web/utils.py
@@ -853,6 +853,7 @@ class SafePlaywrightURLLoader(PlaywrightURLLoader, RateLimitMixin, URLProcessing
                                 raise ValueError(f'page.goto() returned None for url {url}')
 
                             text = self.evaluator.evaluate(page, browser, response)
+                            page.unroute_all(behavior='ignoreErrors')
                             metadata = {'source': url}
                             yield Document(page_content=text, metadata=metadata)
                     except Exception as e:
@@ -888,6 +889,7 @@ class SafePlaywrightURLLoader(PlaywrightURLLoader, RateLimitMixin, URLProcessing
                                 raise ValueError(f'page.goto() returned None for url {url}')
 
                             text = await self.evaluator.evaluate_async(page, browser, response)
+                            await page.unroute_all(behavior='ignoreErrors')
                             metadata = {'source': url}
                             yield Document(page_content=text, metadata=metadata)
                     except Exception as e:


### PR DESCRIPTION
# Pull Request

## Checklist

- [x] This PR targets the `dev` branch.
- [x] This PR links to a well-described, confirmed Issue or active Discussion: `Closes #28869`.
- [x] A maintainer explicitly asked me to open this PR, or this PR only updates i18n/localization.
- [x] The change is one logical unit with no unrelated commits.
- [x] I matched nearby code patterns and avoided unnecessary new settings, abstractions, or dependencies.
- [x] I manually tested the changed workflow and any nearby behavior that could be affected.
- [ ] I updated relevant docs, including the [Open WebUI Docs Repository](https://github.com/open-webui/docs), if needed.
- [ ] I added screenshots for UI changes, and a recording when motion or interaction matters.
- [x] I reviewed any AI-generated code before submitting it.
- [x] The PR title uses one of the prefixes listed below.

## Summary

The Playwright web loader logs an uncaught `TargetClosedError` traceback, several times per page, whenever a page finishes loading while background subrequests are still in flight. Pages that fire analytics or telemetry beacons after load, Wix sites among them, hit it reliably. Reported in #28869, confirmed there by another user.

Anchored to `dev` at `6ea321370e5f817e95e0d2f9397c54be86925d9a`. The failure has two stages, and the second one is the cleanup path:

```python
except Exception as e:
    log.debug('Playwright loader could not fetch %s: %s', req.url, e)
    await route.abort()
    return
```

[utils.py#L818-L821](https://github.com/open-webui/open-webui/blob/6ea321370e5f817e95e0d2f9397c54be86925d9a/backend/open_webui/retrieval/web/utils.py#L818-L821). The page closes, its aiohttp session goes with it, and a route handler still in flight fails its fetch with `Session is closed`. That part is caught and logged at DEBUG, which is fine. The `route.abort()` meant to clean up then runs against a target that no longer exists, raises `TargetClosedError`, and escapes the handler, so Playwright reports it as `Error occurred in event listener` with a full traceback. `route.fulfill()` on the success path is exposed the same way.

The invariant is that a page's route handlers must not outlive the page, and the code that closes the page owns it. Playwright drains them on request, which is also what its own error message recommends:

```diff
                             text = self.evaluator.evaluate(page, browser, response)
+                            page.unroute_all(behavior='ignoreErrors')
                             metadata = {'source': url}

                             text = await self.evaluator.evaluate_async(page, browser, response)
+                            await page.unroute_all(behavior='ignoreErrors')
                             metadata = {'source': url}
```

One line in `lazy_load` and one in `alazy_load`, placed after the evaluator runs while the page is still open. `_intercept_navigation_sync` has the same unguarded `route.abort()` as the async version, so both loaders need it. `behavior='ignoreErrors'` is available on both the sync and async `Page` in the pinned `playwright==1.60.0`.

## Testing

1. Ran a web search in `Legacy` function calling mode with SearXNG as the search engine and Playwright as the web loader engine, against results including Wix hosted pages, on a local instance at `http://localhost:5173`. Before the change the backend log carries repeated `Error occurred in event listener` blocks with the `TargetClosedError` traceback. On this branch they are gone.
2. The `Playwright loader could not fetch <url>: Session is closed` DEBUG lines remain, which is the aiohttp side of the same teardown and is expected. Only the uncaught traceback is removed.
3. Search results themselves were unchanged before and after, since this was never a functional failure.

Supporting checks: the file compiles, `ruff format` reports it already formatted so the hunk introduces no formatting drift, and the `unroute_all` signature was confirmed against the installed `playwright==1.60.0` rather than assumed from a newer release.

## Changelog Entry

### Fixed

- The Playwright web loader no longer logs uncaught `TargetClosedError` tracebacks when a page finishes loading with background subrequests still in flight.

## Additional Context

One case is deliberately left out of this diff. If `page.goto()` or the evaluator raises, the drain is skipped and the page can still close with routes in flight, so the same traceback is reachable on the error path. Covering it means wrapping the block in `try/finally`, which is a larger diff and a reindent for a rarer path. I kept the change to the reported case and am happy to extend it if you would rather have both covered.

This PR was prepared with AI copilot assistance and I have thoroughly reviewed and manually tested it.

## Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
