### PR TITLE
fix(models): allow admin to fetch inactive models to restore visibility of disabled models

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -873,8 +873,16 @@ if ENABLE_SCIM:
 
 @app.get('/api/models')
 @app.get('/api/v1/models')  # Experimental: Compatibility with OpenAI API
-async def get_models(request: Request, refresh: bool = False, user=Depends(get_verified_user)):
-    all_models = await get_all_models(request, refresh=refresh, user=user)
+async def get_models(
+    request: Request,
+    refresh: bool = False,
+    include_inactive: bool = False,
+    user=Depends(get_verified_user),
+):
+    if include_inactive and user.role != 'admin':
+        include_inactive = False
+
+    all_models = await get_all_models(request, refresh=refresh, user=user, include_inactive=include_inactive)
 
     # Filter out filter pipelines
     models = [
@@ -887,7 +895,8 @@ async def get_models(request: Request, refresh: bool = False, user=Depends(get_v
 
     # Access-filter first so the per-model payload work below only runs for
     # models the caller can actually see.
-    models = await get_filtered_models(models, user)
+    if not (include_inactive and user.role == 'admin'):
+        models = await get_filtered_models(models, user)
 
     for model in models:
         info = model.get('info') if isinstance(model.get('info'), dict) else {}

--- a/backend/open_webui/test_admin_models_bulk_disable.py
+++ b/backend/open_webui/test_admin_models_bulk_disable.py
@@ -1,0 +1,203 @@
+import asyncio
+import os
+import tempfile
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Create a temporary directory for clean disposable test data
+temp_dir = tempfile.TemporaryDirectory()
+os.environ['DATA_DIR'] = temp_dir.name
+os.environ['DATABASE_URL'] = f'sqlite:///{temp_dir.name}/test.db'
+os.environ['WEBUI_SECRET_KEY'] = 'test-secret-key-123456789012'
+
+from open_webui.main import get_models
+from open_webui.models.models import ModelForm, ModelMeta, ModelParams, Models
+from open_webui.models.users import UserModel
+
+
+async def run_tests():
+    print('=================================================================')
+    print('STARTING REGRESSION TEST: Admin Models Bulk Disable & Multi-Provider')
+    print('=================================================================')
+
+    admin_user = UserModel(
+        id='admin-user-id',
+        name='Admin User',
+        email='admin@example.com',
+        role='admin',
+        created_at=0,
+        updated_at=0,
+        last_active_at=0,
+    )
+
+    regular_user = UserModel(
+        id='regular-user-id',
+        name='Regular User',
+        email='user@example.com',
+        role='user',
+        created_at=0,
+        updated_at=0,
+        last_active_at=0,
+    )
+
+    mock_request = MagicMock()
+    mock_request.app.state.MODELS = {}
+    mock_request.app.state.BASE_MODELS = []
+    mock_request.app.state.redis = None
+
+    # 1. Multiple configured model providers
+    provider_models = [
+        # Provider 1: NVIDIA NIM
+        {'id': 'nvidia/nemotron-4-340b-instruct', 'name': 'NVIDIA Nemotron 340B', 'owned_by': 'openai'},
+        {'id': 'meta/llama-3.1-70b-instruct', 'name': 'Meta Llama 3.1 70B', 'owned_by': 'openai'},
+        # Provider 2: OpenRouter
+        {'id': 'anthropic/claude-3.5-sonnet', 'name': 'Claude 3.5 Sonnet', 'owned_by': 'openai'},
+        {'id': 'deepseek/deepseek-chat', 'name': 'DeepSeek V2.5', 'owned_by': 'openai'},
+        # Provider 3: Google Generative Language API
+        {'id': 'google/gemini-1.5-pro', 'name': 'Gemini 1.5 Pro', 'owned_by': 'openai'},
+        # Provider 4: GitHub Copilot
+        {'id': 'copilot/gpt-4o', 'name': 'Copilot GPT-4o', 'owned_by': 'openai'},
+        # Provider 5: Local OpenAI endpoint
+        {'id': 'local/mistral-nemo', 'name': 'Local Mistral Nemo', 'owned_by': 'openai'},
+    ]
+
+    print(f'\n[TEST 1] Testing baseline: {len(provider_models)} models from 5 providers')
+    with patch(
+        'open_webui.utils.models.get_all_base_models', new=AsyncMock(return_value=[m.copy() for m in provider_models])
+    ):
+        with patch('open_webui.utils.models.Config.get_many', new=AsyncMock(return_value={})):
+            res = await get_models(mock_request, refresh=True, include_inactive=False, user=admin_user)
+            active_ids = [m['id'] for m in res['data']]
+            assert len(active_ids) == 7, f'Expected 7 models, got {len(active_ids)}'
+            print(f'  ✓ Baseline active models returned: {len(active_ids)}')
+
+    # 2. Add custom/preset models
+    print('\n[TEST 2] Adding custom/preset model based on one of the provider models')
+    custom_form = ModelForm(
+        id='wallfire-mcp',
+        name='Wallfire MCP',
+        base_model_id='nvidia/nemotron-4-340b-instruct',
+        meta=ModelMeta(),
+        params=ModelParams(),
+        is_active=True,
+    )
+    await Models.insert_new_model(custom_form, admin_user.id)
+    with patch(
+        'open_webui.utils.models.get_all_base_models', new=AsyncMock(return_value=[m.copy() for m in provider_models])
+    ):
+        with patch('open_webui.utils.models.Config.get_many', new=AsyncMock(return_value={})):
+            res = await get_models(mock_request, refresh=True, include_inactive=False, user=admin_user)
+            active_ids = [m['id'] for m in res['data']]
+            assert 'wallfire-mcp' in active_ids
+            assert len(active_ids) == 8
+            print(f'  ✓ Total active models including custom model: {len(active_ids)}')
+
+    # 3. Simulate "Disable All Models" action
+    print("\n[TEST 3] Simulating 'Disable All Models' from Admin -> Models")
+    for m in provider_models:
+        form = ModelForm(
+            id=m['id'],
+            name=m['name'],
+            base_model_id=None,
+            meta=ModelMeta(),
+            params=ModelParams(),
+            is_active=False,
+        )
+        await Models.insert_new_model(form, admin_user.id)
+
+    # Also disable the custom preset model
+    await Models.update_model_by_id(
+        'wallfire-mcp',
+        ModelForm(
+            id='wallfire-mcp',
+            name='Wallfire MCP',
+            base_model_id='nvidia/nemotron-4-340b-instruct',
+            meta=ModelMeta(),
+            params=ModelParams(),
+            is_active=False,
+        ),
+    )
+    print('  ✓ All 7 provider base models and 1 custom preset model marked as is_active=False in DB')
+
+    # 4. Standard chat endpoint check: /api/models (include_inactive=False)
+    print('\n[TEST 4] Standard chat endpoint GET /api/models (include_inactive=False)')
+    with patch(
+        'open_webui.utils.models.get_all_base_models', new=AsyncMock(return_value=[m.copy() for m in provider_models])
+    ):
+        with patch('open_webui.utils.models.Config.get_many', new=AsyncMock(return_value={})):
+            res = await get_models(mock_request, refresh=True, include_inactive=False, user=admin_user)
+            active_ids = [m['id'] for m in res['data']]
+            assert len(active_ids) == 0, f'Expected 0 active models for chat, got {len(active_ids)}: {active_ids}'
+            # Verify app.state.MODELS is also empty
+            assert len(mock_request.app.state.MODELS) == 0, 'request.app.state.MODELS must not contain inactive models'
+            print('  ✓ Normal chat endpoint correctly hides all disabled models (returned 0 models)')
+            print('  ✓ request.app.state.MODELS has 0 inactive models')
+
+    # 5. Admin endpoint check: /api/models?include_inactive=true
+    print('\n[TEST 5] Admin model management GET /api/models?include_inactive=true')
+    with patch(
+        'open_webui.utils.models.get_all_base_models', new=AsyncMock(return_value=[m.copy() for m in provider_models])
+    ):
+        with patch('open_webui.utils.models.Config.get_many', new=AsyncMock(return_value={})):
+            res = await get_models(mock_request, refresh=True, include_inactive=True, user=admin_user)
+            all_ids = [m['id'] for m in res['data']]
+            assert len(all_ids) == 8, f'Expected 8 models for Admin, got {len(all_ids)}: {all_ids}'
+            for m in res['data']:
+                assert m.get('is_active') is False, f'Model {m["id"]} should have is_active=False'
+            print(f'  ✓ Admin endpoint returned all {len(all_ids)} models with is_active=False:')
+            for m in res['data']:
+                print(f'     - {m["id"]}: is_active={m["is_active"]}, preset={m.get("preset", False)}')
+
+    # 6. Non-admin security check: non-admin requesting include_inactive=True
+    print('\n[TEST 6] Non-admin security: regular user requesting include_inactive=True')
+    with patch(
+        'open_webui.utils.models.get_all_base_models', new=AsyncMock(return_value=[m.copy() for m in provider_models])
+    ):
+        with patch('open_webui.utils.models.Config.get_many', new=AsyncMock(return_value={})):
+            res = await get_models(mock_request, refresh=True, include_inactive=True, user=regular_user)
+            user_ids = [m['id'] for m in res['data']]
+            assert len(user_ids) == 0, f'Non-admin should not receive inactive models! Got: {user_ids}'
+            print('  ✓ Non-admin request correctly forced include_inactive=False (returned 0 models)')
+
+    # 7. Enable All Models action
+    print("\n[TEST 7] Simulating 'Enable All Models' from Admin -> Models")
+    for m in provider_models:
+        await Models.update_model_by_id(
+            m['id'],
+            ModelForm(
+                id=m['id'],
+                name=m['name'],
+                base_model_id=None,
+                meta=ModelMeta(),
+                params=ModelParams(),
+                is_active=True,
+            ),
+        )
+    await Models.update_model_by_id(
+        'wallfire-mcp',
+        ModelForm(
+            id='wallfire-mcp',
+            name='Wallfire MCP',
+            base_model_id='nvidia/nemotron-4-340b-instruct',
+            meta=ModelMeta(),
+            params=ModelParams(),
+            is_active=True,
+        ),
+    )
+
+    with patch(
+        'open_webui.utils.models.get_all_base_models', new=AsyncMock(return_value=[m.copy() for m in provider_models])
+    ):
+        with patch('open_webui.utils.models.Config.get_many', new=AsyncMock(return_value={})):
+            res = await get_models(mock_request, refresh=True, include_inactive=False, user=admin_user)
+            restored_ids = [m['id'] for m in res['data']]
+            assert len(restored_ids) == 8
+            assert len(mock_request.app.state.MODELS) == 8
+            print(f'  ✓ Successfully restored all {len(restored_ids)} models to chat endpoint and app.state.MODELS')
+
+    print('\n=================================================================')
+    print('ALL REGRESSION TESTS PASSED SUCCESSFULLY! ✓')
+    print('=================================================================')
+
+
+if __name__ == '__main__':
+    asyncio.run(run_tests())

--- a/backend/open_webui/utils/models.py
+++ b/backend/open_webui/utils/models.py
@@ -66,7 +66,12 @@ async def get_all_base_models(request: Request, user: UserModel = None):
     return function_models + openai_models + ollama_models
 
 
-async def get_all_models(request, refresh: bool = False, user: UserModel = None):
+async def get_all_models(
+    request,
+    refresh: bool = False,
+    user: UserModel = None,
+    include_inactive: bool = False,
+):
     config = await Config.get_many(
         'models.base_models_cache',
         'evaluation.arena.enable',
@@ -107,6 +112,8 @@ async def get_all_models(request, refresh: bool = False, user: UserModel = None)
 
     # deep copy the base models to avoid modifying the original list
     models = [model.copy() for model in base_models]
+    for model in models:
+        model.setdefault('is_active', True)
 
     # If there are no models, return an empty list
     if len(models) == 0:
@@ -181,7 +188,8 @@ async def get_all_models(request, refresh: bool = False, user: UserModel = None)
             model = base_model_lookup.get(custom_model.id)
 
             if model:
-                if custom_model.is_active:
+                model['is_active'] = custom_model.is_active
+                if custom_model.is_active or include_inactive:
                     model['name'] = custom_model.name
                     model['info'] = custom_model.model_dump()
                     schema = get_chat_variables_schema(custom_model.params.model_dump().get('system'))
@@ -202,10 +210,12 @@ async def get_all_models(request, refresh: bool = False, user: UserModel = None)
 
                     model['action_ids'] = action_ids
                     model['filter_ids'] = filter_ids
+                    if not custom_model.is_active and not include_inactive:
+                        models = [m for m in models if m is not model]
                 else:
                     models = [m for m in models if m is not model]
 
-        elif custom_model.is_active:
+        elif custom_model.is_active or include_inactive:
             if custom_model.id in existing_ids:
                 continue
 
@@ -230,6 +240,7 @@ async def get_all_models(request, refresh: bool = False, user: UserModel = None)
                 'owned_by': owned_by,
                 'connection_type': connection_type,
                 'preset': True,
+                'is_active': custom_model.is_active,
                 **({'pipe': pipe} if pipe is not None else {}),
                 **({'provider': base_model.get('provider')} if base_model and base_model.get('provider') else {}),
                 **({'loaded': base_model.get('loaded')} if base_model and base_model.get('loaded') is not None else {}),
@@ -438,7 +449,7 @@ async def get_all_models(request, refresh: bool = False, user: UserModel = None)
 
     log.debug('get_all_models() returned %s models', len(models))
 
-    models_dict = {model['id']: model for model in models}
+    models_dict = {model['id']: model for model in models if model.get('is_active', True)}
     if isinstance(request.app.state.MODELS, RedisDict):
         try:
             request.app.state.MODELS.set(models_dict)

--- a/src/lib/apis/index.ts
+++ b/src/lib/apis/index.ts
@@ -24,11 +24,15 @@ export const getModels = async (
 	token: string = '',
 	connections: object | null = null,
 	base: boolean = false,
-	refresh: boolean = false
+	refresh: boolean = false,
+	include_inactive: boolean = false
 ) => {
 	const searchParams = new URLSearchParams();
 	if (refresh) {
 		searchParams.append('refresh', 'true');
+	}
+	if (include_inactive) {
+		searchParams.append('include_inactive', 'true');
 	}
 
 	let error = null;

--- a/src/lib/components/admin/Settings/Models.svelte
+++ b/src/lib/components/admin/Settings/Models.svelte
@@ -268,14 +268,7 @@
 		}
 
 		baseModels = await getBaseModels(localStorage.token, selectedTag);
-		allModels = await getModels(localStorage.token);
-
-		const providerModels = await getModels(localStorage.token, null, true);
-		const allModelIds = new Set<string>(allModels.map((model: ModelListItem) => model.id));
-		allModels = [
-			...allModels,
-			...providerModels.filter((model: ModelListItem) => !allModelIds.has(model.id))
-		];
+		allModels = await getModels(localStorage.token, null, false, false, true);
 
 		const baseModelIds = new Set<string>(baseModels.map((model: ModelListItem) => model.id));
 
@@ -287,7 +280,8 @@
 				if (baseModel) {
 					return {
 						...m,
-						...baseModel
+						...baseModel,
+						is_active: baseModel?.is_active ?? m?.is_active ?? true
 					};
 				} else {
 					return {
@@ -295,7 +289,7 @@
 						id: m.id,
 						name: m.name,
 
-						is_active: true
+						is_active: m?.is_active ?? true
 					};
 				}
 			});


### PR DESCRIPTION
# Pull Request

## Checklist

- [x] This PR targets the `dev` branch.
- [x] This PR links to a well-described, confirmed Issue or active Discussion: Relates to #29037
- [ ] A maintainer explicitly asked me to open this PR, or this PR only updates i18n/localization.
- [x] The change is one logical unit with no unrelated commits.
- [x] I matched nearby code patterns and avoided unnecessary new settings, abstractions, or dependencies.
- [x] I manually tested the changed workflow and any nearby behavior that could be affected.
- [ ] I updated relevant docs, including the [Open WebUI Docs Repository](https://github.com/open-webui/docs), if needed.
- [ ] I added screenshots for UI changes, and a recording when motion or interaction matters.
- [x] I reviewed any AI-generated code before submitting it.
- [x] The PR title uses one of the prefixes listed below.

## Summary

In previous releases and current `dev`, clicking **Disable All Models** (or disabling models individually) creates database records with `is_active = False`.

While PR #29037 addressed external provider models by querying `/api/models/base` on the frontend, it left two issues:
1. **Disabled custom/preset models (`base_model_id != None`) still permanently disappear from Admin -> Models**: `/api/models` purges inactive models, while `/api/models/base` only returns external provider models and `/api/v1/models/base` only returns `base_model_id IS NULL` rows. Disabled custom models vanish from the admin UI and cannot be re-enabled.
2. **Fragile frontend multi-endpoint stitching**: Admin -> Models was making 3 separate calls (`/api/v1/models/base`, `/api/models`, and `/api/models/base`), merging them with client-side Set logic on every page load.

This PR introduces an `include_inactive: bool = False` query parameter to `/api/models` (enforced for admin users only). This cleanly separates chat model selection (which strictly filters out inactive models) from Admin model management (which receives all models with their true `is_active` state). `request.app.state.MODELS` continues to strictly cache only active models, ensuring no chat prompts can ever route to disabled models.

## Testing

Ran automated multi-provider regression tests in `backend/open_webui/test_admin_models_bulk_disable.py`:
- 5 concurrent simulated providers (NVIDIA NIM, OpenRouter, Google Generative Language, GitHub Copilot, local endpoint) + custom preset model (`wallfire-mcp`).
- Verified baseline discovery (8 models).
- Verified bulk disable marks `is_active=False` in DB.
- Verified `/api/models` without `include_inactive` hides all disabled models (0 returned) and `app.state.MODELS` has 0 inactive models.
- Verified `/api/models?include_inactive=true` returns all 8 models (including custom preset models) with `is_active=False`.
- Verified non-admin callers requesting `include_inactive=True` are restricted to active models only.
- Verified bulk enable restores all models to chat `/api/models` and `app.state.MODELS`.

## Changelog Entry

### Fixed
- Fixed disabled custom/preset models disappearing from Admin -> Models.
- Added `include_inactive` parameter to `/api/models` for admin model management, ensuring both provider models and custom models remain visible and manageable under Admin -> Models -> Disabled.

## Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
