### PR TITLE
fix: delegate Local Network Access permission to the Pyodide sandbox iframe

### DIFF
--- a/src/lib/pyodide/pyodideSandboxHost.ts
+++ b/src/lib/pyodide/pyodideSandboxHost.ts
@@ -209,6 +209,10 @@ export class PyodideSandboxHost {
 	constructor() {
 		this.iframe = document.createElement('iframe');
 		this.iframe.setAttribute('sandbox', 'allow-scripts');
+		this.iframe.setAttribute(
+			'allow',
+			'local-network-access; local-network; loopback-network'
+		);
 		this.iframe.setAttribute('aria-hidden', 'true');
 		this.iframe.setAttribute('title', 'pyodide-sandbox');
 		this.iframe.style.display = 'none';


### PR DESCRIPTION
## Checklist

- [x] This PR targets the `dev` branch.
- [x] This PR links to a well-described, confirmed Issue or active Discussion: `Fixes #29671`.
- [ ] A maintainer explicitly asked me to open this PR, or this PR only updates i18n/localization.
- [x] The change is one logical unit with no unrelated commits.
- [x] I matched nearby code patterns and avoided unnecessary new settings, abstractions, or dependencies.
- [x] I manually tested the changed workflow and any nearby behavior that could be affected.
- [x] I updated relevant docs, including the [Open WebUI Docs Repository](https://github.com/open-webui/docs), if needed. (No docs change needed — restores previously-working behavior.)
- [x] I added screenshots for UI changes, and a recording when motion or interaction matters. (N/A — no UI change.)
- [x] I reviewed any AI-generated code before submitting it.
- [x] The PR title uses one of the prefixes listed below: `fix`.

## Summary

When Open WebUI is served from a **public HTTPS origin** (e.g. Cloud Run `*.run.app`), user code in the Pyodide code interpreter can no longer fetch services on the user's own machine (`http://127.0.0.1` / `http://localhost`). Chrome's Local Network Access (LNA) permission blocks public→loopback fetches unless the embedder **delegates** the permission to the executing context — and the Pyodide sandbox iframe (`sandbox="allow-scripts"`, opaque origin `null`) can never match the permission's default allowlist `'self'`, even after the user grants "Allow local network" to the top-level site. Localhost- and LAN-hosted instances are unaffected (Chromium only gates public→local/loopback today), so this only reproduces on public-origin deployments.

Fix: delegate the LNA permissions to the iframe via the Permissions-Policy `allow` attribute — `local-network-access` (legacy alias) plus `local-network` and `loopback-network` (current fine-grained names) for browser compatibility. Delegation does not bypass the top-level LNA user consent; it only lets the iframe participate in it.

Fixes #29671

## Testing

- Public-origin (Cloud Run `*.run.app`) Open WebUI 0.11.3, model with Code Interpreter (Pyodide engine), companion HTTP service on `127.0.0.1:8765`: `pyfetch("http://127.0.0.1:8765/health")` **fails 100%** before the change (request blocked by LNA; granting the site-level "Allow local network" permission does not help), **succeeds 100%** after adding the `allow` attribute to the built bundle. Verified end-to-end over multiple runs.
- Localhost-hosted instance (127.0.0.1) unaffected before and after — no regression (loopback→loopback is not gated by LNA).
- `pyodideSandboxHost.ts` is byte-identical from 0.10.2 through current `dev`/`main`, so the same verification covers all recent versions.

## Changelog Entry

### Added

-

### Changed

-

### Fixed

- Pyodide code interpreter: user code can reach `127.0.0.1`/`localhost` services again when Open WebUI is served from a public HTTPS origin (delegate Local Network Access permission to the sandbox iframe).

### Removed

-

### Security

-

### Breaking Changes

-

## Additional Context

- Spec references: [WICG Local Network Access](https://wicg.github.io/local-network-access/) — §2.6 defines `local-network`/`loopback-network` as policy-controlled features with default allowlist `'self'`; §3.1 rejects fetches whose client document is not *allowed to use* the permission (an opaque-origin iframe never is, without embedder delegation); §2.2 note explains why non-public-hosted instances are exempt today.
- The `enable_pyodide_file_persistence` worker path is unaffected (the worker runs on the page's own origin and inherits the document's permissions).
- Opened without a maintainer request: the issue contains the full analysis, this PR is the trivial 4-line fix for it (single `setAttribute` call). Happy to close it if maintainers prefer to handle it from the issue — the patch applies as-is either way.

## Contributor License Agreement

<!--
DO NOT DELETE THIS SECTION.
Your PR will not be reviewed or merged until you check the box below confirming that you have read and agree to the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
