### PR TITLE
fix: provide model context for initial title generation (#29533)

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -1450,12 +1450,21 @@ async def chat_completion(
                             **metadata,
                             'message_id': all_assistant_ids[0],
                         }
+                        title_model_id = next(
+                            (
+                                entry['model_id']
+                                for entry in message_ids
+                                if entry.get('message_id') == all_assistant_ids[0]
+                            ),
+                            None,
+                        )
                         event_emitter = await get_event_emitter(title_metadata, update_db=False)
                         title_ctx = {
                             'request': request,
                             'form_data': form_data,
                             'user': user,
                             'metadata': title_metadata,
+                            'model': title_model_id,
                             'tasks': {TASKS.TITLE_GENERATION: initial_title_generation},
                             'event_emitter': event_emitter,
                         }

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -3669,6 +3669,11 @@ async def background_tasks_handler(ctx):
             return
         message = messages_map.get(metadata['message_id'])
 
+        # The initial title-generation task can run before the persisted assistant
+        # message carries its model field. Fall back to the model passed in ctx.
+        if message and 'model' not in message and 'model' in ctx:
+            message['model'] = ctx['model']
+
         message_list = get_message_list(messages_map, metadata['message_id'])
 
         # Remove details tags and files from the messages.


### PR DESCRIPTION
## Summary

Initial title generation for new chats can run before the persisted assistant message carries its `model` field, causing the background task to fail with `KeyError: 'model'` and leave the full first message as the chat title.

This change:
- Passes the new chat's first assistant model into the title task context.
- Falls back to that model in `background_tasks_handler` when the loaded assistant message does not yet have a `model` field.

## Changes
- `backend/open_webui/main.py`
- `backend/open_webui/utils/middleware.py`

Closes #29533
