### PR TITLE
fix: scale dropdown menu item text with the UI scale setting

### DIFF
--- a/src/lib/components/common/DropdownMenu.svelte
+++ b/src/lib/components/common/DropdownMenu.svelte
@@ -4,7 +4,7 @@
 </script>
 
 <div
-	class={`app-dropdown-menu rounded-xl! p-0.5! border border-gray-100 dark:border-gray-800 z-50 bg-white dark:bg-gray-850 dark:text-white shadow-lg ${className} [&>button]:flex [&>button]:w-full [&>button]:h-[1.6875rem] [&>button]:items-center [&>button]:gap-2 [&>button]:rounded-xl! [&>button]:px-2! [&>button]:text-[13px] [&>button:hover]:bg-gray-50/60 dark:[&>button:hover]:bg-gray-800/60 [&>a]:flex [&>a]:w-full [&>a]:h-[1.6875rem] [&>a]:items-center [&>a]:gap-2 [&>a]:rounded-xl! [&>a]:px-2! [&>a]:text-[13px] [&>a:hover]:bg-gray-50/60 dark:[&>a:hover]:bg-gray-800/60 [&>button_svg]:size-3.5 [&>a_svg]:size-3.5 [&>hr]:my-0.5 [&>hr]:mx-1`}
+	class={`app-dropdown-menu rounded-xl! p-0.5! border border-gray-100 dark:border-gray-800 z-50 bg-white dark:bg-gray-850 dark:text-white shadow-lg ${className} [&>button]:flex [&>button]:w-full [&>button]:h-[1.6875rem] [&>button]:items-center [&>button]:gap-2 [&>button]:rounded-xl! [&>button]:px-2! [&>button]:text-[0.8125rem] [&>button:hover]:bg-gray-50/60 dark:[&>button:hover]:bg-gray-800/60 [&>a]:flex [&>a]:w-full [&>a]:h-[1.6875rem] [&>a]:items-center [&>a]:gap-2 [&>a]:rounded-xl! [&>a]:px-2! [&>a]:text-[0.8125rem] [&>a:hover]:bg-gray-50/60 dark:[&>a:hover]:bg-gray-800/60 [&>button_svg]:size-3.5 [&>a_svg]:size-3.5 [&>hr]:my-0.5 [&>hr]:mx-1`}
 	{style}
 >
 	<slot />


### PR DESCRIPTION
# Pull Request

## Checklist

- [x] This PR targets the `dev` branch.
- [x] This PR links to a well-described, confirmed Issue or active Discussion: `Closes #29488`.
- [x] A maintainer explicitly asked me to open this PR, or this PR only updates i18n/localization.
- [x] The change is one logical unit with no unrelated commits.
- [x] I matched nearby code patterns and avoided unnecessary new settings, abstractions, or dependencies.
- [x] I manually tested the changed workflow and any nearby behavior that could be affected.
- [ ] I updated relevant docs, including the [Open WebUI Docs Repository](https://github.com/open-webui/docs), if needed.
- [x] I added screenshots for UI changes, and a recording when motion or interaction matters.
- [x] I reviewed any AI-generated code before submitting it.
- [x] The PR title uses one of the prefixes listed below.

## Summary

`UI Scale` leaves some popup menu items at their original size while the rest of the menu grows, reported in #29488 with the user menu, the chat three dot menu, and the `Chats` header menu.

Anchored to `dev` at `6ea321370e5f817e95e0d2f9397c54be86925d9a`. `UI Scale` works by scaling the root font size, so everything sized in `rem` follows it, at [app.css#L20-L24](https://github.com/open-webui/open-webui/blob/6ea321370e5f817e95e0d2f9397c54be86925d9a/src/app.css#L20-L24):

```css
html {
	word-break: break-word;
	/* font-size scales the entire document via the same UI control */
	font-size: calc(1rem * var(--app-text-scale, 1));
}
```

`DropdownMenu.svelte` styles its items with an absolute pixel size instead, so those items never move:

```diff
-[&>button]:text-[13px]  ...  [&>a]:text-[13px]
+[&>button]:text-[0.8125rem]  ...  [&>a]:text-[0.8125rem]
```

`0.8125rem` is exactly `13px` at the default root size, so nothing changes at `1.0x` and the text now tracks the setting at every other value.

This also explains why only some items are affected, which the reporter noticed but read slightly differently. The `[&>button]` and `[&>a]` selectors match direct children only. In the user menu, `Workspace`, `Notes`, `Calendar`, `Automations`, and `Playground` each sit inside a wrapper `div`, so the rule does not reach them and their own `text-[0.8125rem]` applies and scales. `Admin Panel`, `Settings`, and `Sign Out` are direct children, so they are pinned at 13px. The distinction is direct child versus nested, not link versus div.

The same class list already sets `[&>button]:h-[1.6875rem]`, which does scale, so the row grows while the label stays put. That is the mismatch visible in the issue screenshots, and it is also why the problem is invisible at `1.0x` and clearer the higher the scale goes.

One file, one line. `text-[13px]` occurred exactly twice in `src/`, both of them here, and `DropdownMenu.svelte` is shared by all three menus named in the issue, so a single change covers every reported surface.

## Testing

1. Set `Settings` > `Interface` > `UI Scale` above `1.0x`, then opened the bottom left user menu, a chat's three dot menu, and the `Chats` header menu. Every item now scales together, where previously `Admin Panel`, `Settings`, and `Sign Out` stayed at their original size while the rows around them grew.
2. Checked the same menus at `1.0x` to confirm the default rendering is unchanged.

Supporting checks: `npx prettier --check` passes on the changed file, and the class list carries no remaining absolute pixel values.

| Surface | Before | After |
| --- | --- | --- |
| User menu at a raised UI Scale | <img width="252" height="364" alt="image" src="https://github.com/user-attachments/assets/ff34c7fe-a22c-48a0-9b6e-5df13faa2d9c" /> | <img width="252" height="364" alt="image" src="https://github.com/user-attachments/assets/baac2a74-e669-4d59-a38b-0261d4c53769" /> |
| Chat three dot menu at a raised UI Scale | <img width="255" height="358" alt="image" src="https://github.com/user-attachments/assets/9a108392-75ff-478f-a882-cb412657574b" /> | <img width="255" height="358" alt="image" src="https://github.com/user-attachments/assets/eed81b74-11d6-4664-a688-43ae9a255195" /> |
| Menus at 1.0x, unchanged | <img width="257" height="305" alt="image" src="https://github.com/user-attachments/assets/c52d75fb-72ba-4f84-9a4b-ef21413c4f70" /> | <img width="257" height="305" alt="image" src="https://github.com/user-attachments/assets/c57c8a92-b47a-4329-8db6-d6ec459cb7e1" /> |

Before is current `dev`, After is this branch.

## Changelog Entry

### Fixed

- Popup menu items now scale with the `UI Scale` setting instead of staying at a fixed size.

## Additional Context

The rem value is used rather than removing the rule, so items that rely on the shared menu styling keep the size they have today. Dropping `text-[13px]` outright would leave those items inheriting whatever the surrounding context provides, which is a larger and less predictable change than the report calls for.

This PR was prepared with AI copilot assistance and I have thoroughly reviewed and manually tested it.

## Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
