### PR TITLE
feat: support inline images for terminal chat uploads

### DIFF
--- a/backend/open_webui/utils/terminals.py
+++ b/backend/open_webui/utils/terminals.py
@@ -8,7 +8,7 @@ TERMINAL_CONTEXT_HEADER = 'X-Terminal-Context-Id'
 TERMINAL_CONTEXT_DEFAULT = 'default'
 TERMINAL_CONTEXT_TYPES = {'chat', 'automation'}
 TERMINAL_CONTEXT_ID_SOURCES = {'chat': 'chat_id', 'automation': 'automation_id'}
-TERMINAL_CHAT_UPLOAD_MODES = {'default', 'filesystem'}
+TERMINAL_CHAT_UPLOAD_MODES = {'default', 'filesystem', 'filesystem_inline_images'}
 
 
 def is_terminal_orchestrator(connection: dict) -> bool:

--- a/src/lib/apis/terminal/index.ts
+++ b/src/lib/apis/terminal/index.ts
@@ -87,7 +87,7 @@ export type TerminalServer = {
 	name: string;
 	contexts?: Record<string, false | { context_id?: string }>;
 	config?: {
-		chat_uploads?: 'default' | 'filesystem';
+		chat_uploads?: 'default' | 'filesystem' | 'filesystem_inline_images';
 		[key: string]: unknown;
 	};
 };

--- a/src/lib/components/AddTerminalServerModal.svelte
+++ b/src/lib/components/AddTerminalServerModal.svelte
@@ -36,7 +36,7 @@
 	let auth_type = 'bearer';
 	let path = '/openapi.json';
 	let enabled = false;
-	let chatUploads: 'default' | 'filesystem' = 'default';
+	let chatUploads: 'default' | 'filesystem' | 'filesystem_inline_images' = 'default';
 	let chatContextMode: 'default' | 'chat_id' | 'off' = 'default';
 	let automationContextMode: 'default' | 'automation_id' | 'off' = 'default';
 	let showAdvanced = false;
@@ -81,7 +81,12 @@
 			auth_type = connection?.auth_type ?? 'bearer';
 			path = connection?.path ?? '/openapi.json';
 			enabled = connection?.enabled ?? true;
-			chatUploads = connection?.config?.chat_uploads === 'filesystem' ? 'filesystem' : 'default';
+			chatUploads =
+				connection?.config?.chat_uploads === 'filesystem_inline_images'
+					? 'filesystem_inline_images'
+					: connection?.config?.chat_uploads === 'filesystem'
+						? 'filesystem'
+						: 'default';
 			accessGrants = connection?.config?.access_grants ?? [];
 
 			// Restore policy state
@@ -383,7 +388,7 @@
 		else delete connectionConfig.access_grants;
 		if (useContexts) connectionConfig.contexts = contexts;
 		else delete connectionConfig.contexts;
-		if (chatUploads === 'filesystem') connectionConfig.chat_uploads = 'filesystem';
+		if (chatUploads !== 'default') connectionConfig.chat_uploads = chatUploads;
 		else delete connectionConfig.chat_uploads;
 
 		const result = {
@@ -556,6 +561,9 @@
 									>
 										<option value="default">{$i18n.t('Default')}</option>
 										<option value="filesystem">{$i18n.t('Filesystem')}</option>
+										<option value="filesystem_inline_images"
+											>{$i18n.t('Filesystem (Inline Images)')}</option
+										>
 									</select>
 								</div>
 							</div>

--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -884,13 +884,19 @@
 		if (!selectedId) return null;
 
 		const systemTerminal = (servers ?? []).find(
-			(t: any) => t.id && t.id === selectedId && t.config?.chat_uploads === 'filesystem'
+			(t: any) =>
+				t.id &&
+				t.id === selectedId &&
+				['filesystem', 'filesystem_inline_images'].includes(t.config?.chat_uploads)
 		);
 		if (systemTerminal) return systemTerminal;
 
 		return (
 			(settingsValue?.terminalServers ?? []).find(
-				(t: any) => t.url === selectedId && t.enabled && t.config?.chat_uploads === 'filesystem'
+				(t: any) =>
+					t.url === selectedId &&
+					t.enabled &&
+					['filesystem', 'filesystem_inline_images'].includes(t.config?.chat_uploads)
 			) ?? null
 		);
 	};
@@ -902,6 +908,12 @@
 		}
 
 		const filesystemUploadTerminal = getFilesystemUploadTerminal();
+
+		const uploadToFilesystem =
+			!!filesystemUploadTerminal &&
+			(filesystemUploadTerminal.config?.chat_uploads === 'filesystem' ||
+				(filesystemUploadTerminal.config?.chat_uploads === 'filesystem_inline_images' &&
+					!file.type.startsWith('image/')));
 
 		if (!filesystemUploadTerminal && fileUploadCapableModels.length !== selectedModelIds.length) {
 			toast.error($i18n.t('Model(s) do not support file upload'));
@@ -933,7 +945,7 @@
 
 		files = [...files, fileItem];
 
-		if (filesystemUploadTerminal) {
+		if (uploadToFilesystem) {
 			try {
 				const cwd =
 					(

--- a/src/lib/i18n/locales/en-GB/translation.json
+++ b/src/lib/i18n/locales/en-GB/translation.json
@@ -1266,6 +1266,7 @@
 	"Filename matches": "",
 	"Files": "",
 	"Filesystem": "",
+	"Filesystem (Inline Images)": "",
 	"Fill the required fields first.": "",
 	"Fill the source fields and test query first.": "",
 	"Filter": "",


### PR DESCRIPTION
## Summary

- add an optional `Filesystem (Inline Images)` terminal chat upload mode
- keep images as normal inline chat uploads while storing other files in the terminal filesystem
- preserve the existing `Filesystem` behavior where all uploaded files are stored in the terminal filesystem
- keep `Default` behavior unchanged

## Related Issue

Closes #29545

## Contributor License Agreement

<!--
DO NOT DELETE THIS SECTION.
Your PR will not be reviewed or merged until you check the box below confirming that you have read and fully agree to the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.