### PR TITLE
fix(ui): use bits-ui Popover in SourceToken so click triggers close

### DIFF
--- a/src/lib/components/chat/Messages/Markdown/SourceToken.svelte
+++ b/src/lib/components/chat/Messages/Markdown/SourceToken.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { LinkPreview } from 'bits-ui';
+	import { Popover } from 'bits-ui';
 	import { decodeString } from '$lib/utils';
 	import Source from './Source.svelte';
 
@@ -45,8 +45,8 @@
 		{@const identifier = token.citationIdentifiers ? token.citationIdentifiers[0] : id - 1}
 		<Source id={identifier} title={sourceIds[id - 1]} {onClick} />
 	{:else}
-		<LinkPreview.Root openDelay={0} bind:open={openPreview}>
-			<LinkPreview.Trigger>
+		<Popover.Root bind:open={openPreview}>
+			<Popover.Trigger>
 				<button
 					aria-label={`${getDisplayTitle(formattedTitle(decodeString(sourceIds[token.ids[0] - 1])))} +${(token?.ids ?? []).length - 1} more sources`}
 					class="text-[0.625rem] w-fit translate-y-[2px] px-2 py-0.5 dark:bg-white/5 dark:text-white/80 dark:hover:text-white bg-gray-50 text-black/80 hover:text-black transition rounded-xl"
@@ -59,9 +59,9 @@
 						<span class="dark:text-white/50 text-black/50">+{(token?.ids ?? []).length - 1}</span>
 					</span>
 				</button>
-			</LinkPreview.Trigger>
-			<LinkPreview.Portal>
-				<LinkPreview.Content class="z-[999]" align="start" strategy="fixed" sideOffset={6}>
+			</Popover.Trigger>
+			<Popover.Portal>
+				<Popover.Content class="z-[999]" align="start" strategy="fixed" sideOffset={6}>
 					<div class="bg-gray-50 dark:bg-gray-850 rounded-xl p-1 cursor-pointer">
 						{#each token.citationIdentifiers ?? token.ids as identifier}
 							{@const id =
@@ -71,9 +71,9 @@
 							</div>
 						{/each}
 					</div>
-				</LinkPreview.Content>
-			</LinkPreview.Portal>
-		</LinkPreview.Root>
+				</Popover.Content>
+			</Popover.Portal>
+		</Popover.Root>
 	{/if}
 {:else}
 	<span>{token.raw}</span>


### PR DESCRIPTION
Closes #29529

## Summary
Clicking the source-list preview button did not close the popover: `bits-ui` v2 `LinkPreview.Root` does not honor `bind:open` while the toggling button's local state advances, leaving the preview stuck open until the user clicked outside. Swap `LinkPreview.*` for `Popover.*` (same `bits-ui` package, same opening semantics) so `bind:open` drives open/close consistently.

## What changed
`src/lib/components/chat/Messages/Markdown/SourceToken.svelte` — pure rename:
- `import { LinkPreview } from 'bits-ui'` → `import { Popover } from 'bits-ui'`
- `<LinkPreview.Root bind:open={openPreview}>` → `<Popover.Root bind:open={openPreview}>`
- `LinkPreview.Trigger` / `Portal` / `Content` (and matching closing tags) → `Popover.*`

Removed the now-redundant `openDelay={0}` on the Root (Popover.Root does not accept `openDelay`; the button's own `on:click` already toggles `openPreview` synchronously).

## How I checked
1. `grep -n "LinkPreview\\|Popover" src/lib/components/chat/Messages/Markdown/SourceToken.svelte`
   - Before: 9 occurrences of `LinkPreview.*`
   - After:  0 occurrences of `LinkPreview.*`, 9 of `Popover.*`
2. All subcomponents used (`Trigger`, `Portal`, `Content`) exist in bits-ui v2 `Popover` namespace per upstream docs.
3. No class/styling/event props were touched; only the imported namespace and tag names changed.

## Out of scope
Other `LinkPreview` usages (Markdown blocks, etc.) intentionally untouched; they have their own issue threads and may need a separate fix.

## Checklist
- [x] targets `dev` branch
- [x] closes #29529
- [x] one logical unit, no unrelated commits
- [x] matches bits-ui v2 import conventions (`import { Popover } from 'bits-ui'`)

## Contributor License Agreement
- [x] I have read and agree to the CLA.
