### PR TITLE
fix(oauth): honor OAUTH_BLOCKED_GROUPS when auto-creating groups

### DIFF
--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -1662,7 +1662,10 @@ class OAuthManager:
             log.debug('Using creator ID %s for potential group creation.', creator_id)
 
             for group_name in user_oauth_groups:
-                if group_name not in all_group_names:
+                if (
+                    group_name not in all_group_names
+                    and not is_in_blocked_groups(group_name, blocked_groups)
+                ):
                     log.info("Group '%s' not found via OAuth claim. Creating group...", group_name)
                     try:
                         new_group_form = GroupForm(


### PR DESCRIPTION
Closes #29558

## Summary
`update_user_groups` checks `OAUTH_BLOCKED_GROUPS` in two of three places
(member addition and member removal). The group-creation branch is missing the
same guard, so any blocked group name present in the OAuth claim is still
auto-created on first login and then added to the user on subsequent logins,
bypassing the `OAUTH_BLOCKED_GROUPS` configuration.

## What changed
`backend/open_webui/utils/oauth.py` — in the `ENABLE_OAUTH_GROUP_CREATION`
creation loop, replace the single-line condition

```python
if group_name not in all_group_names:
```

with

```python
if (
    group_name not in all_group_names
    and not is_in_blocked_groups(group_name, blocked_groups)
):
```

so all three paths (creation, member addition, member removal) are symmetric
and reuse the existing `is_in_blocked_groups` helper.

## How I checked
1. `grep -n "is_in_blocked_groups" backend/open_webui/utils/oauth.py`
   - Before: 2 matches (member addition + member removal)
   - After:  3 matches (creation + member addition + member removal)
2. Manual trace with IdP claim `groups: ["my-team","admins"]` and
   `OAUTH_BLOCKED_GROUPS='["admins"]'`:
   - Before: `admins` is auto-created, then added to user on next login.
   - After: `admins` is skipped at creation; `my-team` is created and added
     as expected.
3. Diff is scoped to one `if` condition in `update_user_groups`; no other
   branches, signatures, or call sites are touched.

## Out of scope
OAuth authorization, token caching, and permission-propagation paths are
intentionally untouched.

## Checklist
- [x] targets `dev` branch
- [x] closes #29558
- [x] one logical unit, no unrelated commits
- [x] matches existing `is_in_blocked_groups` call style in the same file

## Contributor License Agreement
- [x] I have read and agree to the CLA.
