### PR TITLE
fix: make slash command labels readable in light theme

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -715,7 +715,7 @@ html.high-contrast.dark .ProseMirror p.is-editor-empty:first-child::before {
 }
 
 .tippy-box[data-theme~='transparent'] {
-	@apply bg-transparent p-0 m-0;
+	@apply bg-transparent p-0 m-0 text-inherit;
 }
 
 /* this is a rough fix for the first cursor position when the first paragraph is empty */


### PR DESCRIPTION
Fixes #29510

In **Light** theme the `/` command palette rendered `Temporary`, `Model` and `Settings` as white text on the menu's white background. Other themes were unaffected.

## Why it happened

The menu is not rendered inline. `getSuggestionRenderer` in `src/lib/components/common/RichTextInput/suggestions.ts` mounts it into a **tippy popup** appended to `document.body` with `theme: 'transparent'`, and tippy's own stylesheet sets `.tippy-box { color: #fff }`.

The `transparent` theme neutralised tippy's chrome but not its text colour:

```css
.tippy-box[data-theme~='transparent'] {
	@apply bg-transparent p-0 m-0;
}
```

`DropdownMenu.svelte` then paints `bg-white dark:bg-gray-850 dark:text-white`, defining a text colour **only** for dark mode, and the command rows in `SlashCommands.svelte` set no colour of their own. So in light theme those labels inherited tippy's white onto the dropdown's white.

This also explains why the bug was partial rather than obvious: the secondary text uses `app-muted` (`text-gray-500 dark:text-gray-400`) and the prompt rows use `text-black dark:text-gray-100`, so `Off`, `/model`, `/settings` and every prompt stayed readable. Only the primary labels inherit.

## The change

One line, resetting the colour so the popup inherits from `body` (`#000` light, `#eee` dark):

```diff
 .tippy-box[data-theme~='transparent'] {
-	@apply bg-transparent p-0 m-0;
+	@apply bg-transparent p-0 m-0 text-inherit;
 }
```

## Why here rather than in DropdownMenu

Adding a light-mode text colour to `DropdownMenu` would also fix it, but that component has 50 consumers and only this one is affected. `suggestions.ts` is currently the **only** call site using `theme: 'transparent'`, so fixing the theme is precisely scoped to the suggestion popups, and it hardens the `@` menu against the same trap. The `@` menu is not currently broken only because it sets explicit colours on every row.

## Verification

- `npm run build` passes; the compiled asset contains `.tippy-box[data-theme~=transparent]{...color:inherit;background-color:#0000}`.
- Confirmed by @silentoplayz on a local build: labels render correctly in Light theme, and Dark and system themes are unchanged.

## Noted, not changed

`slash-command-row` is applied to all six command buttons in `SlashCommands.svelte` but is not defined anywhere in the codebase. It looks like a leftover from whatever previously coloured these rows. Out of scope here, but worth a follow-up.
