### PR TITLE
feat: show the first follow-up as ghost text in the empty chat input

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -607,6 +607,15 @@ html.high-contrast.dark .ProseMirror p.is-editor-empty:first-child::before {
 	}
 }
 
+.ProseMirror p.is-editor-empty.ai-autocompletion:first-child::before {
+	content: attr(data-suggestion);
+	color: #a0a0a0;
+}
+
+.ProseMirror p.is-editor-empty.ai-autocompletion:first-child::after {
+	content: none;
+}
+
 .ai-autocompletion::after {
 	color: #a0a0a0;
 

--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -408,6 +408,22 @@
 		chatInputElement?.focus(options);
 	};
 
+	$: {
+		const lastMessage = history?.currentId ? history.messages[history.currentId] : null;
+		const followUp =
+			lastMessage?.role === 'assistant' && lastMessage?.done
+				? (lastMessage?.followUps ?? [])[0]
+				: null;
+
+		if (
+			$config?.features?.enable_autocomplete_generation &&
+			($settings?.promptAutocomplete ?? false) &&
+			($settings?.insertFollowUpPrompt ?? false)
+		) {
+			chatInputElement?.setSuggestion(prompt === '' && followUp ? followUp : '');
+		}
+	}
+
 	export const setText = async (text?: string, cb?: (text: string) => void) => {
 		const chatInput = document.getElementById('chat-input');
 

--- a/src/lib/components/common/RichTextInput.svelte
+++ b/src/lib/components/common/RichTextInput.svelte
@@ -520,6 +520,23 @@
 		focus();
 	};
 
+	export const setSuggestion = (text: string) => {
+		if (!editor || !editor.view) return;
+		const { state, dispatch } = editor.view;
+		const node = state.doc.firstChild;
+		if (!node || node.type.name !== 'paragraph' || state.doc.childCount !== 1) return;
+		if (node.textContent !== '') return;
+		if ((node.attrs['data-suggestion'] ?? null) === (text || null)) return;
+		dispatch(
+			state.tr.setNodeMarkup(0, null, {
+				...node.attrs,
+				class: text ? 'ai-autocompletion' : null,
+				'data-prompt': text ? '' : null,
+				'data-suggestion': text || null
+			})
+		);
+	};
+
 	export const insertContent = (content) => {
 		if (!editor || !editor.view) return;
 		const { state, view } = editor;

--- a/src/lib/components/common/RichTextInput/AutoCompletion.js
+++ b/src/lib/components/common/RichTextInput/AutoCompletion.js
@@ -274,7 +274,11 @@ export const AIAutocompletion = Extension.create({
 							// Iterate over all nodes in the document
 							const tr = state.tr;
 							state.doc.descendants((node, pos) => {
-								if (node.type.name === 'paragraph' && node.attrs['data-suggestion']) {
+								if (
+									node.type.name === 'paragraph' &&
+									node.attrs['data-suggestion'] &&
+									node.attrs['data-prompt']
+								) {
 									// Remove suggestion from this paragraph
 									tr.setNodeMarkup(pos, null, {
 										...node.attrs,


### PR DESCRIPTION
# Pull Request

## Checklist

- [x] This PR targets the `dev` branch.
- [x] This PR links to a well-described, confirmed Issue or active Discussion: `Closes #29668`.
- [ ] A maintainer explicitly asked me to open this PR, or this PR only updates i18n/localization.
- [x] The change is one logical unit with no unrelated commits.
- [x] I matched nearby code patterns and avoided unnecessary new settings, abstractions, or dependencies.
- [x] I manually tested the changed workflow and any nearby behavior that could be affected.
- [ ] I updated relevant docs, including the [Open WebUI Docs Repository](https://github.com/open-webui/docs), if needed.
- [ ] I added screenshots for UI changes, and a recording when motion or interaction matters.
- [x] I reviewed any AI-generated code before submitting it.
- [x] The PR title uses one of the prefixes listed below.

## Summary

After a reply finishes, its first follow-up now appears as grey ghost text in the empty chat input. `Tab` accepts it into the composer, typing replaces it, and clearing the field brings it back. It never sends on its own, and the `Follow up` list under the reply is unchanged. Requested in #29668.

No new model call, no new endpoint, no new setting. The follow-ups are the ones already generated for every reply, and the ghost text and `Tab` acceptance are the ones the autocompletion extension already provides. The feature is on only when two existing toggles are on, `Prompt Autocompletion` and `Insert Follow-Up Prompt to Input`. A `Tab` here is exactly an insert of a follow-up into the composer, with one key instead of a click, so those are the toggles that describe it.

## What changed

**`MessageInput.svelte`.** A reactive block watches the last message. When it is a finished assistant reply with follow-ups and the composer is empty, and both toggles are on, it hands the first follow-up to the input as a suggestion. When the composer has text, or there is nothing to suggest, it clears the suggestion instead. `history` is already reassigned when follow-ups arrive, so no new event is needed.

**`RichTextInput.svelte`.** The input gains one exported function, `setSuggestion`. It follows the pattern the input already uses to expose `setText` and `focus` to its parent. It acts only on a document that is a single empty paragraph. It sets the same three attributes the autocompletion extension already uses for a suggestion. It is a no-op when that suggestion is already set, so the reactive block cannot loop through the editor's `onUpdate`.

**`AutoCompletion.js`.** The `mouseup` handler clears every suggestion in the document. That is right for a typed suggestion whose caret may move, but it would have erased the ghost the moment the user clicked into the composer to focus it. It now skips a suggestion whose `data-prompt` is empty, which only the empty-field case produces. Typed suggestions clear on click as before. `Tab` acceptance, swipe-right acceptance and clearing on the next keypress are the existing extension code, untouched.

**`app.css`.** On an empty paragraph, the ghost is drawn through the placeholder's `::before` slot. That puts it on the caret's line and gives it the placeholder's float, absolute positioning and single-line clamp. The `::after` used for typed suggestions is suppressed in that state, so nothing draws twice. Without this rule, the ghost rendered a line below the caret. It came after the paragraph's trailing line break, and the placeholder showed underneath it.

## Testing

I tested this locally on the branch, with both toggles on:

- The first follow-up appears in the empty composer after a reply.
- `Tab` accepts it in place.
- Typing replaces it, and deleting back to empty brings it back.
- Clicking into the composer keeps it.
- Sending clears it until the next reply, and a new empty chat shows nothing.
- With either toggle off, nothing appears.
- A multi-model chat behaves the same with `Display Multi-model Responses in Tabs` on and off.

Mechanical checks, run at my direction with AI copilot assistance:

| Check | Result |
|---|---|
| `npm run build` | exit 0 |
| `npx vitest run` | 2 files, 8 tests, passing |
| `npx prettier --check` on the four changed files | already formatted |
| New `i18n.t` keys, new settings, new dependencies | none |
| Added code comments, Svelte 5 runes | none |

## Changelog Entry

### Added

- When a reply finishes, its first suggested follow-up appears as ghost text in the empty chat input and can be accepted with `Tab`. Shown only when both `Prompt Autocompletion` and `Insert Follow-Up Prompt to Input` are enabled.

## Screenshots

#### Ghost text in the empty composer after a reply

<img width="1963" height="1292" alt="image" src="https://github.com/user-attachments/assets/eb19dd77-8d65-4f81-9b9b-6b696265b130" />

<img width="1963" height="1292" alt="image" src="https://github.com/user-attachments/assets/273119ba-553d-4fdf-937e-2474ada46a22" />

<img width="1963" height="1292" alt="image" src="https://github.com/user-attachments/assets/c4568fb3-f5a2-4729-8764-520f5dc129b4" />

## Additional Context

Two behaviours are inherited rather than chosen. The empty-field ghost takes the placeholder's single-line clamp, so a follow-up wider than the composer truncates with an ellipsis rather than wrapping, the same as the placeholder does today. Pressing a bare modifier key with the composer focused dismisses the ghost, as it does for a typed suggestion. It returns on the next change to the composer.

This is a narrower cousin of #28087 and #28089, which generated suggestions from an attached document with a new endpoint and settings. This one adds no backend and no settings.

This PR was prepared with AI copilot assistance. I have thoroughly reviewed it.

## Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
