### PR TITLE
fix: apply new model's defaults before reading them on send

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -982,10 +982,8 @@
 	}
 
 	let settingDefaults = false;
-	const setDefaults = async () => {
-		if (settingDefaults) return;
-		settingDefaults = true;
-
+	let defaultsPromise = Promise.resolve();
+	const applyDefaults = async () => {
 		try {
 			if (!$tools) {
 				tools.set(await getTools(localStorage.token));
@@ -1094,6 +1092,13 @@
 		} finally {
 			settingDefaults = false;
 		}
+	};
+
+	const setDefaults = () => {
+		if (settingDefaults) return defaultsPromise;
+		settingDefaults = true;
+		defaultsPromise = applyDefaults().catch((error) => console.error(error));
+		return defaultsPromise;
 	};
 
 	const showMessage = async (message, scroll = true, save = true) => {
@@ -2867,6 +2872,8 @@
 	//////////////////////////
 
 	const submitPrompt = async (inputContent, inputFiles) => {
+		await defaultsPromise;
+
 		const _files = structuredClone(inputFiles);
 
 		chatFiles.push(
@@ -3054,6 +3061,7 @@
 		prompt = '';
 	};
 
+	let awaitingDefaults = false;
 	const submitHandler = async (userPrompt, { _raw = false } = {}) => {
 		console.log('submitHandler', userPrompt, $chatId);
 
@@ -3086,6 +3094,15 @@
 		if (modelCommandMatch) {
 			handleModelCommand(modelCommandMatch[1]?.trim() ?? '');
 			return;
+		}
+
+		// Drop a second send that races this wait, since prompt isn't cleared until after it
+		if (awaitingDefaults) return;
+		awaitingDefaults = true;
+		try {
+			await defaultsPromise;
+		} finally {
+			awaitingDefaults = false;
 		}
 
 		if (pendingOAuthTools.length > 0) {


### PR DESCRIPTION
Switching the composer's model mid-chat and sending right away could ship the previous model's feature flags: applying the new model's default tools/skills/features (including web_search) is asynchronous, and nothing made a send wait for it, so features.web_search could go out false even though the toggle showed on.

Track the in-flight defaults application in a promise and have the send path await it before reading tools/skills/features, with a small guard so a second rapid send can't slip past that wait and read stale state too. The wait is scoped to just that point rather than the whole send handler, so it doesn't delay clearing the input or block a follow-up message from queuing while the assistant is still generating.

Fixes #29326

## Contributor License Agreement

<!--
DO NOT DELETE THIS SECTION.
Your PR will not be reviewed or merged until you check the box below confirming that you have read and agree to the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
