### PR TITLE
fix: stop creating an empty legacy chat database for users who never had local chats

### DIFF
--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -72,7 +72,13 @@
 	const checkLocalDBChats = async () => {
 		try {
 			// Check if IndexedDB exists
-			DB = await openDB('Chats', 1);
+			DB = await openDB('Chats', 1, {
+				upgrade: (db, oldVersion, newVersion, tx) => {
+					// Only probing for a legacy database, so undo the implicit creation; nothing awaits tx.done
+					tx.done.catch(() => {});
+					tx.abort();
+				}
+			});
 
 			if (!DB) {
 				return;


### PR DESCRIPTION
Open WebUI opens the legacy 'Chats' IndexedDB on startup to look for chats that predate server-side storage. That open call carries no upgrade callback, so for anyone who never had local chats it creates the database instead of merely probing for it, and the read that follows fails against the missing object store and is swallowed. Every such user ends up with an empty 'Chats' database sitting in browser storage, recreated on every load.

The upgrade callback now aborts, which rolls the implicit creation back, so nothing is left behind and the open rejects into the existing catch. Users with a real legacy database are unaffected: their upgrade never fires, and their chats are still read and offered for export.

Measured in Chrome against the real idb build: indexedDB.databases() goes from listing an empty Chats entry after every load to listing nothing, with no unhandled rejection and no connection left open.

This stops new empty databases from being created. Removing the ones earlier builds already left behind needs the connection closed before the delete, and is handled separately.

Spotted while investigating #29538.

## Contributor License Agreement

<!--
DO NOT DELETE THIS SECTION.
Your PR will not be reviewed or merged until you check the box below confirming that you have read and agree to the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
