### PR TITLE
fix: stop ask_user cutting off long questions, labels and descriptions

### DIFF
--- a/backend/open_webui/tools/builtin.py
+++ b/backend/open_webui/tools/builtin.py
@@ -64,6 +64,7 @@ from open_webui.routers.retrieval import search_web as _search_web
 from open_webui.socket.main import sio
 from open_webui.tasks import stop_item_tasks
 from open_webui.tools.knowledge_fs import kb_exec  # noqa: F401 — re-exported
+from open_webui.utils.ask_user import normalize_ask_user_request
 from open_webui.utils.chat_id import is_saved_chat_id
 from open_webui.utils.json_codec import JSONCodec
 from open_webui.utils.notifications import notify_target
@@ -525,64 +526,15 @@ async def ask_user(
     Use this when the next step depends on user intent, preference, or a tradeoff that cannot be inferred safely.
 
     :param questions: 1-3 question objects, each with id, header, question, and 2-3 options. Each option needs label and description.
+        Longer text is rejected. Character limits: id 64, header 48, question 500, label 80, description 240.
     :param allow_other: Whether users may enter a free-form answer instead of choosing one of the options
     :param timeout_ms: How long the browser should keep the prompt open before cancelling it
     :return: JSON with status and answers keyed by question id
     """
     try:
-        if not isinstance(questions, list) or not 1 <= len(questions) <= 3:
-            raise ValueError('ask_user requires 1-3 questions.')
-
-        normalized_questions = []
-        seen_ids = set()
-        for index, question in enumerate(questions):
-            if not isinstance(question, dict):
-                raise ValueError('Each question must be an object.')
-
-            question_id = str(question.get('id') or '').strip()[:64]
-            if not question_id:
-                raise ValueError('Each question requires a non-empty id.')
-            if question_id in seen_ids:
-                raise ValueError(f'Duplicate question id: {question_id}')
-            seen_ids.add(question_id)
-
-            options = question.get('options')
-            if not isinstance(options, list) or not 2 <= len(options) <= 3:
-                raise ValueError('Each question requires 2-3 options.')
-
-            normalized_options = []
-            for option in options:
-                if not isinstance(option, dict):
-                    raise ValueError('Each option must be an object.')
-
-                label = str(option.get('label') or '').strip()[:80]
-                description = str(option.get('description') or '').strip()[:240]
-                if not label or not description:
-                    raise ValueError('Each option requires a label and description.')
-
-                normalized_options.append(
-                    {
-                        'label': label,
-                        'description': description,
-                    }
-                )
-
-            question_text = str(question.get('question') or '').strip()[:500]
-            if not question_text:
-                raise ValueError('Each question requires question text.')
-
-            normalized_questions.append(
-                {
-                    'id': question_id,
-                    'header': str(question.get('header') or '').strip()[:48] or f'Question {index + 1}',
-                    'question': question_text,
-                    'options': normalized_options,
-                    'allow_other': bool(question.get('allow_other', allow_other)),
-                }
-            )
-
-        if isinstance(timeout_ms, bool) or not isinstance(timeout_ms, int) or not 60_000 <= timeout_ms <= 240_000:
-            timeout_ms = 120_000
+        request = normalize_ask_user_request(
+            {'questions': questions, 'allow_other': allow_other, 'timeout_ms': timeout_ms}
+        )
 
         if __event_call__ is None:
             return JSONCodec.dumps(
@@ -593,16 +545,7 @@ async def ask_user(
                 ensure_ascii=False,
             )
 
-        output = await __event_call__(
-            {
-                'type': 'request:user_input',
-                'data': {
-                    'questions': normalized_questions,
-                    'allow_other': allow_other,
-                    'timeout_ms': timeout_ms,
-                },
-            }
-        )
+        output = await __event_call__({'type': 'request:user_input', 'data': request})
 
         if not isinstance(output, dict):
             return JSONCodec.dumps({'status': 'error', 'error': 'Invalid user input response.'}, ensure_ascii=False)

--- a/backend/open_webui/utils/ask_user.py
+++ b/backend/open_webui/utils/ask_user.py
@@ -34,12 +34,18 @@ def normalize_ask_user_request(arguments: dict) -> dict:
         if not isinstance(question, dict):
             raise ValueError('Each question must be an object.')
 
-        question_id = str(question.get('id') or '').strip()[:64]
+        question_id = str(question.get('id') or '').strip()
         if not question_id:
             raise ValueError('Each question requires a non-empty id.')
+        if len(question_id) > 64:
+            raise ValueError('Each question id must be at most 64 characters.')
         if question_id in seen_ids:
             raise ValueError(f'Duplicate question id: {question_id}')
         seen_ids.add(question_id)
+
+        header = str(question.get('header') or '').strip()
+        if len(header) > 48:
+            raise ValueError('Each question header must be at most 48 characters.')
 
         options = question.get('options')
         if not isinstance(options, list) or not 2 <= len(options) <= 3:
@@ -49,20 +55,26 @@ def normalize_ask_user_request(arguments: dict) -> dict:
         for option in options:
             if not isinstance(option, dict):
                 raise ValueError('Each option must be an object.')
-            label = str(option.get('label') or '').strip()[:80]
-            description = str(option.get('description') or '').strip()[:240]
+            label = str(option.get('label') or '').strip()
+            description = str(option.get('description') or '').strip()
             if not label or not description:
                 raise ValueError('Each option requires a label and description.')
+            if len(label) > 80:
+                raise ValueError('Each option label must be at most 80 characters.')
+            if len(description) > 240:
+                raise ValueError('Each option description must be at most 240 characters.')
             normalized_options.append({'label': label, 'description': description})
 
-        question_text = str(question.get('question') or '').strip()[:500]
+        question_text = str(question.get('question') or '').strip()
         if not question_text:
             raise ValueError('Each question requires question text.')
+        if len(question_text) > 500:
+            raise ValueError('Each question text must be at most 500 characters.')
 
         normalized_questions.append(
             {
                 'id': question_id,
-                'header': str(question.get('header') or '').strip()[:48] or f'Question {index + 1}',
+                'header': header or f'Question {index + 1}',
                 'question': question_text,
                 'options': normalized_options,
                 'allow_other': bool(question.get('allow_other', allow_other)),

--- a/src/lib/components/chat/AskUserCard.svelte
+++ b/src/lib/components/chat/AskUserCard.svelte
@@ -207,7 +207,7 @@
 											: 'text-gray-700 hover:text-gray-950 dark:text-gray-300 dark:hover:text-white'}"
 										on:click={() => selectOption(question, option, optionIndex)}
 									>
-										<span class="min-w-0 shrink-0 text-xs">{option.label}</span>
+										<span class="max-w-[50%] text-xs">{option.label}</span>
 										<Tooltip
 											as="span"
 											className="min-w-0 flex-1"
@@ -215,7 +215,7 @@
 											placement="top-start"
 										>
 											<span
-												class="block truncate text-xs leading-relaxed text-gray-500 transition-colors group-hover:text-gray-700 dark:text-gray-400 dark:group-hover:text-gray-300"
+												class="line-clamp-2 text-xs leading-relaxed text-gray-500 transition-colors group-hover:text-gray-700 dark:text-gray-400 dark:group-hover:text-gray-300"
 											>
 												{option.description}
 											</span>


### PR DESCRIPTION
## Before / after

Same card, same data, on a local instance. "Before" is the two classes as they are on `dev`.

| | Before (`dev`) | After (this PR) |
|---|---|---|
| **Desktop** — three 240-character descriptions | <img width="3696" height="1180" alt="ask_user-before-desktop" src="https://github.com/user-attachments/assets/40d83845-7b3e-494a-b0db-6fcdc847df6d" /> <br> | <img width="3696" height="1412" alt="ask_user-after-desktop" src="https://github.com/user-attachments/assets/caebc18c-83e3-4c33-815d-9330f48ae294" /> <br>|
| **Desktop** — 78-character option label |<img width="3696" height="892" alt="ask_user-before-desktop-longlabel" src="https://github.com/user-attachments/assets/83bbb58c-770c-4eba-8bfd-d88b806b9043" /> <br>| <img width="3696" height="1044" alt="ask_user-after-desktop-longlabel" src="https://github.com/user-attachments/assets/aaf85796-6cdf-42d3-8db9-c12f77988441" /><br>|
| **Mobile, 420px** | <img width="1664" height="1492" alt="ask_user-before-mobile" src="https://github.com/user-attachments/assets/65e9cbcd-c09a-401a-a582-3f2071610410" /> <br>| <img width="1664" height="1724" alt="ask_user-after-mobile" src="https://github.com/user-attachments/assets/1acb80c2-4887-49bc-83b7-0e34da487e79" /><br>|

Descriptions go from one clipped line to two, a long label wraps within half the row instead of pushing the description out of it, and the 388-character question renders in full in every shot.

The ask_user card showed text that stopped mid-word. Question text, option labels and option descriptions written by the model were silently sliced to fixed lengths before they ever reached the browser, and the card then clipped every option description to a single line while a long label pushed the description out of its row entirely. Nothing told the user, or the model, that anything had been dropped.

Over-limit text is now rejected with an error naming the field and the limit, and the limits are stated in the tool description so the model writes text that fits on the first try. That matches how every other ask_user validation already behaves, and the model simply shortens and calls again instead of the user silently losing the tail of a sentence. The two copies of the normalizer, one in the builtin and one on the tool-call path, are collapsed into the single existing one so both paths enforce the same rule.

In the card, a long option label now wraps within half the row instead of squeezing the description to nothing, and descriptions render on two lines with the full text still in the hover tooltip. Leaving descriptions unclamped was tried and reverted: three options at the full 240 characters make the card 1596px tall at a 320px viewport.

Fixes #29563

## Contributor License Agreement

<!--
DO NOT DELETE THIS SECTION.
Your PR will not be reviewed or merged until you check the box below confirming that you have read and agree to the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
