### PR TITLE
fix: resolve same-instance file URLs behind proxies and subpaths

### DIFF
--- a/backend/open_webui/routers/images.py
+++ b/backend/open_webui/routers/images.py
@@ -477,6 +477,82 @@ def _is_same_origin(url: str, base_url: str) -> bool:
     )
 
 
+# The file-content route this app serves: /api/v1/files/{id}/content, optionally
+# followed by a filename. Anchored so a lookalike path such as
+# /evil/api/v1/files/x/content on the same host cannot match.
+_LOCAL_FILE_CONTENT_RE = re.compile(r'^/api/v1/files/(?P<file_id>[^/]+)/content(?:/[^/]*)?$')
+
+
+def _resolve_local_file_path(url: str, trusted_origins: list[str]) -> str | None:
+    """Return the local route for ``url`` if it points back at this deployment.
+
+    An absolute URL to our own file store must be read through the local file route
+    with the caller's identity: the endpoint requires an authenticated session, so an
+    anonymous self-fetch is rejected (401), and on a private-network deployment the
+    SSRF guard blocks it before that. Returning None leaves the URL on the ordinary
+    external path, so third-party URLs are untouched and no credentials are ever
+    attached to them.
+
+    Matching on origin rather than ``netloc`` alone also normalises default ports, and
+    the returned path has any deployment subpath prefix stripped so the local branch
+    sees the canonical route.
+    """
+    try:
+        parsed = urlparse(url)
+        if parsed.scheme not in ('http', 'https'):
+            return None
+
+        for origin in trusted_origins:
+            if not origin or not _is_same_origin(url, origin):
+                continue
+
+            # This forces our prefix to be a path that is in origin
+            prefix = urlparse(origin).path.rstrip('/')
+            path = parsed.path
+            if prefix:
+                if not path.startswith(prefix):
+                    continue
+                path = path[len(prefix) :]
+
+            if _LOCAL_FILE_CONTENT_RE.match(path):
+                return path
+    except ValueError:
+        log.debug('Could not parse image URL as a local file route: %s', url)
+
+    return None
+
+
+async def _trusted_self_origins(request: Request) -> list[str]:
+    """Origins that mean 'this deployment'.
+
+    The admin-configured WEBUI_URL is authoritative and is checked first: behind a
+    reverse proxy, request.base_url can be an internal address that never matches the
+    public URL the client was given. base_url remains the fallback for deployments that
+    leave WEBUI_URL unset.
+
+    base_url reflects X-Forwarded-* headers, so it is client-influenced. That is safe
+    here because a match only routes the read through get_file_content_by_id(), which
+    still enforces this user's access control -- it avoids an unauthenticated
+    self-fetch, it never grants access.
+    """
+    origins = []
+
+    try:
+        values = await get_config_values({'WEBUI_URL': 'webui.url'})
+        webui_url = (values.get('WEBUI_URL') or '').strip()
+        if webui_url:
+            origins.append(webui_url)
+    except Exception as e:
+        log.debug('Could not read webui.url config: %s', e)
+
+    try:
+        origins.append(str(request.base_url))
+    except Exception as e:
+        log.debug('Could not derive request base_url: %s', e)
+
+    return origins
+
+
 async def get_image_data(data: str, headers=None, trusted_base_url: str | None = None):
     try:
         if data.startswith('http://') or data.startswith('https://'):
@@ -912,19 +988,16 @@ async def image_edits(
     model = image_config.IMAGE_EDIT_MODEL if form_data.model is None else form_data.model
 
     try:
+        trusted_origins = await _trusted_self_origins(request)
 
         async def load_url_image(data):
             if data.startswith('data:'):
                 return data
-
+            # This decouples image_edits with validating URL and fetching them
             if data.startswith('http://') or data.startswith('https://'):
-                parsed = urlparse(data)
-                if (
-                    parsed.netloc == urlparse(str(request.base_url)).netloc
-                    and parsed.path.startswith('/api/v1/files/')
-                    and '/content' in parsed.path
-                ):
-                    return await load_url_image(parsed.path)
+                local_path = _resolve_local_file_path(data, trusted_origins)
+                if local_path:
+                    return await load_url_image(local_path)
 
                 # Validate URL to prevent SSRF attacks against local/private networks.
                 # allow_redirects=False prevents redirect-based SSRF: validate_url() is

--- a/backend/open_webui/test/routers/test_images_local_file_urls.py
+++ b/backend/open_webui/test/routers/test_images_local_file_urls.py
@@ -1,0 +1,59 @@
+"""Regression tests for same-instance file URLs in the image-edit loader (#29220).
+
+An absolute URL pointing back at this deployment must be resolved through the local
+file route (with the caller's identity) rather than fetched anonymously over HTTP.
+"""
+
+import pytest
+
+from open_webui.routers.images import _resolve_local_file_path
+
+FILE_ID = 'b4dcc0cc-a7f9-47db-9b99-6cb8ec42d0d3'
+CONTENT_PATH = f'/api/v1/files/{FILE_ID}/content'
+SELF = ['http://localhost:8080']
+
+
+@pytest.mark.parametrize(
+    'url,origins,expected',
+    [
+        # --- resolves to the local route ---
+        (f'http://localhost:8080{CONTENT_PATH}', SELF, CONTENT_PATH),
+        (f'http://localhost:8080{CONTENT_PATH}/picture.png', SELF, f'{CONTENT_PATH}/picture.png'),
+        (f'http://localhost:8080{CONTENT_PATH}?download=1', SELF, CONTENT_PATH),
+        # default port is normalised, so an explicit :80 still matches
+        (f'http://localhost{CONTENT_PATH}', ['http://localhost:80'], CONTENT_PATH),
+        # behind a proxy the configured public URL matches even though base_url does not
+        (
+            f'https://chat.example.com{CONTENT_PATH}',
+            ['https://chat.example.com', 'http://127.0.0.1:8080/'],
+            CONTENT_PATH,
+        ),
+        # subpath deployment: the prefix is stripped from the returned route
+        (
+            f'https://host.example/openwebui{CONTENT_PATH}',
+            ['https://host.example/openwebui'],
+            CONTENT_PATH,
+        ),
+        # --- stays on the external path ---
+        (f'http://evil.example{CONTENT_PATH}', SELF, None),
+        # userinfo injection must not read as same-origin
+        (f'http://localhost:8080@evil.example{CONTENT_PATH}', SELF, None),
+        # suffix confusion
+        (f'http://localhost:8080evil.example{CONTENT_PATH}', SELF, None),
+        # same origin, different port
+        (f'http://localhost:9999{CONTENT_PATH}', SELF, None),
+        # same origin but not the file-content route
+        ('http://localhost:8080/api/v1/chats/', SELF, None),
+        # unanchored lookalike path
+        (f'http://localhost:8080/evil{CONTENT_PATH}', SELF, None),
+        # a subpath deployment must not match the unprefixed route
+        (f'https://host.example{CONTENT_PATH}', ['https://host.example/openwebui'], None),
+        # non-http scheme
+        (f'file://{CONTENT_PATH}', SELF, None),
+        # no usable origin configured
+        (f'http://localhost:8080{CONTENT_PATH}', [], None),
+        (f'http://localhost:8080{CONTENT_PATH}', [''], None),
+    ],
+)
+def test_resolve_local_file_path(url, origins, expected):
+    assert _resolve_local_file_path(url, origins) == expected


### PR DESCRIPTION
<!--
Important checks for contributors:
1. Target the `dev` branch. PRs targeting `main` will be closed.
2. Code pull requests are not the default contribution path.
3. Do not open a code PR as the first step. Start with a well-written Issue or Discussion unless a maintainer asked for the PR or the change is only i18n/localization.
4. Do not delete the Contributor License Agreement section at the bottom. The CLA bot requires it.
-->

# Pull Request

## Checklist

- [x] This PR targets the `dev` branch.
- [x] This PR links to a well-described, confirmed Issue or active Discussion: `Relates to #29220`.
- [ ] A maintainer explicitly asked me to open this PR, or this PR only updates i18n/localization.
- [x] The change is one logical unit with no unrelated commits.
- [x] I matched nearby code patterns and avoided unnecessary new settings, abstractions, or dependencies.
- [x] I manually tested the changed workflow and any nearby behavior that could be affected.
- [ ] I updated relevant docs, including the [Open WebUI Docs Repository](https://github.com/open-webui/docs), if needed.
- [ ] I added screenshots for UI changes, and a recording when motion or interaction matters.
- [x] I reviewed any AI-generated code before submitting it.
- [x] The PR title uses one of the prefixes listed below.

## Summary

Follow-up to 50413f348, which routes an absolute URL pointing back at this instance
through the local file route instead of fetching it anonymously. That check compares raw
`netloc` against `request.base_url`, so three ordinary deployment shapes still fall
through to the anonymous fetch and fail with `400: [ERROR: Error loading image]`:

| Deployment shape | Resolves locally today? |
| --- | --- |
| plain `http://localhost:8080` | yes |
| behind a reverse proxy (`request.base_url` is an internal address) | **no** |
| subpath deployment (`https://host/openwebui/...`) | **no** |
| explicit default port (`http://host:80/...`) | **no** |

This PR moves the decision into `_resolve_local_file_path()`, which checks the
admin-configured `WEBUI_URL` first and falls back to `request.base_url`. Origins are
compared with the existing `_is_same_origin()` helper so default ports normalise, the
route is matched with an anchored pattern rather than `startswith` plus substring, and
any subpath prefix is stripped before the local branch sees the path.

Access control is unchanged: local reads still go through `get_file_content_by_id()`,
which enforces the caller's permissions. No credentials are attached to third-party
requests. The change removes a self-request rather than authenticating an external one.

Note: `_is_same_origin()` raises `ValueError` on a malformed authority such as
`http://host:8080evil.example/`, since `urlparse` cannot cast the port. The resolver
treats that as "not this deployment". `get_image_data()` has the same exposure and is
untouched here.

## Testing

```
pytest backend/open_webui/test/routers/test_images_local_file_urls.py -q
16 passed in 31.26s
```

16 cases: the three fixed shapes, plus userinfo injection, suffix confusion, mismatched
port, non-`http(s)` scheme, unanchored lookalike paths, and empty origin lists.

End-to-end on a patched 0.11.3 build with `WEBUI_URL=https://chat.example.com` while
listening on `127.0.0.1:8098`, via `POST /api/v1/images/edit`:

| image argument | result |
| --- | --- |
| `http://127.0.0.1:8098/api/v1/files/{id}/content` | loaded |
| `https://chat.example.com/api/v1/files/{id}/content` | loaded |
| `/api/v1/files/{id}/content` | loaded |
| `{id}` | loaded |
| `http://127.0.0.1:9999/api/v1/files/{id}/content` | blocked by SSRF guard |
| `https://evil.example/api/v1/files/{id}/content` | blocked by SSRF guard |

All four self-URL forms now behave identically; the two absolute ones previously failed
with `400: [ERROR: Error loading image]`. The access log shows zero requests to
`/api/v1/files/{id}/content` from the edit path, and the negative controls still hit the
SSRF guard.

## Changelog Entry

### Fixed

- Image editing now resolves same-instance file URLs behind a reverse proxy, on subpath
  deployments, and when the URL carries an explicit default port, instead of failing
  with `400: [ERROR: Error loading image]`.

## Additional Context

No UI changes, no new settings or dependencies. The only config consulted is the
existing `WEBUI_URL`.

The test file is the first Python test in the repo, so there is no `pytest` CI job yet
(`pytest-asyncio` is already in the `dev` group). Happy to drop it if you would rather
not start a test tree here.

## Contributor License Agreement

<!--
DO NOT DELETE THIS SECTION.
Your PR will not be reviewed or merged until you check the box below confirming that you have read and agree to the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
