### PR TITLE
feat: shift quick delete for notes in list and grid views

### DIFF
--- a/src/lib/components/notes/Notes.svelte
+++ b/src/lib/components/notes/Notes.svelte
@@ -44,6 +44,7 @@
 	import { downloadPdf, createNoteHandler } from './utils';
 
 	import EllipsisHorizontal from '../icons/EllipsisHorizontal.svelte';
+	import GarbageBin from '../icons/GarbageBin.svelte';
 	import DeleteConfirmDialog from '$lib/components/common/ConfirmDialog.svelte';
 	import Search from '../icons/Search.svelte';
 	import Spinner from '../common/Spinner.svelte';
@@ -66,6 +67,7 @@
 	let selectedNote = null;
 	let openNoteMenuId: string | null = null;
 	let showDeleteConfirm = false;
+	let shiftKey = false;
 
 	let notes = {};
 
@@ -323,8 +325,33 @@
 		dropzoneElement?.addEventListener('drop', onDrop);
 		dropzoneElement?.addEventListener('dragleave', onDragLeave);
 
+		const onKeyDown = (event: KeyboardEvent) => {
+			if (event.key === 'Shift') {
+				shiftKey = true;
+				openNoteMenuId = null;
+			}
+		};
+
+		const onKeyUp = (event: KeyboardEvent) => {
+			if (event.key === 'Shift') {
+				shiftKey = false;
+			}
+		};
+
+		const onBlur = () => {
+			shiftKey = false;
+		};
+
+		window.addEventListener('keydown', onKeyDown);
+		window.addEventListener('keyup', onKeyUp);
+		window.addEventListener('blur', onBlur);
+
 		return () => {
 			clearTimeout(searchDebounceTimer);
+
+			window.removeEventListener('keydown', onKeyDown);
+			window.removeEventListener('keyup', onKeyUp);
+			window.removeEventListener('blur', onBlur);
 
 			if (dropzoneElement) {
 				dropzoneElement?.removeEventListener('dragover', onDragOver);
@@ -628,52 +655,69 @@
 														</Tooltip>
 													</div>
 
-													<NoteMenu
-														show={openNoteMenuId === note.id}
-														onDownload={(type) => {
-															selectedNote = note;
+													{#if shiftKey}
+														<Tooltip content={$i18n.t('Delete')}>
+															<button
+																class="flex size-5 shrink-0 items-center justify-center rounded-lg text-gray-400 transition hover:text-gray-700 dark:text-gray-500 dark:hover:text-gray-200"
+																type="button"
+																aria-label={$i18n.t('Delete')}
+																on:click={(e) => {
+																	e.preventDefault();
+																	e.stopPropagation();
+																	deleteNoteHandler(note.id);
+																}}
+															>
+																<GarbageBin className="size-3.5" />
+															</button>
+														</Tooltip>
+													{:else}
+														<NoteMenu
+															show={openNoteMenuId === note.id}
+															onDownload={(type) => {
+																selectedNote = note;
 
-															downloadHandler(type);
-														}}
-														onCopyLink={async () => {
-															const baseUrl = window.location.origin;
-															const res = await copyToClipboard(`${baseUrl}/notes/${note.id}`);
+																downloadHandler(type);
+															}}
+															onCopyLink={async () => {
+																const baseUrl = window.location.origin;
+																const res = await copyToClipboard(`${baseUrl}/notes/${note.id}`);
 
-															if (res) {
-																toast.success($i18n.t('Copied link to clipboard'));
-															} else {
-																toast.error($i18n.t('Failed to copy link'));
-															}
-														}}
-														onDelete={() => {
-															selectedNote = note;
-															showDeleteConfirm = true;
-														}}
-														isPinned={note.is_pinned ?? false}
-														onPin={async () => {
-															await toggleNotePinnedStatusById(localStorage.token, note.id);
-															pinnedNotes.set(
-																await getPinnedNoteList(localStorage.token).catch(() => [])
-															);
-															init();
-														}}
-														onChange={(state) => {
-															openNoteMenuId = state ? note.id : null;
-														}}
-													>
-														<button
-															class="flex size-5 shrink-0 items-center justify-center rounded-lg text-gray-400 transition hover:text-gray-700 dark:text-gray-500 dark:hover:text-gray-200"
-															type="button"
-															aria-label={$i18n.t('Note Menu')}
-															on:click={(e) => {
-																e.preventDefault();
-																e.stopPropagation();
-																openNoteMenuId = openNoteMenuId === note.id ? null : note.id;
+																if (res) {
+																	toast.success($i18n.t('Copied link to clipboard'));
+																} else {
+																	toast.error($i18n.t('Failed to copy link'));
+																}
+															}}
+															onDelete={() => {
+																selectedNote = note;
+																showDeleteConfirm = true;
+															}}
+															isPinned={note.is_pinned ?? false}
+															onPin={async () => {
+																await toggleNotePinnedStatusById(localStorage.token, note.id);
+																pinnedNotes.set(
+																	await getPinnedNoteList(localStorage.token).catch(() => [])
+																);
+																init();
+															}}
+															onChange={(state) => {
+																openNoteMenuId = state ? note.id : null;
 															}}
 														>
-															<EllipsisHorizontal className="size-3.5" />
-														</button>
-													</NoteMenu>
+															<button
+																class="flex size-5 shrink-0 items-center justify-center rounded-lg text-gray-400 transition hover:text-gray-700 dark:text-gray-500 dark:hover:text-gray-200"
+																type="button"
+																aria-label={$i18n.t('Note Menu')}
+																on:click={(e) => {
+																	e.preventDefault();
+																	e.stopPropagation();
+																	openNoteMenuId = openNoteMenuId === note.id ? null : note.id;
+																}}
+															>
+																<EllipsisHorizontal className="size-3.5" />
+															</button>
+														</NoteMenu>
+													{/if}
 												</div>
 											</button>
 										{/each}
@@ -699,43 +743,60 @@
 														</Tooltip>
 													</a>
 
-													<NoteMenu
-														onDownload={(type) => {
-															selectedNote = note;
+													{#if shiftKey}
+														<Tooltip content={$i18n.t('Delete')}>
+															<button
+																class="flex size-5 items-center justify-center rounded-lg text-gray-400 transition hover:text-gray-700 dark:text-gray-500 dark:hover:text-gray-200"
+																type="button"
+																aria-label={$i18n.t('Delete')}
+																on:click={(e) => {
+																	e.preventDefault();
+																	e.stopPropagation();
+																	deleteNoteHandler(note.id);
+																}}
+															>
+																<GarbageBin className="size-3.5" />
+															</button>
+														</Tooltip>
+													{:else}
+														<NoteMenu
+															onDownload={(type) => {
+																selectedNote = note;
 
-															downloadHandler(type);
-														}}
-														onCopyLink={async () => {
-															const baseUrl = window.location.origin;
-															const res = await copyToClipboard(`${baseUrl}/notes/${note.id}`);
+																downloadHandler(type);
+															}}
+															onCopyLink={async () => {
+																const baseUrl = window.location.origin;
+																const res = await copyToClipboard(`${baseUrl}/notes/${note.id}`);
 
-															if (res) {
-																toast.success($i18n.t('Copied link to clipboard'));
-															} else {
-																toast.error($i18n.t('Failed to copy link'));
-															}
-														}}
-														onDelete={() => {
-															selectedNote = note;
-															showDeleteConfirm = true;
-														}}
-														isPinned={note.is_pinned ?? false}
-														onPin={async () => {
-															await toggleNotePinnedStatusById(localStorage.token, note.id);
-															pinnedNotes.set(
-																await getPinnedNoteList(localStorage.token).catch(() => [])
-															);
-															init();
-														}}
-													>
-														<button
-															class="flex size-5 items-center justify-center rounded-lg text-gray-400 transition hover:text-gray-700 dark:text-gray-500 dark:hover:text-gray-200"
-															type="button"
-															aria-label={$i18n.t('Note Menu')}
+																if (res) {
+																	toast.success($i18n.t('Copied link to clipboard'));
+																} else {
+																	toast.error($i18n.t('Failed to copy link'));
+																}
+															}}
+															onDelete={() => {
+																selectedNote = note;
+																showDeleteConfirm = true;
+															}}
+															isPinned={note.is_pinned ?? false}
+															onPin={async () => {
+																await toggleNotePinnedStatusById(localStorage.token, note.id);
+																pinnedNotes.set(
+																	await getPinnedNoteList(localStorage.token).catch(() => [])
+																);
+																init();
+															}}
 														>
-															<EllipsisHorizontal className="size-3.5" />
-														</button>
-													</NoteMenu>
+															<button
+																class="flex size-5 items-center justify-center rounded-lg text-gray-400 transition hover:text-gray-700 dark:text-gray-500 dark:hover:text-gray-200"
+																type="button"
+																aria-label={$i18n.t('Note Menu')}
+															>
+																<EllipsisHorizontal className="size-3.5" />
+															</button>
+														</NoteMenu>
+													{/if}
 												</div>
 
 												<a href={`/notes/${note.id}`} class="mt-1 flex min-h-0 flex-1 flex-col">


### PR DESCRIPTION
# Pull Request

## Checklist

- [x] This PR targets the `dev` branch.
- [x] This PR links to a well-described, confirmed Issue or active Discussion: `Closes #29633`.
- [ ] A maintainer explicitly asked me to open this PR, or this PR only updates i18n/localization.
- [x] The change is one logical unit with no unrelated commits.
- [x] I matched nearby code patterns and avoided unnecessary new settings, abstractions, or dependencies.
- [x] I manually tested the changed workflow and any nearby behavior that could be affected.
- [ ] I updated relevant docs, including the [Open WebUI Docs Repository](https://github.com/open-webui/docs), if needed.
- [x] I added screenshots for UI changes, and a recording when motion or interaction matters.
- [x] I reviewed any AI-generated code before submitting it.
- [x] The PR title uses one of the prefixes listed below.

## Summary

Holding Shift turns a row's trailing control into a one click delete across most of Open WebUI. `Models`, `Prompts`, `Tools` and `Skills` carry it, as do the chat sidebar, the search modal, the files modal and admin `Functions`. Notes did not: `Notes.svelte` had no reference to `shiftKey`, so deleting a note meant the `...` menu, then Delete, then the confirmation modal, three interactions per note in a surface with no bulk selection. Requested in #29633.

While Shift is held, each note's `...` trigger is replaced by a delete button that calls the existing `deleteNoteHandler(note.id)` directly. This applies to both the List and Grid views, which render the same `NoteMenu`. Releasing Shift, or blurring the window, restores the menu.

Nothing changes when Shift is not held. The menu and its confirmation modal are untouched, and stay the only delete path for anyone who never presses Shift.

The key tracking is copied from `Prompts.svelte` rather than written fresh. `keydown` and `keyup` set `shiftKey`, `blur` clears it, and all three listeners are removed in the `onMount` teardown next to the existing dropzone listeners. No new component, prop, store or helper.

The diff reads larger than it is. Ignoring whitespace it is 61 added lines and none removed, since wrapping the two existing `NoteMenu` blocks in `{#if shiftKey}` moved them one indent level.

## Testing

I tested this locally on the branch, in both the List and Grid views, and the behavior is what I asked for in #29633.

Mechanical checks, run at my direction with AI copilot assistance:

| Check | Result |
|---|---|
| `npm run build` | exit 0, no warnings for `Notes.svelte` |
| `npx vitest run` | 2 files, 8 tests, passing |
| `npx prettier --check` on the changed file | already formatted, no rewrite |
| New `i18n.t` keys introduced | none, all four keys in the diff already exist in `en-US` |
| Added code comments, Svelte 5 runes | none |

## Changelog Entry

### Added

- Holding Shift on the Notes page now replaces each note's menu button with a delete button that removes the note in one click, in both the List and Grid views. This matches the existing Shift behavior on `Models`, `Prompts`, `Tools`, `Skills`, the chat sidebar and the files modal. The menu and its confirmation modal are unchanged when Shift is not held.

### Screenshots and Videos

https://github.com/user-attachments/assets/36d6650d-6ec8-4649-ba30-3c050f2ca1dc

## Additional Context

One detail differs from the workspace pages and is worth a look during review. There, Shift swaps a separate trailing button and leaves the menu alone. In the Notes List view, the menu is itself the element being swapped, so a menu left open would reopen when Shift was released. `onKeyDown` therefore also clears `openNoteMenuId`. The Grid view does not track that state and needed nothing.

`Knowledge.svelte` is the other surface with no Shift delete. It is out of scope here and this PR does not touch it.

#23172 reported that rapid Shift deletion on the chat list produced a burst of error toasts. That path is separate from this one, and this PR does not change it.

This PR was prepared with AI copilot assistance. I have thoroughly reviewed it.

## Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
