### PR TITLE
feat: make Serper base URL configurable via SERPER_API_BASE_URL

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -1239,6 +1239,8 @@ SERPSTACK_HTTPS = os.getenv('SERPSTACK_HTTPS', 'True').lower() == 'true'
 
 SERPER_API_KEY = os.getenv('SERPER_API_KEY', '')
 
+SERPER_API_BASE_URL = os.getenv('SERPER_API_BASE_URL', 'https://google.serper.dev')
+
 SERPLY_API_KEY = os.getenv('SERPLY_API_KEY', '')
 
 SERPHOUSE_API_KEY = os.getenv('SERPHOUSE_API_KEY', '')

--- a/backend/open_webui/retrieval/web/serper.py
+++ b/backend/open_webui/retrieval/web/serper.py
@@ -11,6 +11,7 @@ log = logging.getLogger(__name__)
 
 async def search_serper(
     api_key: str,
+    api_base_url: str,
     query: str,
     count: int,
     filter_list: list[str] | None = None,
@@ -19,7 +20,8 @@ async def search_serper(
 
     Results are sorted by their position field before truncation.
     """
-    url = 'https://google.serper.dev/search'
+    base_url = (api_base_url or 'https://google.serper.dev').strip().rstrip('/') or 'https://google.serper.dev'
+    url = f'{base_url}/search'
     headers = {'X-API-KEY': api_key, 'Content-Type': 'application/json'}
 
     session = await get_session()

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -2588,6 +2588,7 @@ async def search_web(request: Request, engine: str, query: str, user=None) -> li
         if config.SERPER_API_KEY:
             return await search_serper(
                 config.SERPER_API_KEY,
+                config.SERPER_API_BASE_URL,
                 query,
                 config.WEB_SEARCH_RESULT_COUNT,
                 config.WEB_SEARCH_DOMAIN_FILTER_LIST,


### PR DESCRIPTION
The Serper endpoint is hardcoded in `retrieval/web/serper.py`:

```python
url = "https://google.serper.dev/search"
```

Anyone who needs the request to go somewhere else — an egress proxy on a locked-down network, a regional endpoint, or a local mock during tests — has to patch the file and carry the patch across upgrades.

### Approach

This mirrors the pattern already in the codebase for SERPHouse: an env-backed companion setting declared next to the API key, passed through the router into the search function.

`config.py`:

```python
SERPER_API_KEY = os.getenv("SERPER_API_KEY", "")

SERPER_API_BASE_URL = os.getenv("SERPER_API_BASE_URL", "https://google.serper.dev")
```

`routers/retrieval.py`:

```python
return await search_serper(
    config.SERPER_API_KEY,
    config.SERPER_API_BASE_URL,
    query,
    ...
)
```

`retrieval/web/serper.py` takes it as a parameter and normalises it, the same way `search_serphouse` normalises `domain`.

### Notes

- Six added lines across three files, no new dependency.
- Default is the existing URL, so behaviour is unchanged unless the variable is set.
- Normalisation covers empty string, whitespace, a trailing slash, and a bare `/` — each falls back to or resolves to a valid endpoint rather than producing `/search`.

Happy to add `SERPER_API_BASE_URL` to the environment-variable documentation in a follow-up, or in this PR if you would prefer it together.