### PR TITLE
fix: app hangs on the loading spinner while cleaning up legacy local chat storage

### DIFF
--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -69,6 +69,12 @@
 		}
 	};
 
+	// deleteDB() stays blocked as long as a connection is open
+	const deleteLocalDBChats = async () => {
+		DB.close();
+		await deleteDB('Chats');
+	};
+
 	const checkLocalDBChats = async () => {
 		try {
 			// Check if IndexedDB exists
@@ -82,7 +88,7 @@
 			localDBChats = chats.map((item, idx) => chats[chats.length - 1 - idx]);
 
 			if (localDBChats.length === 0) {
-				await deleteDB('Chats');
+				await deleteLocalDBChats();
 			}
 		} catch (error) {
 			// IndexedDB Not Found
@@ -245,9 +251,9 @@
 		}
 
 		clearChatInputStorage();
+		checkLocalDBChats();
 		try {
 			await Promise.all([
-				checkLocalDBChats(),
 				setBanners().catch((e) => console.error('Failed to load banners:', e)),
 				setTools().catch((e) => console.error('Failed to load tools:', e)),
 				setUserSettings(async () => {
@@ -509,7 +515,7 @@
 
 												const tx = DB.transaction('chats', 'readwrite');
 												await Promise.all([tx.store.clear(), tx.done]);
-												await deleteDB('Chats');
+												await deleteLocalDBChats();
 
 												localDBChats = [];
 											}}


### PR DESCRIPTION
Users who still had the old browser-side chat database could land on the loading spinner forever, with a silent console and no way out short of clearing site data. The sidebar rendered, the chat area never did.

The startup migration check opens the legacy 'Chats' IndexedDB and deletes it when it holds no chats. It never closed its own connection first, and indexedDB.deleteDatabase() stays blocked for as long as any connection is open, so the delete never completed and the awaited startup chain never finished. The same await sat behind the migration dialog's "Download & Delete" button, leaving that dialog up after the export had already been saved.

The connection is now closed before the delete, and the migration check no longer blocks startup: it is best-effort, it already swallows its own errors, and nothing between it and the first render reads its results, so a browser whose IndexedDB never answers can no longer keep the app from loading.

Measured against the real idb build with the legacy database seeded: the delete goes from never settling to completing in ~165 ms, in both the startup path and the dialog button.

Fixes #29538

## Contributor License Agreement

<!--
DO NOT DELETE THIS SECTION.
Your PR will not be reviewed or merged until you check the box below confirming that you have read and agree to the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
