### PR TITLE
fix: pass file.meta through to vector DB chunks on file upload

### DIFF
--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -1967,6 +1967,7 @@ async def process_file(
                         Document(
                             page_content=doc.page_content,
                             metadata={
+                                **file.meta,
                                 **filter_metadata(doc.metadata),
                                 'name': file.filename,
                                 'created_by': file.user_id,


### PR DESCRIPTION
Custom metadata attached to a file upload (e.g. via the API's metadata field) was stored on the file row but silently dropped when the file was chunked and embedded for RAG, so it never reached the LLM through retrieved sources.

process_file() builds chunk metadata in several branches; three of them already merge the file's meta dict in, but the branch used for a fresh upload processed through a document loader did not. Bring it in line with the others so custom metadata flows through consistently regardless of upload path.

Reported in open-webui/open-webui#29486.

## Contributor License Agreement

<!--
DO NOT DELETE THIS SECTION.
Your PR will not be reviewed or merged until you check the box below confirming that you have read and agree to the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
