### PR TITLE
fix: do not persist Function deactivation on load failure

### DIFF
--- a/backend/open_webui/utils/plugin.py
+++ b/backend/open_webui/utils/plugin.py
@@ -309,7 +309,9 @@ async def load_function_module_by_id(function_id: str, content: str | None = Non
         # Cleanup by removing the module in case of error
         del sys.modules[module_name]
 
-        await Functions.update_function_by_id(function_id, {'is_active': False})
+        # Do not persist a deactivation: a transient load failure (broken
+        # dependency, partial edit) must fail this request only, so the
+        # Function loads again on the next request once the cause is fixed.
         raise e
     finally:
         os.unlink(temp_file.name)


### PR DESCRIPTION
# Pull Request

Closes #29681

## Summary

`load_function_module_by_id` in `backend/open_webui/utils/plugin.py` persists `is_active: False` whenever exec-ing a Function's stored content raises. After that write, `get_active_filter_ids` (which filters `is_active=True`) excludes the Function from every model and every user on all later requests. Nothing in code re-enables it and nothing notifies the admin beyond a single `log.error` line; the admin panel toggle silently moves to off.

Any transient load failure triggers this: a dependency the filter imports removed or version-bumped by an upgrade, an optional import failing on a new Python version, or a partially saved edit. For a global (`is_global=True`) moderation/safety filter, one transient error becomes a standing, silent bypass: the request that triggered the error fails closed, and every request after it runs with the filter gone.

Change: on a load failure, fail the request (as today) but do not write the deactivation to the database, so the Function loads again on the next request once the underlying cause is fixed. The module cleanup (`del sys.modules[...]`) and the `log.error` signal are unchanged.

## Testing

The repo has no Python test suite, so the change was verified with a runnable harness (https://gist.github.com/AUTHENSOR/1dc7d1fbe048eb494fe160ac65040d84) that imports the real `utils/plugin.py` and `utils/filter.py` and replaces only the Functions DB layer with an in-memory store recording every `update_function_by_id` call:

1. Healthy global filter blocks marker content (control).
2. The same filter's content raises on import (simulated dependency loss): the request fails; on this branch no `update_function_by_id` call is recorded and `is_active` stays `True`. On current `main` this phase records exactly `('safety-global', {'is_active': False})`.
3. After the content is repaired, the same filter resolves again and blocks the marker: a transient failure no longer persists.

## Changelog Entry

### Fixed

- A Function (including global safety filters) is no longer permanently disabled in the database by a single transient load error; the failing request errors and the Function loads again once the cause is fixed.

## Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
