### PR TITLE
feat: notify teammates when mentioned in channels

### DIFF
--- a/backend/open_webui/routers/channels.py
+++ b/backend/open_webui/routers/channels.py
@@ -979,9 +979,7 @@ async def get_channel_mention_user_ids(channel, message, sender_id, db=None) -> 
         # Group and DM access is membership-based. ``is_active`` is the
         # membership flag used by the channel model; it is not presence.
         member_ids = {
-            member.user_id
-            for member in await Channels.get_members_by_channel_id(channel.id, db=db)
-            if member.is_active
+            member.user_id for member in await Channels.get_members_by_channel_id(channel.id, db=db) if member.is_active
         }
         allowed_user_ids = {u.id for u in await Users.get_users_by_user_ids(list(member_ids), db=db)}
     else:

--- a/backend/open_webui/routers/channels.py
+++ b/backend/open_webui/routers/channels.py
@@ -1279,6 +1279,7 @@ async def post_new_message(
             log.debug(e)
 
         active_user_ids = await get_user_ids_from_room(f'channel:{channel.id}')
+
         # NOTE: We intentionally do NOT pass db to background_handler.
         # Background tasks should manage their own short-lived sessions to avoid
         # holding database connections during slow operations (e.g., LLM calls).

--- a/backend/open_webui/routers/channels.py
+++ b/backend/open_webui/routers/channels.py
@@ -44,7 +44,7 @@ from open_webui.socket.main import (
 )
 from open_webui.utils.access_control import filter_allowed_access_grants, has_permission
 from open_webui.utils.auth import get_admin_user, get_verified_user
-from open_webui.utils.channels import extract_mentions, replace_mentions
+from open_webui.utils.channels import extract_mentions, extract_user_mention_ids, replace_mentions
 from open_webui.utils.files import get_image_base64_from_file_id
 from open_webui.utils.models import (
     get_all_models,
@@ -973,6 +973,25 @@ async def send_notification(request, channel, message, active_user_ids, db=None)
     return True
 
 
+async def get_channel_mention_user_ids(channel, message, sender_id, db=None) -> list[str]:
+    """Resolve encoded user mentions to valid users authorized to read a channel."""
+    if channel.type in ['group', 'dm']:
+        # Group and DM access is membership-based. ``is_active`` is the
+        # membership flag used by the channel model; it is not presence.
+        member_ids = {
+            member.user_id
+            for member in await Channels.get_members_by_channel_id(channel.id, db=db)
+            if member.is_active
+        }
+        allowed_user_ids = {u.id for u in await Users.get_users_by_user_ids(list(member_ids), db=db)}
+    else:
+        # Standard channels use read access grants (including public grants),
+        # rather than ChannelMember rows.
+        allowed_user_ids = {u.id for u in await get_channel_users_with_access(channel, 'read', db=db)}
+
+    return extract_user_mention_ids(message.content, sender_id, allowed_user_ids)
+
+
 async def model_response_handler(request, channel, message, user, db=None):
     MODELS = {model['id']: model for model in await get_filtered_models(await get_all_models(request, user=user), user)}
 
@@ -1141,7 +1160,9 @@ async def model_response_handler(request, channel, message, user, db=None):
     return True
 
 
-async def new_message_handler(request: Request, id: str, form_data: MessageForm, user, db):
+async def new_message_handler(
+    request: Request, id: str, form_data: MessageForm, user, db, mention_user_ids_out: list[str] | None = None
+):
     channel = await Channels.get_channel_by_id(id, db=db)
     if not channel:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
@@ -1176,9 +1197,18 @@ async def new_message_handler(request: Request, id: str, form_data: MessageForm,
                         await Channels.update_member_active_status(channel.id, member.user_id, True, db=db)
 
             message = await Messages.get_message_by_id(message.id, db=db)
+
+            # Mentions are authoritative only when they refer to valid users
+            # authorized to read this channel. This prevents a crafted U:
+            # mention from notifying an unrelated instance user.
+            resolved_mention_user_ids = await get_channel_mention_user_ids(channel, message, user.id, db=db)
+            if mention_user_ids_out is not None:
+                mention_user_ids_out.extend(resolved_mention_user_ids)
+
             event_data = {
                 'channel_id': channel.id,
                 'message_id': message.id,
+                'mention_user_ids': resolved_mention_user_ids,
                 'data': {
                     'type': 'message',
                     'data': {'temp_id': form_data.temp_id, **message.model_dump()},
@@ -1232,7 +1262,15 @@ async def post_new_message(
     await check_channels_access(request, user)
 
     try:
-        message, channel = await new_message_handler(request, id, form_data, user, db)
+        mention_user_ids = []
+        message, channel = await new_message_handler(
+            request,
+            id,
+            form_data,
+            user,
+            db,
+            mention_user_ids_out=mention_user_ids,
+        )
         try:
             if files := message.data.get('files', []):
                 for file in files:
@@ -1243,7 +1281,6 @@ async def post_new_message(
             log.debug(e)
 
         active_user_ids = await get_user_ids_from_room(f'channel:{channel.id}')
-
         # NOTE: We intentionally do NOT pass db to background_handler.
         # Background tasks should manage their own short-lived sessions to avoid
         # holding database connections during slow operations (e.g., LLM calls).
@@ -2033,9 +2070,12 @@ async def post_webhook_message(
     # Get full message and emit event
     message = await Messages.get_message_by_id(message.id, db=db)
 
+    mention_user_ids = await get_channel_mention_user_ids(channel, message, message.user_id, db=db)
+
     event_data = {
         'channel_id': channel.id,
         'message_id': message.id,
+        'mention_user_ids': mention_user_ids,
         'data': {
             'type': 'message',
             'data': {

--- a/backend/open_webui/routers/channels.py
+++ b/backend/open_webui/routers/channels.py
@@ -44,7 +44,12 @@ from open_webui.socket.main import (
 )
 from open_webui.utils.access_control import filter_allowed_access_grants, has_permission
 from open_webui.utils.auth import get_admin_user, get_verified_user
-from open_webui.utils.channels import extract_mentions, extract_user_mention_ids, replace_mentions
+from open_webui.utils.channels import (
+    contains_user_mentions,
+    extract_mentions,
+    extract_user_mention_ids,
+    replace_mentions,
+)
 from open_webui.utils.files import get_image_base64_from_file_id
 from open_webui.utils.models import (
     get_all_models,
@@ -975,6 +980,11 @@ async def send_notification(request, channel, message, active_user_ids, db=None)
 
 async def get_channel_mention_user_ids(channel, message, sender_id, db=None) -> list[str]:
     """Resolve encoded user mentions to valid users authorized to read a channel."""
+    # Avoid membership/access queries for the common case of a message without
+    # a user mention.
+    if not contains_user_mentions(message.content):
+        return []
+
     if channel.type in ['group', 'dm']:
         # Group and DM access is membership-based. ``is_active`` is the
         # membership flag used by the channel model; it is not presence.

--- a/backend/open_webui/routers/channels.py
+++ b/backend/open_webui/routers/channels.py
@@ -1158,9 +1158,7 @@ async def model_response_handler(request, channel, message, user, db=None):
     return True
 
 
-async def new_message_handler(
-    request: Request, id: str, form_data: MessageForm, user, db, mention_user_ids_out: list[str] | None = None
-):
+async def new_message_handler(request: Request, id: str, form_data: MessageForm, user, db):
     channel = await Channels.get_channel_by_id(id, db=db)
     if not channel:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=ERROR_MESSAGES.NOT_FOUND)
@@ -1200,13 +1198,9 @@ async def new_message_handler(
             # authorized to read this channel. This prevents a crafted U:
             # mention from notifying an unrelated instance user.
             resolved_mention_user_ids = await get_channel_mention_user_ids(channel, message, user.id, db=db)
-            if mention_user_ids_out is not None:
-                mention_user_ids_out.extend(resolved_mention_user_ids)
-
             event_data = {
                 'channel_id': channel.id,
                 'message_id': message.id,
-                'mention_user_ids': resolved_mention_user_ids,
                 'data': {
                     'type': 'message',
                     'data': {'temp_id': form_data.temp_id, **message.model_dump()},
@@ -1220,6 +1214,13 @@ async def new_message_handler(
                 event_data,
                 to=f'channel:{channel.id}',
             )
+
+            if resolved_mention_user_ids:
+                await emit_to_users(
+                    'events:channel',
+                    {**event_data, 'data': {**event_data['data'], 'type': 'mention'}},
+                    resolved_mention_user_ids,
+                )
 
             if message.parent_id:
                 # If this message is a reply, emit to the parent message as well
@@ -1260,15 +1261,7 @@ async def post_new_message(
     await check_channels_access(request, user)
 
     try:
-        mention_user_ids = []
-        message, channel = await new_message_handler(
-            request,
-            id,
-            form_data,
-            user,
-            db,
-            mention_user_ids_out=mention_user_ids,
-        )
+        message, channel = await new_message_handler(request, id, form_data, user, db)
         try:
             if files := message.data.get('files', []):
                 for file in files:
@@ -2069,12 +2062,9 @@ async def post_webhook_message(
     # Get full message and emit event
     message = await Messages.get_message_by_id(message.id, db=db)
 
-    mention_user_ids = await get_channel_mention_user_ids(channel, message, message.user_id, db=db)
-
     event_data = {
         'channel_id': channel.id,
         'message_id': message.id,
-        'mention_user_ids': mention_user_ids,
         'data': {
             'type': 'message',
             'data': {
@@ -2099,6 +2089,14 @@ async def post_webhook_message(
         event_data,
         to=f'channel:{channel.id}',
     )
+
+    resolved_mention_user_ids = await get_channel_mention_user_ids(channel, message, message.user_id, db=db)
+    if resolved_mention_user_ids:
+        await emit_to_users(
+            'events:channel',
+            {**event_data, 'data': {**event_data['data'], 'type': 'mention'}},
+            resolved_mention_user_ids,
+        )
 
     await publish_event(
         request,

--- a/backend/open_webui/utils/channels.py
+++ b/backend/open_webui/utils/channels.py
@@ -10,6 +10,13 @@ def extract_mentions(message: str, triggerChar: str = '@'):
     return [{'id_type': id_type, 'id': id_value} for id_type, id_value in matches]
 
 
+def extract_user_mention_ids(message: str, sender_id: str, allowed_user_ids: set[str]) -> list[str]:
+    """Return unique, authorized IDs from persisted encoded U mentions."""
+    mentioned_ids = set(re.findall(r'<@U:([^|>]+)(?:\|[^>]*)?>', message))
+    mentioned_ids.discard(sender_id)
+    return sorted(mentioned_ids.intersection(allowed_user_ids))
+
+
 def replace_mentions(message: str, triggerChar: str = '@', use_label: bool = True):
     """
     Replace mentions in the message with either their label (after the pipe `|`)

--- a/backend/open_webui/utils/channels.py
+++ b/backend/open_webui/utils/channels.py
@@ -1,5 +1,7 @@
 import re
 
+USER_MENTION_ID_PATTERN = re.compile(r'<@U:([^|>]+)(?:\|[^>]*)?>')
+
 
 def extract_mentions(message: str, triggerChar: str = '@'):
     # Escape triggerChar in case it's a regex special character
@@ -12,9 +14,14 @@ def extract_mentions(message: str, triggerChar: str = '@'):
 
 def extract_user_mention_ids(message: str, sender_id: str, allowed_user_ids: set[str]) -> list[str]:
     """Return unique, authorized IDs from persisted encoded U mentions."""
-    mentioned_ids = set(re.findall(r'<@U:([^|>]+)(?:\|[^>]*)?>', message))
+    mentioned_ids = set(USER_MENTION_ID_PATTERN.findall(message))
     mentioned_ids.discard(sender_id)
     return sorted(mentioned_ids.intersection(allowed_user_ids))
+
+
+def contains_user_mentions(message: str) -> bool:
+    """Return whether a message contains at least one encoded user mention."""
+    return USER_MENTION_ID_PATTERN.search(message) is not None
 
 
 def replace_mentions(message: str, triggerChar: str = '@', use_label: bool = True):

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -1035,10 +1035,12 @@ export const cleanText = (content: string) => {
 	return removeFormattings(removeEmojis(content.trim()));
 };
 
+// Serialized user mentions use <@U:user-id|display label>.
+const USER_MENTION_TAG_REGEX = /<@U:[^|>]+(?:\|([^>]*))?>/g;
+
 export const cleanNotificationText = (content: string) => {
-	const contentWithReadableMentions = content.replace(
-		/<@U:[^|>]+(?:\|([^>]*))?>/g,
-		(_match, label) => (label ? `@${label}` : '@teammate')
+	const contentWithReadableMentions = content.replace(USER_MENTION_TAG_REGEX, (_match, label) =>
+		label ? `@${label}` : '@teammate'
 	);
 
 	return cleanText(contentWithReadableMentions);

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -1039,11 +1039,9 @@ export const cleanText = (content: string) => {
 const USER_MENTION_TAG_REGEX = /<@U:[^|>]+(?:\|([^>]*))?>/g;
 
 export const cleanNotificationText = (content: string) => {
-	const contentWithReadableMentions = content.replace(USER_MENTION_TAG_REGEX, (_match, label) =>
-		label ? `@${label}` : '@teammate'
-	);
+	const contentWithoutMentions = content.replace(USER_MENTION_TAG_REGEX, ' ');
 
-	return cleanText(contentWithReadableMentions);
+	return cleanText(contentWithoutMentions);
 };
 
 export const removeDetails = (content, types) => {

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -1044,6 +1044,13 @@ export const cleanNotificationText = (content: string) => {
 	return cleanText(contentWithoutMentions);
 };
 
+export const containsUserMention = (content: string, userId: string) => {
+	if (!userId) return false;
+
+	const escapedUserId = escapeRegExp(userId);
+	return new RegExp(`<@U:${escapedUserId}(?:\\|[^>]*)?>`).test(content);
+};
+
 export const removeDetails = (content, types) => {
 	return replaceOutsideCode(content, (segment) => {
 		for (const type of types) {

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -1035,6 +1035,15 @@ export const cleanText = (content: string) => {
 	return removeFormattings(removeEmojis(content.trim()));
 };
 
+export const cleanNotificationText = (content: string) => {
+	const contentWithReadableMentions = content.replace(
+		/<@U:[^|>]+(?:\|([^>]*))?>/g,
+		(_match, label) => (label ? `@${label}` : '@teammate')
+	);
+
+	return cleanText(contentWithReadableMentions);
+};
+
 export const removeDetails = (content, types) => {
 	return replaceOutsideCode(content, (segment) => {
 		for (const type of types) {

--- a/src/lib/utils/notification.test.ts
+++ b/src/lib/utils/notification.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import { cleanNotificationText } from './index';
+
+describe('cleanNotificationText', () => {
+	it('replaces serialized user mentions with readable labels', () => {
+		expect(cleanNotificationText('<@U:13c44bd0|Jonathan Flower> sup')).toBe('@Jonathan Flower sup');
+	});
+
+	it('does not expose an internal ID when a mention has no label', () => {
+		expect(cleanNotificationText('<@U:13c44bd0> hello')).toBe('@teammate hello');
+	});
+
+	it('removes markdown while preserving ordinary notification text', () => {
+		expect(cleanNotificationText('**Hello** `there`')).toBe('Hello there');
+	});
+});

--- a/src/lib/utils/notification.test.ts
+++ b/src/lib/utils/notification.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { cleanNotificationText } from './index';
+import { cleanNotificationText, containsUserMention } from './index';
 
 describe('cleanNotificationText', () => {
 	it('removes serialized user mentions from notification text', () => {
@@ -13,5 +13,20 @@ describe('cleanNotificationText', () => {
 
 	it('removes markdown while preserving ordinary notification text', () => {
 		expect(cleanNotificationText('**Hello** `there`')).toBe('Hello there');
+	});
+});
+
+describe('containsUserMention', () => {
+	it('matches only the requested encoded user mention', () => {
+		expect(containsUserMention('<@U:user-1|Ada> hello', 'user-1')).toBe(true);
+		expect(containsUserMention('<@U:user-10|Grace> hello', 'user-1')).toBe(false);
+	});
+
+	it('accepts mentions without a display label', () => {
+		expect(containsUserMention('<@U:user-1> hello', 'user-1')).toBe(true);
+	});
+
+	it('does not match when the user ID is unavailable', () => {
+		expect(containsUserMention('<@U:> hello', '')).toBe(false);
 	});
 });

--- a/src/lib/utils/notification.test.ts
+++ b/src/lib/utils/notification.test.ts
@@ -3,12 +3,12 @@ import { describe, expect, it } from 'vitest';
 import { cleanNotificationText } from './index';
 
 describe('cleanNotificationText', () => {
-	it('replaces serialized user mentions with readable labels', () => {
-		expect(cleanNotificationText('<@U:13c44bd0|Jonathan Flower> sup')).toBe('@Jonathan Flower sup');
+	it('removes serialized user mentions from notification text', () => {
+		expect(cleanNotificationText('<@U:13c44bd0|Jonathan Flower> sup')).toBe('sup');
 	});
 
 	it('does not expose an internal ID when a mention has no label', () => {
-		expect(cleanNotificationText('<@U:13c44bd0> hello')).toBe('@teammate hello');
+		expect(cleanNotificationText('<@U:13c44bd0> hello')).toBe('hello');
 	});
 
 	it('removes markdown while preserving ordinary notification text', () => {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -82,7 +82,9 @@
 	import { getChannels } from '$lib/apis/channels';
 
 	const handledChannelMentionKeys = new Set();
+	const handledChannelUnreadKeys = new Set();
 	const MAX_HANDLED_CHANNEL_MENTIONS = 500;
+	const MAX_HANDLED_CHANNEL_UNREADS = 500;
 
 	const unregisterServiceWorkers = async () => {
 		if ('serviceWorker' in navigator) {
@@ -813,8 +815,17 @@
 
 		const type = event?.data?.type ?? null;
 		const data = event?.data?.data ?? null;
-		const mentionUserIds = Array.isArray(event?.mention_user_ids) ? event.mention_user_ids : [];
-		const isMentioned = type === 'message' && mentionUserIds.includes($user?.id);
+		const isMentioned = type === 'mention';
+		const unreadKey = `${event.channel_id}:${event.message_id}`;
+		const isNewUnreadMessage =
+			(type === 'message' || type === 'mention') && !handledChannelUnreadKeys.has(unreadKey);
+		if (isNewUnreadMessage) {
+			if (handledChannelUnreadKeys.size >= MAX_HANDLED_CHANNEL_UNREADS) {
+				const oldestKey = handledChannelUnreadKeys.values().next().value;
+				if (oldestKey) handledChannelUnreadKeys.delete(oldestKey);
+			}
+			handledChannelUnreadKeys.add(unreadKey);
+		}
 
 		if (isMentioned && event?.user?.id !== $user?.id) {
 			const mentionKey = `${event.channel_id}:${event.message_id}:${$user?.id}`;
@@ -838,15 +849,17 @@
 					});
 				}
 
-				toast.custom(NotificationToast, {
-					componentProps: {
-						onClick: () => goto(`/channels/${event.channel_id}`),
-						content: data?.content,
-						title
-					},
-					duration: 15000,
-					unstyled: true
-				});
+				if ($isLastActiveTab) {
+					toast.custom(NotificationToast, {
+						componentProps: {
+							onClick: () => goto(`/channels/${event.channel_id}`),
+							content: data?.content,
+							title
+						},
+						duration: 15000,
+						unstyled: true
+					});
+				}
 			}
 		}
 
@@ -858,7 +871,7 @@
 					channels.set(
 						$channels.map((ch) => {
 							if (ch.id === event.channel_id) {
-								if (type === 'message') {
+								if (isNewUnreadMessage) {
 									return {
 										...ch,
 										unread_count: (ch.unread_count ?? 0) + 1,
@@ -886,7 +899,7 @@
 				}
 			}
 
-			if (type === 'message' && !isMentioned) {
+			if (type === 'message') {
 				const title = `${data?.user?.name}${event?.channel?.type !== 'dm' ? ` (#${event?.channel?.name})` : ''}`;
 
 				if ($isLastActiveTab) {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -81,7 +81,7 @@
 	import dayjs from 'dayjs';
 	import { getChannels } from '$lib/apis/channels';
 
-	const handledChannelMentionKeys: Set<string> = new Set();
+	const handledChannelMentionKeys = new Set();
 	const MAX_HANDLED_CHANNEL_MENTIONS = 500;
 
 	const unregisterServiceWorkers = async () => {
@@ -813,9 +813,7 @@
 
 		const type = event?.data?.type ?? null;
 		const data = event?.data?.data ?? null;
-		const mentionUserIds: string[] = Array.isArray(event?.mention_user_ids)
-			? event.mention_user_ids
-			: [];
+		const mentionUserIds = Array.isArray(event?.mention_user_ids) ? event.mention_user_ids : [];
 		const isMentioned = type === 'message' && mentionUserIds.includes($user?.id);
 
 		if (isMentioned && event?.user?.id !== $user?.id) {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -66,6 +66,7 @@
 	import {
 		bestMatchingLanguage,
 		cleanText,
+		cleanNotificationText,
 		displayFileHandler,
 		getUserTimezone,
 		removeAllDetails
@@ -844,7 +845,7 @@
 					Notification.permission === 'granted'
 				) {
 					new Notification(`${title} / Open WebUI`, {
-						body: data?.content,
+						body: cleanNotificationText(data?.content ?? ''),
 						icon: `${WEBUI_API_BASE_URL}/users/${data?.user?.id}/profile/image`
 					});
 				}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -81,6 +81,9 @@
 	import dayjs from 'dayjs';
 	import { getChannels } from '$lib/apis/channels';
 
+	const handledChannelMentionKeys: Set<string> = new Set();
+	const MAX_HANDLED_CHANNEL_MENTIONS = 500;
+
 	const unregisterServiceWorkers = async () => {
 		if ('serviceWorker' in navigator) {
 			try {
@@ -808,10 +811,49 @@
 			}
 		}
 
+		const type = event?.data?.type ?? null;
+		const data = event?.data?.data ?? null;
+		const mentionUserIds: string[] = Array.isArray(event?.mention_user_ids)
+			? event.mention_user_ids
+			: [];
+		const isMentioned = type === 'message' && mentionUserIds.includes($user?.id);
+
+		if (isMentioned && event?.user?.id !== $user?.id) {
+			const mentionKey = `${event.channel_id}:${event.message_id}:${$user?.id}`;
+			if (!handledChannelMentionKeys.has(mentionKey)) {
+				if (handledChannelMentionKeys.size >= MAX_HANDLED_CHANNEL_MENTIONS) {
+					const oldestKey = handledChannelMentionKeys.values().next().value;
+					if (oldestKey) handledChannelMentionKeys.delete(oldestKey);
+				}
+				handledChannelMentionKeys.add(mentionKey);
+				const title = `${data?.user?.name}${event?.channel?.type !== 'dm' ? ` (#${event?.channel?.name})` : ''}`;
+
+				if (
+					$isLastActiveTab &&
+					($settings?.notificationEnabled ?? false) &&
+					typeof Notification !== 'undefined' &&
+					Notification.permission === 'granted'
+				) {
+					new Notification(`${title} / Open WebUI`, {
+						body: data?.content,
+						icon: `${WEBUI_API_BASE_URL}/users/${data?.user?.id}/profile/image`
+					});
+				}
+
+				toast.custom(NotificationToast, {
+					componentProps: {
+						onClick: () => goto(`/channels/${event.channel_id}`),
+						content: data?.content,
+						title
+					},
+					duration: 15000,
+					unstyled: true
+				});
+			}
+		}
+
 		if ((!channel || isInBackground) && event?.user?.id !== $user?.id) {
 			await tick();
-			const type = event?.data?.type ?? null;
-			const data = event?.data?.data ?? null;
 
 			if ($channels) {
 				if ($channels.find((ch) => ch.id === event.channel_id) && $channelId !== event.channel_id) {
@@ -846,7 +888,7 @@
 				}
 			}
 
-			if (type === 'message') {
+			if (type === 'message' && !isMentioned) {
 				const title = `${data?.user?.name}${event?.channel?.type !== 'dm' ? ` (#${event?.channel?.name})` : ''}`;
 
 				if ($isLastActiveTab) {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -67,6 +67,7 @@
 		bestMatchingLanguage,
 		cleanText,
 		cleanNotificationText,
+		containsUserMention,
 		displayFileHandler,
 		getUserTimezone,
 		removeAllDetails
@@ -817,6 +818,8 @@
 		const type = event?.data?.type ?? null;
 		const data = event?.data?.data ?? null;
 		const isMentioned = type === 'mention';
+		const isCurrentUserMentioned =
+			type === 'message' && containsUserMention(data?.content ?? '', $user?.id ?? '');
 		const unreadKey = `${event.channel_id}:${event.message_id}`;
 		const isNewUnreadMessage =
 			(type === 'message' || type === 'mention') && !handledChannelUnreadKeys.has(unreadKey);
@@ -854,7 +857,7 @@
 					toast.custom(NotificationToast, {
 						componentProps: {
 							onClick: () => goto(`/channels/${event.channel_id}`),
-							content: data?.content,
+							content: cleanNotificationText(data?.content ?? ''),
 							title
 						},
 						duration: 15000,
@@ -900,11 +903,15 @@
 				}
 			}
 
-			if (type === 'message') {
+			if (type === 'message' && !isCurrentUserMentioned) {
 				const title = `${data?.user?.name}${event?.channel?.type !== 'dm' ? ` (#${event?.channel?.name})` : ''}`;
 
 				if ($isLastActiveTab) {
-					if ($settings?.notificationEnabled ?? false) {
+					if (
+						($settings?.notificationEnabled ?? false) &&
+						typeof Notification !== 'undefined' &&
+						Notification.permission === 'granted'
+					) {
 						// LICENSE covers this Open WebUI notification identifier.
 						// Do not alter, remove, obscure, or replace it except as LICENSE permits:
 						// https://docs.openwebui.com/license.
@@ -920,7 +927,7 @@
 						onClick: () => {
 							goto(`/channels/${event.channel_id}`);
 						},
-						content: data?.content,
+						content: cleanNotificationText(data?.content ?? ''),
 						title: `${title}`
 					},
 					duration: 15000,

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -909,7 +909,7 @@
 						// Do not alter, remove, obscure, or replace it except as LICENSE permits:
 						// https://docs.openwebui.com/license.
 						new Notification(`${title} / Open WebUI`, {
-							body: data?.content,
+							body: cleanNotificationText(data?.content ?? ''),
 							icon: `${WEBUI_API_BASE_URL}/users/${data?.user?.id}/profile/image`
 						});
 					}

--- a/test/test_utils_channels.py
+++ b/test/test_utils_channels.py
@@ -1,4 +1,4 @@
-from open_webui.utils.channels import extract_user_mention_ids
+from open_webui.utils.channels import contains_user_mentions, extract_user_mention_ids
 
 
 def test_extract_user_mention_ids_returns_unique_authorized_users():
@@ -29,3 +29,8 @@ def test_extract_user_mention_ids_rejects_unauthorized_and_self_mentions():
     message = '<@U:user-1|Sender> <@U:user-2|Teammate> <@U:user-3|Other>'
 
     assert extract_user_mention_ids(message, 'user-1', {'user-1', 'user-4'}) == []
+
+
+def test_contains_user_mentions_only_matches_encoded_user_mentions():
+    assert contains_user_mentions('<@U:user-1|Teammate> hello') is True
+    assert contains_user_mentions('@Teammate <@M:model-1|Model>') is False

--- a/test/test_utils_channels.py
+++ b/test/test_utils_channels.py
@@ -1,0 +1,31 @@
+from open_webui.utils.channels import extract_user_mention_ids
+
+
+def test_extract_user_mention_ids_returns_unique_authorized_users():
+    message = '<@U:user-2|Ada> <@U:user-2|Ada> <@U:user-3|Grace>'
+
+    assert extract_user_mention_ids(message, 'user-1', {'user-2', 'user-4'}) == ['user-2']
+
+
+def test_extract_user_mention_ids_excludes_sender_and_non_users():
+    message = '<@U:user-1|Sender> <@U:user-2|Ada> <@M:model-1|Model> <@U:user-3|Other>'
+
+    assert extract_user_mention_ids(message, 'user-1', {'user-1', 'user-2'}) == ['user-2']
+
+
+def test_extract_user_mention_ids_requires_encoded_mentions():
+    message = '@user-2 <@M:user-2|Model> <@U:user-2|Teammate'
+
+    assert extract_user_mention_ids(message, 'user-1', {'user-2'}) == []
+
+
+def test_extract_user_mention_ids_accepts_only_user_mentions():
+    message = '@user-2 <@M:user-2|Model> <@U:user-2|Teammate>'
+
+    assert extract_user_mention_ids(message, 'user-1', {'user-2'}) == ['user-2']
+
+
+def test_extract_user_mention_ids_rejects_unauthorized_and_self_mentions():
+    message = '<@U:user-1|Sender> <@U:user-2|Teammate> <@U:user-3|Other>'
+
+    assert extract_user_mention_ids(message, 'user-1', {'user-1', 'user-4'}) == []


### PR DESCRIPTION
## Summary

- Deliver targeted Socket.IO channel events when a message mentions an authorized teammate.
- Show in-app and browser notifications with the cleaned message body, without exposing serialized user IDs or mention markup.
- Avoid duplicate generic notifications and skip unnecessary access lookups for messages without user mentions.

## Implementation

- Resolves encoded user mentions against channel membership or read access before targeting recipients.
- Keeps the broadcast channel event and targeted mention event separate.
- Cleans notification text consistently across toast and browser notification paths.
- Adds focused frontend and backend regression coverage for parsing, authorization, formatting, and delivery behavior.

## Validation

- Backend channel utility tests pass.
- Frontend notification tests pass.
- Frontend formatting/build checks pass.
- Docker workflow passes.
- Feature was verified in the Workplace Labs fork deployment.

## Changelog

### Added

- Notify authorized channel teammates when they are mentioned.