### PR TITLE
feat: shift quick delete for automations

### DIFF
--- a/src/routes/(app)/automations/+page.svelte
+++ b/src/routes/(app)/automations/+page.svelte
@@ -33,6 +33,7 @@
 	import Search from '$lib/components/icons/Search.svelte';
 	import XMark from '$lib/components/icons/XMark.svelte';
 	import EllipsisHorizontal from '$lib/components/icons/EllipsisHorizontal.svelte';
+	import GarbageBin from '$lib/components/icons/GarbageBin.svelte';
 	import Select from '$lib/components/common/Select.svelte';
 	import Dropdown from '$lib/components/common/Dropdown.svelte';
 	import DropdownMenu from '$lib/components/common/DropdownMenu.svelte';
@@ -57,6 +58,7 @@
 	let cloneFrom: AutomationResponse | null = null;
 
 	let showDeleteConfirm = false;
+	let shiftKey = false;
 	let deleteTarget: AutomationResponse | null = null;
 	let openAutomationMenuId: string | null = null;
 
@@ -367,8 +369,33 @@
 		syncHeader();
 		ensureChannels();
 
+		const onKeyDown = (event: KeyboardEvent) => {
+			if (event.key === 'Shift') {
+				shiftKey = true;
+				openAutomationMenuId = null;
+			}
+		};
+
+		const onKeyUp = (event: KeyboardEvent) => {
+			if (event.key === 'Shift') {
+				shiftKey = false;
+			}
+		};
+
+		const onBlur = () => {
+			shiftKey = false;
+		};
+
+		window.addEventListener('keydown', onKeyDown);
+		window.addEventListener('keyup', onKeyUp);
+		window.addEventListener('blur', onBlur);
+
 		return () => {
 			clearTimeout(searchDebounceTimer);
+
+			window.removeEventListener('keydown', onKeyDown);
+			window.removeEventListener('keyup', onKeyUp);
+			window.removeEventListener('blur', onBlur);
 		};
 	});
 
@@ -617,60 +644,79 @@
 								</Tooltip>
 							</div>
 
-							<div class="flex shrink-0 flex-row items-center gap-1.5 self-center">
-								<AutomationMenu
-									show={openAutomationMenuId === automation.id}
-									editHandler={() => {
-										goto(`/automations/${automation.id}`);
-									}}
-									cloneHandler={() => {
-										cloneHandler(automation);
-									}}
-									runHandler={() => {
-										runNowHandler(automation);
-									}}
-									deleteHandler={() => {
-										deleteTarget = automation;
-										showDeleteConfirm = true;
-									}}
-									onClose={() => {
-										openAutomationMenuId = null;
-									}}
-								>
-									<button
-										class="flex size-6 items-center justify-center rounded-lg text-gray-400 transition dark:text-gray-500"
-										type="button"
-										aria-label={$i18n.t('Automation Menu')}
-										on:click={(e) => {
-											e.preventDefault();
-											e.stopPropagation();
-											openAutomationMenuId =
-												openAutomationMenuId === automation.id ? null : automation.id;
-										}}
-									>
-										<EllipsisHorizontal className="size-4" />
-									</button>
-								</AutomationMenu>
-
-								<button
-									class="flex h-6 items-center"
-									type="button"
-									on:click={(e) => {
-										e.stopPropagation();
-										e.preventDefault();
-									}}
-								>
-									<Tooltip
-										content={automation.is_active ? $i18n.t('Enabled') : $i18n.t('Disabled')}
-									>
-										<Switch
-											bind:state={automation.is_active}
-											on:change={() => {
-												toggleHandler(automation);
+							<div class="flex shrink-0 flex-row items-center self-center">
+								{#if shiftKey}
+									<Tooltip content={$i18n.t('Delete')}>
+										<button
+											class="flex size-6 items-center justify-center rounded-lg text-gray-400 transition dark:text-gray-500"
+											type="button"
+											aria-label={$i18n.t('Delete')}
+											on:click={(e) => {
+												e.preventDefault();
+												e.stopPropagation();
+												deleteHandler(automation);
 											}}
-										/>
+										>
+											<GarbageBin className="size-4" />
+										</button>
 									</Tooltip>
-								</button>
+								{:else}
+									<div class="flex shrink-0 flex-row items-center gap-1.5 self-center">
+										<AutomationMenu
+											show={openAutomationMenuId === automation.id}
+											editHandler={() => {
+												goto(`/automations/${automation.id}`);
+											}}
+											cloneHandler={() => {
+												cloneHandler(automation);
+											}}
+											runHandler={() => {
+												runNowHandler(automation);
+											}}
+											deleteHandler={() => {
+												deleteTarget = automation;
+												showDeleteConfirm = true;
+											}}
+											onClose={() => {
+												openAutomationMenuId = null;
+											}}
+										>
+											<button
+												class="flex size-6 items-center justify-center rounded-lg text-gray-400 transition dark:text-gray-500"
+												type="button"
+												aria-label={$i18n.t('Automation Menu')}
+												on:click={(e) => {
+													e.preventDefault();
+													e.stopPropagation();
+													openAutomationMenuId =
+														openAutomationMenuId === automation.id ? null : automation.id;
+												}}
+											>
+												<EllipsisHorizontal className="size-4" />
+											</button>
+										</AutomationMenu>
+
+										<button
+											class="flex h-6 items-center"
+											type="button"
+											on:click={(e) => {
+												e.stopPropagation();
+												e.preventDefault();
+											}}
+										>
+											<Tooltip
+												content={automation.is_active ? $i18n.t('Enabled') : $i18n.t('Disabled')}
+											>
+												<Switch
+													bind:state={automation.is_active}
+													on:change={() => {
+														toggleHandler(automation);
+													}}
+												/>
+											</Tooltip>
+										</button>
+									</div>
+								{/if}
 							</div>
 						</div>
 					{/each}


### PR DESCRIPTION
# Pull Request

## Checklist

- [x] This PR targets the `dev` branch.
- [x] This PR links to a well-described, confirmed Issue or active Discussion: `Closes #29637`.
- [ ] A maintainer explicitly asked me to open this PR, or this PR only updates i18n/localization.
- [x] The change is one logical unit with no unrelated commits.
- [x] I matched nearby code patterns and avoided unnecessary new settings, abstractions, or dependencies.
- [x] I manually tested the changed workflow and any nearby behavior that could be affected.
- [ ] I updated relevant docs, including the [Open WebUI Docs Repository](https://github.com/open-webui/docs), if needed.
- [ ] I added screenshots for UI changes, and a recording when motion or interaction matters.
- [x] I reviewed any AI-generated code before submitting it.
- [x] The PR title uses one of the prefixes listed below.

## Summary

Holding Shift turns a row's trailing controls into a one click delete across most of Open WebUI. Deleting an automation still takes three interactions. Open the `...` menu, click Delete, then confirm in the modal. Requested in #29637.

While Shift is held, each automation's trailing group is replaced by a delete button that calls the existing `deleteHandler(automation)` directly. Releasing Shift, or blurring the window, restores the group. Nothing changes when Shift is not held, and the menu with its confirmation modal stays the only delete path for anyone who never presses Shift.

This follows `Skills.svelte`, which is the closest existing surface because its rows carry the same two trailing controls, a menu and an enable toggle. Shift there hides both and puts the delete button where the toggle was, so the `{#if}` wraps the whole group rather than the menu alone. The unpressed branch keeps the original container and both controls unchanged.

The key tracking is copied from the same file. `keydown` and `keyup` set `shiftKey`, `blur` clears it, and all three listeners are removed in the existing `onMount` teardown beside the search debounce timer. They are registered after the permission check, so a redirected user never installs them. No new component, prop, store or helper.

`onKeyDown` also clears `openAutomationMenuId`, because the menu is inside the branch being swapped and would otherwise reopen when Shift was released. Notes needed the same guard in #29635.

Ignoring whitespace the change is 46 added lines and none removed. The raw diff looks larger because the surviving markup moved one indent level into the `{:else}`.

## Testing

I tested this locally on the branch and the behavior matches `Skills`, including the toggle hiding with the menu and returning in place afterwards.

Mechanical checks, run at my direction with AI copilot assistance:

| Check | Result |
|---|---|
| `npm run build` | exit 0, no warnings for the changed page |
| `npx vitest run` | 2 files, 8 tests, passing |
| `npx prettier --check` on the changed file | already formatted, no rewrite |
| New `i18n.t` keys introduced | none, both keys in the diff already exist in `en-US` |
| Added code comments, Svelte 5 runes | none |

## Changelog Entry

### Added

- Holding Shift on the Automations page now replaces each automation's menu and enable toggle with a delete button that removes it in one click, matching the existing Shift behavior on `Skills`. The menu and its confirmation modal are unchanged when Shift is not held.

## Additional Context

Notes received the same treatment in #29635, merged as 0b804c5. This applies it to the one remaining list surface with the two control layout.

`Knowledge.svelte` also has no Shift delete. It is out of scope here and this PR does not touch it.

This PR was prepared with AI copilot assistance. I have thoroughly reviewed it.

## Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
