### PR TITLE
fix: default converted Responses function tools to strict=false

### DIFF
--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -1416,8 +1416,12 @@ def convert_to_responses_payload(payload: dict) -> dict:
                         converted_tool['description'] = func['description']
                     if 'parameters' in func:
                         converted_tool['parameters'] = func['parameters']
-                    if 'strict' in func:
-                        converted_tool['strict'] = func['strict']
+                    # The Responses API defaults function tools to strict schemas, while
+                    # Chat Completions defaults to loose ones. Tools converted from Chat
+                    # Completions (including MCP/OpenAPI-derived ones) usually carry loose
+                    # schemas, so default to strict=False to keep omission semantics for
+                    # optional properties. Explicit values are preserved.
+                    converted_tool['strict'] = func.get('strict', False)
                 converted_tools.append(converted_tool)
             else:
                 # Already in correct format or unknown format, pass through


### PR DESCRIPTION
# Pull Request

## Checklist

- [x] This PR targets the `dev` branch.
- [x] This PR links to a well-described, confirmed Issue or active Discussion: `Closes #27750`.
- [ ] A maintainer explicitly asked me to open this PR, or this PR only updates i18n/localization.
- [x] The change is one logical unit with no unrelated commits.
- [x] I matched nearby code patterns and avoided unnecessary new settings, abstractions, or dependencies.
- [x] I manually tested the changed workflow and any nearby behavior that could be affected.
- [x] I updated relevant docs, including the [Open WebUI Docs Repository](https://github.com/open-webui/docs), if needed. (No docs changes needed.)
- [ ] I added screenshots for UI changes, and a recording when motion or interaction matters. (No UI changes.)
- [x] I reviewed any AI-generated code before submitting it.
- [x] The PR title uses one of the prefixes listed below.

## Summary

Closes #27750.

Chat Completions function tools default to **loose** schemas; the Responses API defaults function tools to **strict**. `convert_to_responses_payload()` forwarded `strict` only when the source tool already had the field:

```python
if 'strict' in func:
    converted_tool['strict'] = func['strict']
```

MCP- and OpenAPI-derived tools rarely set a tool-level `strict`, so their loose schemas were sent to `/v1/responses` with `strict` omitted and were therefore treated as strict. With optional properties in the schema, the model then materializes unused properties as empty strings, zeros, `false`, or empty arrays, and can populate mutually exclusive properties together. Open WebUI forwards those arguments to the tool unchanged, which breaks search/filter style tools where an empty value is not equivalent to omission (see the issue for a reproduction and example arguments).

This PR defaults the converted tool to `strict: False` so omission semantics are preserved:

```python
converted_tool['strict'] = func.get('strict', False)
```

Behavior:
- Loose tool with no `strict` → `strict: false` (was: field omitted).
- Explicit `strict: true` / `strict: false` → preserved unchanged.
- Tools already in Responses format, and non-function built-in tools (e.g. `web_search`), pass through untouched.

`strict: true` is not a drop-in alternative here: a strict adapter would additionally have to mark every property required, set `additionalProperties: false`, make optional properties nullable, strip nulls before tool execution, and preserve semantic rules such as mutually exclusive filters.

## Testing

- Ran `convert_to_responses_payload()` directly against the four relevant tool shapes and confirmed the emitted Responses tools:
  - loose tool, no `strict` → `{'type': 'function', 'name': 'search', 'parameters': {...}, 'strict': False}`
  - `strict: true` → preserved as `True`
  - `strict: false` → preserved as `False`
  - native Responses tool (`{'type': 'function', 'name': ...}`) and `{'type': 'web_search'}` → passed through unchanged
- `ruff format --check backend/open_webui/routers/openai.py` → already formatted.

## Changelog Entry

### Fixed

- Function tools converted from the Chat Completions format to the Responses API now explicitly send `strict: false` when the source tool does not specify strict mode, so optional JSON Schema properties keep omission semantics instead of being materialized as empty strings, zeros, `false`, or empty arrays.

## Additional Context

The change is limited to `convert_to_responses_payload()` in `backend/open_webui/routers/openai.py`; explicit `strict` values and already-native Responses tools are unaffected.

## Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ReTdyXgcbfMBwEZjtsSXz
