### PR TITLE
fix: use raw strings for the regex escapes in the knowledge filesystem

### DIFF
--- a/backend/open_webui/tools/knowledge_fs.py
+++ b/backend/open_webui/tools/knowledge_fs.py
@@ -69,22 +69,23 @@ def match_budget():
 
 
 def is_regex_pattern(pattern: str) -> bool:
-    """Detect if a pattern looks like regex (|, .*, .+, \d, \w, \s, [...])."""
+    r"""Detect if a pattern looks like regex (|, .*, .+, \d, \w, \s, [...])."""
     return (
         '|' in pattern
         or '.*' in pattern
         or '.+' in pattern
         or '.?' in pattern
-        or '\d' in pattern
-        or '\w' in pattern
-        or '\s' in pattern
+        or r'\d' in pattern
+        or r'\w' in pattern
+        or r'\s' in pattern
         or bool(re.search(r'\[.+\]', pattern))
     )
 
 
 def normalize_regex(pattern: str) -> str:
-    """Normalize POSIX BRE patterns to Python regex (\| → |)."""
-    return pattern.replace('\\|', '|').replace('\|', '|')
+    r"""Normalize POSIX BRE patterns to Python regex (\| → |)."""
+    # Two passes: an escaped backslash in front of a pipe leaves a second escape behind.
+    return pattern.replace(r'\|', '|').replace(r'\|', '|')
 
 
 def validate_regex_quantifiers(pattern: str) -> str | None:


### PR DESCRIPTION
The regex detection helpers wrote their backslash escapes in ordinary string literals, so Python reported six invalid escape sequences on import. They work today because Python leaves an unrecognised escape as its two characters, but that behaviour is deprecated and becomes a syntax error in a future release, at which point the knowledge filesystem tools stop importing at all.

The literals are now raw, which is the same two characters with no warning. Pattern detection and normalisation are unchanged: verified identical output over every string up to length five drawn from the characters these helpers look at.

## Contributor License Agreement

<!--
DO NOT DELETE THIS SECTION.
Your PR will not be reviewed or merged until you check the box below confirming that you have read and agree to the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
