### PR TITLE
fix: keep the chat alive when tool call arguments are not a JSON object

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -3132,13 +3132,12 @@ async def execute_tool_call_for_output(request, form_data, user, metadata, event
                 params = ast.literal_eval(tool_args)
             except Exception as e:
                 log.debug(e)
-                return {
-                    'tool_call_id': tool_call.get('id', ''),
-                    'content': (
-                        'Error: Tool call arguments could not be parsed. '
-                        'The model generated malformed or incomplete JSON.'
-                    ),
-                }
+                params = None
+    if not isinstance(params, dict):
+        return {
+            'tool_call_id': tool_call.get('id', ''),
+            'content': 'Error: Tool call arguments could not be parsed. The model must generate a valid JSON object.',
+        }
     tool_call.setdefault('function', {})['arguments'] = JSONCodec.dumps(params)
 
     tool = tools.get(name)
@@ -5633,7 +5632,9 @@ async def streaming_chat_response_handler(response, ctx):
                                     params = ast.literal_eval(tool_args)
                                 except Exception as e:
                                     log.debug(e)
-                                    return None
+                                    params = None
+                        if not isinstance(params, dict):
+                            return None
                         tool_call.setdefault('function', {})['arguments'] = JSONCodec.dumps(params)
                         return params
 
@@ -5702,8 +5703,8 @@ async def streaming_chat_response_handler(response, ctx):
                                 {
                                     'tool_call_id': tool_call_id,
                                     'content': (
-                                        'Error: Tool call arguments could not be parsed. The model generated '
-                                        f'malformed or incomplete JSON for `{tool_function_name}`. Please try again.'
+                                        'Error: Tool call arguments could not be parsed. The model must generate '
+                                        f'a valid JSON object for `{tool_function_name}`. Please try again.'
                                     ),
                                 }
                             )


### PR DESCRIPTION
A model can emit a tool call whose arguments string is valid JSON but not an object ("foo", 3, [1], true). Open WebUI passed that straight through as the tool parameters and then treated it as a dict, which raised AttributeError outside any error handling and killed the entire chat response: the reply died mid-stream and all partial output was lost, with only 'str' object has no attribute 'items' in the log.

Tool arguments that do not decode to an object are now treated as unparseable, exactly like malformed JSON already was. That single tool call comes back with the existing parse-error message so the model can retry it, the tool is never invoked, and the rest of the response finishes normally. Both messages were reworded because they now also cover well-formed JSON of the wrong shape.

Fixes #29323

## Contributor License Agreement

<!--
DO NOT DELETE THIS SECTION.
Your PR will not be reviewed or merged until you check the box below confirming that you have read and agree to the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
