### PR TITLE
fix: honor USER_AGENT in _fetch_url web fetches

### DIFF
--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -58,6 +58,7 @@ from open_webui.env import (
     SENTENCE_TRANSFORMERS_CROSS_ENCODER_MODEL_KWARGS,
     SENTENCE_TRANSFORMERS_CROSS_ENCODER_SIGMOID_ACTIVATION_FUNCTION,
     SENTENCE_TRANSFORMERS_MODEL_KWARGS,
+    USER_AGENT,
 )
 from open_webui.events import EVENTS, publish_event
 from open_webui.internal.db import get_async_db, get_async_session
@@ -2192,6 +2193,11 @@ async def _fetch_url(url: str, max_size_mb: int | str | None) -> dict:
             max_bytes = None
 
     async with get_ssrf_safe_session() as session:
+        if USER_AGENT:
+            # Same convention as the web loader session: honor the operator's
+            # USER_AGENT so fetches stop identifying as the bare aiohttp default
+            # (rejected by sites like Wikipedia).
+            session.headers['User-Agent'] = USER_AGENT
         async with session.get(
             url, ssl=AIOHTTP_CLIENT_SESSION_SSL, allow_redirects=AIOHTTP_CLIENT_ALLOW_REDIRECTS
         ) as response:


### PR DESCRIPTION
## Description

`_fetch_url` (the default web loader's URL attachment fetch) issued its aiohttp GET with the bare default User-Agent, ignoring the `USER_AGENT` environment variable. Operators who set `USER_AGENT` per the deployment docs still saw their URL attachments rejected by sites that block the Python/aiohttp default — e.g. Wikipedia returning 403, as reported in #29617.

This sets the session's `User-Agent` header when `USER_AGENT` is configured, mirroring the existing convention in the web loader session (`retrieval/web/utils.py` already does `session.headers['User-Agent'] = USER_AGENT`). Behavior with `USER_AGENT` unset is unchanged.

Fixes #29617

## Added

-

## Changed

- `_fetch_url` now applies the configured `USER_AGENT` to its SSRF-safe session before fetching.

## Removed

-

## Security

- No change to the SSRF-safe connector, validation, or redirect handling; only the request header changes when the operator has explicitly configured `USER_AGENT`.

## Breaking Changes

-

## Additional Context

Verified against a local HTTP server that accepts only the configured custom User-Agent and otherwise returns 403:

- unpatched `dev`: `ClientResponseError 403` (custom User-Agent not sent — the reported behavior)
- patched: fetch succeeds and is classified as a web page
- with `USER_AGENT` unset: request proceeds exactly as before

## Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.