### PR TITLE
fix: open grouped citation sources on click

### DIFF
--- a/src/lib/components/chat/Messages/Markdown/SourceToken.svelte
+++ b/src/lib/components/chat/Messages/Markdown/SourceToken.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { LinkPreview } from 'bits-ui';
 	import { decodeString } from '$lib/utils';
 	import Source from './Source.svelte';
 
@@ -8,7 +7,6 @@
 	export let sourceIds = [];
 	export let onClick: Function = () => {};
 
-	let containerElement;
 	let openPreview = false;
 
 	// Helper function to return only the domain from a URL
@@ -45,35 +43,40 @@
 		{@const identifier = token.citationIdentifiers ? token.citationIdentifiers[0] : id - 1}
 		<Source id={identifier} title={sourceIds[id - 1]} {onClick} />
 	{:else}
-		<LinkPreview.Root openDelay={0} bind:open={openPreview}>
-			<LinkPreview.Trigger>
-				<button
-					aria-label={`${getDisplayTitle(formattedTitle(decodeString(sourceIds[token.ids[0] - 1])))} +${(token?.ids ?? []).length - 1} more sources`}
-					class="text-[0.625rem] w-fit translate-y-[2px] px-2 py-0.5 dark:bg-white/5 dark:text-white/80 dark:hover:text-white bg-gray-50 text-black/80 hover:text-black transition rounded-xl"
-					on:click={() => {
-						openPreview = !openPreview;
-					}}
-				>
-					<span class="line-clamp-1">
-						{getDisplayTitle(formattedTitle(decodeString(sourceIds[token.ids[0] - 1])))}
-						<span class="dark:text-white/50 text-black/50">+{(token?.ids ?? []).length - 1}</span>
-					</span>
-				</button>
-			</LinkPreview.Trigger>
-			<LinkPreview.Portal>
-				<LinkPreview.Content class="z-[999]" align="start" strategy="fixed" sideOffset={6}>
+		<div class="relative inline-block">
+			<button
+				aria-label={`${getDisplayTitle(formattedTitle(decodeString(sourceIds[token.ids[0] - 1])))} +${(token?.ids ?? []).length - 1} more sources`}
+				class="text-[0.625rem] w-fit translate-y-[2px] px-2 py-0.5 dark:bg-white/5 dark:text-white/80 dark:hover:text-white bg-gray-50 text-black/80 hover:text-black transition rounded-xl"
+				on:click={() => {
+					openPreview = !openPreview;
+				}}
+			>
+				<span class="line-clamp-1">
+					{getDisplayTitle(formattedTitle(decodeString(sourceIds[token.ids[0] - 1])))}
+					<span class="dark:text-white/50 text-black/50">+{(token?.ids ?? []).length - 1}</span>
+				</span>
+			</button>
+			{#if openPreview}
+				<div class="absolute left-0 top-full z-[999] mt-1 min-w-max">
 					<div class="bg-gray-50 dark:bg-gray-850 rounded-xl p-1 cursor-pointer">
 						{#each token.citationIdentifiers ?? token.ids as identifier}
 							{@const id =
 								typeof identifier === 'string' ? parseInt(identifier.split('#')[0]) : identifier}
 							<div class="">
-								<Source id={identifier} title={sourceIds[id - 1]} {onClick} />
+								<Source
+									id={identifier}
+									title={sourceIds[id - 1]}
+									onClick={(sourceId) => {
+										openPreview = false;
+										onClick(sourceId);
+									}}
+								/>
 							</div>
 						{/each}
 					</div>
-				</LinkPreview.Content>
-			</LinkPreview.Portal>
-		</LinkPreview.Root>
+				</div>
+			{/if}
+		</div>
 	{/if}
 {:else}
 	<span>{token.raw}</span>


### PR DESCRIPTION
## Checklist

- [x] This PR targets the `dev` branch.
- [x] This PR links to a well-described, confirmed Issue or active Discussion: `Closes #29529`.
- [ ] A maintainer explicitly asked me to open this PR, or this PR only updates i18n/localization.
- [x] The change is one logical unit with no unrelated commits.
- [x] I matched nearby code patterns and avoided unnecessary new settings, abstractions, or dependencies.
- [x] I manually tested the changed workflow and any nearby behavior that could be affected.
- [ ] I updated relevant docs, including the [Open WebUI Docs Repository](https://github.com/open-webui/docs), if needed.
- [ ] I added screenshots for UI changes, and a recording when motion or interaction matters.
- [x] I reviewed any AI-generated code before submitting it.
- [x] The PR title uses one of the prefixes listed below.

## Summary

The grouped citation badge (`+N`) used `LinkPreview`, which is designed for hover-triggered popovers. Repurposing it for click-toggled behavior caused the grouped source list to never open on click.

## Testing

Click-tested the grouped `+N` badge: clicking now opens the list of grouped sources; clicking a source from the list closes the dropdown and invokes the existing source callback.

## Changelog Entry

### Added

-

### Changed

-

### Fixed

- The grouped citation badge (`+N`) used `LinkPreview`, which is designed for hover-triggered popovers. Repurposing it for click-toggled behavior caused the grouped source list to never open on click.

### Removed

-

### Security

-

### Breaking Changes

-

## Additional Context

Closes #29529. 

## Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
