### PR TITLE
refac(images): request an unencoded body when fetching remote chat images

### DIFF
--- a/backend/open_webui/utils/files.py
+++ b/backend/open_webui/utils/files.py
@@ -74,9 +74,16 @@ async def get_image_base64_from_url(url: str, user=None) -> Optional[str]:
             # rebinding DNS answer that passed validate_url cannot reach an internal address.
             async with get_ssrf_safe_session() as session:
                 async with session.get(
-                    url, ssl=AIOHTTP_CLIENT_SESSION_SSL, allow_redirects=AIOHTTP_CLIENT_ALLOW_REDIRECTS
+                    url,
+                    ssl=AIOHTTP_CLIENT_SESSION_SSL,
+                    allow_redirects=AIOHTTP_CLIENT_ALLOW_REDIRECTS,
+                    headers={'Accept-Encoding': 'identity'},
                 ) as response:
                     response.raise_for_status()
+                    # Accept-Encoding is only a request; the sender can still compress and pick our decompressed size.
+                    encodings = response.headers.getall('Content-Encoding', ())
+                    if any(encoding.lower() not in ('', 'identity') for encoding in encodings):
+                        return None
                     image_data = bytearray()
                     total = 0
                     async for chunk in response.content.iter_chunked(64 * 1024):


### PR DESCRIPTION
The remote chat-image fetch now asks for an identity-encoded response and skips one that comes back content-encoded.

An image whose host stores and echoes a `Content-Encoding` regardless of what the client asks for (an S3 or MinIO object uploaded with that metadata) is no longer inlined; the message is forwarded with the original URL instead, the same way an unreachable image already behaves.

## Contributor License Agreement

<!--
DO NOT DELETE THIS SECTION.
Your PR will not be reviewed or merged until you check the box below confirming that you have read and agree to the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
