### PR TITLE
fix: do not offer ask_user in chats that cannot resolve it

### DIFF
--- a/backend/open_webui/utils/tools.py
+++ b/backend/open_webui/utils/tools.py
@@ -575,14 +575,17 @@ async def get_builtin_tools(
             await Config.get('user.permissions'),
         )
 
+    metadata = extra_params.get('__metadata__') or {}
+
     # Time utilities - available for date calculations
     if is_builtin_tool_enabled('time'):
         builtin_functions.extend([get_current_timestamp, calculate_timestamp])
 
-    if is_builtin_tool_enabled('user_input', True):
+    # User input - answers are resolved against the stored assistant message;
+    # temporary and channel IDs have no chats row to resolve them against.
+    if is_builtin_tool_enabled('user_input', True) and is_saved_chat_id(metadata.get('chat_id')):
         builtin_functions.append(ask_user)
 
-    metadata = extra_params.get('__metadata__') or {}
     chat_files = metadata.get('files') or extra_params.get('__files__') or []
     has_chat_files = any(
         isinstance(item, dict)


### PR DESCRIPTION
# Pull Request

Closes #29248.

## Checklist

- [x] This PR targets the `dev` branch.
- [x] This PR links to a well-described, confirmed Issue or active Discussion: `Closes #29248`.
- [ ] A maintainer explicitly asked me to open this PR, or this PR only updates i18n/localization.
- [x] The change is one logical unit with no unrelated commits.
- [x] I matched nearby code patterns and avoided unnecessary new settings, abstractions, or dependencies.
- [ ] I manually tested the changed workflow and any nearby behavior that could be affected.
- [x] I updated relevant docs, including the [Open WebUI Docs Repository](https://github.com/open-webui/docs), if needed.
- [x] I added screenshots for UI changes, and a recording when motion or interaction matters.
- [x] I reviewed any AI-generated code before submitting it.
- [x] The PR title uses one of the prefixes listed below.

Two boxes are left unticked deliberately, so please read them as stated rather than as oversights:

- No maintainer asked for this PR. #29248 carries the `confirmed issue` label and names the exact one-line guard, so I took it as ready to implement, but I have not been asked. Close this if unsolicited PRs are unwelcome here even for confirmed issues — no hard feelings.
- I did not run a live instance. What I did verify is described under Testing. If a maintainer wants an end-to-end run on a real deployment before merging, that check is still outstanding.

No screenshots: the change removes a tool from the model's tool list, so there is nothing new to show.

## Summary

In a temporary chat, the model can still call the built-in `ask_user` tool. The question card renders and accepts answers, but submitting them fails and the temporary chat is discarded, losing the whole conversation.

Answering an `ask_user` card is resolved entirely against stored state. `resolve_tool_call_output` loads the chat by id, finds the pending `function_call` on the stored message, and appends the answers as a `function_call_output`. A temporary chat is never written to the database, so that first lookup fails and `POST /api/v1/chats/{id}/messages/{message_id}/resolve` returns 401. The frontend's error handler for the failed resolve calls `loadChat()`, which cannot find a temporary chat and falls through to `goto('/')` — so the conversation disappears rather than merely erroring.

The tool was nevertheless injected unconditionally:

```python
if is_builtin_tool_enabled('user_input', True):
    builtin_functions.append(ask_user)
```

This PR guards that injection with `is_saved_chat_id`, exactly as the task management builtins in the same function already do, and for the same reason — their comment reads *"Task state is stored on the chats row; local/channel IDs do not have one."* `ask_user` depends on the same stored state.

`metadata` was bound a few lines below the `user_input` block, so the assignment moves up above it. Nothing between the old and new position reads `metadata`, and no other code path injects `ask_user`, so the guard is the only reachable entry point.

The guard also covers channel chats (`channel:` ids), which have no chats row either and would hit the same dead end.

## Testing

I did not run a live Open WebUI instance for this, and I would rather say so than tick a box I did not earn. What I did check:

- Traced every caller: `ask_user` is injected in exactly one place (`utils/tools.py`), so no other path can reintroduce it into an unsaved chat.
- Confirmed nothing between the old and new position of the `metadata` assignment reads `metadata`, so moving it is inert.
- Exercised the guard predicate directly against the real `utils/chat_id.py`:

  ```
  'temporary:abc'   -> ask_user injected: False
  'local:abc'       -> ask_user injected: False   # legacy temporary prefix
  'channel:xyz'     -> ask_user injected: False
  '8f2e-uuid-real'  -> ask_user injected: True    # saved chat, unchanged
  None              -> ask_user injected: False
  ''                -> ask_user injected: False
  ```

  Saved chats keep the tool; every id that has no chats row loses it. `None`/`''` (a direct `/api/chat/completions` call with no chat id) also has nothing to resolve against, so excluding it is correct.
- `is_builtin_tool_enabled('user_input', True)` keeps its `True` default, so the admin-facing toggle behaves as before for saved chats.

## Changelog Entry

### Fixed

- Temporary and channel chats no longer offer the built-in `ask_user` tool. Answering its card there could not be resolved and discarded the conversation.

## Additional Context

#29248 suggests the injection guard alone is enough, and I agree: it makes the failing resolve unreachable for this case. The wider fragility it points at — `loadChat()` throwing a temporary chat away when any resolve call fails — is a separate concern, closer to #29249, and I left it alone to keep this one logical unit.

## Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
