### PR TITLE
fix: clean up vector data and files when deleting a knowledge directory

### DIFF
--- a/backend/open_webui/models/knowledge.py
+++ b/backend/open_webui/models/knowledge.py
@@ -1069,6 +1069,36 @@ class KnowledgeTable:
         for child_id in child_ids:
             await self._delete_files_in_subtree(child_id, db=db)
 
+    async def get_files_in_subtree(
+        self,
+        knowledge_id: str,
+        directory_id: str,
+        db: Optional[AsyncSession] = None,
+    ) -> list[FileModel]:
+        """Get all files in a directory and its subdirectories."""
+        async with get_async_db_context(db) as db:
+            directory_ids = await self._get_directory_ids_in_subtree(directory_id, db=db)
+            result = await db.execute(
+                select(File)
+                .join(KnowledgeFile, File.id == KnowledgeFile.file_id)
+                .filter(KnowledgeFile.knowledge_id == knowledge_id)
+                .filter(KnowledgeFile.directory_id.in_(directory_ids))
+            )
+            return [FileModel.model_validate(file) for file in result.scalars().all()]
+
+    async def _get_directory_ids_in_subtree(
+        self,
+        directory_id: str,
+        db: AsyncSession,
+    ) -> list[str]:
+        """Collect a directory id together with every descendant directory id."""
+        directory_ids = [directory_id]
+        result = await db.execute(select(KnowledgeDirectory.id).filter_by(parent_id=directory_id))
+        child_ids = [row[0] for row in result.all()]
+        for child_id in child_ids:
+            directory_ids.extend(await self._get_directory_ids_in_subtree(child_id, db=db))
+        return directory_ids
+
     async def move_file_to_directory(
         self,
         knowledge_id: str,

--- a/backend/open_webui/routers/knowledge.py
+++ b/backend/open_webui/routers/knowledge.py
@@ -2321,6 +2321,9 @@ async def delete_knowledge_directory(
             detail=ERROR_MESSAGES.NOT_FOUND,
         )
 
+    # Collect before delete_directory drops the KnowledgeFile rows
+    files = [] if move_files else await Knowledges.get_files_in_subtree(id, dir_id, db=db)
+
     success = await Knowledges.delete_directory(
         directory_id=dir_id,
         move_files_to_parent=move_files,
@@ -2331,6 +2334,22 @@ async def delete_knowledge_directory(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail='Failed to delete directory.',
         )
+
+    for file in files:
+        try:
+            await ASYNC_VECTOR_DB_CLIENT.delete(collection_name=id, filter={'file_id': file.id})
+            await ASYNC_VECTOR_DB_CLIENT.delete(collection_name=id, filter={'hash': file.hash})
+        except Exception as e:
+            log.debug('This was most likely caused by bypassing embedding processing')
+            log.debug(e)
+
+        if (
+            not ENABLE_KNOWLEDGE_FILE_RETENTION
+            and not await Knowledges.get_knowledges_by_file_id(file.id, db=db)
+            and (file.user_id == user.id or user.role == 'admin')
+        ):
+            await delete_file_resource(file, db)
+
     await publish_event(
         request,
         EVENTS.KNOWLEDGE_DIRECTORY_DELETED,


### PR DESCRIPTION
Deleting a directory in a knowledge base with "Delete all contents inside this directory" took the contained files out of the knowledge base but left their embeddings in the knowledge collection. The deleted content was still retrieved into answers, and uploading the same content again was rejected as duplicate content, permanently.

Every other removal path already purges those chunks. The directory path now does the same: the files in the deleted subtree are collected before their links are dropped, and their chunks are removed by file id and by hash regardless of ENABLE_KNOWLEDGE_FILE_RETENTION. The file record, the stored copy and the per-file collection are removed only when retention is disabled, the file is no longer referenced by any knowledge base and the actor owns it or is an admin, which is what removing a file individually does.

The lookup is scoped to the knowledge base from the request, so a directory nested under a different knowledge base's directory no longer has its file's chunks deleted from the wrong collection.

Fixes #29636

## Contributor License Agreement

<!--
DO NOT DELETE THIS SECTION.
Your PR will not be reviewed or merged until you check the box below confirming that you have read and agree to the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
