### PR TITLE
fix: report version check failures instead of claiming the running version is latest

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -2575,8 +2575,8 @@ async def get_app_latest_release_version(user=Depends(get_verified_user)):
 
                 return {'current': VERSION, 'latest': latest_version[1:]}
     except Exception as e:
-        log.debug(e)
-        return {'current': VERSION, 'latest': VERSION}
+        log.warning(f'Version update check failed: {e}')
+        return {'current': VERSION, 'latest': None}
 
 
 @app.get('/api/changelog')

--- a/src/lib/components/admin/Settings/General.svelte
+++ b/src/lib/components/admin/Settings/General.svelte
@@ -27,10 +27,10 @@
 
 	export let saveHandler: Function;
 
-	let updateAvailable: boolean | null = false;
+	let updateAvailable: boolean | null = null;
 	let version = {
 		current: WEBUI_VERSION,
-		latest: WEBUI_VERSION
+		latest: ''
 	};
 
 	let adminConfig: any = null;
@@ -47,7 +47,7 @@
 		version = await getVersionUpdates(localStorage.token).catch((error) => {
 			return {
 				current: WEBUI_VERSION,
-				latest: WEBUI_VERSION
+				latest: null
 			};
 		});
 
@@ -91,6 +91,10 @@
 		defaultInterfaceSettings = getDefaultInterfaceSettings();
 
 		banners = [...$_banners];
+
+		if ($config?.features?.enable_version_update_check) {
+			checkForVersionUpdates();
+		}
 	});
 </script>
 
@@ -112,17 +116,23 @@
 							<Tooltip content={WEBUI_BUILD_HASH}>v{WEBUI_VERSION}</Tooltip>
 
 							{#if $config?.features?.enable_version_update_check}
-								<a
-									href="https://github.com/open-webui/open-webui/releases/tag/v{version.latest}"
-									target="_blank"
-									class="text-gray-500 hover:text-gray-700 dark:text-gray-500 dark:hover:text-gray-300"
-								>
-									{updateAvailable === null
-										? $i18n.t('Checking for updates...')
-										: updateAvailable
-											? `(v${version.latest} ${$i18n.t('available!')})`
-											: $i18n.t('(latest)')}
-								</a>
+								{#if version.latest === null}
+									<span class="text-gray-500 dark:text-gray-500"
+										>{$i18n.t('Could not check for updates')}</span
+									>
+								{:else}
+									<a
+										href="https://github.com/open-webui/open-webui/releases/tag/v{version.latest}"
+										target="_blank"
+										class="text-gray-500 hover:text-gray-700 dark:text-gray-500 dark:hover:text-gray-300"
+									>
+										{updateAvailable === null
+											? $i18n.t('Checking for updates...')
+											: updateAvailable
+												? `(v${version.latest} ${$i18n.t('available!')})`
+												: $i18n.t('(latest)')}
+									</a>
+								{/if}
 							{/if}
 						</div>
 

--- a/src/lib/components/chat/Settings/About.svelte
+++ b/src/lib/components/chat/Settings/About.svelte
@@ -27,7 +27,7 @@
 		version = await getVersionUpdates(localStorage.token).catch((error) => {
 			return {
 				current: WEBUI_VERSION,
-				latest: WEBUI_VERSION
+				latest: null
 			};
 		});
 
@@ -66,21 +66,25 @@
 						</Tooltip>
 
 						{#if $config?.features?.enable_version_update_check}
-							<a
-								href="https://github.com/open-webui/open-webui/releases/tag/v{version.latest}"
-								target="_blank"
-							>
-								{updateAvailable === null
-									? $i18n.t('Checking for updates...')
-									: updateAvailable
-										? `(v${version.latest} ${$i18n.t('available!')})`
-										: $i18n.t('(latest)')}
-							</a>
+							{#if version.latest === null}
+								<span>{$i18n.t('Could not check for updates')}</span>
+							{:else}
+								<a
+									href="https://github.com/open-webui/open-webui/releases/tag/v{version.latest}"
+									target="_blank"
+								>
+									{updateAvailable === null
+										? $i18n.t('Checking for updates...')
+										: updateAvailable
+											? `(v${version.latest} ${$i18n.t('available!')})`
+											: $i18n.t('(latest)')}
+								</a>
+							{/if}
 						{/if}
 					</div>
 
 					<button
-						class={actionButtonClass}
+						class="self-start {actionButtonClass}"
 						on:click={() => {
 							showChangelog.set(true);
 						}}

--- a/src/lib/i18n/locales/en-US/translation.json
+++ b/src/lib/i18n/locales/en-US/translation.json
@@ -691,6 +691,7 @@
 	"Copying to clipboard was successful!": "",
 	"Copyright (c)": "",
 	"CORS must be properly configured by the provider to allow requests from Open WebUI.": "",
+	"Could not check for updates": "",
 	"Could not load release notes.": "",
 	"Could not read file.": "",
 	"Couldn't find your language?": "",

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -658,7 +658,7 @@ export const copyToClipboard = async (text, html = null, formatted = false) => {
 };
 
 export const compareVersion = (latest, current) => {
-	return current === '0.0.0'
+	return !latest || current === '0.0.0'
 		? false
 		: current.localeCompare(latest, undefined, {
 				numeric: true,

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -446,7 +446,7 @@
 		version = await getVersionUpdates(localStorage.token).catch((error) => {
 			return {
 				current: WEBUI_VERSION,
-				latest: WEBUI_VERSION
+				latest: null
 			};
 		});
 	};


### PR DESCRIPTION
# Pull Request

## Checklist

- [x] This PR targets the `dev` branch.
- [x] This PR links to a well-described, confirmed Issue or active Discussion: `Closes #29580`.
- [ ] A maintainer explicitly asked me to open this PR, or this PR only updates i18n/localization.
- [x] The change is one logical unit with no unrelated commits.
- [x] I matched nearby code patterns and avoided unnecessary new settings, abstractions, or dependencies.
- [x] I manually tested the changed workflow and any nearby behavior that could be affected.
- [ ] I updated relevant docs, including the [Open WebUI Docs Repository](https://github.com/open-webui/docs), if needed.
- [x] I added screenshots for UI changes, and a recording when motion or interaction matters.
- [x] I reviewed any AI-generated code before submitting it.
- [x] The PR title uses one of the prefixes listed below.

## Summary

`GET /api/version/updates` returns the running version as `latest` whenever the GitHub request fails, so an instance that cannot reach GitHub reports itself up to date no matter how far behind it is. The exception is logged at `debug`, below the default level, so nothing records that the check never happened. Reported in #29580.

The failure path now says it failed:

```diff
     except Exception as e:
-        log.debug(e)
-        return {'current': VERSION, 'latest': VERSION}
+        log.warning(f'Version update check failed: {e}')
+        return {'current': VERSION, 'latest': None}
```

`OFFLINE_MODE` is untouched. That path already short-circuits the endpoint and hides the badge, and it is the model this follows.

**A null `latest` cannot be handed to `compareVersion` as it stands.** `current.localeCompare(null)` coerces to the string `"null"`, and `"0.10.2"` sorts before it, so the old function returns `true`. The backend change on its own would have replaced a false `(latest)` with a false "update available" plus an update toast. Measured, before and after:

| `compareVersion(latest, current)` | before | after |
|---|---|---|
| `(null, '0.10.2')` | `true` | `false` |
| `('0.11.3', '0.10.2')` | `true` | `true` |
| `('0.10.2', '0.10.2')` | `false` | `false` |

So the guard is part of the fix, not a tidy-up:

```diff
-	return current === '0.0.0'
+	return !latest || current === '0.0.0'
```

The three callers of `getVersionUpdates` stop substituting the running version in their `catch`, and the two badge surfaces gain a third state alongside `Checking for updates...` and `(latest)`. When `latest` is unknown the badge is plain text rather than a link, since there is no release to link to.

## A second defect on the admin surface

`Admin Settings` > `General` renders the same badge, and it was wrong in a worse way than the issue describes. It initialises `updateAvailable = false` with `version.latest = WEBUI_VERSION`, and its `onMount` never calls `checkForVersionUpdates`. It therefore claims `(latest)` immediately, from a hardcoded value, **having made no request at all**, on every install regardless of network.

`About.svelte` already does this correctly. Its `updateAvailable` starts `null`, its `latest` starts empty, and it checks on mount. The admin page now matches it. Without that change, the null branch in that file is unreachable, since `latest` is never null there.

This does mean the admin page now performs the version check on mount, the same as About. Flagging it as the one behaviour change here beyond the reported bug.

## A layout defect the longer string exposed

`See what's new` sits directly under the badge in a `flex flex-col`, so the button stretches to the column width while its default `text-align: center` centres the label. The label therefore drifts right as the badge string grows. Glyph offset from the column's left edge, measured in the rendered DOM:

| Badge | before | after |
|---|---|---|
| `(latest)` | 0px | 0px |
| `(v0.11.4 available!)` | 29px | 0px |
| `Could not check for updates` | 56px | 0px |

The middle row is current `dev`, so the label already shifts on any instance with an update available. The new string only widens the gap. `self-start` sizes the button to its content, matching the admin surface, whose button is already content sized because it sits in a block container rather than a flex column.

## Testing

The checks below were run at my direction with AI copilot assistance, driving a browser and `curl` against a throwaway instance. I have reviewed the results.

The instance used its own sqlite database (`DATABASE_URL` set explicitly, confirmed as `Context impl SQLiteImpl` in the startup log before any request) and a copied frontend build, on a port confirmed free.

Failure was induced with the proxy variables from the issue, `HTTP_PROXY`/`HTTPS_PROXY` pointed at `http://127.0.0.1:9`, so the GitHub request fails without touching the network. The endpoint builds its session with `trust_env=True`.

Same build, backend file reverted and restored to compare:

| | `dev` | this branch |
|---|---|---|
| `GET /api/version/updates`, unreachable | `{"current":"0.11.3","latest":"0.11.3"}` | `{"current":"0.11.3","latest":null}` |
| Server log at `GLOBAL_LOG_LEVEL=INFO` | nothing | `WARNING ... Version update check failed: Cannot connect to host 127.0.0.1:9` |

Both surfaces, both states:

| Surface | GitHub | API | Rendered |
|---|---|---|---|
| `Settings` > `About` | unreachable | `latest: null` | `Could not check for updates`, no link |
| `Settings` > `About` | reachable | `latest: "0.11.3"` | `(latest)`, link to the real release tag |
| `Admin` > `General` | unreachable | `latest: null` | `Could not check for updates`, no link |
| `Admin` > `General` | reachable | `latest: "0.11.3"` | `(latest)`, link to the real release tag |

No update toast appeared in the failure state, which is what the `compareVersion` guard prevents. The admin badge was identified by its class and its position inside the admin form, since both surfaces now render the same string and matching on text alone would not distinguish them.

`npm run build` passes. `npx vitest run` passes at 2 files and 8 tests. `ruff format --check` reports `main.py` already formatted.

## Changelog Entry

### Fixed

- A failed version check no longer reports the running version as the latest release. Both `Settings` > `About` and `Admin Settings` > `General` now show that the check could not complete. The failure is logged at `warning` rather than `debug`, and no update notification is raised from an unknown version.
- `Admin Settings` > `General` now performs the version check when it opens. It previously showed `(latest)` without contacting GitHub at all.
- `See what's new` in `Settings` > `About` no longer shifts right as the version badge text grows.

## Screenshots

| Surface | Before | After |
|---|---|---|
| `Settings` > `About`, GitHub unreachable | <img width="3000" height="1640" alt="image" src="https://github.com/user-attachments/assets/697f2709-d594-48ed-aa4a-ec4d58ae71c0" /> | <img width="3000" height="1640" alt="image" src="https://github.com/user-attachments/assets/0f124656-66d7-4bf1-ae26-a0487de83e02" /> |
| `Admin Settings` > `General`, GitHub unreachable | <img width="3000" height="1640" alt="image" src="https://github.com/user-attachments/assets/7871c004-ef78-4d02-9781-b8bea6bc593f" /> | <img width="3000" height="1640" alt="image" src="https://github.com/user-attachments/assets/c4512323-f1aa-4dda-89ce-4e2013be998d" /> |

Before is current `dev`, After is this branch.

## Additional Context

The wording of the new badge string is a product call. I used `Could not check for updates`, matching the Expected Behavior in #29580, and it is a single `en-US` key if something else reads better.

Only `en-US/translation.json` is touched. The other locales fall back to the English literal, and multi-locale sync is a release-time job.

This PR was prepared with AI copilot assistance. I have thoroughly reviewed it.

## Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.


