### PR TITLE
fix(oauth): honor OAUTH_BLOCKED_GROUPS when auto-creating groups

### DIFF
--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -1662,6 +1662,14 @@ class OAuthManager:
             log.debug('Using creator ID %s for potential group creation.', creator_id)
 
             for group_name in user_oauth_groups:
+                if not group_name:
+                    continue
+                # OAUTH_BLOCKED_GROUPS must apply to creation, not only membership
+                # add/remove — otherwise ENABLE_OAUTH_GROUP_CREATION floods the
+                # group table with blocked IdP groups on every login.
+                if is_in_blocked_groups(group_name, blocked_groups):
+                    log.debug("Skipping creation of blocked OAuth group '%s'", group_name)
+                    continue
                 if group_name not in all_group_names:
                     log.info("Group '%s' not found via OAuth claim. Creating group...", group_name)
                     try:


### PR DESCRIPTION
## Summary
`update_user_groups()` already skipped blocked names when adding/removing memberships, but the `ENABLE_OAUTH_GROUP_CREATION` loop did not. With IdPs that emit a user's full directory membership, every login created thousands of orphan group objects that the blocklist was meant to prevent.

Skip names matching `OAUTH_BLOCKED_GROUPS` (same `is_in_blocked_groups()` helper) before insert.

Fixes #29558

## Test plan
- [ ] `ENABLE_OAUTH_GROUP_CREATION=true`, `OAUTH_BLOCKED_GROUPS` matching most IdP groups
- [ ] Login: user is not joined to blocked groups **and** blocked group rows are not created
- [ ] Unblocked missing groups still auto-create as before


Made with [Cursor](https://cursor.com)