### PR TITLE
fix: clarify error when a workspace model's base model is restricted

### DIFF
--- a/backend/open_webui/constants.py
+++ b/backend/open_webui/constants.py
@@ -70,6 +70,9 @@ class ERROR_MESSAGES(str, Enum):
     ACCESS_PROHIBITED = (
         'You do not have permission to access this resource. Please contact your administrator for assistance.'
     )
+    BASE_MODEL_ACCESS_PROHIBITED = (
+        'Access to the base model is restricted. Please contact your administrator for assistance.'
+    )
     ACTION_PROHIBITED = 'The requested action has been restricted as a security measure.'
 
     FILE_NOT_SENT = 'FILE_NOT_SENT'

--- a/backend/open_webui/utils/access_control/__init__.py
+++ b/backend/open_webui/utils/access_control/__init__.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 from open_webui.config import DEFAULT_USER_PERMISSIONS
+from open_webui.constants import ERROR_MESSAGES
 from open_webui.models.access_grants import (
     has_anyone_read_access_grant,
     has_public_read_access_grant,
@@ -385,7 +386,7 @@ async def check_model_access(
 
             # Enforce access on chained base models
             if not await has_base_model_access(user.id, model_info, user_role=user.role, user_group_ids=user_group_ids):
-                raise HTTPException(status_code=403, detail='Model not found')
+                raise HTTPException(status_code=403, detail=ERROR_MESSAGES.BASE_MODEL_ACCESS_PROHIBITED)
     else:
         if user.role != 'admin':
             raise HTTPException(status_code=403, detail='Model not found')

--- a/backend/open_webui/utils/models.py
+++ b/backend/open_webui/utils/models.py
@@ -8,6 +8,7 @@ from open_webui.config import (
     BYPASS_ADMIN_ACCESS_CONTROL,
     DEFAULT_ARENA_MODEL,
 )
+from open_webui.constants import ERROR_MESSAGES
 from open_webui.env import BYPASS_MODEL_ACCESS_CONTROL, ENABLE_PLUGINS, GLOBAL_LOG_LEVEL, REDIS_KEY_PREFIX
 from open_webui.functions import get_function_models
 from open_webui.models.access_grants import AccessGrants
@@ -492,7 +493,7 @@ async def check_model_access(user, model, model_info=None, db=None):
         if not await has_base_model_access(
             user.id, model_info, user_role=user.role, user_group_ids=user_group_ids, db=db
         ):
-            raise Exception('Model not found')
+            raise Exception(ERROR_MESSAGES.BASE_MODEL_ACCESS_PROHIBITED)
 
 
 async def get_filtered_models(models, user, db=None):


### PR DESCRIPTION
Fixes #29506

A workspace model built on a restricted base model always failed with a generic "Model not found", identical to the message for a model that genuinely doesn't exist or that the user has no access to at all. That made a very common, self-inflicted misconfiguration (base model access not set up to match the workspace model) look like a missing model, with no way to tell the two apart.

The base-model-chain denial now gets its own message naming the base model as the cause. The other two denial reasons keep the generic message unchanged, since revealing them would let a non-admin infer whether a private model ID exists; that risk doesn't apply here because the caller already has legitimate access to the workspace model whose base is restricted.

## Contributor License Agreement

<!--
DO NOT DELETE THIS SECTION.
Your PR will not be reviewed or merged until you check the box below confirming that you have read and agree to the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
