### PR TITLE
test retry

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -5665,6 +5665,8 @@ async def streaming_chat_response_handler(response, ctx):
                                 except Exception as e:
                                     log.debug(e)
                                     return None
+                        if not isinstance(params, dict):
+                            return None
                         tool_call.setdefault('function', {})['arguments'] = JSONCodec.dumps(params)
                         return params
 


### PR DESCRIPTION
## Summary

When a model emits a tool call whose `arguments` parse to a JSON scalar (for example a bare string) instead of an object, `parse_tool_params` returned the scalar and `execute_tool_call` crashed on `params.items()`, killing the whole chat response.

This change treats any non-dict parsed tool arguments as an invalid tool call, matching the existing graceful-skip path already used when JSON parsing fails.

## Validation
- Deterministic repro from the issue now returns `None` instead of reaching `.items()`:
  - `JSONCodec.loads('"foo"')` → `"foo"` → guard returns `None` → tool call is skipped.

## Changes
- `backend/open_webui/utils/middleware.py`

Closes #29323
