### PR TITLE
fix: report a web search where no page loaded as a loader failure

### DIFF
--- a/backend/open_webui/constants.py
+++ b/backend/open_webui/constants.py
@@ -99,6 +99,14 @@ class ERROR_MESSAGES(str, Enum):
     INVALID_URL = 'The URL you provided is invalid. Please double-check and try again.'
 
     WEB_SEARCH_ERROR = 'Something went wrong while searching the web.'
+    WEB_SEARCH_NO_CONTENT_ERROR = (
+        'None of the web search results could be loaded. '
+        'Check the web loader configuration in Admin Settings > Web Search.'
+    )
+    WEB_SEARCH_EMBEDDING_ERROR = (
+        'Failed to embed and store the retrieved web pages. '
+        'Check the embedding configuration in Admin Settings > Documents.'
+    )
 
     OLLAMA_API_DISABLED = 'The Ollama API is disabled. Please enable it to use this feature.'
 

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -2934,6 +2934,14 @@ async def process_web_search(request: Request, form_data: SearchForm, user=Depen
                 'loaded_count': len(docs),
             }
         else:
+            # Nothing loaded, so nothing ever reaches the embedding step. Name the loader here and
+            # leave the embedding message below for failures that are actually about embedding.
+            if not any(doc.page_content.strip() for doc in docs):
+                raise HTTPException(
+                    status.HTTP_404_NOT_FOUND,
+                    detail=ERROR_MESSAGES.WEB_SEARCH_NO_CONTENT_ERROR,
+                )
+
             # Create a single collection for all documents
             # Bind the ephemeral collection to its owner so filter_accessible_collections can scope it per-user.
             collection_name = f'web-search-{user.id}-{calculate_sha256_string("-".join(form_data.queries))}'[:63]
@@ -2953,7 +2961,7 @@ async def process_web_search(request: Request, form_data: SearchForm, user=Depen
                 log.exception(f'Error saving web search results to vector DB: {e}')
                 raise HTTPException(
                     status.HTTP_500_INTERNAL_SERVER_ERROR,
-                    detail='Failed to embed and store the retrieved web pages. Check the embedding configuration in Admin Settings > Documents.',
+                    detail=ERROR_MESSAGES.WEB_SEARCH_EMBEDDING_ERROR,
                 )
 
             return {


### PR DESCRIPTION
## Checklist

- [x] This PR targets the `dev` branch.
- [x] This PR links to a well-described, confirmed Issue or active Discussion: `Closes #29327`.
- [ ] A maintainer explicitly asked me to open this PR, or this PR only updates i18n/localization. — see Additional Context.
- [x] The change is one logical unit with no unrelated commits.
- [x] I matched nearby code patterns and avoided unnecessary new settings, abstractions, or dependencies.
- [x] I manually tested the changed workflow and any nearby behavior that could be affected.
- [x] I updated relevant docs, including the [Open WebUI Docs Repository](https://github.com/open-webui/docs), if needed. — no user-facing docs describe this message.
- [x] I added screenshots for UI changes, and a recording when motion or interaction matters. — backend only, no UI change.
- [x] I reviewed any AI-generated code before submitting it.
- [x] The PR title uses one of the prefixes listed below.

## Summary

Closes #29327.

When every URL in a web search batch fails to load, `docs` reaches `save_docs_to_vector_db` empty and is rejected with `EMPTY_CONTENT`. `process_web_search` turns any exception from that call into one fixed message that names the embedding configuration, so a blocked page and a genuinely broken embedding model are indistinguishable, and the message sends the reader to the wrong settings page.

This checks for retrieved content before the collection is created and reports the loader instead, leaving the embedding message for failures that really are about embedding.

Two things the issue raises are deliberately left alone:

- The bypass path is untouched. With `BYPASS_WEB_SEARCH_EMBEDDING_AND_RETRIEVAL` enabled the request still returns normally on an empty batch, exactly as before. The issue calls that inconsistency a product decision, so this PR does not settle it.
- Surfacing the failure instead of returning an unusable collection, from #26883, is kept as is. Only the message changes.

The embedding message also moves into `ERROR_MESSAGES`, next to the other web search details this handler already reads from there (#28948). It was the only inline `detail` string left in `process_web_search`, and its wording is unchanged.

## Testing

Two containers from `ghcr.io/open-webui/open-webui:dev`, whose copies of both changed files are byte-identical to `dev` (verified by md5). One left unpatched as a baseline, one with the two patched files bind-mounted over the installed package, so the only difference between them is this diff. Web search points at a stub SearXNG endpoint so the result URLs are fixed, with the default `safe_web` loader.

| Scenario | Baseline (`dev`) | With this PR |
|---|---|---|
| Every result URL fails to load | `500` — `Failed to embed and store the retrieved web pages. Check the embedding configuration in Admin Settings > Documents.` | `404` — `None of the web search results could be loaded. Check the web loader configuration in Admin Settings > Web Search.` |
| One result loads, one fails | `200`, collection created | `200`, collection created — identical |
| Results load, embedding deliberately broken | `500` — embedding message | `500` — embedding message, unchanged |
| Every URL fails, `BYPASS_WEB_SEARCH_EMBEDDING_AND_RETRIEVAL=true` | `200`, `loaded_count: 2` | `200`, `loaded_count: 2` — identical |

Row 1 is the report in #29327. Rows 2 to 4 are the behavior that had to stay the same.

`ruff format` reports both files already formatted. `ruff check` on the two files returns one finding fewer than `dev`, because the hard-coded message was the longest `E501` line in the file.

## Changelog Entry

### Fixed

- A web search where no result page could be loaded is now reported as a web loader failure instead of an embedding configuration failure, which named the wrong settings page and hid the real cause.

## Additional Context

Reopened from #29605, which the CLA bot closed because the checkbox was left unchecked. Same branch and same diff; the CLA is now accepted above.

No maintainer asked for this PR, so the third checklist item is left unchecked. The issue is labelled `confirmed issue`, no pull request references it, and the reporter deliberately proposed no diff because one of their three options is a product decision. This takes only the option that does not make that call: name the actual failure, change nothing else. Happy to close it if you would rather keep the fix in your own hands, or to reshape it if you prefer one of the other two options.

## Contributor License Agreement

<!--
DO NOT DELETE THIS SECTION.
Your PR will not be reviewed or merged until you check the box below confirming that you have read and agree to the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

