### PR TITLE
fix: show relevance badge for single-source citations

### DIFF
--- a/src/lib/components/chat/Messages/Citations.svelte
+++ b/src/lib/components/chat/Messages/Citations.svelte
@@ -80,6 +80,11 @@
 			return false;
 		}
 
+		// A single distance cannot be an outlier
+		if (distances.length === 1) {
+			return true;
+		}
+
 		if (
 			(inRange === distances.length - 1 && outOfRange === 1) ||
 			(outOfRange === distances.length - 1 && inRange === 1)


### PR DESCRIPTION
A response with exactly one citation never showed its relevance badge, even though the source carried a perfectly valid score. Adding a second citation made the badge appear for that same source, so the score looked like it came and went at random.

calculateShowRelevance hides relevance when a result set mixes distance metrics (cosine in -1..1 next to unbounded L2), since those numbers are not comparable. With a single distance that check degenerates: distances.length - 1 is 0, so the "all but one are out of range" clause matches whatever the value is, and the score is hidden. A lone distance cannot be a mix of two metrics, so it now returns before the outlier check runs.

Sets of two or more distances behave exactly as before, mixed-metric sets are still suppressed.

Fixes #29646

## Contributor License Agreement

<!--
DO NOT DELETE THIS SECTION.
Your PR will not be reviewed or merged until you check the box below confirming that you have read and agree to the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
