### PR TITLE
fix: enable ask_user submit when the last question uses the other field

### DIFF
--- a/src/lib/components/chat/AskUserCard.svelte
+++ b/src/lib/components/chat/AskUserCard.svelte
@@ -87,7 +87,7 @@
 			return answer?.type === 'option' || (answer?.type === 'other' && answer.text.trim() !== '');
 		});
 
-	$: complete = hasAnswers();
+	$: complete = hasAnswers(answers);
 
 	const submit = (selected = answers) => {
 		if (!hasAnswers(selected)) {


### PR DESCRIPTION
# Pull Request

## Checklist

- [x] This PR targets the `dev` branch.
- [x] This PR links to a well-described, confirmed Issue or active Discussion: `Closes #29311`.
- [x] A maintainer explicitly asked me to open this PR, or this PR only updates i18n/localization.
- [x] The change is one logical unit with no unrelated commits.
- [x] I matched nearby code patterns and avoided unnecessary new settings, abstractions, or dependencies.
- [x] I manually tested the changed workflow and any nearby behavior that could be affected.
- [ ] I updated relevant docs, including the [Open WebUI Docs Repository](https://github.com/open-webui/docs), if needed.
- [x] I added screenshots for UI changes, and a recording when motion or interaction matters.
- [x] I reviewed any AI-generated code before submitting it.
- [x] The PR title uses one of the prefixes listed below.

## Summary

`Submit answers` stays disabled when the last `ask_user` question is answered with free text in the `Other` field, reported in #29311 and reproduced by two other people.

Anchored to `dev` at `6ea321370e5f817e95e0d2f9397c54be86925d9a`. The flag behind that button is never recomputed, at [AskUserCard.svelte#L90](https://github.com/open-webui/open-webui/blob/6ea321370e5f817e95e0d2f9397c54be86925d9a/src/lib/components/chat/AskUserCard.svelte#L90):

```svelte
$: complete = hasAnswers();
```

`hasAnswers` reads `answers` from its default parameter, so the statement itself never mentions it. Svelte does not look inside the function body, so the reactive statement is compiled with no dependencies at all:

```js
$.legacy_pre_effect(() => {}, () => { $.set(complete, hasAnswers()); });
```

`complete` is evaluated once during initialization, while `answers` is still `{}`, and stays `false` for the life of the card.

```diff
-	$: complete = hasAnswers();
+	$: complete = hasAnswers(answers);
```

which compiles to a tracked dependency:

```js
$.legacy_pre_effect(() => ($.get(answers)), () => { $.set(complete, hasAnswers($.get(answers))); });
```

The statement directly above already does this correctly, passing `answers` through rather than relying on the default, and `submit(selected)` and `advance(selected)` call `hasAnswers` the same way, so this matches what the file already does.

## Testing

1. Ran an `ask_user` prompt and answered the final question by typing into the `Other` field. `Submit answers` now enables as soon as the field has text, and submits it. Before the change the button stayed greyed out no matter what was typed.
2. Ran a multi question prompt answering an early question with `Other` and the last with a preset option, to confirm the existing auto submit path still works and the earlier free text answer is still carried through.
3. Checked the `Cancel`, `Previous`, and `Next` controls behave as before.

Supporting checks: compiled the component with the project's own Svelte compiler before and after to confirm the dependency list changes from empty to `answers`, and `npx prettier --check` passes on the changed file.

| Surface | Before | After |
| --- | --- | --- |
| Last question answered with `Other` text | <img width="1966" height="437" alt="image" src="https://github.com/user-attachments/assets/e62e0405-fa96-4cac-a92e-2554a1fdb608" /> | <img width="1966" height="437" alt="image" src="https://github.com/user-attachments/assets/ab61ba19-40b5-4692-87f2-0bfa561fa8bc" /> |

Before is current `dev`, After is this branch.

## Changelog Entry

### Fixed

- `ask_user` prompts can now be submitted when the final question is answered with free text in the `Other` field.

## Additional Context

Why the button being permanently disabled was not obvious sooner: choosing a preset option on the last question never uses it. `selectOption` calls `advance`, which calls `submit` directly once the last question is reached, so that path bypasses the button. Earlier questions advance through `Next`, which has no disabled gate. Free text on the final question is the only route that depends on `complete`, which is why the report is scoped exactly there.

One related detail left alone deliberately: `hasAnswers` also reads `questions`, which this statement still does not track. `questions` is a prop that is fixed for the lifetime of the card, so it cannot go stale in practice, and adding it would need a guard expression that reads worse than the problem it prevents. Happy to widen it if you would rather have the dependency complete.

This PR was prepared with AI copilot assistance and I have thoroughly reviewed and manually tested it.

## Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
