### PR TITLE
feat: execute a configured tool over the API

### DIFF
--- a/backend/open_webui/routers/tools.py
+++ b/backend/open_webui/routers/tools.py
@@ -39,6 +39,9 @@ from open_webui.utils.plugin import (
     resolve_valves_schema_options,
 )
 from open_webui.utils.tools import get_tool_servers, get_tool_specs
+
+# Aliased: this module's own `get_tools` is a route handler, which would shadow it.
+from open_webui.utils.tools import get_tools as load_tool_callables
 from pydantic import BaseModel, HttpUrl
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -478,6 +481,116 @@ async def get_tools_by_id(id: str, user=Depends(get_verified_user), db: AsyncSes
             status_code=status.HTTP_404_NOT_FOUND,
             detail=ERROR_MESSAGES.NOT_FOUND,
         )
+
+
+############################
+# ExecuteToolById
+############################
+
+
+class ToolCallForm(BaseModel):
+    name: str
+    arguments: dict = {}
+
+
+@router.post('/id/{id}/execute')
+async def execute_tool_by_id(
+    request: Request,
+    id: str,
+    form_data: ToolCallForm,
+    user=Depends(get_verified_user),
+):
+    """Call one function of a tool directly, outside a chat completion.
+
+    Tool execution otherwise only happens inside the chat pipeline, which means an
+    API client can reach a tool only by handing the whole loop to a model. This runs
+    exactly the callable the pipeline would, so an external client can drive its own
+    agent loop and still use the tools configured here.
+
+    Access control is not re-implemented: `get_tools` performs the same per-user check
+    the chat pipeline relies on and silently drops tools the caller may not read, so an
+    inaccessible id is indistinguishable from a missing one (a 404 either way).
+
+    A tool bundles several functions (one per method), so `id` selects the bundle and
+    `name` the function within it — the same pair the model produces as a tool call.
+    All three kinds work: a local tool, an OpenAPI tool server, and an MCP server.
+    """
+    # Local imports: utils.middleware pulls in several routers at module scope, so
+    # importing it at the top of a router risks an import cycle.
+    from open_webui.utils.middleware import connect_mcp_server, get_system_oauth_token
+
+    async def noop_emitter(event):
+        # The chat pipeline streams tool progress to a websocket session; there is no
+        # session here, so events are dropped rather than left unset (a tool that
+        # declares __event_emitter__ would otherwise get None and crash on call).
+        return None
+
+    extra_params = {
+        '__event_emitter__': noop_emitter,
+        '__event_call__': noop_emitter,
+        '__user__': user.model_dump(),
+        '__metadata__': {},
+        '__request__': request,
+        '__oauth_token__': await get_system_oauth_token(request, user),
+        '__model__': None,
+        '__messages__': [],
+        '__files__': [],
+        '__chat_id__': None,
+        '__message_id__': None,
+    }
+
+    def not_found(detail: str = ERROR_MESSAGES.NOT_FOUND):
+        return HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=detail)
+
+    async def run(callable, name):
+        try:
+            return await callable()
+        except TypeError as e:
+            # Wrong/missing arguments against the spec — a client error, not a server one.
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+        except HTTPException:
+            raise
+        except Exception as e:
+            log.exception(f'Error executing tool {id}.{name}')
+            raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e))
+
+    # MCP servers are resolved outside get_tools (which handles local + OpenAPI only),
+    # mirroring the chat pipeline's own split. The connection is per-call here — there
+    # is no chat session to hold it open — so it is always closed again.
+    if id.startswith('server:mcp:'):
+        server_id = id[len('server:mcp:') :]
+        result = await connect_mcp_server(request, server_id, user, {}, extra_params)
+        if result is None:
+            raise not_found()
+
+        client, tool_specs = result
+        try:
+            names = {spec['name'] for spec in tool_specs}
+            name = form_data.name
+            # The pipeline registers these as `<server_id>_<name>`, so a name copied from
+            # a model's tool call arrives prefixed. Accept either form.
+            if name not in names and name.startswith(f'{server_id}_'):
+                name = name[len(server_id) + 1 :]
+            if name not in names:
+                raise not_found(
+                    f"MCP server '{server_id}' has no tool '{form_data.name}'. Available: {', '.join(sorted(names))}"
+                )
+            value = await run(lambda: client.call_tool(name, function_args=form_data.arguments), name)
+        finally:
+            await client.disconnect()
+
+        return {'tool_id': id, 'name': name, 'result': value}
+
+    tools = await load_tool_callables(request, [id], user, extra_params)
+    if not tools:
+        raise not_found()
+
+    tool = tools.get(form_data.name)
+    if tool is None:
+        raise not_found(f"Tool '{id}' has no function '{form_data.name}'. Available: {', '.join(sorted(tools))}")
+
+    value = await run(lambda: tool['callable'](**form_data.arguments), form_data.name)
+    return {'tool_id': tool['tool_id'], 'name': form_data.name, 'result': value}
 
 
 ############################


### PR DESCRIPTION
Adds `POST /api/v1/tools/id/{id}/execute`, which runs one function of a configured tool and returns its result.

Draft because I would like a read on whether the endpoint is wanted at all, and on the two shape questions at the bottom, before polishing.

### The gap

Tools can be listed over the API (`GET /api/v1/tools/`, including each one's `specs`) but not called. Execution happens only inside the chat pipeline: you pass `tool_ids` in a chat completion and Open WebUI runs the whole model loop server-side. So an external client that wants to use the tools configured here has to hand over its entire agent loop to do it.

That is a real constraint for anything that already has a loop of its own. My case is a browser extension that drives its own agent and wants Open WebUI's tools as steps in it — with its own approval gate and its own step rendering, which it loses entirely when the loop runs server-side. The same applies to any external orchestrator, a CI job that wants one tool's output, or a script testing a tool it just wrote without wrapping it in a conversation.

Listing tools and being unable to invoke one also reads as an oversight in the API surface: the specs are right there and describe exactly how to call something the API then declines to call.

### What it does

```
POST /api/v1/tools/id/{id}/execute
{ "name": "search_web", "arguments": { "query": "..." } }

→ { "tool_id": "searxng_web_search", "name": "search_web", "result": ... }
```

A tool bundles several functions (one per method), so `id` selects the bundle and `name` the function — the same pair a model emits as a tool call.

All three kinds work:

- **Local Python tools** and **OpenAPI tool servers** via `get_tools`, which is what the chat pipeline uses.
- **MCP servers** via `connect_mcp_server`, mirroring the pipeline's own split (`get_tools`' `server:` branch handles OpenAPI only). The connection is opened and closed per call, since there is no chat session to hold it open, and both the bare and `<server_id>_`-prefixed function names are accepted because a name copied from a model's tool call arrives prefixed.

### Why it should be safe to add

- **No existing code path changes.** One route, `+113` lines, one file.
- **Access control is not re-implemented.** `get_tools` applies the same per-user check the chat pipeline relies on and drops tools the caller may not read, so an inaccessible id 404s exactly like a missing one. The endpoint cannot reach a tool its caller could not already use through chat.
- **Errors are typed rather than generic**: 404 for an unknown tool or function (listing the available function names), 400 for wrong arguments (a `TypeError` from the callable is a client error, not a 500), 500 only for a genuine failure inside the tool.
- Imports from `utils.middleware` are function-local, because that module imports several routers at module scope and a top-level import from a router invites a cycle.

### Verified

Against 0.11.0 with three local tools configured:

- `search_web` executed and returned real results
- unknown function → 404 naming the real ones, wrong arguments → 400, no auth → 401
- the existing `tool_ids` chat path still works unchanged

Not exercised: the MCP branch and the OpenAPI-server branch, since that instance has neither configured. Both follow the pipeline's own code paths, but I would not claim them tested.

### Two questions I would rather ask than guess

1. **Should the response report timing?** It currently reports none. `middleware.py` stamps `started_at` / `ended_at` / `duration` on reasoning and code-interpreter output items, but nothing times a tool call anywhere, so there is no convention to copy for this. If it is wanted, I would add `duration_ms` for the callable plus a total for the request — `duration` in seconds as an int (the existing convention) would read `0` for most tool calls. Happy to add it here or leave it out.

2. **Is the MCP per-call connect acceptable?** Opening and closing a connection per request is the honest thing to do without a session, but it makes an MCP call materially more expensive than a local one, and that cost is invisible in the response today (see question 1).

Also happy to split the MCP half out if the local + OpenAPI half is easier to accept on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
