### PR TITLE
fix: make slash command labels readable in light theme

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -715,7 +715,7 @@ html.high-contrast.dark .ProseMirror p.is-editor-empty:first-child::before {
 }
 
 .tippy-box[data-theme~='transparent'] {
-	@apply bg-transparent p-0 m-0;
+	@apply bg-transparent p-0 m-0 text-inherit;
 }
 
 /* this is a rough fix for the first cursor position when the first paragraph is empty */


### PR DESCRIPTION
## Checklist

- [x] This PR targets the `dev` branch.
- [x] This PR links to a well-described, confirmed Issue or active Discussion: `Closes #29510`.
- [ ] A maintainer explicitly asked me to open this PR, or this PR only updates i18n/localization.
- [x] The change is one logical unit with no unrelated commits.
- [x] I matched nearby code patterns and avoided unnecessary new settings, abstractions, or dependencies.
- [x] I manually tested the changed workflow and any nearby behavior that could be affected.
- [ ] I updated relevant docs, including the [Open WebUI Docs Repository](https://github.com/open-webui/docs), if needed.
- [x] I added screenshots for UI changes, and a recording when motion or interaction matters.
- [x] I reviewed any AI-generated code before submitting it.
- [x] The PR title uses one of the prefixes listed below.

## Summary

Closes #29510.

In **Light** theme the `/` command palette rendered `Temporary`, `Model` and `Settings` as white text on the menu's white background, so they were invisible. Other themes were unaffected.

The menu is not rendered inline. `getSuggestionRenderer` in `src/lib/components/common/RichTextInput/suggestions.ts` mounts it into a **tippy popup** appended to `document.body` with `theme: 'transparent'`, and tippy's own stylesheet sets `.tippy-box { color: #fff }`. The `transparent` theme neutralised tippy's chrome but not its text colour:

```css
.tippy-box[data-theme~='transparent'] {
	@apply bg-transparent p-0 m-0;
}
```

`DropdownMenu.svelte` then paints `bg-white dark:bg-gray-850 dark:text-white`, defining a text colour **only** for dark mode, and the command rows in `SlashCommands.svelte` set no colour of their own. In light theme those labels therefore inherited tippy's white onto the dropdown's white.

That also explains why the breakage was partial rather than obvious. The secondary text uses `app-muted` (`text-gray-500 dark:text-gray-400`) and the prompt rows use `text-black dark:text-gray-100`, so `Off`, `/model`, `/settings` and every prompt stayed readable. Only the primary labels inherit.

The change is one line, resetting the colour so the popup inherits from `body` (`#000` in light, `#eee` in dark):

```diff
 .tippy-box[data-theme~='transparent'] {
-	@apply bg-transparent p-0 m-0;
+	@apply bg-transparent p-0 m-0 text-inherit;
 }
```

**Why here rather than in `DropdownMenu`.** Adding a light-mode text colour to `DropdownMenu` would also fix it, but that component has 50 consumers and only this one is affected. `suggestions.ts` is currently the **only** call site using `theme: 'transparent'`, so fixing the theme is precisely scoped to the suggestion popups, and it hardens the `@` menu against the same trap. The `@` menu is not broken today only because it sets explicit colours on every row.

## Testing

- Typed `/` in the chat input in **Light** theme: `Temporary`, `Model` and `Settings` now render in the normal foreground colour.
- Rechecked **Dark** and system themes: unchanged.
- Rechecked the `@` menu and the `Prompts` and `Skills` sections of the `/` menu: unchanged, since they already set explicit colours.
- `npm run build` passes. The compiled asset contains `.tippy-box[data-theme~=transparent]{...color:inherit;background-color:#0000}`.

Verified on a local build of `dev` at commit `0c7ddbdb4`.

### Screenshots

Before is current `dev`, After is this branch.

| Surface | Before | After |
| :--- | :--- | :--- |
| `/` command menu, Light theme | <img width="395" height="424" alt="image" src="https://github.com/user-attachments/assets/af6a7087-fcb8-426b-ab50-83b57d3cafb1" /> | <img width="395" height="424" alt="image" src="https://github.com/user-attachments/assets/5aac2dfa-946a-4fcc-a30f-3ff3dd8dbb5b" /> |
| `/` command menu, Dark theme (no regression) | <img width="395" height="424" alt="image" src="https://github.com/user-attachments/assets/0e26a695-5bd0-4beb-86b2-9cbf52994612" /> | <img width="395" height="424" alt="image" src="https://github.com/user-attachments/assets/e2e52776-be72-47ae-aeb0-982cbacef47f" /> |


## Changelog Entry

### Fixed

- Slash command menu labels (`Temporary`, `Model`, `Settings`) were invisible in Light theme, rendering as white text on the menu's white background.

## Additional Context

Two notes for reviewers.

The "a maintainer explicitly asked me to open this PR" box is left unchecked because that would not be accurate. I found the bug, filed #29510 with the full root cause first, and this PR is a one-line CSS change against it. Happy for it to be handled as a report rather than a code contribution if that is preferred.

Separately, and out of scope here: the class `slash-command-row` is applied to all six command buttons in `SlashCommands.svelte` but is not defined anywhere in the codebase. It looks like a leftover from whatever previously coloured these rows, and may be worth a follow-up cleanup.

## Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

