### PR TITLE
fix: stop the browser back button creating extra notes

### DIFF
--- a/src/lib/components/layout/SearchModal.svelte
+++ b/src/lib/components/layout/SearchModal.svelte
@@ -534,7 +534,7 @@
 						{
 							label: $i18n.t('Create a new note'),
 							onClick: async () => {
-								await goto(`/notes?content=${query}`);
+								await goto(`/notes/new?content=${encodeURIComponent(query)}`);
 								show = false;
 								onClose();
 							},

--- a/src/routes/(app)/notes/+page.svelte
+++ b/src/routes/(app)/notes/+page.svelte
@@ -24,7 +24,7 @@
 			const res = await createNoteHandler(title, content);
 
 			if (res) {
-				goto(`/notes/${res.id}`);
+				goto(`/notes/${res.id}`, { replaceState: true });
 			}
 			return;
 		}

--- a/src/routes/(app)/notes/new/+page.svelte
+++ b/src/routes/(app)/notes/new/+page.svelte
@@ -14,7 +14,7 @@
 		const res = await createNoteHandler(title, content);
 
 		if (res) {
-			goto(`/notes/${res.id}`);
+			goto(`/notes/${res.id}`, { replaceState: true });
 		}
 	});
 </script>


### PR DESCRIPTION
# Pull Request

## Checklist

- [x] This PR targets the `dev` branch.
- [x] This PR links to a well-described, confirmed Issue or active Discussion: `Closes #29642`.
- [ ] A maintainer explicitly asked me to open this PR, or this PR only updates i18n/localization.
- [x] The change is one logical unit with no unrelated commits.
- [x] I matched nearby code patterns and avoided unnecessary new settings, abstractions, or dependencies.
- [x] I manually tested the changed workflow and any nearby behavior that could be affected.
- [ ] I updated relevant docs, including the [Open WebUI Docs Repository](https://github.com/open-webui/docs), if needed.
- [ ] I added screenshots for UI changes, and a recording when motion or interaction matters.
- [x] I reviewed any AI-generated code before submitting it.
- [x] The PR title uses one of the prefixes listed below.

## Summary

`Create a new note` in the search modal navigated to `/notes?content=<query>`, and the Notes list route treats that parameter as an instruction to create a note and redirect. Reported in #29642. Three defects come out of that one line.

**Back created notes without limit.** The redirect used `goto` without `replaceState`, so `/notes?content=` stayed in history. Pressing Back re-ran `onMount`, which created another note and pushed again, so every Back press wrote a new note and nothing ever navigated backwards.

**From `/notes` itself, the action did nothing.** SvelteKit reuses the page component across a same-route navigation, so `onMount` never re-ran. The create call and the redirect live in that block, so neither happened. The URL changed to `/notes?content=` and the user stayed on the list.

**The search text was truncated.** The query was interpolated into the URL unencoded, so it ended at the first `&`, `#` or `=`, and a `+` arrived as a space.

The fix points the action at `/notes/new`, the route that already exists for this and reads the same `title` and `content` parameters:

```diff
-	await goto(`/notes?content=${query}`);
+	await goto(`/notes/new?content=${encodeURIComponent(query)}`);
```

`/notes/new` had no callers anywhere in the codebase. It sits under the same `notes/+layout.svelte` guard as `/notes`, so the feature flag and permission checks are unchanged, and being a distinct route it mounts every time, including when the user is already on `/notes`.

Both note-creating routes also gain `replaceState`, so the transient URL never stays in history:

```diff
-	goto(`/notes/${res.id}`);
+	goto(`/notes/${res.id}`, { replaceState: true });
```

That matches every other redirect-on-mount route in the codebase, under `workspace` and `admin` and in both layout guards. It still matters after the routing change, because `/notes?content=` and `/notes/new` can both be reached directly by URL.

`notes/+page.svelte` and `notes/new/+page.svelte` are the only two routes that create a resource inside `onMount`, which is why the missing `replaceState` cost a database row per keypress here rather than a harmless bounce.

## Testing

I tested all three fixes locally on the branch and they behave as described.

Encoding, verified against `URLSearchParams` on the receiving side:

| Search text | Before | After |
|---|---|---|
| `foo & bar` | `foo ` | `foo & bar` |
| `x=1&y=2` | `x=1` | `x=1&y=2` |
| `a#b` | `a` | `a#b` |
| `plus+sign` | `plus sign` | `plus+sign` |
| `café ☕` | `café ☕` | `café ☕` |

Mechanical checks, run at my direction with AI copilot assistance:

| Check | Result |
|---|---|
| `npm run build` | exit 0 |
| `npx vitest run` | 2 files, 8 tests, passing |
| `npx prettier --check` on the changed files | already formatted, no rewrite |
| New `i18n.t` keys introduced | none |
| Added code comments, Svelte 5 runes | none |

## Changelog Entry

### Fixed

- Creating a note from the search modal no longer leaves a note-creating URL in browser history, so the browser Back button stops creating a new note on every press.
- `Create a new note` in the search modal now works when the Notes page is already open. It previously changed the URL and did nothing else.
- Search text containing `&`, `#`, `=` or `+` now reaches the new note intact instead of being truncated or altered.

## Additional Context

One behavior change worth naming. After creating a note this way, Back now returns to whatever preceded the search modal. That is usually the chat that was open, rather than a page that creates another note. It matches the other redirect routes, and no previous behavior is lost, since Back did not navigate backwards at all.

This PR was prepared with AI copilot assistance. I have thoroughly reviewed it.

## Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
