### PR TITLE
fix: show literal ASCII sequences instead of arrow ligatures

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -19,6 +19,7 @@
 
 html {
 	word-break: break-word;
+	font-variant-ligatures: no-contextual;
 	/* font-size scales the entire document via the same UI control */
 	font-size: calc(1rem * var(--app-text-scale, 1));
 }


### PR DESCRIPTION
# Pull Request

## Checklist

- [x] This PR targets the `dev` branch.
- [x] This PR links to a well-described, confirmed Issue or active Discussion: `Closes #29594`.
- [ ] A maintainer explicitly asked me to open this PR, or this PR only updates i18n/localization.
- [x] The change is one logical unit with no unrelated commits.
- [x] I matched nearby code patterns and avoided unnecessary new settings, abstractions, or dependencies.
- [x] I manually tested the changed workflow and any nearby behavior that could be affected.
- [ ] I updated relevant docs, including the [Open WebUI Docs Repository](https://github.com/open-webui/docs), if needed.
- [x] I added screenshots for UI changes, and a recording when motion or interaction matters.
- [x] I reviewed any AI-generated code before submitting it.
- [x] The PR title uses one of the prefixes listed below.

## Summary

`<---` typed into a saved memory displays as `←`. #29594 reports this as the text being converted into a Unicode character.

Nothing converts the text. Inter ships arrow substitutions as OpenType contextual alternates, and Open WebUI sets no `font-variant-ligatures`, so `<---` is stored and sent exactly as typed while being drawn as an arrow.

I confirmed the stored value is untouched by loading Open WebUI's own `static/assets/fonts/Inter-Variable.ttf` in isolation and reading the DOM back. Every field holds `U+3C U+2D U+2D U+2D`, and only the glyphs differ.

| Element, each containing `<---` | Renders |
|---|---|
| `<textarea>` in Inter | `←` |
| `<textarea>` with `font-variant-ligatures: none` | `<---` |
| `contenteditable` in Inter | `←` |
| plain `<div>` in Inter | `←` |

The consequence for the reporter is that the memory rule already worked. The model received `<---`. The display was the only misleading part, at both ends of the exchange. It affects what you type and what the model writes back.

This sets `font-variant-ligatures: no-contextual` on `html`, alongside the existing document-wide typography there. It inherits, so it covers editable fields and rendered content with no new selector.

```diff
 html {
 	word-break: break-word;
+	font-variant-ligatures: no-contextual;
 	/* font-size scales the entire document via the same UI control */
 	font-size: calc(1rem * var(--app-text-scale, 1));
 }
```

I chose `no-contextual` over `none` after testing all three candidates. `none`, `no-contextual`, and `font-feature-settings: "calt" 0` each fix it, which places the arrow in contextual alternates. `no-contextual` disables that one feature and leaves standard ligatures such as `fi` and `fl` intact, so ordinary prose is unaffected.

One file, one line.

## Testing

Manual checks on this branch:

1. Settings, Personalization, Add Memory. Typed `<--- <--- <---` and saved. The editor shows the literal characters, and so does the saved memory in the list behind it. On `dev`, both show arrows.
2. Reopened the saved memory with Edit. Content round-trips unchanged.
3. Chat composer and the system prompt field. Typed `<---` and `-->`. Both render as typed.
4. Ordinary prose across the interface, checking that disabling contextual alternates did not disturb normal text.

Supporting evidence I gathered separately, which is not a substitute for the above:

- Isolated the bundled Inter file in a scratch page and read `textarea.value` back for each variant, confirming identical DOM values across all of them.
- `npm run build` passes and the declaration reaches the compiled stylesheet as `font-variant-ligatures:no-contextual`.

## Changelog Entry

### Fixed

- Literal character sequences such as `<---` no longer display as arrow glyphs in saved memories, input fields, and chat messages. The stored text was always correct, and only the rendering substituted an arrow.

## Additional Context

The reporter's steps 3 and 4 say `<---` displays correctly in the chat input. I could not reproduce that distinction. A `contenteditable` in Inter ligates exactly like a `<textarea>`, so both surfaces should have shown the arrow. Their environment is the Desktop build, which may resolve a different font. It does not affect the fix, since this covers every surface either way.

One scope point worth flagging for review. This change is document-wide rather than scoped to the Memory field. Restricting it to editable fields fixes the box you type into and leaves the rendered memory list and chat messages still drawing arrows, which is half the problem. If a narrower scope is preferred, the same declaration on `:is(input, textarea, [contenteditable='true'], .ProseMirror)` matches the existing grouping at `src/app.css` and covers editing only.

| Surface | Before | After |
|---|---|---|
| Personalization, saved memories list | <img width="1258" height="275" alt="image" src="https://github.com/user-attachments/assets/d82daa85-7056-4e3e-b3a5-8f5509875216" /> | <img width="1258" height="275" alt="image" src="https://github.com/user-attachments/assets/63e15a0f-eaa0-4cd2-b3b6-41994111499f" /> |
| Edit Memory modal | <img width="606" height="375" alt="image" src="https://github.com/user-attachments/assets/c6b03662-8ec1-4696-bc74-64bc98b4bde1" /> | <img width="606" height="375" alt="image" src="https://github.com/user-attachments/assets/1c542ef1-e3aa-4dcb-bba1-639e342cf596" /> |

Before is current `dev`, After is this branch.

This PR was prepared with AI copilot assistance. I have thoroughly reviewed and manually tested it.

## Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
