### PR TITLE
fix: apply the shared metadata size cap to the last four vector DB backends

### DIFF
--- a/backend/open_webui/retrieval/vector/dbs/milvus_multitenancy.py
+++ b/backend/open_webui/retrieval/vector/dbs/milvus_multitenancy.py
@@ -24,6 +24,7 @@ from open_webui.retrieval.vector.main import (
     VectorDBBase,
     VectorItem,
 )
+from open_webui.retrieval.vector.utils import process_metadata
 from pymilvus import DataType
 from pymilvus import MilvusClient as Client
 from pymilvus.exceptions import MilvusException
@@ -191,7 +192,7 @@ class MilvusClient(VectorDBBase):
                     'id': item['id'],
                     'vector': item['vector'],
                     'text': text,
-                    'metadata': item['metadata'],
+                    'metadata': process_metadata(item['metadata']),
                     RESOURCE_ID_FIELD: resource_id,
                 }
             )

--- a/backend/open_webui/retrieval/vector/dbs/oracle23ai.py
+++ b/backend/open_webui/retrieval/vector/dbs/oracle23ai.py
@@ -57,7 +57,7 @@ from open_webui.retrieval.vector.main import (
     VectorDBBase,
     VectorItem,
 )
-from open_webui.retrieval.vector.utils import iter_filter_conditions
+from open_webui.retrieval.vector.utils import iter_filter_conditions, process_metadata
 from open_webui.utils.json_codec import JSONCodec
 
 log = logging.getLogger(__name__)
@@ -400,7 +400,7 @@ class Oracle23aiClient(VectorDBBase):
         Returns:
             str: JSON representation of metadata
         """
-        return json.dumps(metadata, default=self._decimal_handler) if metadata else '{}'
+        return json.dumps(process_metadata(metadata), default=self._decimal_handler) if metadata else '{}'
 
     def _json_to_metadata(self, json_str: str) -> Dict:
         """

--- a/backend/open_webui/retrieval/vector/dbs/qdrant.py
+++ b/backend/open_webui/retrieval/vector/dbs/qdrant.py
@@ -22,7 +22,7 @@ from open_webui.retrieval.vector.main import (
     VectorDBBase,
     VectorItem,
 )
-from open_webui.retrieval.vector.utils import iter_filter_conditions
+from open_webui.retrieval.vector.utils import iter_filter_conditions, process_metadata
 from qdrant_client import QdrantClient as Qclient
 from qdrant_client.http.models import PointStruct
 from qdrant_client.models import models
@@ -136,7 +136,7 @@ class QdrantClient(VectorDBBase):
             PointStruct(
                 id=item['id'],
                 vector=item['vector'],
-                payload={'text': item['text'], 'metadata': item['metadata']},
+                payload={'text': item['text'], 'metadata': process_metadata(item['metadata'])},
             )
             for item in items
         ]

--- a/backend/open_webui/retrieval/vector/dbs/qdrant_multitenancy.py
+++ b/backend/open_webui/retrieval/vector/dbs/qdrant_multitenancy.py
@@ -23,7 +23,7 @@ from open_webui.retrieval.vector.main import (
     VectorDBBase,
     VectorItem,
 )
-from open_webui.retrieval.vector.utils import iter_filter_conditions
+from open_webui.retrieval.vector.utils import iter_filter_conditions, process_metadata
 from qdrant_client import QdrantClient as Qclient
 from qdrant_client.http.exceptions import UnexpectedResponse
 from qdrant_client.http.models import PointStruct
@@ -182,7 +182,7 @@ class QdrantClient(VectorDBBase):
                 vector=item['vector'],
                 payload={
                     'text': item['text'],
-                    'metadata': item['metadata'],
+                    'metadata': process_metadata(item['metadata']),
                     TENANT_ID_FIELD: tenant_id,
                 },
             )


### PR DESCRIPTION
Chunk metadata inserted into the vector DB carries arbitrary client- supplied fields (e.g. custom metadata from file uploads), so it needs the same size cap, type coercion and null-byte sanitization every other backend already applies through process_metadata(). Four backends never called it: Qdrant, Qdrant multitenancy, Milvus multitenancy and Oracle23ai, so an oversized or malformed metadata blob went into those unfiltered.

Wire process_metadata() in at each backend's single insert/upsert chokepoint, matching the pattern already used by the other eleven backends.

## Contributor License Agreement

<!--
DO NOT DELETE THIS SECTION.
Your PR will not be reviewed or merged until you check the box below confirming that you have read and agree to the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
