### PR TITLE
feat: notify teammates when mentioned in channels

### DIFF
--- a/backend/open_webui/routers/channels.py
+++ b/backend/open_webui/routers/channels.py
@@ -44,7 +44,12 @@ from open_webui.socket.main import (
 )
 from open_webui.utils.access_control import filter_allowed_access_grants, has_permission
 from open_webui.utils.auth import get_admin_user, get_verified_user
-from open_webui.utils.channels import extract_mentions, replace_mentions
+from open_webui.utils.channels import (
+    contains_user_mentions,
+    extract_mentions,
+    extract_user_mention_ids,
+    replace_mentions,
+)
 from open_webui.utils.files import get_image_base64_from_file_id
 from open_webui.utils.models import (
     get_all_models,
@@ -973,6 +978,28 @@ async def send_notification(request, channel, message, active_user_ids, db=None)
     return True
 
 
+async def get_channel_mention_user_ids(channel, message, sender_id, db=None) -> list[str]:
+    """Resolve encoded user mentions to valid users authorized to read a channel."""
+    # Avoid membership/access queries for the common case of a message without
+    # a user mention.
+    if not contains_user_mentions(message.content):
+        return []
+
+    if channel.type in ['group', 'dm']:
+        # Group and DM access is membership-based. ``is_active`` is the
+        # membership flag used by the channel model; it is not presence.
+        member_ids = {
+            member.user_id for member in await Channels.get_members_by_channel_id(channel.id, db=db) if member.is_active
+        }
+        allowed_user_ids = {u.id for u in await Users.get_users_by_user_ids(list(member_ids), db=db)}
+    else:
+        # Standard channels use read access grants (including public grants),
+        # rather than ChannelMember rows.
+        allowed_user_ids = {u.id for u in await get_channel_users_with_access(channel, 'read', db=db)}
+
+    return extract_user_mention_ids(message.content, sender_id, allowed_user_ids)
+
+
 async def model_response_handler(request, channel, message, user, db=None):
     MODELS = {model['id']: model for model in await get_filtered_models(await get_all_models(request, user=user), user)}
 
@@ -1176,6 +1203,11 @@ async def new_message_handler(request: Request, id: str, form_data: MessageForm,
                         await Channels.update_member_active_status(channel.id, member.user_id, True, db=db)
 
             message = await Messages.get_message_by_id(message.id, db=db)
+
+            # Mentions are authoritative only when they refer to valid users
+            # authorized to read this channel. This prevents a crafted U:
+            # mention from notifying an unrelated instance user.
+            resolved_mention_user_ids = await get_channel_mention_user_ids(channel, message, user.id, db=db)
             event_data = {
                 'channel_id': channel.id,
                 'message_id': message.id,
@@ -1192,6 +1224,13 @@ async def new_message_handler(request: Request, id: str, form_data: MessageForm,
                 event_data,
                 to=f'channel:{channel.id}',
             )
+
+            if resolved_mention_user_ids:
+                await emit_to_users(
+                    'events:channel',
+                    {**event_data, 'data': {**event_data['data'], 'type': 'mention'}},
+                    resolved_mention_user_ids,
+                )
 
             if message.parent_id:
                 # If this message is a reply, emit to the parent message as well
@@ -2060,6 +2099,14 @@ async def post_webhook_message(
         event_data,
         to=f'channel:{channel.id}',
     )
+
+    resolved_mention_user_ids = await get_channel_mention_user_ids(channel, message, message.user_id, db=db)
+    if resolved_mention_user_ids:
+        await emit_to_users(
+            'events:channel',
+            {**event_data, 'data': {**event_data['data'], 'type': 'mention'}},
+            resolved_mention_user_ids,
+        )
 
     await publish_event(
         request,

--- a/backend/open_webui/utils/channels.py
+++ b/backend/open_webui/utils/channels.py
@@ -1,5 +1,7 @@
 import re
 
+USER_MENTION_ID_PATTERN = re.compile(r'<@U:([^|>]+)(?:\|[^>]*)?>')
+
 
 def extract_mentions(message: str, triggerChar: str = '@'):
     # Escape triggerChar in case it's a regex special character
@@ -8,6 +10,18 @@ def extract_mentions(message: str, triggerChar: str = '@'):
 
     matches = re.findall(pattern, message)
     return [{'id_type': id_type, 'id': id_value} for id_type, id_value in matches]
+
+
+def extract_user_mention_ids(message: str, sender_id: str, allowed_user_ids: set[str]) -> list[str]:
+    """Return unique, authorized IDs from persisted encoded U mentions."""
+    mentioned_ids = set(USER_MENTION_ID_PATTERN.findall(message))
+    mentioned_ids.discard(sender_id)
+    return sorted(mentioned_ids.intersection(allowed_user_ids))
+
+
+def contains_user_mentions(message: str) -> bool:
+    """Return whether a message contains at least one encoded user mention."""
+    return USER_MENTION_ID_PATTERN.search(message) is not None
 
 
 def replace_mentions(message: str, triggerChar: str = '@', use_label: bool = True):

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -1035,6 +1035,22 @@ export const cleanText = (content: string) => {
 	return removeFormattings(removeEmojis(content.trim()));
 };
 
+// Serialized user mentions use <@U:user-id|display label>.
+const USER_MENTION_TAG_REGEX = /<@U:[^|>]+(?:\|([^>]*))?>/g;
+
+export const cleanNotificationText = (content: string) => {
+	const contentWithoutMentions = content.replace(USER_MENTION_TAG_REGEX, ' ');
+
+	return cleanText(contentWithoutMentions);
+};
+
+export const containsUserMention = (content: string, userId: string) => {
+	if (!userId) return false;
+
+	const escapedUserId = escapeRegExp(userId);
+	return new RegExp(`<@U:${escapedUserId}(?:\\|[^>]*)?>`).test(content);
+};
+
 export const removeDetails = (content, types) => {
 	return replaceOutsideCode(content, (segment) => {
 		for (const type of types) {

--- a/src/lib/utils/notification.test.ts
+++ b/src/lib/utils/notification.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { cleanNotificationText, containsUserMention } from './index';
+
+describe('cleanNotificationText', () => {
+	it('removes serialized user mentions from notification text', () => {
+		expect(cleanNotificationText('<@U:13c44bd0|Jonathan Flower> sup')).toBe('sup');
+	});
+
+	it('does not expose an internal ID when a mention has no label', () => {
+		expect(cleanNotificationText('<@U:13c44bd0> hello')).toBe('hello');
+	});
+
+	it('removes markdown while preserving ordinary notification text', () => {
+		expect(cleanNotificationText('**Hello** `there`')).toBe('Hello there');
+	});
+});
+
+describe('containsUserMention', () => {
+	it('matches only the requested encoded user mention', () => {
+		expect(containsUserMention('<@U:user-1|Ada> hello', 'user-1')).toBe(true);
+		expect(containsUserMention('<@U:user-10|Grace> hello', 'user-1')).toBe(false);
+	});
+
+	it('accepts mentions without a display label', () => {
+		expect(containsUserMention('<@U:user-1> hello', 'user-1')).toBe(true);
+	});
+
+	it('does not match when the user ID is unavailable', () => {
+		expect(containsUserMention('<@U:> hello', '')).toBe(false);
+	});
+});

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -66,6 +66,8 @@
 	import {
 		bestMatchingLanguage,
 		cleanText,
+		cleanNotificationText,
+		containsUserMention,
 		displayFileHandler,
 		getUserTimezone,
 		removeAllDetails
@@ -80,6 +82,11 @@
 	import { getUserSettings } from '$lib/apis/users';
 	import dayjs from 'dayjs';
 	import { getChannels } from '$lib/apis/channels';
+
+	const handledChannelMentionKeys = new Set();
+	const handledChannelUnreadKeys = new Set();
+	const MAX_HANDLED_CHANNEL_MENTIONS = 500;
+	const MAX_HANDLED_CHANNEL_UNREADS = 500;
 
 	const unregisterServiceWorkers = async () => {
 		if ('serviceWorker' in navigator) {
@@ -808,17 +815,67 @@
 			}
 		}
 
+		const type = event?.data?.type ?? null;
+		const data = event?.data?.data ?? null;
+		const isMentioned = type === 'mention';
+		const isCurrentUserMentioned =
+			type === 'message' && containsUserMention(data?.content ?? '', $user?.id ?? '');
+		const unreadKey = `${event.channel_id}:${event.message_id}`;
+		const isNewUnreadMessage =
+			(type === 'message' || type === 'mention') && !handledChannelUnreadKeys.has(unreadKey);
+		if (isNewUnreadMessage) {
+			if (handledChannelUnreadKeys.size >= MAX_HANDLED_CHANNEL_UNREADS) {
+				const oldestKey = handledChannelUnreadKeys.values().next().value;
+				if (oldestKey) handledChannelUnreadKeys.delete(oldestKey);
+			}
+			handledChannelUnreadKeys.add(unreadKey);
+		}
+
+		if (isMentioned && event?.user?.id !== $user?.id) {
+			const mentionKey = `${event.channel_id}:${event.message_id}:${$user?.id}`;
+			if (!handledChannelMentionKeys.has(mentionKey)) {
+				if (handledChannelMentionKeys.size >= MAX_HANDLED_CHANNEL_MENTIONS) {
+					const oldestKey = handledChannelMentionKeys.values().next().value;
+					if (oldestKey) handledChannelMentionKeys.delete(oldestKey);
+				}
+				handledChannelMentionKeys.add(mentionKey);
+				const title = `${data?.user?.name}${event?.channel?.type !== 'dm' ? ` (#${event?.channel?.name})` : ''}`;
+
+				if (
+					$isLastActiveTab &&
+					($settings?.notificationEnabled ?? false) &&
+					typeof Notification !== 'undefined' &&
+					Notification.permission === 'granted'
+				) {
+					new Notification(`${title} / Open WebUI`, {
+						body: cleanNotificationText(data?.content ?? ''),
+						icon: `${WEBUI_API_BASE_URL}/users/${data?.user?.id}/profile/image`
+					});
+				}
+
+				if ($isLastActiveTab) {
+					toast.custom(NotificationToast, {
+						componentProps: {
+							onClick: () => goto(`/channels/${event.channel_id}`),
+							content: cleanNotificationText(data?.content ?? ''),
+							title
+						},
+						duration: 15000,
+						unstyled: true
+					});
+				}
+			}
+		}
+
 		if ((!channel || isInBackground) && event?.user?.id !== $user?.id) {
 			await tick();
-			const type = event?.data?.type ?? null;
-			const data = event?.data?.data ?? null;
 
 			if ($channels) {
 				if ($channels.find((ch) => ch.id === event.channel_id) && $channelId !== event.channel_id) {
 					channels.set(
 						$channels.map((ch) => {
 							if (ch.id === event.channel_id) {
-								if (type === 'message') {
+								if (isNewUnreadMessage) {
 									return {
 										...ch,
 										unread_count: (ch.unread_count ?? 0) + 1,
@@ -846,16 +903,20 @@
 				}
 			}
 
-			if (type === 'message') {
+			if (type === 'message' && !isCurrentUserMentioned) {
 				const title = `${data?.user?.name}${event?.channel?.type !== 'dm' ? ` (#${event?.channel?.name})` : ''}`;
 
 				if ($isLastActiveTab) {
-					if ($settings?.notificationEnabled ?? false) {
+					if (
+						($settings?.notificationEnabled ?? false) &&
+						typeof Notification !== 'undefined' &&
+						Notification.permission === 'granted'
+					) {
 						// LICENSE covers this Open WebUI notification identifier.
 						// Do not alter, remove, obscure, or replace it except as LICENSE permits:
 						// https://docs.openwebui.com/license.
 						new Notification(`${title} / Open WebUI`, {
-							body: data?.content,
+							body: cleanNotificationText(data?.content ?? ''),
 							icon: `${WEBUI_API_BASE_URL}/users/${data?.user?.id}/profile/image`
 						});
 					}
@@ -866,7 +927,7 @@
 						onClick: () => {
 							goto(`/channels/${event.channel_id}`);
 						},
-						content: data?.content,
+						content: cleanNotificationText(data?.content ?? ''),
 						title: `${title}`
 					},
 					duration: 15000,

--- a/test/test_utils_channels.py
+++ b/test/test_utils_channels.py
@@ -1,0 +1,36 @@
+from open_webui.utils.channels import contains_user_mentions, extract_user_mention_ids
+
+
+def test_extract_user_mention_ids_returns_unique_authorized_users():
+    message = '<@U:user-2|Ada> <@U:user-2|Ada> <@U:user-3|Grace>'
+
+    assert extract_user_mention_ids(message, 'user-1', {'user-2', 'user-4'}) == ['user-2']
+
+
+def test_extract_user_mention_ids_excludes_sender_and_non_users():
+    message = '<@U:user-1|Sender> <@U:user-2|Ada> <@M:model-1|Model> <@U:user-3|Other>'
+
+    assert extract_user_mention_ids(message, 'user-1', {'user-1', 'user-2'}) == ['user-2']
+
+
+def test_extract_user_mention_ids_requires_encoded_mentions():
+    message = '@user-2 <@M:user-2|Model> <@U:user-2|Teammate'
+
+    assert extract_user_mention_ids(message, 'user-1', {'user-2'}) == []
+
+
+def test_extract_user_mention_ids_accepts_only_user_mentions():
+    message = '@user-2 <@M:user-2|Model> <@U:user-2|Teammate>'
+
+    assert extract_user_mention_ids(message, 'user-1', {'user-2'}) == ['user-2']
+
+
+def test_extract_user_mention_ids_rejects_unauthorized_and_self_mentions():
+    message = '<@U:user-1|Sender> <@U:user-2|Teammate> <@U:user-3|Other>'
+
+    assert extract_user_mention_ids(message, 'user-1', {'user-1', 'user-4'}) == []
+
+
+def test_contains_user_mentions_only_matches_encoded_user_mentions():
+    assert contains_user_mentions('<@U:user-1|Teammate> hello') is True
+    assert contains_user_mentions('@Teammate <@M:model-1|Model>') is False


### PR DESCRIPTION
<!--
Important checks for contributors:
1. Target the `dev` branch. PRs targeting `main` will be closed.
2. Code pull requests are not the default contribution path.
3. This PR follows Discussion #29552 before implementation.
4. Do not delete the Contributor License Agreement section at the bottom.
-->

# Pull Request

## Checklist

- [x] This PR targets the `dev` branch.
- [x] This PR links to a well-described, confirmed Issue or active Discussion: Relates to https://github.com/open-webui/open-webui/discussions/29552
- [ ] A maintainer explicitly asked me to open this PR, or this PR only updates i18n/localization.
- [x] The change is one logical unit with no unrelated commits.
- [x] I matched nearby code patterns and avoided unnecessary new settings, abstractions, or dependencies.
- [x] I manually tested the changed workflow and nearby notification behavior.
- [ ] I updated relevant docs, including the Open WebUI Docs Repository, if needed. No user-facing documentation change is needed for this implementation.
- [x] I added a screenshot for the UI behavior.
- [x] I reviewed the implementation, including AI-generated code, before submitting it.
- [x] The PR title uses the `feat` prefix.

## Summary

When a teammate is mentioned in an Open WebUI channel, the channel badge updates but the mentioned teammate does not receive a targeted in-app or browser notification. In affected notification paths, the preview can also expose serialized mention markup and an internal user ID.

This change delivers targeted notifications to authorized mentioned teammates and displays only the cleaned message body, while preserving generic notifications for non-mentioned recipients.

## Implementation

- Resolve encoded user mentions against channel membership or channel read access before targeting recipients.
- Emit the existing channel broadcast plus a targeted `events:channel` mention event.
- Clean mention markup consistently for in-app toasts and browser notifications.
- Prevent duplicate generic and targeted notifications.
- Skip unnecessary access lookups when a message contains no user mention.
- Add focused frontend and backend regression coverage.

## Testing

- Backend focused channel utility tests pass.
- Frontend focused notification tests pass.
- Frontend formatting and build checks pass.
- Docker workflow passes.
- Manually verified targeted notification delivery and cleaned notification text in the Workplace Labs fork deployment.

## Screenshot

![In-app notification showing cleaned channel mention message](https://video.aiforhrmastermind.com/public/default/codex-clipboard-BLHeok.png)

## Changelog Entry

### Added

- Notify authorized channel teammates when they are mentioned.

### Changed

- Remove serialized user mention markup from channel notification previews.

### Fixed

- Trigger targeted in-app and browser notifications for channel teammate mentions.

### Removed

-

### Security

-

### Breaking Changes

-

## Additional Context

The earlier parent PR was closed by repository automation because it contained 10 commits, lacked a linked discussion, and omitted the CLA section. This resubmission is based on the latest parent `dev` branch and contains one squashed feature commit.

Related discussion: https://github.com/open-webui/open-webui/discussions/29552

## Contributor License Agreement

<!--
DO NOT DELETE THIS SECTION.
Your PR will not be reviewed or merged until you check the box below confirming that you have read and agree to the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.