### PR TITLE
fix: remove the stray background band from the Attach Webpage modal footer

### DIFF
--- a/src/lib/components/chat/MessageInput/AttachWebpageModal.svelte
+++ b/src/lib/components/chat/MessageInput/AttachWebpageModal.svelte
@@ -80,7 +80,7 @@
 					required
 				/>
 
-				<div class="flex justify-end gap-2 pt-3 bg-gray-50 dark:bg-gray-900/50">
+				<div class="flex justify-end gap-2 pt-3">
 					<button
 						class="px-3.5 py-1.5 text-sm font-normal bg-black hover:bg-gray-800 text-white dark:bg-white dark:text-black dark:hover:bg-gray-200 transition rounded-full"
 						type="submit"


### PR DESCRIPTION
# Pull Request

## Checklist

- [x] This PR targets the `dev` branch.
- [x] This PR links to a well-described, confirmed Issue or active Discussion: `Closes #29663`.
- [ ] A maintainer explicitly asked me to open this PR, or this PR only updates i18n/localization.
- [x] The change is one logical unit with no unrelated commits.
- [x] I matched nearby code patterns and avoided unnecessary new settings, abstractions, or dependencies.
- [x] I manually tested the changed workflow and any nearby behavior that could be affected.
- [ ] I updated relevant docs, including the [Open WebUI Docs Repository](https://github.com/open-webui/docs), if needed.
- [ ] I added screenshots for UI changes, and a recording when motion or interaction matters.
- [x] I reviewed any AI-generated code before submitting it.
- [x] The PR title uses one of the prefixes listed below.

## Summary

The Attach Webpage modal draws a grey band between the URL box and the `Add` button. Reported in #29663. The row holding the button carries its own background:

```diff
-	<div class="flex justify-end gap-2 pt-3 bg-gray-50 dark:bg-gray-900/50">
+	<div class="flex justify-end gap-2 pt-3">
```

That row is the only modal button row in `src/lib/components` with a background. Of the 38 `justify-end` rows across the modal components, the other 37 sit directly on the modal surface, including the one in `InputVariablesModal.svelte` next door. The classes have been on this line since the modal was introduced in 2a95cbc. In dark mode, they paint gray-900 at half opacity on a gray-900 surface, which is invisible. The band therefore only shows on the Light theme, or under a theme that recolours the modal.

Removing the two classes makes the row match every other modal footer. Nothing else in the modal changes.

## Testing

I tested this locally on the branch on the Light and Dark themes and with a custom theme applied. The band is gone in all three and the `Add` button sits on the modal background.

Mechanical checks, run at my direction with AI copilot assistance:

| Check | Result |
|---|---|
| `npm run build` | exit 0 |
| `npx vitest run` | 2 files, 8 tests, passing |
| `npx prettier --check` on the changed file | already formatted |
| Added code comments, Svelte 5 runes | none |

## Changelog Entry

### Fixed

- The Attach Webpage modal no longer shows a stray background band behind the `Add` button.

## Screenshots

| Theme | Before | After |
|---|---|---|
| Light |<img width="600" height="238" alt="image" src="https://github.com/user-attachments/assets/12f9d6ea-14b7-4a57-9ead-be461fb06af2" /> | <img width="600" height="238" alt="image" src="https://github.com/user-attachments/assets/06327120-12bb-43e7-80a9-9c9eca716461" /> |

## Additional Context

This PR was prepared with AI copilot assistance. I have thoroughly reviewed it.

## Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
