### PR TITLE
feat: preserve Responses API state across chat turns

### DIFF
--- a/backend/open_webui/migrations/versions/e2a43c7819b6_add_response_id_to_chat_message.py
+++ b/backend/open_webui/migrations/versions/e2a43c7819b6_add_response_id_to_chat_message.py
@@ -1,0 +1,78 @@
+"""add response id to chat message
+
+Revision ID: e2a43c7819b6
+Revises: d4c1a8e37b62
+Create Date: 2026-09-03 00:00:00.000000
+
+"""
+
+import json
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = 'e2a43c7819b6'
+down_revision: str | None = 'd4c1a8e37b62'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _iter_response_id_updates(conn, chat):
+    for chat_id, chat_data in conn.execute(sa.select(chat.c.id, chat.c.chat)):
+        if isinstance(chat_data, str):
+            try:
+                chat_data = json.loads(chat_data)
+            except (TypeError, ValueError):
+                continue
+        if not isinstance(chat_data, dict):
+            continue
+
+        messages = chat_data.get('history', {}).get('messages', {})
+        if not isinstance(messages, dict):
+            continue
+
+        for message_id, message in messages.items():
+            if not isinstance(message, dict):
+                continue
+            response_id = message.get('responseId') or message.get('response_id')
+            if isinstance(response_id, str) and response_id:
+                yield {
+                    'message_row_id': f'{chat_id}-{message_id}',
+                    'response_id_value': response_id,
+                }
+
+
+def upgrade() -> None:
+    op.add_column('chat_message', sa.Column('response_id', sa.Text(), nullable=True))
+
+    conn = op.get_bind()
+    chat = sa.table(
+        'chat',
+        sa.column('id', sa.Text()),
+        sa.column('chat', sa.JSON()),
+    )
+    chat_message = sa.table(
+        'chat_message',
+        sa.column('id', sa.Text()),
+        sa.column('response_id', sa.Text()),
+    )
+    update_statement = (
+        chat_message.update()
+        .where(chat_message.c.id == sa.bindparam('message_row_id'))
+        .values(response_id=sa.bindparam('response_id_value'))
+    )
+
+    updates = []
+    for update in _iter_response_id_updates(conn, chat):
+        updates.append(update)
+        if len(updates) >= 1000:
+            conn.execute(update_statement, updates)
+            updates.clear()
+
+    if updates:
+        conn.execute(update_statement, updates)
+
+
+def downgrade() -> None:
+    op.drop_column('chat_message', 'response_id')

--- a/backend/open_webui/migrations/versions/f7d8e9a0b1c2_add_responses_status_to_chat_message.py
+++ b/backend/open_webui/migrations/versions/f7d8e9a0b1c2_add_responses_status_to_chat_message.py
@@ -1,0 +1,27 @@
+"""add Responses status to chat message
+
+Revision ID: f7d8e9a0b1c2
+Revises: e2a43c7819b6
+Create Date: 2026-09-04 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = 'f7d8e9a0b1c2'
+down_revision: str | None = 'e2a43c7819b6'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column('chat_message', sa.Column('response_status', sa.Text(), nullable=True))
+    op.add_column('chat_message', sa.Column('incomplete_details', sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('chat_message', 'incomplete_details')
+    op.drop_column('chat_message', 'response_status')

--- a/backend/open_webui/models/chat_messages.py
+++ b/backend/open_webui/models/chat_messages.py
@@ -143,6 +143,8 @@ class ChatMessage(Base):
     # Model (for assistant messages)
     model_id = Column(Text, nullable=True, index=True)
     response_id = Column(Text, nullable=True)
+    response_status = Column(Text, nullable=True)
+    incomplete_details = Column(JSON, nullable=True)
 
     # Attachments
     files = Column(JSON, nullable=True)
@@ -190,6 +192,8 @@ class ChatMessageModel(BaseModel):
     output: Optional[list] = None
     model_id: Optional[str] = None
     response_id: Optional[str] = None
+    response_status: Optional[str] = None
+    incomplete_details: Optional[dict] = None
     files: Optional[list] = None
     sources: Optional[list] = None
     embeds: Optional[list] = None
@@ -224,6 +228,10 @@ class ChatMessageTable:
             message.model_id = data.get('model_id') or data.get('model')
         if 'response_id' in data or 'responseId' in data:
             message.response_id = data.get('response_id') or data.get('responseId')
+        if 'response_status' in data or 'responseStatus' in data:
+            message.response_status = data.get('response_status') or data.get('responseStatus')
+        if 'incomplete_details' in data or 'incompleteDetails' in data:
+            message.incomplete_details = data.get('incomplete_details') or data.get('incompleteDetails')
         if 'files' in data:
             message.files = data.get('files')
         if 'sources' in data:
@@ -259,6 +267,8 @@ class ChatMessageTable:
             output=data.get('output'),
             model_id=data.get('model_id') or data.get('model'),
             response_id=data.get('response_id') or data.get('responseId'),
+            response_status=data.get('response_status') or data.get('responseStatus'),
+            incomplete_details=data.get('incomplete_details') or data.get('incompleteDetails'),
             files=data.get('files'),
             sources=data.get('sources'),
             embeds=data.get('embeds'),
@@ -357,6 +367,8 @@ class ChatMessageTable:
         'parent_id': 'parentId',
         'model_id': 'model',
         'response_id': 'responseId',
+        'response_status': 'responseStatus',
+        'incomplete_details': 'incompleteDetails',
         'status_history': 'statusHistory',
         'context_summary': 'contextSummary',
         'created_at': 'timestamp',

--- a/backend/open_webui/models/chat_messages.py
+++ b/backend/open_webui/models/chat_messages.py
@@ -142,6 +142,7 @@ class ChatMessage(Base):
 
     # Model (for assistant messages)
     model_id = Column(Text, nullable=True, index=True)
+    response_id = Column(Text, nullable=True)
 
     # Attachments
     files = Column(JSON, nullable=True)
@@ -188,6 +189,7 @@ class ChatMessageModel(BaseModel):
     content: Optional[Any] = None  # str or list of blocks
     output: Optional[list] = None
     model_id: Optional[str] = None
+    response_id: Optional[str] = None
     files: Optional[list] = None
     sources: Optional[list] = None
     embeds: Optional[list] = None
@@ -220,6 +222,8 @@ class ChatMessageTable:
             message.output = data.get('output')
         if 'model_id' in data or 'model' in data:
             message.model_id = data.get('model_id') or data.get('model')
+        if 'response_id' in data or 'responseId' in data:
+            message.response_id = data.get('response_id') or data.get('responseId')
         if 'files' in data:
             message.files = data.get('files')
         if 'sources' in data:
@@ -254,6 +258,7 @@ class ChatMessageTable:
             content=data.get('content'),
             output=data.get('output'),
             model_id=data.get('model_id') or data.get('model'),
+            response_id=data.get('response_id') or data.get('responseId'),
             files=data.get('files'),
             sources=data.get('sources'),
             embeds=data.get('embeds'),
@@ -351,6 +356,7 @@ class ChatMessageTable:
     DB_TO_JSON_KEY_MAP = {
         'parent_id': 'parentId',
         'model_id': 'model',
+        'response_id': 'responseId',
         'status_history': 'statusHistory',
         'context_summary': 'contextSummary',
         'created_at': 'timestamp',

--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -51,7 +51,11 @@ from open_webui.utils.payload import (
     apply_model_params_to_body_openai,
     apply_system_prompt_to_body,
 )
-from open_webui.utils.responses_state import apply_responses_stateful_payload, convert_responses_result
+from open_webui.utils.responses_state import (
+    apply_responses_stateful_payload,
+    convert_responses_result,
+    convert_to_responses_payload,
+)
 from open_webui.utils.session_pool import (
     cleanup_response,
     get_client_timeout,
@@ -1249,186 +1253,6 @@ def convert_to_azure_payload(url, payload: dict, api_version: str):
     return url, payload
 
 
-# Fields accepted by the Responses API for each input item type.
-RESPONSES_ALLOWED_FIELDS: dict[str, set[str]] = {
-    'message': {'type', 'role', 'content'},
-    'function_call': {'type', 'call_id', 'name', 'arguments', 'id'},
-    'function_call_output': {'type', 'call_id', 'output'},
-}
-
-
-def _normalize_stored_item(item: dict) -> dict:
-    """Strip local-only fields from a stored output item before replaying it.
-
-    Open WebUI stores extra bookkeeping fields (``id``, ``status``,
-    ``started_at``, ``ended_at``, ``duration``, ``_tag_type``,
-    ``attributes``, ``summary``, etc.) that the Responses API does
-    not accept.  This helper returns a copy containing only the
-    fields the API understands.
-    """
-    item_type = item.get('type', '')
-    allowed = RESPONSES_ALLOWED_FIELDS.get(item_type)
-    if allowed is None:
-        # Unknown type — pass through as-is (e.g. reasoning, extension items).
-        return item
-    return {k: v for k, v in item.items() if k in allowed}
-
-
-def convert_to_responses_payload(payload: dict) -> dict:
-    """
-    Convert Chat Completions payload to Responses API format.
-
-    Chat Completions: { messages: [{role, content}], ... }
-    Responses API: { input: [{type: "message", role, content: [...]}], instructions: "system" }
-    """
-    messages = payload.pop('messages', [])
-
-    system_content = ''
-    input_items = []
-
-    for msg in messages:
-        role = msg.get('role', 'user')
-        content = msg.get('content', '')
-
-        # Check for stored output items (from previous Responses API turn)
-        stored_output = msg.get('output')
-        if stored_output and isinstance(stored_output, list):
-            input_items.extend(_normalize_stored_item(item) for item in stored_output)
-            continue
-
-        if role == 'system':
-            if isinstance(content, str):
-                system_content = content
-            elif isinstance(content, list):
-                system_content = '\n'.join(p.get('text', '') for p in content if p.get('type') == 'text')
-            continue
-
-        # Handle assistant messages with tool_calls (from convert_output_to_messages)
-        if role == 'assistant' and msg.get('tool_calls'):
-            # Add text content as message if present
-            if content:
-                text = (
-                    content
-                    if isinstance(content, str)
-                    else '\n'.join(p.get('text', '') for p in content if p.get('type') == 'text')
-                )
-                if text.strip():
-                    input_items.append(
-                        {
-                            'type': 'message',
-                            'role': 'assistant',
-                            'content': [{'type': 'output_text', 'text': text}],
-                        }
-                    )
-            # Convert each tool_call to a function_call input item
-            for tool_call in msg['tool_calls']:
-                func = tool_call.get('function', {})
-                input_items.append(
-                    {
-                        'type': 'function_call',
-                        'call_id': tool_call.get('id', ''),
-                        'name': func.get('name', ''),
-                        'arguments': func.get('arguments', '{}'),
-                    }
-                )
-            continue
-
-        # Handle tool result messages
-        if role == 'tool':
-            input_items.append(
-                {
-                    'type': 'function_call_output',
-                    'call_id': msg.get('tool_call_id', ''),
-                    'output': msg.get('content', ''),
-                }
-            )
-            continue
-
-        # Convert content format
-        text_type = 'output_text' if role == 'assistant' else 'input_text'
-
-        if isinstance(content, str):
-            content_parts = [{'type': text_type, 'text': content}]
-        elif isinstance(content, list):
-            content_parts = []
-            for part in content:
-                if part.get('type') == 'text':
-                    content_parts.append({'type': text_type, 'text': part.get('text', '')})
-                elif part.get('type') == 'image_url':
-                    url_data = part.get('image_url', {})
-                    if isinstance(url_data, dict):
-                        url = url_data.get('url', '')
-                        detail = url_data.get('detail') or 'auto'
-                    else:
-                        url = url_data if isinstance(url_data, str) else ''
-                        detail = 'auto'
-                    content_parts.append({'type': 'input_image', 'image_url': url, 'detail': detail})
-                elif part.get('type') == 'file':
-                    # OpenAI-compatible proxy path only. Open WebUI attachments are handled
-                    # separately via metadata.files/RAG and must not be converted here.
-                    file = part.get('file')
-                    if isinstance(file, dict):
-                        file_part = {k: file[k] for k in ('file_id', 'file_data', 'filename') if k in file}
-                        if 'file_id' in file_part or 'file_data' in file_part:
-                            content_parts.append({'type': 'input_file', **file_part})
-        else:
-            content_parts = [{'type': text_type, 'text': str(content)}]
-
-        input_items.append({'type': 'message', 'role': role, 'content': content_parts})
-
-    responses_payload = {**payload, 'input': input_items}
-
-    # Forward previous_response_id when the middleware has set it
-    # (only used when ENABLE_RESPONSES_API_STATEFUL is enabled).
-    previous_response_id = responses_payload.pop('previous_response_id', None)
-    if previous_response_id:
-        responses_payload['previous_response_id'] = previous_response_id
-
-    if system_content:
-        responses_payload['instructions'] = system_content
-
-    if 'max_tokens' in responses_payload:
-        responses_payload['max_output_tokens'] = responses_payload.pop('max_tokens')
-
-    if 'max_completion_tokens' in responses_payload:
-        responses_payload['max_output_tokens'] = responses_payload.pop('max_completion_tokens')
-
-    # Remove Chat Completions-only parameters not supported by the Responses API
-    for unsupported_key in (
-        'stream_options',
-        'logit_bias',
-        'frequency_penalty',
-        'presence_penalty',
-        'stop',
-    ):
-        responses_payload.pop(unsupported_key, None)
-
-    # Convert Chat Completions tools format to Responses API format
-    # Chat Completions: {"type": "function", "function": {"name": ..., "description": ..., "parameters": ...}}
-    # Responses API:    {"type": "function", "name": ..., "description": ..., "parameters": ...}
-    if 'tools' in responses_payload and isinstance(responses_payload['tools'], list):
-        converted_tools = []
-        for tool in responses_payload['tools']:
-            if isinstance(tool, dict) and 'function' in tool:
-                func = tool['function']
-                converted_tool = {'type': tool.get('type', 'function')}
-                if isinstance(func, dict):
-                    converted_tool['name'] = func.get('name', '')
-                    if 'description' in func:
-                        converted_tool['description'] = func['description']
-                    if 'parameters' in func:
-                        converted_tool['parameters'] = func['parameters']
-                    if 'strict' in func:
-                        converted_tool['strict'] = func['strict']
-                converted_tools.append(converted_tool)
-            else:
-                # Already in correct format or unknown format, pass through
-                converted_tools.append(tool)
-        responses_payload['tools'] = converted_tools
-
-    return responses_payload
-
-
 @router.post('/chat/completions')
 async def generate_chat_completion(
     request: Request,
@@ -1533,7 +1357,10 @@ async def generate_chat_completion(
     headers, cookies = await get_headers_and_cookies(request, url, key, api_config, metadata, user=user)
 
     is_responses = api_config.get('api_type') == 'responses'
-    payload = apply_responses_stateful_payload(payload, is_responses, ENABLE_RESPONSES_API_STATEFUL)
+    try:
+        payload = apply_responses_stateful_payload(payload, is_responses, ENABLE_RESPONSES_API_STATEFUL)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     if api_config.get('azure') or api_config.get('provider') == 'azure':
         # Only set api-key header if not using Azure Entra ID authentication

--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -28,6 +28,7 @@ from open_webui.env import (
     BYPASS_MODEL_ACCESS_CONTROL,
     ENABLE_FORWARD_USER_INFO_HEADERS,
     ENABLE_OPENAI_API_PASSTHROUGH,
+    ENABLE_RESPONSES_API_STATEFUL,
     FORWARD_SESSION_INFO_HEADER_CHAT_ID,
     MODELS_CACHE_TTL,
     REDIS_KEY_PREFIX,
@@ -50,6 +51,7 @@ from open_webui.utils.payload import (
     apply_model_params_to_body_openai,
     apply_system_prompt_to_body,
 )
+from open_webui.utils.responses_state import apply_responses_stateful_payload, convert_responses_result
 from open_webui.utils.session_pool import (
     cleanup_response,
     get_client_timeout,
@@ -1427,40 +1429,6 @@ def convert_to_responses_payload(payload: dict) -> dict:
     return responses_payload
 
 
-def convert_responses_result(response: dict) -> dict:
-    """
-    Convert non-streaming Responses API result to Chat Completions format.
-
-    Extracts text from message output items so all downstream consumers
-    (frontend tasks, get_content_from_response) work without modification.
-    """
-    output_items = response.get('output', [])
-
-    content = ''
-    for item in output_items:
-        if item.get('type') == 'message':
-            for part in item.get('content', []):
-                if part.get('type') == 'output_text':
-                    content += part.get('text', '')
-
-    return {
-        'id': response.get('id', ''),
-        'object': 'chat.completion',
-        'model': response.get('model', ''),
-        'choices': [
-            {
-                'index': 0,
-                'message': {
-                    'role': 'assistant',
-                    'content': content,
-                },
-                'finish_reason': 'stop',
-            }
-        ],
-        'usage': response.get('usage', {}),
-    }
-
-
 @router.post('/chat/completions')
 async def generate_chat_completion(
     request: Request,
@@ -1565,6 +1533,7 @@ async def generate_chat_completion(
     headers, cookies = await get_headers_and_cookies(request, url, key, api_config, metadata, user=user)
 
     is_responses = api_config.get('api_type') == 'responses'
+    payload = apply_responses_stateful_payload(payload, is_responses, ENABLE_RESPONSES_API_STATEFUL)
 
     if api_config.get('azure') or api_config.get('provider') == 'azure':
         # Only set api-key header if not using Azure Entra ID authentication

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -125,6 +125,13 @@ from open_webui.utils.misc import (
 from open_webui.utils.payload import apply_params_to_form_data, apply_system_prompt_to_body, resolve_system_prompt
 from open_webui.utils.plugin import load_function_module_by_id
 from open_webui.utils.response import merge_usage, normalize_usage
+from open_webui.utils.responses_state import (
+    get_completed_response_metadata,
+    get_openai_url_idx,
+    get_stateful_response_id,
+    pop_stateful_response_id,
+    trim_stateful_messages,
+)
 from open_webui.utils.sanitize import sanitize_code
 from open_webui.utils.task import (
     get_task_model_id,
@@ -888,11 +895,7 @@ def handle_responses_streaming_event(
                 if item.get('type') == 'reasoning' and item.get('status') != 'completed':
                     item['status'] = 'completed'
 
-        return new_output, {
-            'usage': response_data.get('usage'),
-            'done': True,
-            'response_id': response_data.get('id'),
-        }
+        return new_output, get_completed_response_metadata(response_data)
 
     elif event_type == 'response.in_progress':
         # State Machine Event: In Progress
@@ -2128,6 +2131,34 @@ async def convert_url_images_to_base64(form_data, user=None):
 MESSAGE_REPLAY_KEYS = ('id', 'role', 'content', 'output', 'files', 'contextSummary', 'usage', 'model')
 
 
+async def load_stateful_response_id(chat_id: str, user_message_id: str, model_id: str | None) -> str | None:
+    messages_map = await Chats.get_messages_map_by_chat_id(chat_id)
+    if not messages_map:
+        return None
+    return get_stateful_response_id(messages_map, user_message_id, model_id)
+
+
+async def is_stateful_responses_model(request, model: dict) -> bool:
+    """Check the resolved connection before changing replay semantics."""
+    if not ENABLE_RESPONSES_API_STATEFUL:
+        return False
+
+    url_idx = get_openai_url_idx(model, request.app.state.MODELS)
+    if url_idx is None:
+        return False
+
+    try:
+        # Imported lazily to avoid a module cycle: the OpenAI router imports
+        # middleware helpers through the normal chat request path.
+        from open_webui.routers.openai import get_openai_connection
+
+        _, _, api_config = await get_openai_connection(url_idx)
+        return api_config.get('api_type') == 'responses'
+    except Exception:
+        log.exception('Unable to determine whether model %s uses the Responses API', model.get('id'))
+        return False
+
+
 async def load_messages_from_db(chat_id: str, message_id: str) -> Optional[list[dict]]:
     """
     Load the message chain from DB up to message_id,
@@ -2382,6 +2413,16 @@ async def process_chat_payload(request, form_data, user, metadata, model):
     # which the frontend strips, causing tool calls to be merged into content.
     chat_id = metadata.get('chat_id')
     user_message_id = metadata.get('user_message_id')
+    stateful_responses = await is_stateful_responses_model(request, model)
+
+    if stateful_responses and is_saved_chat_id(chat_id) and user_message_id:
+        previous_response_id = await load_stateful_response_id(
+            chat_id,
+            user_message_id,
+            form_data.get('model'),
+        )
+        if previous_response_id:
+            form_data['previous_response_id'] = previous_response_id
 
     if is_saved_chat_id(chat_id) and user_message_id:
         db_messages = await load_messages_from_db(chat_id, user_message_id)
@@ -2424,7 +2465,7 @@ async def process_chat_payload(request, form_data, user, metadata, model):
     if regeneration_prompt:
         form_data['messages'].append({'role': 'user', 'content': regeneration_prompt})
 
-    if is_saved_chat_id(chat_id) and user_message_id:
+    if is_saved_chat_id(chat_id) and user_message_id and not form_data.get('previous_response_id'):
         if getattr(request.state, 'direct', False) and hasattr(request.state, 'model'):
             compaction_models = {
                 **dict(request.app.state.MODELS.items()),
@@ -3082,6 +3123,15 @@ async def process_chat_payload(request, form_data, user, metadata, model):
             raise Exception(f'{e}')
 
     form_data = normalize_messages_for_model(form_data)
+
+    if form_data.get('previous_response_id'):
+        # Hermes already owns the transcript referenced by previous_response_id.
+        # Re-sending OpenWebUI's replay duplicates history and, after Hermes has
+        # compacted it, can restore the very context that compaction removed.
+        form_data['messages'] = trim_stateful_messages(
+            form_data.get('messages', []),
+            regeneration=bool(regeneration_prompt),
+        )
 
     return form_data, metadata, events
 
@@ -4118,6 +4168,7 @@ async def non_streaming_chat_response_handler(response, ctx):
                     usage = normalize_usage(response_data.get('usage', {}) or {})
 
                     if save_to_chat:
+                        response_id = response_data.get('response_id') if ENABLE_RESPONSES_API_STATEFUL else None
                         await Chats.upsert_message_to_chat_by_id_and_message_id(
                             metadata['chat_id'],
                             metadata['message_id'],
@@ -4125,6 +4176,7 @@ async def non_streaming_chat_response_handler(response, ctx):
                                 'done': True,
                                 'role': 'assistant',
                                 'output': response_output,
+                                **({'responseId': response_id} if response_id else {}),
                                 **({'usage': usage} if usage else {}),
                             },
                         )
@@ -4887,10 +4939,12 @@ async def streaming_chat_response_handler(response, ctx):
                                     # calls. The outer middleware manages the
                                     # actual completion signal.
                                     if response_metadata:
-                                        if ENABLE_RESPONSES_API_STATEFUL:
-                                            response_id = response_metadata.pop('response_id', None)
-                                            if response_id:
-                                                last_response_id = response_id
+                                        response_id = pop_stateful_response_id(
+                                            response_metadata,
+                                            ENABLE_RESPONSES_API_STATEFUL,
+                                        )
+                                        if response_id:
+                                            last_response_id = response_id
 
                                         # Normalize and capture usage for DB persistence
                                         if response_metadata.get('usage'):
@@ -6222,6 +6276,7 @@ async def streaming_chat_response_handler(response, ctx):
                         {
                             'done': True,
                             'output': current_output,
+                            **({'responseId': last_response_id} if last_response_id else {}),
                             **({'usage': usage} if usage else {}),
                         },
                     )

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -126,9 +126,10 @@ from open_webui.utils.payload import apply_params_to_form_data, apply_system_pro
 from open_webui.utils.plugin import load_function_module_by_id
 from open_webui.utils.response import merge_usage, normalize_usage
 from open_webui.utils.responses_state import (
-    get_completed_response_metadata,
+    build_stateful_tool_continuation_messages,
     get_openai_url_idx,
     get_stateful_response_id,
+    handle_responses_lifecycle_event,
     pop_stateful_response_id,
     trim_stateful_messages,
 )
@@ -555,7 +556,15 @@ def deep_merge(target, source):
         return source
 
 
-RESPONSE_COMPLETION_RESPONSE_FIELDS = ('error', 'id', 'output', 'usage')
+RESPONSE_COMPLETION_RESPONSE_FIELDS = (
+    'error',
+    'id',
+    'incomplete_details',
+    'output',
+    'previous_response_id',
+    'status',
+    'usage',
+)
 
 
 def get_response_completion_event_data(event: dict) -> dict:
@@ -881,34 +890,13 @@ def handle_responses_streaming_event(
 
         return current_output, None
 
-    elif event_type == 'response.completed':
-        # State Machine Event: Completed
-        response_data = data.get('response', {})
-        final_output = response_data.get('output')
-
-        # Some providers send an empty output on response.completed despite having streamed items
-        new_output = final_output if final_output else current_output
-
-        # Ensure reasoning items are marked as completed in the final output
-        if new_output:
-            for item in new_output:
-                if item.get('type') == 'reasoning' and item.get('status') != 'completed':
-                    item['status'] = 'completed'
-
-        return new_output, get_completed_response_metadata(response_data)
-
-    elif event_type == 'response.in_progress':
-        # State Machine Event: In Progress
-        # We could extract metadata if needed, but for now just acknowledge iteration
-        return current_output, None
-
-    elif event_type == 'response.failed':
-        # State Machine Event: Failed
-        error = data.get('response', {}).get('error', {})
-        return current_output, {'error': error}
-
     else:
-        return current_output, None
+        lifecycle_result = handle_responses_lifecycle_event(
+            event_type,
+            data.get('response', {}),
+            current_output,
+        )
+        return lifecycle_result if lifecycle_result is not None else (current_output, None)
 
 
 def get_source_context(sources: list, source_ids: dict = None, include_content: bool = True) -> str:
@@ -2415,7 +2403,7 @@ async def process_chat_payload(request, form_data, user, metadata, model):
     user_message_id = metadata.get('user_message_id')
     stateful_responses = await is_stateful_responses_model(request, model)
 
-    if stateful_responses and is_saved_chat_id(chat_id) and user_message_id:
+    if stateful_responses and not form_data.get('conversation') and is_saved_chat_id(chat_id) and user_message_id:
         previous_response_id = await load_stateful_response_id(
             chat_id,
             user_message_id,
@@ -3124,10 +3112,9 @@ async def process_chat_payload(request, form_data, user, metadata, model):
 
     form_data = normalize_messages_for_model(form_data)
 
-    if form_data.get('previous_response_id'):
-        # Hermes already owns the transcript referenced by previous_response_id.
-        # Re-sending OpenWebUI's replay duplicates history and, after Hermes has
-        # compacted it, can restore the very context that compaction removed.
+    if stateful_responses and (form_data.get('previous_response_id') or form_data.get('conversation')):
+        # The upstream owns the transcript referenced by previous_response_id
+        # or conversation. Re-sending OpenWebUI's replay duplicates history.
         form_data['messages'] = trim_stateful_messages(
             form_data.get('messages', []),
             regeneration=bool(regeneration_prompt),
@@ -4106,9 +4093,11 @@ async def non_streaming_chat_response_handler(response, ctx):
             choices = response_data.get('choices', [])
             response_output = response_data.get('output')
             content = choices[0].get('message', {}).get('content') if choices else ''
+            response_status = response_data.get('response_status')
+            response_done = response_status not in {'queued', 'in_progress'}
 
-            if choices and (content or response_output):
-                if content or response_output:
+            if choices and (content or response_output or response_data.get('response_id')):
+                if content or response_output or response_data.get('response_id'):
                     await event_emitter(
                         {
                             'type': 'chat:completion',
@@ -4157,9 +4146,15 @@ async def non_streaming_chat_response_handler(response, ctx):
                         {
                             'type': 'chat:completion',
                             'data': {
-                                'done': True,
+                                'done': response_done,
                                 'output': response_output,
                                 'title': title,
+                                **({'responseStatus': response_status} if response_status else {}),
+                                **(
+                                    {'incompleteDetails': response_data['incomplete_details']}
+                                    if response_data.get('incomplete_details') is not None
+                                    else {}
+                                ),
                             },
                         }
                     )
@@ -4173,10 +4168,16 @@ async def non_streaming_chat_response_handler(response, ctx):
                             metadata['chat_id'],
                             metadata['message_id'],
                             {
-                                'done': True,
+                                'done': response_done,
                                 'role': 'assistant',
                                 'output': response_output,
                                 **({'responseId': response_id} if response_id else {}),
+                                **({'responseStatus': response_status} if response_status else {}),
+                                **(
+                                    {'incompleteDetails': response_data['incomplete_details']}
+                                    if response_data.get('incomplete_details') is not None
+                                    else {}
+                                ),
                                 **({'usage': usage} if usage else {}),
                             },
                         )
@@ -4613,6 +4614,9 @@ async def streaming_chat_response_handler(response, ctx):
 
             usage = None
             last_response_id = None
+            last_response_status = None
+            last_incomplete_details = None
+            last_response_error = None
 
             def full_output():
                 return prior_output + output if prior_output else output
@@ -4696,6 +4700,9 @@ async def streaming_chat_response_handler(response, ctx):
                     nonlocal output
                     nonlocal prior_output
                     nonlocal last_response_id
+                    nonlocal last_response_status
+                    nonlocal last_incomplete_details
+                    nonlocal last_response_error
 
                     response_tool_calls = []
 
@@ -4943,8 +4950,15 @@ async def streaming_chat_response_handler(response, ctx):
                                             response_metadata,
                                             ENABLE_RESPONSES_API_STATEFUL,
                                         )
-                                        if response_id:
+                                        if response_id and response_metadata.get('done'):
                                             last_response_id = response_id
+
+                                        if response_metadata.get('response_status'):
+                                            last_response_status = response_metadata['response_status']
+                                        if response_metadata.get('incomplete_details') is not None:
+                                            last_incomplete_details = response_metadata['incomplete_details']
+                                        if response_metadata.get('error') is not None:
+                                            last_response_error = response_metadata['error']
 
                                         # Normalize and capture usage for DB persistence
                                         if response_metadata.get('usage'):
@@ -5953,14 +5967,20 @@ async def streaming_chat_response_handler(response, ctx):
                             'metadata': metadata,
                         }
 
-                        if ENABLE_RESPONSES_API_STATEFUL and last_response_id:
+                        if ENABLE_RESPONSES_API_STATEFUL and (last_response_id or new_form_data.get('conversation')):
                             system_message = get_system_message(form_data['messages'])
-                            new_form_data['messages'] = (
-                                [system_message] if system_message else []
-                            ) + convert_output_to_messages(
-                                output, raw=True, reasoning_format=get_reasoning_format(model)
+                            tool_outputs = [
+                                item
+                                for item in output
+                                if item.get('type') == 'function_call_output'
+                                and item.get('call_id') in result_status_by_call_id
+                            ]
+                            new_form_data['messages'] = build_stateful_tool_continuation_messages(
+                                system_message,
+                                tool_outputs,
                             )
-                            new_form_data['previous_response_id'] = last_response_id
+                            if not new_form_data.get('conversation'):
+                                new_form_data['previous_response_id'] = last_response_id
                         else:
                             tool_messages = convert_output_to_messages(
                                 output,
@@ -6253,10 +6273,12 @@ async def streaming_chat_response_handler(response, ctx):
                             await emit_message_error(error_content)
                             break
 
-                # Mark all in-progress items as completed
-                for item in output:
-                    if item.get('status') == 'in_progress':
-                        item['status'] = 'completed'
+                # Chat Completions has no response-level status. For Responses,
+                # preserve provider item states unless the response completed.
+                if last_response_status in (None, 'completed'):
+                    for item in output:
+                        if item.get('status') == 'in_progress':
+                            item['status'] = 'completed'
 
                 current_output = full_output()
                 title = await Chats.get_chat_title_by_id(metadata['chat_id']) if save_to_chat else ''
@@ -6264,6 +6286,9 @@ async def streaming_chat_response_handler(response, ctx):
                     'done': True,
                     'output': current_output,
                     'title': title,
+                    **({'responseStatus': last_response_status} if last_response_status else {}),
+                    **({'incompleteDetails': last_incomplete_details} if last_incomplete_details is not None else {}),
+                    **({'error': last_response_error} if last_response_error is not None else {}),
                     **({'usage': usage} if usage else {}),
                 }
 
@@ -6277,6 +6302,13 @@ async def streaming_chat_response_handler(response, ctx):
                             'done': True,
                             'output': current_output,
                             **({'responseId': last_response_id} if last_response_id else {}),
+                            **({'responseStatus': last_response_status} if last_response_status else {}),
+                            **(
+                                {'incompleteDetails': last_incomplete_details}
+                                if last_incomplete_details is not None
+                                else {}
+                            ),
+                            **({'error': {'content': last_response_error}} if last_response_error is not None else {}),
                             **({'usage': usage} if usage else {}),
                         },
                     )

--- a/backend/open_webui/utils/responses_state.py
+++ b/backend/open_webui/utils/responses_state.py
@@ -1,5 +1,29 @@
 """Shared stateful Responses API policy used by routing and chat middleware."""
 
+RESPONSES_TERMINAL_STATUSES = frozenset({'completed', 'failed', 'cancelled', 'incomplete'})
+RESPONSES_LIFECYCLE_EVENTS = frozenset(
+    {
+        'response.cancelled',
+        'response.completed',
+        'response.created',
+        'response.failed',
+        'response.in_progress',
+        'response.incomplete',
+        'response.queued',
+    }
+)
+RESPONSES_LOCAL_ITEM_FIELDS = frozenset(
+    {
+        '_tag_type',
+        'attributes',
+        'duration',
+        'end_tag',
+        'ended_at',
+        'start_tag',
+        'started_at',
+    }
+)
+
 
 def get_stateful_response_id(messages_map: dict, user_message_id: str, model_id: str | None) -> str | None:
     """Return the response anchor for the branch containing *user_message_id*."""
@@ -32,8 +56,11 @@ def get_openai_url_idx(model: dict, models: dict) -> int | None:
 
 def apply_responses_stateful_payload(payload: dict, is_responses: bool, enabled: bool) -> dict:
     """Apply stateful-only fields after the target API type is known."""
-    if is_responses and enabled:
-        payload.setdefault('store', True)
+    if is_responses:
+        if payload.get('conversation') is not None and payload.get('previous_response_id'):
+            raise ValueError('conversation and previous_response_id cannot be used together')
+        if enabled:
+            payload['store'] = True
     elif not is_responses:
         payload.pop('previous_response_id', None)
     return payload
@@ -47,13 +74,284 @@ def trim_stateful_messages(messages: list[dict], regeneration: bool = False) -> 
     return ([system_message] if system_message else []) + current_input
 
 
-def get_completed_response_metadata(response: dict) -> dict:
-    """Return middleware metadata carried by a Responses completion event."""
-    return {
+def get_response_metadata(response: dict) -> dict:
+    """Return response-level state carried by a Responses lifecycle event."""
+    status = response.get('status')
+    metadata = {
         'usage': response.get('usage'),
-        'done': True,
         'response_id': response.get('id'),
+        'response_status': status,
     }
+    if status in RESPONSES_TERMINAL_STATUSES:
+        metadata['done'] = True
+    if response.get('error') is not None:
+        metadata['error'] = response['error']
+    if response.get('incomplete_details') is not None:
+        metadata['incomplete_details'] = response['incomplete_details']
+    return metadata
+
+
+def handle_responses_lifecycle_event(
+    event_type: str,
+    response: dict,
+    current_output: list[dict],
+) -> tuple[list[dict], dict] | None:
+    """Apply a Responses lifecycle event without interpreting output item types."""
+    if event_type not in RESPONSES_LIFECYCLE_EVENTS:
+        return None
+
+    final_output = response.get('output')
+    output = final_output if final_output else current_output
+    if event_type == 'response.completed':
+        output = [
+            {**item, 'status': 'completed'}
+            if item.get('type') == 'reasoning' and item.get('status') != 'completed'
+            else item
+            for item in output
+        ]
+    return output, get_response_metadata(response)
+
+
+def normalize_responses_input_item(item: dict) -> dict | None:
+    """Remove OpenWebUI-only fields while preserving native Responses item fields."""
+    item_type = item.get('type', '')
+    if item_type.startswith('open_webui:'):
+        return None
+
+    normalized = dict(item)
+    if item_type in {'message', 'reasoning', 'function_call', 'function_call_output'}:
+        normalized = {key: value for key, value in normalized.items() if key not in RESPONSES_LOCAL_ITEM_FIELDS}
+    if item_type == 'function_call_output':
+        return {key: normalized[key] for key in ('type', 'call_id', 'output') if key in normalized}
+    if item_type == 'function_call':
+        normalized.pop('approved', None)
+    return normalized
+
+
+def _convert_responses_content_part(part: dict, role: str) -> dict | None:
+    part_type = part.get('type')
+    text_type = 'output_text' if role == 'assistant' else 'input_text'
+    if part_type == 'text':
+        return {'type': text_type, 'text': part.get('text', '')}
+    if part_type == 'image_url':
+        image = part.get('image_url', {})
+        if isinstance(image, dict):
+            image_url = image.get('url', '')
+            detail = image.get('detail') or 'auto'
+        else:
+            image_url = image if isinstance(image, str) else ''
+            detail = 'auto'
+        return {'type': 'input_image', 'image_url': image_url, 'detail': detail}
+    if part_type == 'file':
+        file = part.get('file')
+        if not isinstance(file, dict):
+            return None
+        file_part = {key: file[key] for key in ('file_id', 'file_data', 'filename') if key in file}
+        return {'type': 'input_file', **file_part} if {'file_id', 'file_data'} & file_part.keys() else None
+    return dict(part)
+
+
+def _convert_responses_tool_choice(tool_choice):
+    if not isinstance(tool_choice, dict) or tool_choice.get('type') != 'function':
+        return tool_choice
+    function = tool_choice.get('function')
+    if isinstance(function, dict):
+        return {'type': 'function', 'name': function.get('name', '')}
+    return tool_choice
+
+
+def _convert_responses_text_config(payload: dict) -> None:
+    response_format = payload.pop('response_format', None)
+    if not isinstance(response_format, dict):
+        return
+
+    format_type = response_format.get('type')
+    if format_type == 'json_schema' and isinstance(response_format.get('json_schema'), dict):
+        text_format = {'type': 'json_schema', **response_format['json_schema']}
+    else:
+        text_format = dict(response_format)
+    payload['text'] = {**(payload.get('text') or {}), 'format': text_format}
+
+
+def _convert_message_content(content, role: str) -> list[dict]:
+    text_type = 'output_text' if role == 'assistant' else 'input_text'
+    if isinstance(content, str):
+        return [{'type': text_type, 'text': content}]
+    if isinstance(content, list):
+        return [
+            converted
+            for part in content
+            if isinstance(part, dict) and (converted := _convert_responses_content_part(part, role)) is not None
+        ]
+    return [{'type': text_type, 'text': str(content)}]
+
+
+def _convert_assistant_tool_calls(message: dict) -> list[dict]:
+    items = []
+    content = message.get('content')
+    if content:
+        text = (
+            content
+            if isinstance(content, str)
+            else '\n'.join(part.get('text', '') for part in content if part.get('type') in {'text', 'output_text'})
+        )
+        if text.strip():
+            items.append(
+                {
+                    'type': 'message',
+                    'role': 'assistant',
+                    'content': [{'type': 'output_text', 'text': text}],
+                }
+            )
+
+    for tool_call in message['tool_calls']:
+        function = tool_call.get('function', {})
+        items.append(
+            {
+                'type': 'function_call',
+                'call_id': tool_call.get('id', ''),
+                'name': function.get('name', ''),
+                'arguments': function.get('arguments', '{}'),
+            }
+        )
+    return items
+
+
+def _convert_responses_messages(messages: list[dict]) -> tuple[list[str], list[dict]]:
+    system_parts = []
+    input_items = []
+
+    for message in messages:
+        role = message.get('role', 'user')
+        content = message.get('content', '')
+        stored_output = message.get('output')
+        if isinstance(stored_output, list):
+            input_items.extend(
+                normalized
+                for item in stored_output
+                if isinstance(item, dict) and (normalized := normalize_responses_input_item(item)) is not None
+            )
+            continue
+
+        if role == 'system':
+            if isinstance(content, str):
+                system_parts.append(content)
+            elif isinstance(content, list):
+                system_parts.extend(
+                    part.get('text', '')
+                    for part in content
+                    if part.get('type') in {'text', 'input_text', 'output_text'}
+                )
+            continue
+
+        if role == 'assistant' and message.get('tool_calls'):
+            input_items.extend(_convert_assistant_tool_calls(message))
+            continue
+
+        if role == 'tool':
+            input_items.append(
+                {
+                    'type': 'function_call_output',
+                    'call_id': message.get('tool_call_id', ''),
+                    'output': content,
+                }
+            )
+            continue
+
+        input_items.append({'type': 'message', 'role': role, 'content': _convert_message_content(content, role)})
+
+    return system_parts, input_items
+
+
+def _convert_responses_tools(payload: dict) -> None:
+    legacy_functions = payload.pop('functions', None)
+    if legacy_functions and not payload.get('tools'):
+        payload['tools'] = [{'type': 'function', **function} for function in legacy_functions]
+
+    legacy_function_call = payload.pop('function_call', None)
+    if legacy_function_call is not None and 'tool_choice' not in payload:
+        payload['tool_choice'] = (
+            {'type': 'function', 'name': legacy_function_call.get('name', '')}
+            if isinstance(legacy_function_call, dict)
+            else legacy_function_call
+        )
+
+    tools = payload.get('tools')
+    if isinstance(tools, list):
+        payload['tools'] = [
+            {
+                'type': tool.get('type', 'function'),
+                **tool.get('function', {}),
+            }
+            if isinstance(tool, dict) and isinstance(tool.get('function'), dict)
+            else tool
+            for tool in tools
+        ]
+    if 'tool_choice' in payload:
+        payload['tool_choice'] = _convert_responses_tool_choice(payload['tool_choice'])
+
+
+def _convert_responses_stream_options(payload: dict) -> None:
+    stream_options = payload.get('stream_options')
+    if isinstance(stream_options, dict) and 'include_obfuscation' in stream_options:
+        payload['stream_options'] = {'include_obfuscation': stream_options['include_obfuscation']}
+    else:
+        payload.pop('stream_options', None)
+
+
+def _drop_unsupported_responses_fields(payload: dict) -> None:
+    for unsupported_key in (
+        'audio',
+        'frequency_penalty',
+        'logit_bias',
+        'logprobs',
+        'modalities',
+        'n',
+        'prediction',
+        'presence_penalty',
+        'seed',
+        'stop',
+    ):
+        payload.pop(unsupported_key, None)
+
+
+def convert_to_responses_payload(payload: dict) -> dict:
+    """Convert a Chat Completions-shaped request to the Responses contract."""
+    payload = dict(payload)
+    system_parts, input_items = _convert_responses_messages(payload.pop('messages', []))
+
+    responses_payload = {**payload, 'input': input_items}
+    if system_parts:
+        responses_payload['instructions'] = '\n'.join(system_parts)
+
+    if 'max_tokens' in responses_payload:
+        responses_payload['max_output_tokens'] = responses_payload.pop('max_tokens')
+    if 'max_completion_tokens' in responses_payload:
+        responses_payload['max_output_tokens'] = responses_payload.pop('max_completion_tokens')
+
+    _convert_responses_text_config(responses_payload)
+    _convert_responses_tools(responses_payload)
+    _convert_responses_stream_options(responses_payload)
+    _drop_unsupported_responses_fields(responses_payload)
+
+    return responses_payload
+
+
+def build_stateful_tool_continuation_messages(system_message: dict | None, tool_outputs: list[dict]) -> list[dict]:
+    """Build a chat-shaped payload containing only new stateful tool outputs."""
+    messages = [system_message] if system_message else []
+    if tool_outputs:
+        messages.append(
+            {
+                'role': 'tool',
+                'output': [
+                    normalized
+                    for item in tool_outputs
+                    if (normalized := normalize_responses_input_item(item)) is not None
+                ],
+            }
+        )
+    return messages
 
 
 def pop_stateful_response_id(metadata: dict, enabled: bool) -> str | None:
@@ -74,9 +372,11 @@ def convert_responses_result(response: dict) -> dict:
                 if part.get('type') == 'output_text':
                     content += part.get('text', '')
 
-    return {
+    status = response.get('status')
+    result = {
         'id': response.get('id', ''),
         'response_id': response.get('id', ''),
+        'response_status': status,
         'output': output_items,
         'object': 'chat.completion',
         'model': response.get('model', ''),
@@ -87,8 +387,13 @@ def convert_responses_result(response: dict) -> dict:
                     'role': 'assistant',
                     'content': content,
                 },
-                'finish_reason': 'stop',
+                'finish_reason': 'stop' if status in (None, 'completed') else status,
             }
         ],
         'usage': response.get('usage', {}),
     }
+    if response.get('error') is not None:
+        result['error'] = response['error']
+    if response.get('incomplete_details') is not None:
+        result['incomplete_details'] = response['incomplete_details']
+    return result

--- a/backend/open_webui/utils/responses_state.py
+++ b/backend/open_webui/utils/responses_state.py
@@ -1,0 +1,94 @@
+"""Shared stateful Responses API policy used by routing and chat middleware."""
+
+
+def get_stateful_response_id(messages_map: dict, user_message_id: str, model_id: str | None) -> str | None:
+    """Return the response anchor for the branch containing *user_message_id*."""
+    user_message = messages_map.get(user_message_id)
+    if not isinstance(user_message, dict) or user_message.get('role') != 'user':
+        return None
+
+    parent = messages_map.get(user_message.get('parentId'))
+    if not isinstance(parent, dict) or parent.get('role') != 'assistant':
+        return None
+
+    parent_model = parent.get('selectedModelId') or parent.get('model')
+    if parent_model and parent_model != model_id:
+        return None
+
+    response_id = parent.get('responseId') or parent.get('response_id')
+    return response_id if isinstance(response_id, str) and response_id else None
+
+
+def get_openai_url_idx(model: dict, models: dict) -> int | None:
+    """Resolve an OpenAI connection index for base models and custom profiles."""
+    connection_model = model
+    if connection_model.get('urlIdx') is None:
+        base_model_id = (model.get('info') or {}).get('base_model_id')
+        connection_model = models.get(base_model_id, {})
+
+    url_idx = connection_model.get('urlIdx')
+    return url_idx if isinstance(url_idx, int) else None
+
+
+def apply_responses_stateful_payload(payload: dict, is_responses: bool, enabled: bool) -> dict:
+    """Apply stateful-only fields after the target API type is known."""
+    if is_responses and enabled:
+        payload.setdefault('store', True)
+    elif not is_responses:
+        payload.pop('previous_response_id', None)
+    return payload
+
+
+def trim_stateful_messages(messages: list[dict], regeneration: bool = False) -> list[dict]:
+    """Keep only instructions and input not already represented by the response anchor."""
+    system_message = next((message for message in messages if message.get('role') == 'system'), None)
+    user_messages = [message for message in messages if message.get('role') == 'user']
+    current_input = user_messages[-2:] if regeneration and len(user_messages) > 1 else user_messages[-1:]
+    return ([system_message] if system_message else []) + current_input
+
+
+def get_completed_response_metadata(response: dict) -> dict:
+    """Return middleware metadata carried by a Responses completion event."""
+    return {
+        'usage': response.get('usage'),
+        'done': True,
+        'response_id': response.get('id'),
+    }
+
+
+def pop_stateful_response_id(metadata: dict, enabled: bool) -> str | None:
+    """Remove and return a valid response ID before emitting generic metadata."""
+    if not enabled:
+        return None
+    response_id = metadata.pop('response_id', None)
+    return response_id if isinstance(response_id, str) and response_id else None
+
+
+def convert_responses_result(response: dict) -> dict:
+    """Convert a non-streaming Responses result for the chat completion middleware."""
+    output_items = response.get('output', [])
+    content = ''
+    for item in output_items:
+        if item.get('type') == 'message':
+            for part in item.get('content', []):
+                if part.get('type') == 'output_text':
+                    content += part.get('text', '')
+
+    return {
+        'id': response.get('id', ''),
+        'response_id': response.get('id', ''),
+        'output': output_items,
+        'object': 'chat.completion',
+        'model': response.get('model', ''),
+        'choices': [
+            {
+                'index': 0,
+                'message': {
+                    'role': 'assistant',
+                    'content': content,
+                },
+                'finish_reason': 'stop',
+            }
+        ],
+        'usage': response.get('usage', {}),
+    }

--- a/test/test_responses_stateful.py
+++ b/test/test_responses_stateful.py
@@ -94,6 +94,32 @@ def test_responses_payload_keeps_anchor_and_enables_storage(responses_state):
     assert result['store'] is True
 
 
+def test_responses_payload_rejects_conversation_with_previous_response_id(responses_state):
+    with pytest.raises(ValueError, match='cannot be used together'):
+        responses_state.apply_responses_stateful_payload(
+            {
+                'conversation': 'conv_1',
+                'previous_response_id': 'resp_1',
+            },
+            is_responses=True,
+            enabled=True,
+        )
+
+
+def test_responses_payload_rejects_invalid_native_state_when_automatic_state_is_disabled(
+    responses_state,
+):
+    with pytest.raises(ValueError, match='cannot be used together'):
+        responses_state.apply_responses_stateful_payload(
+            {
+                'conversation': {'id': 'conv_1'},
+                'previous_response_id': 'resp_1',
+            },
+            is_responses=True,
+            enabled=False,
+        )
+
+
 def test_chat_completions_payload_drops_stateful_anchor(responses_state):
     payload = {
         'messages': [{'role': 'user', 'content': 'Next turn'}],
@@ -112,6 +138,16 @@ def test_disabled_stateful_mode_does_not_force_storage(responses_state):
     result = responses_state.apply_responses_stateful_payload(payload, is_responses=True, enabled=False)
 
     assert 'store' not in result
+
+
+def test_enabled_stateful_mode_overrides_disabled_storage(responses_state):
+    result = responses_state.apply_responses_stateful_payload(
+        {'store': False},
+        is_responses=True,
+        enabled=True,
+    )
+
+    assert result['store'] is True
 
 
 def test_stateful_messages_keep_system_and_current_user_only(responses_state):
@@ -137,14 +173,347 @@ def test_guided_regeneration_keeps_original_and_regeneration_prompts(responses_s
     ) == [original, regeneration]
 
 
-def test_streaming_completion_metadata_exposes_response_id(responses_state):
+def test_streaming_completion_metadata_exposes_response_lifecycle(responses_state):
     usage = {'input_tokens': 10, 'output_tokens': 4}
 
-    metadata = responses_state.get_completed_response_metadata({'id': 'resp_stream', 'usage': usage})
+    metadata = responses_state.get_response_metadata({'id': 'resp_stream', 'status': 'completed', 'usage': usage})
 
-    assert metadata == {'usage': usage, 'done': True, 'response_id': 'resp_stream'}
+    assert metadata == {
+        'usage': usage,
+        'done': True,
+        'response_id': 'resp_stream',
+        'response_status': 'completed',
+    }
     assert responses_state.pop_stateful_response_id(metadata, enabled=True) == 'resp_stream'
-    assert metadata == {'usage': usage, 'done': True}
+    assert metadata == {'usage': usage, 'done': True, 'response_status': 'completed'}
+
+
+@pytest.mark.parametrize('status', ['failed', 'cancelled', 'incomplete'])
+def test_terminal_response_metadata_is_marked_done(responses_state, status):
+    response = {
+        'id': f'resp_{status}',
+        'status': status,
+        'usage': None,
+        'error': {'message': 'failed'} if status == 'failed' else None,
+        'incomplete_details': {'reason': 'max_output_tokens'} if status == 'incomplete' else None,
+    }
+
+    metadata = responses_state.get_response_metadata(response)
+
+    assert metadata['done'] is True
+    assert metadata['response_status'] == status
+    assert metadata['response_id'] == f'resp_{status}'
+
+
+@pytest.mark.parametrize('status', ['queued', 'in_progress'])
+def test_non_terminal_response_metadata_is_not_marked_done(responses_state, status):
+    metadata = responses_state.get_response_metadata({'id': 'resp_pending', 'status': status})
+
+    assert 'done' not in metadata
+    assert metadata['response_status'] == status
+
+
+def test_completed_lifecycle_event_uses_final_output(responses_state):
+    current_output = [{'type': 'message', 'content': []}]
+    final_output = [
+        {
+            'type': 'reasoning',
+            'id': 'rs_1',
+            'status': 'in_progress',
+            'summary': [],
+        }
+    ]
+
+    output, metadata = responses_state.handle_responses_lifecycle_event(
+        'response.completed',
+        {'id': 'resp_1', 'status': 'completed', 'output': final_output},
+        current_output,
+    )
+
+    assert output == [{**final_output[0], 'status': 'completed'}]
+    assert metadata['done'] is True
+    assert metadata['response_id'] == 'resp_1'
+
+
+def test_incomplete_lifecycle_event_preserves_partial_output(responses_state):
+    partial_output = [{'type': 'message', 'status': 'incomplete', 'content': []}]
+    details = {'reason': 'max_output_tokens'}
+
+    output, metadata = responses_state.handle_responses_lifecycle_event(
+        'response.incomplete',
+        {
+            'id': 'resp_partial',
+            'status': 'incomplete',
+            'incomplete_details': details,
+            'output': [],
+        },
+        partial_output,
+    )
+
+    assert output == partial_output
+    assert metadata['incomplete_details'] == details
+    assert metadata['done'] is True
+
+
+def test_non_lifecycle_event_is_ignored(responses_state):
+    assert (
+        responses_state.handle_responses_lifecycle_event(
+            'response.output_text.delta',
+            {},
+            [],
+        )
+        is None
+    )
+
+
+def test_native_response_items_keep_official_fields_and_drop_webui_fields(responses_state):
+    item = {
+        'type': 'reasoning',
+        'id': 'rs_1',
+        'status': 'completed',
+        'summary': [{'type': 'summary_text', 'text': 'Summary'}],
+        'encrypted_content': 'encrypted',
+        'started_at': 1,
+        'duration': 2,
+        'attributes': {'type': 'reasoning_content'},
+    }
+
+    assert responses_state.normalize_responses_input_item(item) == {
+        'type': 'reasoning',
+        'id': 'rs_1',
+        'status': 'completed',
+        'summary': [{'type': 'summary_text', 'text': 'Summary'}],
+        'encrypted_content': 'encrypted',
+    }
+
+
+def test_unknown_response_items_are_forward_compatible(responses_state):
+    item = {
+        'type': 'future_tool_call',
+        'id': 'future_1',
+        'status': 'completed',
+        'files': [{'id': 'file_1'}],
+        'attributes': {'future': True},
+        'new_official_field': True,
+    }
+
+    assert responses_state.normalize_responses_input_item(item) == item
+
+
+def test_openwebui_only_output_items_are_not_replayed(responses_state):
+    item = {
+        'type': 'open_webui:code_interpreter',
+        'id': 'local_1',
+        'code': 'print(1)',
+    }
+
+    assert responses_state.normalize_responses_input_item(item) is None
+
+
+def test_function_call_drops_only_openwebui_approval_state(responses_state):
+    item = {
+        'type': 'function_call',
+        'id': 'fc_1',
+        'call_id': 'call_1',
+        'name': 'terminal',
+        'arguments': '{}',
+        'status': 'completed',
+        'approved': True,
+    }
+
+    assert responses_state.normalize_responses_input_item(item) == {
+        'type': 'function_call',
+        'id': 'fc_1',
+        'call_id': 'call_1',
+        'name': 'terminal',
+        'arguments': '{}',
+        'status': 'completed',
+    }
+
+
+def test_function_output_is_normalized_for_stateful_continuation(responses_state):
+    tool_output = {
+        'type': 'function_call_output',
+        'id': 'local_fco',
+        'call_id': 'call_1',
+        'output': [{'type': 'input_text', 'text': '42'}],
+        'status': 'completed',
+        'files': [{'url': 'local'}],
+    }
+
+    messages = responses_state.build_stateful_tool_continuation_messages(
+        {'role': 'system', 'content': 'Instructions'},
+        [tool_output],
+    )
+
+    assert messages == [
+        {'role': 'system', 'content': 'Instructions'},
+        {
+            'role': 'tool',
+            'output': [
+                {
+                    'type': 'function_call_output',
+                    'call_id': 'call_1',
+                    'output': [{'type': 'input_text', 'text': '42'}],
+                }
+            ],
+        },
+    ]
+
+
+def test_chat_payload_conversion_preserves_native_stateful_fields(responses_state):
+    payload = responses_state.convert_to_responses_payload(
+        {
+            'model': 'hermes',
+            'messages': [
+                {'role': 'system', 'content': 'Managed instructions'},
+                {
+                    'role': 'user',
+                    'content': [
+                        {'type': 'text', 'text': 'Inspect this'},
+                        {
+                            'type': 'image_url',
+                            'image_url': {'url': 'data:image/png;base64,abc', 'detail': 'high'},
+                        },
+                        {
+                            'type': 'file',
+                            'file': {'file_id': 'file_1', 'filename': 'report.pdf'},
+                        },
+                    ],
+                },
+            ],
+            'previous_response_id': 'resp_1',
+            'store': True,
+        }
+    )
+
+    assert payload['instructions'] == 'Managed instructions'
+    assert payload['previous_response_id'] == 'resp_1'
+    assert payload['store'] is True
+    assert payload['input'] == [
+        {
+            'type': 'message',
+            'role': 'user',
+            'content': [
+                {'type': 'input_text', 'text': 'Inspect this'},
+                {
+                    'type': 'input_image',
+                    'image_url': 'data:image/png;base64,abc',
+                    'detail': 'high',
+                },
+                {'type': 'input_file', 'file_id': 'file_1', 'filename': 'report.pdf'},
+            ],
+        }
+    ]
+
+
+def test_stateful_tool_continuation_converts_to_only_function_outputs(responses_state):
+    messages = responses_state.build_stateful_tool_continuation_messages(
+        {'role': 'system', 'content': 'Instructions'},
+        [
+            {
+                'type': 'function_call_output',
+                'id': 'local_fco',
+                'call_id': 'call_1',
+                'output': 'done',
+                'status': 'completed',
+            }
+        ],
+    )
+
+    payload = responses_state.convert_to_responses_payload(
+        {
+            'model': 'hermes',
+            'messages': messages,
+            'previous_response_id': 'resp_tool_call',
+        }
+    )
+
+    assert payload['instructions'] == 'Instructions'
+    assert payload['previous_response_id'] == 'resp_tool_call'
+    assert payload['input'] == [
+        {
+            'type': 'function_call_output',
+            'call_id': 'call_1',
+            'output': 'done',
+        }
+    ]
+
+
+def test_chat_tools_structured_output_and_stream_options_are_converted(responses_state):
+    payload = responses_state.convert_to_responses_payload(
+        {
+            'messages': [{'role': 'user', 'content': 'Go'}],
+            'tools': [
+                {
+                    'type': 'function',
+                    'function': {
+                        'name': 'lookup',
+                        'description': 'Look up a record',
+                        'parameters': {'type': 'object'},
+                        'strict': True,
+                    },
+                }
+            ],
+            'tool_choice': {'type': 'function', 'function': {'name': 'lookup'}},
+            'response_format': {
+                'type': 'json_schema',
+                'json_schema': {
+                    'name': 'result',
+                    'schema': {'type': 'object'},
+                    'strict': True,
+                },
+            },
+            'stream_options': {'include_usage': True, 'include_obfuscation': False},
+            'max_completion_tokens': 100,
+            'n': 2,
+        }
+    )
+
+    assert payload['tools'] == [
+        {
+            'type': 'function',
+            'name': 'lookup',
+            'description': 'Look up a record',
+            'parameters': {'type': 'object'},
+            'strict': True,
+        }
+    ]
+    assert payload['tool_choice'] == {'type': 'function', 'name': 'lookup'}
+    assert payload['text'] == {
+        'format': {
+            'type': 'json_schema',
+            'name': 'result',
+            'schema': {'type': 'object'},
+            'strict': True,
+        }
+    }
+    assert payload['stream_options'] == {'include_obfuscation': False}
+    assert payload['max_output_tokens'] == 100
+    assert 'n' not in payload
+
+
+def test_native_input_content_and_built_in_tools_pass_through(responses_state):
+    payload = responses_state.convert_to_responses_payload(
+        {
+            'messages': [
+                {
+                    'role': 'user',
+                    'content': [
+                        {'type': 'input_text', 'text': 'Search'},
+                        {'type': 'input_file', 'file_data': 'data:application/pdf;base64,abc'},
+                    ],
+                }
+            ],
+            'tools': [{'type': 'web_search'}],
+        }
+    )
+
+    assert payload['input'][0]['content'] == [
+        {'type': 'input_text', 'text': 'Search'},
+        {'type': 'input_file', 'file_data': 'data:application/pdf;base64,abc'},
+    ]
+    assert payload['tools'] == [{'type': 'web_search'}]
 
 
 def test_streaming_response_id_is_not_consumed_when_stateful_mode_is_disabled(responses_state):
@@ -190,3 +559,21 @@ def test_non_streaming_function_call_remains_available_for_processing(responses_
     assert result['response_id'] == 'resp_tool'
     assert result['choices'][0]['message']['content'] == ''
     assert result['output'] == [function_call]
+
+
+def test_non_streaming_incomplete_response_preserves_native_state(responses_state):
+    details = {'reason': 'max_output_tokens'}
+
+    result = responses_state.convert_responses_result(
+        {
+            'id': 'resp_incomplete',
+            'model': 'hermes',
+            'status': 'incomplete',
+            'incomplete_details': details,
+            'output': [],
+        }
+    )
+
+    assert result['response_status'] == 'incomplete'
+    assert result['incomplete_details'] == details
+    assert result['choices'][0]['finish_reason'] == 'incomplete'

--- a/test/test_responses_stateful.py
+++ b/test/test_responses_stateful.py
@@ -1,0 +1,192 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(scope='module')
+def responses_state():
+    """Load the dependency-free production module without booting OpenWebUI."""
+    source = Path(__file__).parents[1] / 'backend/open_webui/utils/responses_state.py'
+    spec = importlib.util.spec_from_file_location('open_webui_responses_state', source)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_response_id_follows_the_selected_branch(responses_state):
+    messages = {
+        'assistant-a': {'role': 'assistant', 'model': 'hermes', 'responseId': 'resp_branch_a'},
+        'assistant-b': {'role': 'assistant', 'model': 'hermes', 'responseId': 'resp_branch_b'},
+        'user-a': {'role': 'user', 'parentId': 'assistant-a'},
+        'user-b': {'role': 'user', 'parentId': 'assistant-b'},
+    }
+
+    assert responses_state.get_stateful_response_id(messages, 'user-a', 'hermes') == 'resp_branch_a'
+    assert responses_state.get_stateful_response_id(messages, 'user-b', 'hermes') == 'resp_branch_b'
+
+
+def test_response_id_accepts_normalized_database_key(responses_state):
+    messages = {
+        'assistant': {'role': 'assistant', 'model': 'hermes', 'response_id': 'resp_from_database'},
+        'user': {'role': 'user', 'parentId': 'assistant'},
+    }
+
+    assert responses_state.get_stateful_response_id(messages, 'user', 'hermes') == 'resp_from_database'
+
+
+def test_response_id_is_not_reused_after_model_switch(responses_state):
+    messages = {
+        'assistant': {'role': 'assistant', 'model': 'hermes', 'responseId': 'resp_hermes'},
+        'user': {'role': 'user', 'parentId': 'assistant'},
+    }
+
+    assert responses_state.get_stateful_response_id(messages, 'user', 'other-model') is None
+
+
+@pytest.mark.parametrize(
+    ('messages', 'user_message_id'),
+    [
+        ({}, 'user'),
+        ({'user': {'role': 'assistant'}}, 'user'),
+        ({'user': {'role': 'user', 'parentId': 'missing'}}, 'user'),
+        ({'assistant': {'role': 'user'}, 'user': {'role': 'user', 'parentId': 'assistant'}}, 'user'),
+        (
+            {
+                'assistant': {'role': 'assistant', 'model': 'hermes'},
+                'user': {'role': 'user', 'parentId': 'assistant'},
+            },
+            'user',
+        ),
+    ],
+)
+def test_response_id_rejects_incomplete_message_chains(responses_state, messages, user_message_id):
+    assert responses_state.get_stateful_response_id(messages, user_message_id, 'hermes') is None
+
+
+def test_openai_connection_is_resolved_for_base_model_and_profile(responses_state):
+    models = {'hermes-base': {'urlIdx': 7}}
+
+    assert responses_state.get_openai_url_idx(models['hermes-base'], models) == 7
+    assert (
+        responses_state.get_openai_url_idx(
+            {'id': 'hermes-profile', 'info': {'base_model_id': 'hermes-base'}},
+            models,
+        )
+        == 7
+    )
+
+
+def test_openai_connection_rejects_models_without_a_connection(responses_state):
+    assert responses_state.get_openai_url_idx({}, {}) is None
+    assert responses_state.get_openai_url_idx({'info': {'base_model_id': 'missing'}}, {}) is None
+
+
+def test_responses_payload_keeps_anchor_and_enables_storage(responses_state):
+    payload = {
+        'messages': [{'role': 'user', 'content': 'Next turn'}],
+        'previous_response_id': 'resp_hermes_1',
+    }
+
+    result = responses_state.apply_responses_stateful_payload(payload, is_responses=True, enabled=True)
+
+    assert result['previous_response_id'] == 'resp_hermes_1'
+    assert result['store'] is True
+
+
+def test_chat_completions_payload_drops_stateful_anchor(responses_state):
+    payload = {
+        'messages': [{'role': 'user', 'content': 'Next turn'}],
+        'previous_response_id': 'resp_from_old_connection',
+    }
+
+    result = responses_state.apply_responses_stateful_payload(payload, is_responses=False, enabled=True)
+
+    assert 'previous_response_id' not in result
+    assert 'store' not in result
+
+
+def test_disabled_stateful_mode_does_not_force_storage(responses_state):
+    payload = {'messages': [{'role': 'user', 'content': 'Next turn'}]}
+
+    result = responses_state.apply_responses_stateful_payload(payload, is_responses=True, enabled=False)
+
+    assert 'store' not in result
+
+
+def test_stateful_messages_keep_system_and_current_user_only(responses_state):
+    system = {'role': 'system', 'content': 'Instructions'}
+    current_user = {'role': 'user', 'content': 'Current'}
+    messages = [
+        system,
+        {'role': 'user', 'content': 'Previous'},
+        {'role': 'assistant', 'content': 'Previous answer'},
+        current_user,
+    ]
+
+    assert responses_state.trim_stateful_messages(messages) == [system, current_user]
+
+
+def test_guided_regeneration_keeps_original_and_regeneration_prompts(responses_state):
+    original = {'role': 'user', 'content': 'Original'}
+    regeneration = {'role': 'user', 'content': 'Try another way'}
+
+    assert responses_state.trim_stateful_messages(
+        [original, {'role': 'assistant', 'content': 'Old answer'}, regeneration],
+        regeneration=True,
+    ) == [original, regeneration]
+
+
+def test_streaming_completion_metadata_exposes_response_id(responses_state):
+    usage = {'input_tokens': 10, 'output_tokens': 4}
+
+    metadata = responses_state.get_completed_response_metadata({'id': 'resp_stream', 'usage': usage})
+
+    assert metadata == {'usage': usage, 'done': True, 'response_id': 'resp_stream'}
+    assert responses_state.pop_stateful_response_id(metadata, enabled=True) == 'resp_stream'
+    assert metadata == {'usage': usage, 'done': True}
+
+
+def test_streaming_response_id_is_not_consumed_when_stateful_mode_is_disabled(responses_state):
+    metadata = {'done': True, 'response_id': 'resp_stream'}
+
+    assert responses_state.pop_stateful_response_id(metadata, enabled=False) is None
+    assert metadata['response_id'] == 'resp_stream'
+
+
+def test_non_streaming_response_preserves_text_and_response_id(responses_state):
+    result = responses_state.convert_responses_result(
+        {
+            'id': 'resp_non_stream',
+            'model': 'hermes',
+            'output': [
+                {
+                    'type': 'message',
+                    'content': [
+                        {'type': 'output_text', 'text': 'Hello '},
+                        {'type': 'output_text', 'text': 'world'},
+                    ],
+                }
+            ],
+            'usage': {'input_tokens': 2, 'output_tokens': 2},
+        }
+    )
+
+    assert result['response_id'] == 'resp_non_stream'
+    assert result['choices'][0]['message']['content'] == 'Hello world'
+    assert result['output'][0]['type'] == 'message'
+
+
+def test_non_streaming_function_call_remains_available_for_processing(responses_state):
+    function_call = {
+        'type': 'function_call',
+        'call_id': 'call_1',
+        'name': 'terminal',
+        'arguments': '{}',
+    }
+
+    result = responses_state.convert_responses_result({'id': 'resp_tool', 'model': 'hermes', 'output': [function_call]})
+
+    assert result['response_id'] == 'resp_tool'
+    assert result['choices'][0]['message']['content'] == ''
+    assert result['output'] == [function_call]

--- a/test/test_responses_stateful_storage.py
+++ b/test/test_responses_stateful_storage.py
@@ -70,6 +70,8 @@ async def chat_message_table(chat_messages_module, monkeypatch):
                 output JSON,
                 model_id TEXT,
                 response_id TEXT,
+                response_status TEXT,
+                incomplete_details JSON,
                 files JSON,
                 sources JSON,
                 embeds JSON,
@@ -110,12 +112,16 @@ async def test_response_id_round_trip_through_normalized_message_table(chat_mess
             'role': 'assistant',
             'model': 'hermes',
             'responseId': 'resp_first',
+            'responseStatus': 'incomplete',
+            'incompleteDetails': {'reason': 'max_output_tokens'},
             'content': 'First response',
         },
     )
 
     messages = await chat_message_table.get_messages_map_by_chat_id('chat-1')
     assert messages['assistant-1']['responseId'] == 'resp_first'
+    assert messages['assistant-1']['responseStatus'] == 'incomplete'
+    assert messages['assistant-1']['incompleteDetails'] == {'reason': 'max_output_tokens'}
     assert 'response_id' not in messages['assistant-1']
 
     await chat_message_table.upsert_message(
@@ -194,6 +200,18 @@ def load_response_id_migration(monkeypatch):
     return module
 
 
+def load_response_status_migration(monkeypatch):
+    alembic_module = types.ModuleType('alembic')
+    alembic_module.op = None
+    monkeypatch.setitem(sys.modules, 'alembic', alembic_module)
+
+    source = ROOT / 'backend/open_webui/migrations/versions/f7d8e9a0b1c2_add_responses_status_to_chat_message.py'
+    spec = importlib.util.spec_from_file_location('open_webui_test_response_status_migration', source)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
 def test_response_id_migration_adds_backfills_and_drops_column(monkeypatch):
     engine = sa.create_engine('sqlite:///:memory:')
     metadata = sa.MetaData()
@@ -256,5 +274,43 @@ def test_response_id_migration_adds_backfills_and_drops_column(monkeypatch):
 
         migration.downgrade()
         assert 'response_id' not in {column['name'] for column in sa.inspect(connection).get_columns('chat_message')}
+
+    engine.dispose()
+
+
+def test_response_status_migration_adds_and_drops_columns(monkeypatch):
+    engine = sa.create_engine('sqlite:///:memory:')
+    metadata = sa.MetaData()
+    sa.Table(
+        'chat_message',
+        metadata,
+        sa.Column('id', sa.Text(), primary_key=True),
+        sa.Column('response_id', sa.Text()),
+    )
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        migration = load_response_status_migration(monkeypatch)
+
+        class MigrationOperations:
+            @staticmethod
+            def add_column(table_name, column):
+                column_type = 'JSON' if isinstance(column.type, sa.JSON) else 'TEXT'
+                connection.execute(sa.text(f'ALTER TABLE {table_name} ADD COLUMN {column.name} {column_type}'))
+
+            @staticmethod
+            def drop_column(table_name, column_name):
+                connection.execute(sa.text(f'ALTER TABLE {table_name} DROP COLUMN {column_name}'))
+
+        migration.op = MigrationOperations
+        migration.upgrade()
+        assert {'response_status', 'incomplete_details'} <= {
+            column['name'] for column in sa.inspect(connection).get_columns('chat_message')
+        }
+
+        migration.downgrade()
+        assert {'response_status', 'incomplete_details'}.isdisjoint(
+            column['name'] for column in sa.inspect(connection).get_columns('chat_message')
+        )
 
     engine.dispose()

--- a/test/test_responses_stateful_storage.py
+++ b/test/test_responses_stateful_storage.py
@@ -1,0 +1,260 @@
+import importlib.util
+import json
+import sys
+import types
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.orm import declarative_base
+
+ROOT = Path(__file__).parents[1]
+
+
+@pytest.fixture(scope='module')
+def responses_state_module():
+    source = ROOT / 'backend/open_webui/utils/responses_state.py'
+    spec = importlib.util.spec_from_file_location('open_webui_storage_test_responses_state', source)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def chat_messages_module(monkeypatch):
+    database_module = types.ModuleType('open_webui.internal.db')
+    database_module.Base = declarative_base()
+    sa.Table(
+        'chat',
+        database_module.Base.metadata,
+        sa.Column('id', sa.Text(), primary_key=True),
+    )
+
+    @asynccontextmanager
+    async def unavailable_database_context(*_args, **_kwargs):
+        raise RuntimeError('Test database context has not been installed')
+        yield
+
+    database_module.get_async_db_context = unavailable_database_context
+
+    response_module = types.ModuleType('open_webui.utils.response')
+    response_module.normalize_usage = lambda value: value
+    response_module.merge_usage = lambda existing, new: {**(existing or {}), **(new or {})}
+
+    monkeypatch.setitem(sys.modules, 'open_webui.internal.db', database_module)
+    monkeypatch.setitem(sys.modules, 'open_webui.utils.response', response_module)
+
+    source = ROOT / 'backend/open_webui/models/chat_messages.py'
+    spec = importlib.util.spec_from_file_location('open_webui_test_chat_messages', source)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest_asyncio.fixture
+async def chat_message_table(chat_messages_module, monkeypatch):
+    engine = create_async_engine('sqlite+aiosqlite:///:memory:')
+    async with engine.begin() as connection:
+        await connection.exec_driver_sql(
+            """
+            CREATE TABLE chat_message (
+                id TEXT PRIMARY KEY,
+                chat_id TEXT NOT NULL,
+                user_id TEXT,
+                role TEXT NOT NULL,
+                parent_id TEXT,
+                content JSON,
+                output JSON,
+                model_id TEXT,
+                response_id TEXT,
+                files JSON,
+                sources JSON,
+                embeds JSON,
+                meta JSON,
+                done BOOLEAN,
+                status_history JSON,
+                error JSON,
+                usage JSON,
+                context_summary TEXT,
+                created_at BIGINT,
+                updated_at BIGINT
+            )
+            """
+        )
+
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+
+    @asynccontextmanager
+    async def database_context(session=None):
+        if session is not None:
+            yield session
+            return
+        async with session_factory() as created_session:
+            yield created_session
+
+    monkeypatch.setattr(chat_messages_module, 'get_async_db_context', database_context)
+    yield chat_messages_module.ChatMessageTable()
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_response_id_round_trip_through_normalized_message_table(chat_message_table):
+    await chat_message_table.upsert_message(
+        message_id='assistant-1',
+        chat_id='chat-1',
+        user_id='user-1',
+        data={
+            'role': 'assistant',
+            'model': 'hermes',
+            'responseId': 'resp_first',
+            'content': 'First response',
+        },
+    )
+
+    messages = await chat_message_table.get_messages_map_by_chat_id('chat-1')
+    assert messages['assistant-1']['responseId'] == 'resp_first'
+    assert 'response_id' not in messages['assistant-1']
+
+    await chat_message_table.upsert_message(
+        message_id='assistant-1',
+        chat_id='chat-1',
+        user_id='user-1',
+        data={'response_id': 'resp_second'},
+    )
+
+    messages = await chat_message_table.get_messages_map_by_chat_id('chat-1')
+    assert messages['assistant-1']['responseId'] == 'resp_second'
+
+
+@pytest.mark.asyncio
+async def test_next_turn_uses_persisted_response_id_without_replaying_history(
+    chat_message_table,
+    responses_state_module,
+):
+    await chat_message_table.upsert_messages(
+        chat_id='chat-2',
+        user_id='user-1',
+        messages={
+            'user-1': {
+                'role': 'user',
+                'content': 'First question',
+            },
+            'assistant-1': {
+                'role': 'assistant',
+                'parentId': 'user-1',
+                'model': 'hermes',
+                'responseId': 'resp_previous',
+                'content': 'First answer',
+            },
+            'user-2': {
+                'role': 'user',
+                'parentId': 'assistant-1',
+                'content': 'Follow-up question',
+            },
+        },
+    )
+
+    messages = await chat_message_table.get_messages_map_by_chat_id('chat-2')
+    response_id = responses_state_module.get_stateful_response_id(messages, 'user-2', 'hermes')
+    replay = [
+        {'role': 'system', 'content': 'Managed instructions'},
+        messages['user-1'],
+        messages['assistant-1'],
+        messages['user-2'],
+    ]
+    payload = responses_state_module.apply_responses_stateful_payload(
+        {
+            'messages': responses_state_module.trim_stateful_messages(replay),
+            'previous_response_id': response_id,
+        },
+        is_responses=True,
+        enabled=True,
+    )
+
+    assert payload['previous_response_id'] == 'resp_previous'
+    assert payload['store'] is True
+    assert [message['content'] for message in payload['messages']] == [
+        'Managed instructions',
+        'Follow-up question',
+    ]
+
+
+def load_response_id_migration(monkeypatch):
+    alembic_module = types.ModuleType('alembic')
+    alembic_module.op = None
+    monkeypatch.setitem(sys.modules, 'alembic', alembic_module)
+
+    source = ROOT / 'backend/open_webui/migrations/versions/e2a43c7819b6_add_response_id_to_chat_message.py'
+    spec = importlib.util.spec_from_file_location('open_webui_test_response_id_migration', source)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_response_id_migration_adds_backfills_and_drops_column(monkeypatch):
+    engine = sa.create_engine('sqlite:///:memory:')
+    metadata = sa.MetaData()
+    chat = sa.Table(
+        'chat',
+        metadata,
+        sa.Column('id', sa.Text(), primary_key=True),
+        sa.Column('chat', sa.JSON()),
+    )
+    chat_message = sa.Table(
+        'chat_message',
+        metadata,
+        sa.Column('id', sa.Text(), primary_key=True),
+    )
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        connection.execute(
+            chat.insert(),
+            [
+                {
+                    'id': 'chat-1',
+                    'chat': {
+                        'history': {
+                            'messages': {
+                                'assistant-1': {'role': 'assistant', 'responseId': 'resp_existing'},
+                                'user-1': {'role': 'user'},
+                            }
+                        }
+                    },
+                },
+                {'id': 'chat-invalid', 'chat': json.dumps({'history': {'messages': []}})},
+            ],
+        )
+        connection.execute(chat_message.insert(), {'id': 'chat-1-assistant-1'})
+
+        migration = load_response_id_migration(monkeypatch)
+
+        class MigrationOperations:
+            @staticmethod
+            def get_bind():
+                return connection
+
+            @staticmethod
+            def add_column(table_name, column):
+                connection.execute(sa.text(f'ALTER TABLE {table_name} ADD COLUMN {column.name} TEXT'))
+
+            @staticmethod
+            def drop_column(table_name, column_name):
+                connection.execute(sa.text(f'ALTER TABLE {table_name} DROP COLUMN {column_name}'))
+
+        migration.op = MigrationOperations
+        migration.upgrade()
+
+        reflected = sa.Table('chat_message', sa.MetaData(), autoload_with=connection)
+        response_id = connection.execute(
+            sa.select(reflected.c.response_id).where(reflected.c.id == 'chat-1-assistant-1')
+        ).scalar_one()
+        assert response_id == 'resp_existing'
+
+        migration.downgrade()
+        assert 'response_id' not in {column['name'] for column in sa.inspect(connection).get_columns('chat_message')}
+
+    engine.dispose()


### PR DESCRIPTION
# Pull Request

Thanks for wanting to improve Open WebUI. The most useful contribution is usually a clear, well-written Issue, not an unsolicited code pull request.

Open a code pull request only when a maintainer asks for one, or when the change is only i18n/localization. For real, reproducible bugs, start with a well-described [Issue](https://github.com/open-webui/open-webui/issues). For feature requests, UI/UX changes, behavior changes, architecture changes, suspected fixes, or unconfirmed approaches, start with an active [Discussion](https://github.com/open-webui/open-webui/discussions).

Before continuing, make sure the linked Issue or Discussion explains the user-facing problem, the expected outcome, the affected workflow, and any examples, logs, screenshots, constraints, or reproduction details needed for maintainers to evaluate it.

If you have implementation notes, include them as reference in the Issue or Discussion. If you want to share code as reference, include it there as a local diff, patch, or branch note. Do not open a pull request for reference code.

Unsolicited PRs may be closed without review, especially when they introduce product, architecture, compatibility, dependency, or maintenance decisions that have not been discussed.

## Checklist

- [x] This PR targets the `dev` branch.
- [x] This PR links to a well-described, confirmed Issue or active Discussion: Relates to #27150 #27096 #24855.
- [ ] A maintainer explicitly asked me to open this PR, or this PR only updates i18n/localization.
- [x] The change is one logical unit with no unrelated commits.
- [x] I matched nearby code patterns and avoided unnecessary new settings, abstractions, or dependencies.
- [x] I manually tested the changed workflow and nearby behavior that could be affected.
- [ ] I updated relevant documentation.
- [x] Screenshots are not applicable because this PR contains no UI changes.
- [x] I reviewed any AI-generated code before submitting it.
- [x] The PR title uses one of the prefixes listed below.

## Summary

This PR adds persistent conversation state for OpenAI-compatible connections configured to use the Responses API.

Open WebUI now stores each completed upstream Responses API `response_id` on the corresponding assistant message. When the user continues a saved chat branch, Open WebUI sends the selected parent response as `previous_response_id` instead of replaying the complete conversation history.

The implementation:

- Resolves the response anchor from the currently selected chat branch.
- Prevents response IDs from being reused after switching models.
- Enables upstream response storage when stateful Responses mode is enabled.
- Sends only the current user input and current instructions when the preceding conversation is already represented by an upstream response anchor.
- Continues tool-call turns using only new `function_call_output` items.
- Preserves native Responses API input and output items.
- Preserves response lifecycle states and incomplete-response details.
- Supports both streaming and non-streaming responses.
- Persists `response_id`, `response_status`, and `incomplete_details` in normalized chat-message storage.
- Migrates response IDs previously stored only in legacy chat JSON.
- Preserves failed, cancelled, and incomplete response metadata instead of treating every response as completed.

The behavior is gated by `ENABLE_RESPONSES_API_STATEFUL` and applies only to connections whose API type is configured as `responses`.

## Testing

Added targeted tests covering:

- Branch-aware response ID selection.
- Model-switch isolation.
- Missing and incomplete response chains.
- Base-model and custom-model connection resolution.
- `previous_response_id` and `conversation` validation.
- Stateful history trimming and guided regeneration.
- Streaming lifecycle events.
- Non-streaming Responses API conversion.
- Tool-call continuation using `function_call_output`.
- Native input items, built-in tools, structured output, and stream options.
- Persistence and retrieval through normalized chat-message storage.
- Migration upgrade, backfill, and downgrade behavior.

Executed the targeted test suite:

```bash
uv run pytest -q \
  test/test_responses_stateful.py \
  test/test_responses_stateful_storage.py
```

Result:

```text
44 passed
```

Additional checks:

- Ruff checks passed for all newly added Python modules and tests.
- All eight changed Python files pass `ruff format --check`.
- `git diff --check` passed.
- The stateful workflow was manually verified with streaming enabled.

## Changelog Entry

### Added

- Persistent Responses API state through `previous_response_id`.
- Normalized storage for response IDs, response statuses, and incomplete-response details.
- Database migrations that preserve existing response IDs from legacy chat data.
- Tests for stateful streaming, non-streaming, tool continuation, persistence, and migrations.

### Changed

- Saved Responses API conversations now continue from the selected upstream response instead of replaying the entire local transcript.
- Tool continuations send only newly produced function outputs when an upstream response anchor is available.
- Responses payload conversion now preserves supported native fields and lifecycle metadata.

### Fixed

- Duplicate conversation history being sent during stateful Responses API turns.
- Conversation state being lost between messages after normalized chat-message storage is enabled.
- Incorrect response reuse across chat branches or model changes.
- Failed and incomplete Responses API calls being persisted as completed responses.
- Non-streaming Responses API results losing native output and response metadata.

### Removed

- None.

### Security

- Response IDs are scoped to the selected saved-chat branch and matching model.
- OpenWebUI-only output fields are removed before native response items are sent upstream.
- Stored upstream responses remain subject to the configured provider's data-retention policy.

### Breaking Changes

- None. Stateful behavior is opt-in through `ENABLE_RESPONSES_API_STATEFUL`.

## Additional Context

This change requires a Responses API provider that supports stored responses and `previous_response_id`.

Two Alembic migrations are included:

1. Add `response_id` and backfill values previously stored in legacy chat JSON.
2. Add `response_status` and `incomplete_details`.

Connections using Chat Completions are unaffected. Responses connections retain the existing stateless behavior while `ENABLE_RESPONSES_API_STATEFUL` is disabled.

Relates to #27150 #27096 #24855

## Contributor License Agreement

<!--
DO NOT DELETE THIS SECTION.
Your PR will not be reviewed or merged until you check the box below confirming that you have read and agree to the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.