### PR TITLE
fix: make native tool-call <source> citations mappable (search_web)

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -5571,7 +5571,9 @@ async def streaming_chat_response_handler(response, ctx):
                 # (1..k) so tool-source ids continue without collision.
                 source_ids = {}
                 if metadata.get('rag_context_applied'):
-                    get_source_context(metadata.get('sources', []), source_ids)
+                    # Only the id counter matters here; skip rendering document
+                    # bodies just to burn ids into the shared counter.
+                    get_source_context(metadata.get('sources', []), source_ids, include_content=False)
                 tool_source_context_injected = False
 
                 # Continuation requests are built as a growing byte-prefix:
@@ -6166,15 +6168,21 @@ async def streaming_chat_response_handler(response, ctx):
                         )
 
                         try:
+                            # Reuse the accumulated turns (which carry every
+                            # tool round + citation block) and convert only the
+                            # code-interpreter item appended after the last
+                            # tool round, so this follow-up stays a byte
+                            # extension of the last tool-call request and the
+                            # model keeps seeing all citation ids.
                             new_form_data = {
                                 **form_data,
                                 'model': model_id,
                                 'stream': True,
                                 'metadata': metadata,
                                 'messages': [
-                                    *form_data['messages'],
+                                    *accumulated_messages,
                                     *convert_output_to_messages(
-                                        output,
+                                        output[converted_upto:],
                                         raw=True,
                                         reasoning_format=get_reasoning_format(model),
                                         flatten_tool_images=True,

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -13,6 +13,7 @@ import sys
 import textwrap
 import time
 from concurrent.futures import ThreadPoolExecutor
+from html import escape
 from typing import Any, Optional
 from uuid import uuid4
 
@@ -942,24 +943,34 @@ def handle_responses_streaming_event(
 def get_source_context(sources: list, source_ids: dict = None, include_content: bool = True) -> str:
     """
     Build <source> tag context string from citation sources.
+
+    name/url are taken from the per-document metadata when available, so tool
+    results (e.g. search_web) render tags the model can map back to a specific
+    result. Attribute values are HTML-escaped.
     """
     context_string = ''
     if source_ids is None:
         source_ids = {}
     for source in sources:
+        source_obj = source.get('source', {}) or {}
         for doc, meta in zip(source.get('document', []), source.get('metadata', [])):
-            source_id = meta.get('source') or source.get('source', {}).get('id') or 'N/A'
+            meta = meta or {}
+            source_id = meta.get('source') or source_obj.get('id') or 'N/A'
             if source_id not in source_ids:
                 source_ids[source_id] = len(source_ids) + 1
-            src_name = source.get('source', {}).get('name')
-            src_type = source.get('source', {}).get('type')
-            src_rid = source.get('source', {}).get('id')
+            src_name = meta.get('name') or source_obj.get('name')
+            src_type = source_obj.get('type')
+            src_rid = source_obj.get('id')
+            src_url = meta.get('url') or (
+                source_id if isinstance(source_id, str) and source_id.startswith(('http://', 'https://')) else ''
+            )
             body = doc if include_content else ''
             context_string += (
                 f'<source id="{source_ids[source_id]}"'
-                + (f' name="{src_name}"' if src_name else '')
-                + (f' resource-type="{src_type}"' if src_type else '')
-                + (f' resource-id="{src_rid}"' if src_rid else '')
+                + (f' name="{escape(str(src_name), quote=True)}"' if src_name else '')
+                + (f' url="{escape(str(src_url), quote=True)}"' if src_url else '')
+                + (f' resource-type="{escape(str(src_type), quote=True)}"' if src_type else '')
+                + (f' resource-id="{escape(str(src_rid), quote=True)}"' if src_rid else '')
                 + f'>{body}</source>\n'
             )
     return context_string
@@ -2987,8 +2998,6 @@ async def process_chat_payload(request, form_data, user, metadata, model):
             form_data['messages'] = await add_file_context(form_data.get('messages', []), chat_id, user)
 
             if (model.get('info', {}).get('meta', {}).get('builtinTools') or {}).get('knowledge', True):
-                from html import escape
-
                 knowledge_tags = []
                 for item in get_attached_knowledge(model, metadata):
                     if not item.get('id') or not item.get('type'):

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -119,7 +119,6 @@ from open_webui.utils.misc import (
     is_string_allowed,
     merge_system_messages,
     prepend_to_first_user_message_content,
-    replace_system_message_content,
     set_last_user_message_content,
     strip_empty_content_blocks,
 )
@@ -3084,6 +3083,7 @@ async def process_chat_payload(request, form_data, user, metadata, model):
     # If context is not empty, insert it into the messages
     if sources and prompt:
         form_data['messages'] = await apply_source_context_to_messages(request, form_data['messages'], sources, prompt)
+    metadata['rag_context_applied'] = bool(sources and prompt)
 
     # If there are citations, add them to the data_items
     sources = [
@@ -5564,23 +5564,33 @@ async def streaming_chat_response_handler(response, ctx):
                     CHAT_RESPONSE_MAX_TOOL_CALL_ITERATIONS,
                 )
                 tool_call_sources = []  # Track citation sources from tool results
-                all_tool_call_sources = []  # Accumulated sources across all iterations
                 user_message = get_last_user_message(form_data['messages'])
+
+                # Shared <source> id counter across iterations. Pre-seed it
+                # with any file sources the pre-loop RAG injection numbered
+                # (1..k) so tool-source ids continue without collision.
+                source_ids = {}
+                if metadata.get('rag_context_applied'):
+                    get_source_context(metadata.get('sources', []), source_ids)
+                tool_source_context_injected = False
+
+                # Continuation requests are built as a growing byte-prefix:
+                # accumulated_messages carries every turn that has already been
+                # sent, and each iteration appends ONLY its own assistant/tool
+                # messages followed by a model-only citation user message. The
+                # request therefore stays a pure extension of the previous one,
+                # so the prompt-cache prefix extends through the user's prompt,
+                # every earlier tool-call round and every citation block.
+                # converted_upto tracks how much of `output` has already been
+                # folded in; `output` is rebound across rounds, so the cursor is
+                # re-anchored to the reset boundary after each continuation.
+                accumulated_messages = list(form_data['messages'])
+                converted_upto = 0
 
                 # Check if citations are enabled for this model
                 citations_enabled = (model.get('info', {}).get('meta', {}).get('capabilities') or {}).get(
                     'citations', True
                 )
-
-                # Use the pre-RAG system content captured before the
-                # initial file-source injection in process_chat_payload.
-                # This ensures restore truly undoes the RAG template.
-                original_system_content = metadata.get('system_prompt')
-                if original_system_content is None:
-                    original_system_message = get_system_message(form_data['messages'])
-                    original_system_content = (
-                        get_content_from_message(original_system_message) if original_system_message else None
-                    )
 
                 while tool_calls and (
                     max_tool_call_iterations is None or tool_call_iterations < max_tool_call_iterations
@@ -5851,65 +5861,36 @@ async def streaming_chat_response_handler(response, ctx):
                                 break
 
                     # Emit citation sources to the frontend for display
+                    pending_source_context = ''
                     if citations_enabled:
                         for source in tool_call_sources:
                             await event_emitter({'type': 'source', 'data': source})
 
-                        # Apply tool source context to messages for the model.
-                        # Restoring to pre-RAG original prevents duplicating
-                        # the RAG template across file and tool sources.
-                        all_tool_call_sources.extend(tool_call_sources)
-                        if all_tool_call_sources and user_message:
-                            # Restore pre-RAG message state before re-applying
-                            # to prevent RAG template duplication.
-                            original_user_message = metadata.get('user_prompt') or user_message
-                            set_last_user_message_content(
-                                original_user_message,
-                                form_data['messages'],
-                            )
-                            if original_system_content is not None:
-                                if get_system_message(form_data['messages']):
-                                    replace_system_message_content(
-                                        original_system_content,
-                                        form_data['messages'],
-                                    )
-                                else:
-                                    form_data['messages'] = add_or_update_system_message(
-                                        original_system_content,
-                                        form_data['messages'],
-                                    )
-                            else:
-                                replace_system_message_content('', form_data['messages'])
-
-                            # Build context: file sources with content,
-                            # tool sources as citation markers only.
-                            source_ids = {}
+                        # Build this iteration's citation block for the model.
+                        # Appended as a user message right after this round's
+                        # tool results — never between an assistant tool_calls
+                        # message and its tool result. First block carries the
+                        # full RAG template; later ones reuse a compact
+                        # <context> wrapper since the instructions were already
+                        # given. rag_context_applied covers the case where the
+                        # file-source injection already rendered the template,
+                        # so the whole conversation has exactly one copy.
+                        if tool_call_sources and user_message:
                             source_context = get_source_context(
-                                metadata.get('sources', []), source_ids
-                            ) + get_source_context(
-                                all_tool_call_sources,
+                                tool_call_sources,
                                 source_ids,
                                 include_content=False,
-                            )
-                            source_context = source_context.strip()
+                            ).strip()
                             if source_context:
-                                rag_content = await rag_template(
-                                    await Config.get('rag.template'),
-                                    source_context,
-                                    user_message,
-                                )
-                                if RAG_SYSTEM_CONTEXT:
-                                    form_data['messages'] = add_or_update_system_message(
-                                        rag_content,
-                                        form_data['messages'],
-                                        append=True,
-                                    )
+                                if tool_source_context_injected or metadata.get('rag_context_applied'):
+                                    pending_source_context = f'<context>\n{source_context}\n</context>'
                                 else:
-                                    form_data['messages'] = add_or_update_user_message(
-                                        rag_content,
-                                        form_data['messages'],
-                                        append=False,
+                                    pending_source_context = await rag_template(
+                                        await Config.get('rag.template'),
+                                        source_context,
+                                        user_message,
                                     )
+                                    tool_source_context_injected = True
                         tool_call_sources.clear()
 
                     # Strip input_image parts (large base64 data URIs) from the
@@ -5949,44 +5930,34 @@ async def streaming_chat_response_handler(response, ctx):
                             )
                             new_form_data['previous_response_id'] = last_response_id
                         else:
-                            tool_messages = convert_output_to_messages(
-                                output,
+                            # Convert only the rounds not yet folded in. The
+                            # earlier turns already sit in accumulated_messages,
+                            # so this emits exactly the current iteration's
+                            # assistant/tool messages and nothing else.
+                            delta_messages = convert_output_to_messages(
+                                output[converted_upto:],
                                 raw=True,
                                 reasoning_format=get_reasoning_format(model),
                                 flatten_tool_images=True,
                             )
+                            accumulated_messages.extend(delta_messages)
+                            converted_upto = len(output)
 
-                            # Chat Completions providers don't support multimodal
-                            # tool messages.  Extract images into a user message.
-                            image_urls = []
-                            for message in tool_messages:
-                                if message.get('role') == 'tool' and isinstance(message.get('content'), list):
-                                    text_parts = []
-                                    for part in message['content']:
-                                        if part.get('type') == 'input_text':
-                                            text_parts.append(part.get('text', ''))
-                                        elif part.get('type') == 'input_image':
-                                            image_urls.append(part.get('image_url', ''))
-                                    message['content'] = ''.join(text_parts)
-
-                            new_form_data['messages'] = [
-                                *form_data['messages'],
-                                *tool_messages,
-                            ]
-
-                            if image_urls:
-                                new_form_data['messages'].append(
+                            # Model-only tool citation context for this iteration,
+                            # placed after its tool results (delta_messages ends
+                            # on this round's tool messages or the flattened
+                            # image message). The next request is then a pure
+                            # byte extension of this one: both the already-sent
+                            # prefix and this block are reused verbatim.
+                            if pending_source_context:
+                                accumulated_messages.append(
                                     {
                                         'role': 'user',
-                                        'content': [
-                                            {
-                                                'type': 'text',
-                                                'text': 'Here are the images from the tool results above. Please analyze them.',
-                                            },
-                                            *[{'type': 'image_url', 'image_url': {'url': url}} for url in image_urls],
-                                        ],
+                                        'content': pending_source_context + '\n',
                                     }
                                 )
+
+                            new_form_data['messages'] = list(accumulated_messages)
 
                         if filter_functions:
                             new_form_data, _ = await process_filter_functions(
@@ -6029,6 +6000,9 @@ async def streaming_chat_response_handler(response, ctx):
                             output = []
                             await stream_body_handler(res, new_form_data)
                             output[:0] = prior_output
+                            # Re-anchor the conversion cursor: prior_output is
+                            # the already-converted part of the rebound list.
+                            converted_upto = len(prior_output)
                             prior_output = []
                         elif getattr(res, 'status_code', 200) >= 400:
                             await emit_message_error(get_message_error_content(get_response_error_detail(res)))


### PR DESCRIPTION
## Checklist

- [x] This PR targets the `dev` branch.
- [x] This PR links to a well-described, confirmed Issue or active Discussion: `Closes #29569`.
- [x] A maintainer explicitly asked me to open this PR, or this PR only updates i18n/localization.
- [x] The change is one logical unit with no unrelated commits.
- [x] I matched nearby code patterns and avoided unnecessary new settings, abstractions, or dependencies.
- [x] I manually tested the changed workflow and any nearby behavior that could be affected.
- [ ] I updated relevant docs, including the [Open WebUI Docs Repository](https://github.com/open-webui/docs), if needed.
- [ ] I added screenshots for UI changes, and a recording when motion or interaction matters.
- [x] I reviewed any AI-generated code before submitting it.
- [x] The PR title uses one of the prefixes listed below.

## Summary

Fixes #29569. With native function calling, the `search_web` tool's injected
context block emitted one identical empty `<source name="search_web">` tag per
result, so the model could not map `[id]` citations back to actual results; the
RAG template insists on `[id]` citations, forcing guesswork.

### 1. Mappable `<source>` tags

`get_source_context()` only ever read name/resource-type/resource-id from the
tool-level `source` object, ignoring the per-result metadata that carries the
actual title and link. It now:

- takes the tag name from the per-document metadata, falling back to the source name;
- emits a `url` attribute from the metadata (or from an `http(s)` metadata source, which covers `fetch_url` and RAG url items);
- HTML-escapes every attribute value (`html.escape(quote=True)`), since result titles can contain quotes.

Per-result `search_web` metadata already carries `source` = link, so tags get
distinct ids the model can cross-map against the tool output:

```xml
<source id="1" name="mathew-cf/opencode-terminal-notifier"
        url="https://github.com/mathew-cf/opencode-terminal-notifier"
        resource-type="tool" resource-id="search_web"></source>
```

This also aligns the model-facing context with the citations UI, which already
prefers `metadata.name`.

### 2. Stop rewriting the user's message every round

The native tool-call loop previously prepended the RAG template + `<source>`
block onto the last user message on each iteration and accumulated sources
globally (ids 1-8 → 1-16 → ...), so the request never shared a byte-prefix with
the previous one and the original user prompt got wrapped with template text.

Continuations are now built as a growing byte-prefix:

- `accumulated_messages` = base conversation; each round appends **only** its own assistant/tool messages (converted from `output[converted_upto:]`) plus a model-only citation user message placed after that round's tool results.
- Role sequence stays `user / assistant(tool_calls) / tool / user / ...` — nothing sits between an assistant `tool_calls` message and its result.
- The first block carries the full RAG template; later rounds reuse a compact `<context>` wrapper (`tool_source_context_injected` / `rag_context_applied`).
- The shared `<source>` id counter is pre-seeded from pre-loop file sources so tool-source ids continue without collisions or gaps, and stays contiguous across rounds.
- Every continuation is a pure byte-extension of the previous one, so the prompt-cache prefix extends through the user's prompt and all tool-call rounds.
- Code-interpreter follow-ups are rebuilt from the same accumulated turns (`output[converted_upto:]`), so citation ids survive the executed-code path.

Known limitations (pre-existing, unchanged by this PR): with
`ENABLE_RESPONSES_API_STATEFUL` the continuation is rebuilt from `[system]` +
converted output and drops appended messages; a request filter that mutates
message dicts sacrifices the byte-prefix property.

## Testing

Manual repro from #29569 (Exa engine, `search_web` only, bypass embedding/loader,
native function calling, `dev` @ `0cf48a0`):

- Confirmed the model-facing context now renders `<source>` tags with distinct ids, the per-result title as `name`, and the result link as `url`, so `[id]` citations map 1:1 to the tool's JSON output.
- Confirmed continuation requests are byte-prefixes of the previous request (no more per-round user-message rewrite).
- `get_source_context()` verified via AST-extraction unit run (no runtime import): name/url rendering, HTML escaping (`&quot;`/`&amp;`), and distinct ids for per-result metadata.
- `ruff check` and `ruff format --check` clean — no new findings vs `dev`.

## Changelog Entry

### Added

-

### Changed

-

### Fixed

- Native tool-call `<source>` citations for `search_web` are now mappable (per-result name + URL, distinct ids), so the model can emit correct inline `[id]` citations.
- Native tool-call continuations are built as a growing byte-prefix, ending the per-iteration rewrite of the user message and its repeated prompt-cache invalidation.

### Removed

-

### Security

-

### Breaking Changes

-

## Additional Context

The reported bug is a prompt-construction/logic issue (no server errors). The
model-facing behavior is fixed here; the frontend citations panel was already
correct because the `{'type': 'source', ...}` events carried the right metadata.

## Contributor License Agreement

<!--
DO NOT DELETE THIS SECTION.
Your PR will not be reviewed or merged until you check the box below confirming that you have read and agree to the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.