### PR TITLE
fix: install black's transitive deps in the pyodide code formatter

### DIFF
--- a/src/lib/components/common/CodeEditor.svelte
+++ b/src/lib/components/common/CodeEditor.svelte
@@ -122,7 +122,15 @@ print(black.format_str("""${code.replace(/\\/g, '\\\\').replace(/`/g, '\\`').rep
 print("${endTag}")
 `;
 
-			const packages = ['black'];
+			// black's pyodide-lock entry declares no dependencies, so micropip installs none of them
+			const packages = [
+				'black',
+				'click',
+				'mypy_extensions',
+				'pathspec',
+				'platformdirs',
+				'pytokens'
+			];
 
 			function handleMessage(event) {
 				const { id: eventId, stdout, stderr } = event.data;


### PR DESCRIPTION
Saving any tool or function in the admin UI threw "ModuleNotFoundError: No module named 'click'" in the browser, even on a fresh tool with no custom code, because the click name never appears in user code at all.

The in-browser formatter runs black through a Pyodide/micropip worker. black needs click, mypy_extensions, pathspec, platformdirs and pytokens at import time, but the vendored pyodide-lock.json records none of these as black's dependencies, and micropip only walks a locked package's declared deps when install() is given explicit constraints, which this worker never does. So only black itself ever got installed.

Requesting the five packages explicitly alongside black fixes it without touching the worker or the lock file.

## Contributor License Agreement

<!--
DO NOT DELETE THIS SECTION.
Your PR will not be reviewed or merged until you check the box below confirming that you have read and agree to the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
