### PR TITLE
fix: open grouped citation sources on click

### DIFF
--- a/src/lib/components/chat/Messages/Markdown/SourceToken.svelte
+++ b/src/lib/components/chat/Messages/Markdown/SourceToken.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { LinkPreview } from 'bits-ui';
 	import { decodeString } from '$lib/utils';
 	import Source from './Source.svelte';
 
@@ -8,7 +7,6 @@
 	export let sourceIds = [];
 	export let onClick: Function = () => {};
 
-	let containerElement;
 	let openPreview = false;
 
 	// Helper function to return only the domain from a URL
@@ -45,35 +43,40 @@
 		{@const identifier = token.citationIdentifiers ? token.citationIdentifiers[0] : id - 1}
 		<Source id={identifier} title={sourceIds[id - 1]} {onClick} />
 	{:else}
-		<LinkPreview.Root openDelay={0} bind:open={openPreview}>
-			<LinkPreview.Trigger>
-				<button
-					aria-label={`${getDisplayTitle(formattedTitle(decodeString(sourceIds[token.ids[0] - 1])))} +${(token?.ids ?? []).length - 1} more sources`}
-					class="text-[0.625rem] w-fit translate-y-[2px] px-2 py-0.5 dark:bg-white/5 dark:text-white/80 dark:hover:text-white bg-gray-50 text-black/80 hover:text-black transition rounded-xl"
-					on:click={() => {
-						openPreview = !openPreview;
-					}}
-				>
-					<span class="line-clamp-1">
-						{getDisplayTitle(formattedTitle(decodeString(sourceIds[token.ids[0] - 1])))}
-						<span class="dark:text-white/50 text-black/50">+{(token?.ids ?? []).length - 1}</span>
-					</span>
-				</button>
-			</LinkPreview.Trigger>
-			<LinkPreview.Portal>
-				<LinkPreview.Content class="z-[999]" align="start" strategy="fixed" sideOffset={6}>
+		<div class="relative inline-block">
+			<button
+				aria-label={`${getDisplayTitle(formattedTitle(decodeString(sourceIds[token.ids[0] - 1])))} +${(token?.ids ?? []).length - 1} more sources`}
+				class="text-[0.625rem] w-fit translate-y-[2px] px-2 py-0.5 dark:bg-white/5 dark:text-white/80 dark:hover:text-white bg-gray-50 text-black/80 hover:text-black transition rounded-xl"
+				on:click={() => {
+					openPreview = !openPreview;
+				}}
+			>
+				<span class="line-clamp-1">
+					{getDisplayTitle(formattedTitle(decodeString(sourceIds[token.ids[0] - 1])))}
+					<span class="dark:text-white/50 text-black/50">+{(token?.ids ?? []).length - 1}</span>
+				</span>
+			</button>
+			{#if openPreview}
+				<div class="absolute left-0 top-full z-[999] mt-1 min-w-max">
 					<div class="bg-gray-50 dark:bg-gray-850 rounded-xl p-1 cursor-pointer">
 						{#each token.citationIdentifiers ?? token.ids as identifier}
 							{@const id =
 								typeof identifier === 'string' ? parseInt(identifier.split('#')[0]) : identifier}
 							<div class="">
-								<Source id={identifier} title={sourceIds[id - 1]} {onClick} />
+								<Source
+									id={identifier}
+									title={sourceIds[id - 1]}
+									onClick={(sourceId) => {
+										openPreview = false;
+										onClick(sourceId);
+									}}
+								/>
 							</div>
 						{/each}
 					</div>
-				</LinkPreview.Content>
-			</LinkPreview.Portal>
-		</LinkPreview.Root>
+				</div>
+			{/if}
+		</div>
 	{/if}
 {:else}
 	<span>{token.raw}</span>


### PR DESCRIPTION
## Summary

The grouped citation badge (`+N`) used `LinkPreview`, which is designed for hover-triggered popovers. Repurposing it for click-toggled behavior caused the grouped source list to never open on click.

This replaces the `LinkPreview` wrapper with a lightweight click-toggled dropdown:
- Clicking the grouped `+N` badge now opens the list of grouped sources.
- Clicking a source from the list closes the dropdown and invokes the existing source callback.

## Changes
- `src/lib/components/chat/Messages/Markdown/SourceToken.svelte`

Closes #29529
