### PR TITLE
fix(a11y): improve aria-labels on AppSidebar navigation buttons

### DIFF
--- a/src/lib/components/app/AppSidebar.svelte
+++ b/src/lib/components/app/AppSidebar.svelte
@@ -19,11 +19,11 @@
 
 		<Tooltip content="Home" placement="right">
 			<button
-				aria-label="Home"
+				aria-label="Navigate to home"
 				class=" cursor-pointer {selected === 'home' ? 'rounded-2xl' : 'rounded-full'}"
 				on:click={() => {
 					selected = 'home';
-
+			
 					if (window.electronAPI) {
 						window.electronAPI.load('home');
 					}
@@ -51,7 +51,7 @@
 			</div>
 		{/if}
 		<button
-			aria-label="Chat"
+			aria-label="Navigate to chat list"
 			class=" cursor-pointer bg-transparent"
 			on:click={() => {
 				selected = '';


### PR DESCRIPTION
**WCAG 4.1.2 Fix**\n\nChanged generic  →  and  →  for better screen reader clarity.\n\nRelated to merged #29160 (EllaFr's folder modal a11y fix).