### PR TITLE
fix: complete repeated tool approvals by call ID

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -131,6 +131,12 @@ from open_webui.utils.task import (
     rag_template,
     tools_function_calling_generation_template,
 )
+from open_webui.utils.tool_approval import (
+    assign_tool_approval_statuses,
+    get_resolved_call_ids,
+    has_unapproved_tool_call,
+    is_paused_for_tool_approval,
+)
 from open_webui.utils.tools import (
     build_tool_server_headers,
     get_attached_knowledge,
@@ -3248,9 +3254,7 @@ async def drain_approved_tool_calls(request, form_data, user, model, metadata) -
     if not isinstance(output, list):
         return False
 
-    result_call_ids = {
-        item.get('call_id') for item in output if item.get('type') == 'function_call_output' and item.get('call_id')
-    }
+    result_call_ids = get_resolved_call_ids(output)
     approved_calls = [
         item
         for item in output
@@ -3261,15 +3265,7 @@ async def drain_approved_tool_calls(request, form_data, user, model, metadata) -
         and item.get('call_id') not in result_call_ids
     ]
     if not approved_calls:
-        if metadata.get('params', {}).get('tool_approval_mode', 'full') == 'ask' and any(
-            item.get('type') == 'function_call'
-            and item.get('name') != 'ask_user'
-            and (item.get('call_id') or item.get('id'))
-            and item.get('status') == 'queued'
-            and item.get('approved') is not True
-            and (item.get('call_id') or item.get('id')) not in result_call_ids
-            for item in output
-        ):
+        if metadata.get('params', {}).get('tool_approval_mode', 'full') == 'ask' and has_unapproved_tool_call(output):
             event_emitter, _ = await get_event_emitter_and_caller(metadata)
             await pause_for_tool_approval(chat_id, message_id, output, form_data, metadata)
             if event_emitter:
@@ -3327,31 +3323,9 @@ async def drain_approved_tool_calls(request, form_data, user, model, metadata) -
         changed = True
 
     if changed:
-        result_call_ids = {
-            item.get('call_id') for item in output if item.get('type') == 'function_call_output' and item.get('call_id')
-        }
-        if metadata.get('params', {}).get('tool_approval_mode', 'full') == 'ask' and any(
-            item.get('type') == 'function_call'
-            and item.get('name') != 'ask_user'
-            and (item.get('call_id') or item.get('id'))
-            and item.get('status') == 'queued'
-            and item.get('approved') is not True
-            and (item.get('call_id') or item.get('id')) not in result_call_ids
-            for item in output
-        ):
+        if metadata.get('params', {}).get('tool_approval_mode', 'full') == 'ask' and has_unapproved_tool_call(output):
             await pause_for_tool_approval(chat_id, message_id, output, form_data, metadata)
-            result_call_ids = {
-                item.get('call_id')
-                for item in output
-                if item.get('type') == 'function_call_output' and item.get('call_id')
-            }
-        paused = any(
-            item.get('type') == 'function_call'
-            and item.get('call_id')
-            and item.get('status') in {'pending', 'queued', 'requires_approval'}
-            and item.get('call_id') not in result_call_ids
-            for item in output
-        )
+        paused = is_paused_for_tool_approval(output)
         if not paused:
             output.append(
                 {
@@ -3436,25 +3410,7 @@ async def drain_approved_tool_calls(request, form_data, user, model, metadata) -
 
 
 async def pause_for_tool_approval(chat_id: str, message_id: str, output: list[dict], form_data: dict, metadata: dict):
-    result_call_ids = {
-        item.get('call_id') for item in output if item.get('type') == 'function_call_output' and item.get('call_id')
-    }
-    has_pending_approval = False
-    for item in output:
-        if item.get('type') == 'function_call' and not item.get('call_id') and item.get('id'):
-            item['call_id'] = item['id']
-
-        if (
-            item.get('type') == 'function_call'
-            and item.get('call_id')
-            and item.get('call_id') not in result_call_ids
-            and item.get('status') != 'rejected'
-        ):
-            if not has_pending_approval:
-                item['status'] = 'pending'
-                has_pending_approval = True
-            elif item.get('status') == 'in_progress':
-                item['status'] = 'queued'
+    assign_tool_approval_statuses(output)
 
     await Chats.upsert_message_to_chat_by_id_and_message_id(
         chat_id,

--- a/backend/open_webui/utils/tool_approval.py
+++ b/backend/open_webui/utils/tool_approval.py
@@ -17,6 +17,88 @@ class ResolveToolCallForm(BaseModel):
     timed_out: bool = False
 
 
+APPROVAL_PENDING_STATUSES = frozenset({'pending', 'queued', 'requires_approval'})
+APPROVAL_TERMINAL_STATUSES = frozenset({'rejected', 'failed', 'incomplete'})
+
+
+def get_tool_call_id(item: dict) -> str | None:
+    return item.get('call_id') or item.get('id') or None
+
+
+def get_resolved_call_ids(output: list[dict]) -> set:
+    """Return call IDs that already have a function-call result."""
+    return {
+        item.get('call_id') for item in output if item.get('type') == 'function_call_output' and item.get('call_id')
+    }
+
+
+def is_paused_for_tool_approval(output: list[dict]) -> bool:
+    """Return whether any unresolved call is waiting for approval or execution."""
+    resolved_call_ids = get_resolved_call_ids(output)
+    return any(
+        item.get('type') == 'function_call'
+        and item.get('call_id')
+        and item.get('status') in APPROVAL_PENDING_STATUSES
+        and item.get('call_id') not in resolved_call_ids
+        for item in output
+    )
+
+
+def has_unapproved_tool_call(output: list[dict]) -> bool:
+    """Return whether a non-ask_user call still needs user approval."""
+    resolved_call_ids = get_resolved_call_ids(output)
+    return any(
+        item.get('type') == 'function_call'
+        and item.get('name') != 'ask_user'
+        and get_tool_call_id(item)
+        and item.get('status') not in APPROVAL_TERMINAL_STATUSES
+        and item.get('approved') is not True
+        and get_tool_call_id(item) not in resolved_call_ids
+        for item in output
+    )
+
+
+def assign_tool_approval_statuses(output: list[dict]) -> None:
+    """Arm every unresolved call in a batch using its own call ID.
+
+    Streaming finalization marks calls `completed` once their arguments are
+    complete, before approval and execution. A call is only resolved when it
+    has a matching `function_call_output`, so unresolved `completed` calls must
+    be re-armed as well. Exactly one call remains `pending`; the rest queue.
+    """
+    resolved_call_ids = get_resolved_call_ids(output)
+    candidates = []
+    has_pending_approval = False
+
+    for item in output:
+        if item.get('type') != 'function_call':
+            continue
+        if not item.get('call_id') and item.get('id'):
+            item['call_id'] = item['id']
+
+        call_id = item.get('call_id')
+        if not call_id or call_id in resolved_call_ids:
+            continue
+
+        status_value = item.get('status')
+        if status_value in APPROVAL_TERMINAL_STATUSES:
+            continue
+        if status_value in {'pending', 'requires_approval'}:
+            has_pending_approval = True
+            continue
+        if status_value == 'queued' and item.get('approved') is True:
+            continue
+
+        candidates.append(item)
+
+    for item in candidates:
+        if has_pending_approval:
+            item['status'] = 'queued'
+        else:
+            item['status'] = 'pending'
+            has_pending_approval = True
+
+
 async def resolve_tool_call_output(
     chat_id: str,
     message_id: str,
@@ -52,9 +134,10 @@ async def resolve_tool_call_output(
     function_call.setdefault('call_id', form_data.call_id)
     tool_name = function_call.get('name')
 
-    if any(
-        item.get('type') == 'function_call_output' and item.get('call_id') == form_data.call_id for item in output
-    ) or function_call.get('status') not in {'pending', 'queued', 'requires_approval'}:
+    if (
+        form_data.call_id in get_resolved_call_ids(output)
+        or function_call.get('status') not in APPROVAL_PENDING_STATUSES
+    ):
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail='Tool call has already been resolved.')
 
     if form_data.action == 'approve':
@@ -115,17 +198,12 @@ async def resolve_tool_call_output(
     if event_emitter:
         await event_emitter({'type': 'chat:completion', 'data': {'output': output}})
 
-    result_call_ids = {
-        item.get('call_id') for item in output if item.get('type') == 'function_call_output' and item.get('call_id')
+    return {
+        'chat': chat,
+        'message': message,
+        'output': output,
+        'paused': is_paused_for_tool_approval(output),
     }
-    paused = any(
-        item.get('type') == 'function_call'
-        and item.get('call_id')
-        and item.get('status') in {'pending', 'queued', 'requires_approval'}
-        and item.get('call_id') not in result_call_ids
-        for item in output
-    )
-    return {'chat': chat, 'message': message, 'output': output, 'paused': paused}
 
 
 async def build_tool_approval_resume_payload(chat_id: str, message_id: str, chat=None) -> dict:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,24 @@
+import atexit
+import os
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+
+BACKEND_DIR = Path(__file__).resolve().parent.parent
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(BACKEND_DIR))
+
+os.environ.setdefault('WEBUI_SECRET_KEY', 'unit-test-secret-key-not-used-for-auth')
+
+# Importing open_webui.config prepares STATIC_DIR. Keep that side effect out of
+# the checkout while collecting backend tests.
+_scratch = Path(tempfile.mkdtemp(prefix='open-webui-tests-'))
+atexit.register(shutil.rmtree, _scratch, True)
+os.environ.setdefault('DATA_DIR', str(_scratch / 'data'))
+os.environ.setdefault('STATIC_DIR', str(_scratch / 'static'))
+os.environ.setdefault('FRONTEND_BUILD_DIR', str(_scratch / 'frontend-build'))
+os.environ.setdefault('ENABLE_DB_MIGRATIONS', 'false')
+(_scratch / 'data').mkdir(parents=True)
+(_scratch / 'static').mkdir(parents=True)

--- a/backend/tests/test_tool_approval_batch.py
+++ b/backend/tests/test_tool_approval_batch.py
@@ -1,0 +1,262 @@
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from open_webui.utils import middleware, tool_approval
+from open_webui.utils.tool_approval import (
+    assign_tool_approval_statuses,
+    get_resolved_call_ids,
+    has_unapproved_tool_call,
+    is_paused_for_tool_approval,
+)
+
+
+CHAT_ID = 'tool-approval-chat'
+MESSAGE_ID = 'tool-approval-message'
+
+
+def function_call(call_id, name='search', arguments='{}', status='completed'):
+    return {
+        'type': 'function_call',
+        'id': call_id,
+        'call_id': call_id,
+        'name': name,
+        'arguments': arguments,
+        'status': status,
+    }
+
+
+def function_output(call_id, text, status='completed'):
+    return {
+        'type': 'function_call_output',
+        'id': f'fco_{call_id}',
+        'call_id': call_id,
+        'output': [{'type': 'input_text', 'text': text}],
+        'status': status,
+    }
+
+
+def call_statuses(output):
+    return {item['call_id']: item['status'] for item in output if item.get('type') == 'function_call'}
+
+
+def results_by_call_id(output):
+    return {
+        item['call_id']: ''.join(part.get('text', '') for part in item.get('output', []))
+        for item in output
+        if item.get('type') == 'function_call_output'
+    }
+
+
+def metadata():
+    return {
+        'chat_id': CHAT_ID,
+        'message_id': MESSAGE_ID,
+        'assistant_message_id': MESSAGE_ID,
+        'params': {'tool_approval_mode': 'ask'},
+    }
+
+
+@pytest.fixture
+def state(monkeypatch):
+    state = {'message': None, 'writes': []}
+    chat = SimpleNamespace(user_id='test-user', variables=None, chat={})
+
+    async def get_chat(chat_id, db=None):
+        assert chat_id == CHAT_ID
+        return chat
+
+    async def get_message(chat_id, message_id):
+        assert (chat_id, message_id) == (CHAT_ID, MESSAGE_ID)
+        return state['message']
+
+    async def upsert(chat_id, message_id, patch, *, touch=True):
+        assert (chat_id, message_id) == (CHAT_ID, MESSAGE_ID)
+        state['writes'].append(patch)
+        state['message'] = {**(state['message'] or {}), **patch}
+        return state['message']
+
+    async def no_messages(*args, **kwargs):
+        return None
+
+    async def no_filters(*args, **kwargs):
+        return []
+
+    async def emitter_pair(metadata):
+        async def emit(event):
+            return None
+
+        return emit, None
+
+    monkeypatch.setattr(middleware.Chats, 'get_chat_by_id', get_chat)
+    monkeypatch.setattr(middleware.Chats, 'get_message_by_id_and_message_id', get_message)
+    monkeypatch.setattr(middleware.Chats, 'upsert_message_to_chat_by_id_and_message_id', upsert)
+    monkeypatch.setattr(middleware, 'load_messages_from_db', no_messages)
+    monkeypatch.setattr(middleware, 'get_filter_functions', no_filters)
+    monkeypatch.setattr(middleware, 'get_event_emitter_and_caller', emitter_pair)
+    monkeypatch.setattr(tool_approval, 'get_event_emitter', AsyncMock(return_value=None))
+    return state
+
+
+async def arm(state, calls):
+    state['message'] = {'id': MESSAGE_ID, 'output': calls}
+    await middleware.pause_for_tool_approval(CHAT_ID, MESSAGE_ID, calls, {'messages': []}, metadata())
+
+
+async def resolve(state, call_id, action='approve', *, timed_out=False):
+    return await tool_approval.resolve_tool_call_output(
+        CHAT_ID,
+        MESSAGE_ID,
+        tool_approval.ResolveToolCallForm(call_id=call_id, action=action, timed_out=timed_out),
+        SimpleNamespace(id='test-user', role='user'),
+    )
+
+
+async def drain(state, monkeypatch, results, executed):
+    async def execute(request, form_data, user, metadata, event_caller, event_emitter, tool_call):
+        call_id = tool_call['id']
+        executed.append(
+            {
+                'call_id': call_id,
+                'name': tool_call['function']['name'],
+                'arguments': tool_call['function']['arguments'],
+            }
+        )
+        return {'tool_call_id': call_id, 'content': results[call_id]}
+
+    monkeypatch.setattr(middleware, 'execute_tool_call_for_output', execute)
+    return await middleware.drain_approved_tool_calls(
+        request=None,
+        form_data={'messages': []},
+        user=None,
+        model={'id': 'test-model'},
+        metadata=metadata(),
+    )
+
+
+def test_arms_each_unresolved_call_by_call_id():
+    output = [
+        function_call('call-a', arguments='{"query":"a"}'),
+        function_call('call-b', arguments='{"query":"b"}'),
+        function_call('call-c', 'fetch'),
+    ]
+
+    assign_tool_approval_statuses(output)
+
+    assert call_statuses(output) == {
+        'call-a': 'pending',
+        'call-b': 'queued',
+        'call-c': 'queued',
+    }
+    assert has_unapproved_tool_call(output)
+    assert is_paused_for_tool_approval(output)
+
+
+def test_preserves_resolved_and_terminal_calls():
+    output = [
+        function_call('call-done'),
+        function_output('call-done', 'done'),
+        function_call('call-rejected', status='rejected'),
+        function_call('call-failed', status='failed'),
+        function_call('call-next'),
+    ]
+
+    assign_tool_approval_statuses(output)
+
+    assert call_statuses(output) == {
+        'call-done': 'completed',
+        'call-rejected': 'rejected',
+        'call-failed': 'failed',
+        'call-next': 'pending',
+    }
+    assert get_resolved_call_ids(output) == {'call-done'}
+
+
+@pytest.mark.asyncio
+async def test_repeated_names_finish_with_correct_arguments_and_results(monkeypatch, state):
+    calls = [
+        function_call('call-a', arguments='{"query":"a"}'),
+        function_call('call-b', arguments='{"query":"b"}'),
+        function_call('call-c', arguments='{"query":"c"}'),
+    ]
+    await arm(state, calls)
+    executed = []
+    results = {'call-a': 'result-a', 'call-b': 'result-b', 'call-c': 'result-c'}
+
+    for index, call_id in enumerate(results):
+        await resolve(state, call_id)
+        assert await drain(state, monkeypatch, results, executed) is (index < 2)
+
+    assert call_statuses(state['message']['output']) == {
+        'call-a': 'completed',
+        'call-b': 'completed',
+        'call-c': 'completed',
+    }
+    assert executed == [
+        {'call_id': 'call-a', 'name': 'search', 'arguments': '{"query":"a"}'},
+        {'call_id': 'call-b', 'name': 'search', 'arguments': '{"query":"b"}'},
+        {'call_id': 'call-c', 'name': 'search', 'arguments': '{"query":"c"}'},
+    ]
+    assert results_by_call_id(state['message']['output']) == results
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('names', [('search',), ('search', 'fetch'), ('search', 'fetch', 'search')])
+async def test_single_mixed_and_repeated_controls(names, monkeypatch, state):
+    calls = [function_call(f'call-{index}', name) for index, name in enumerate(names)]
+    await arm(state, calls)
+    executed = []
+    results = {item['call_id']: item['call_id'] for item in calls}
+
+    for call_id in results:
+        await resolve(state, call_id)
+        await drain(state, monkeypatch, results, executed)
+
+    assert [item['call_id'] for item in executed] == list(results)
+    assert all(status == 'completed' for status in call_statuses(state['message']['output']).values())
+
+
+@pytest.mark.asyncio
+async def test_rejection_failure_and_ask_user_timeout_keep_their_semantics(monkeypatch, state):
+    calls = [function_call('call-reject'), function_call('call-fail')]
+    await arm(state, calls)
+    assert (await resolve(state, 'call-reject', action='reject'))['paused'] is True
+
+    executed = []
+    assert await drain(state, monkeypatch, {'call-fail': 'Error: upstream failed'}, executed) is True
+    await resolve(state, 'call-fail')
+    assert await drain(state, monkeypatch, {'call-fail': 'Error: upstream failed'}, executed) is False
+    assert call_statuses(state['message']['output']) == {
+        'call-reject': 'rejected',
+        'call-fail': 'failed',
+    }
+
+    ask_user = function_call('call-ask', 'ask_user', status='pending')
+    state['message'] = {'id': MESSAGE_ID, 'output': [ask_user]}
+    response = await resolve(state, 'call-ask', action='answer', timed_out=True)
+    assert response['paused'] is False
+    assert json.loads(results_by_call_id(response['output'])['call-ask']) == {
+        'status': 'cancelled',
+        'answers': {},
+        'timed_out': True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_persisted_stale_sibling_is_rearmed_before_execution(monkeypatch, state):
+    output = [
+        function_call('call-a'),
+        function_output('call-a', 'result-a'),
+        function_call('call-b'),
+    ]
+    state['message'] = {'id': MESSAGE_ID, 'output': output}
+    executed = []
+
+    assert await drain(state, monkeypatch, {'call-b': 'result-b'}, executed) is True
+    assert executed == []
+    assert call_statuses(state['message']['output']) == {
+        'call-a': 'completed',
+        'call-b': 'pending',
+    }


### PR DESCRIPTION
# Pull Request

## Checklist

- [x] This PR targets the `dev` branch.
- [x] This PR links to a well-described, confirmed Issue or active Discussion: Closes #29293.
- [ ] A maintainer explicitly asked me to open this PR, or this PR only updates i18n/localization.
- [x] The change is one logical unit with no unrelated commits.
- [x] I matched nearby code patterns and avoided unnecessary new settings, abstractions, or dependencies.
- [ ] I manually tested the changed workflow and any nearby behavior that could be affected.
- [x] I updated relevant docs, including the Open WebUI Docs Repository, if needed. No documentation change is needed for this bug fix.
- [x] I added screenshots for UI changes, and a recording when motion or interaction matters. No UI code changes are included.
- [x] I reviewed any AI-generated code before submitting it.
- [x] The PR title uses an accepted prefix.

## Summary

Closes #29293.

In ask-for-approval mode, streaming finalization can mark every function call in a batch as `completed` once its arguments are complete, before any tool has executed. The old approval pass changed the first unresolved call to `pending`, but only changed later siblings when their status was `in_progress`. Siblings already marked `completed` therefore remained unresolved without a matching `function_call_output`, and that stale state was persisted as `Executing...`.

This change tracks approval and completion by each call's `call_id`:

- exactly one unresolved call is made `pending` and remaining unresolved calls are queued;
- calls with matching outputs, approved calls awaiting execution, and terminal calls are preserved;
- the drain/resume path can re-arm stale persisted calls without executing them before approval;
- paused state and result association consistently use unresolved call IDs.

## Testing

No browser-level manual test was run. The backend regression tests exercise the real pause, resolve, and drain functions with an in-memory persisted message.

- `PYTHONPATH=backend python -m pytest -q backend/tests/test_tool_approval_batch.py` — 8 passed
- Independent acceptance suite covering the same issue contract — 8 passed
- `ruff format --check . --exclude .venv --exclude venv` — 275 files already formatted
- `ruff check --select=F --ignore=F401,F403,F405,F541,F811,F841 .` — passed
- `python -m py_compile backend/open_webui/utils/middleware.py backend/open_webui/utils/tool_approval.py backend/tests/conftest.py backend/tests/test_tool_approval_batch.py` — passed

Coverage includes repeated same-name batches, single and mixed-name controls, per-call argument/result binding, rejection, execution failure, `ask_user` timeout, and recovery of a persisted unresolved sibling.

## Changelog Entry

### Added

- Backend regression coverage for batched tool approval state transitions.

### Changed

-

### Fixed

- Repeated same-name tool calls no longer remain stuck at `Executing...` after approval.

### Removed

-

### Security

-

### Breaking Changes

- None.

## Additional Context

Issue #29293 was reproduced and confirmed on `dev` by a collaborator. No maintainer explicitly invited this PR, so that checklist item remains unchecked. The change is backend-only and introduces no dependencies or settings.

## Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
