### PR TITLE
fix: do not route external preset models to the workspace model editor

### DIFF
--- a/src/lib/components/admin/Settings/Models.svelte
+++ b/src/lib/components/admin/Settings/Models.svelte
@@ -122,6 +122,9 @@
 	const isPresetModel = (model: any) =>
 		!!(model?.preset || model?.base_model_id || model?.info?.base_model_id);
 
+	const isExternalPresetModel = (model: any) =>
+		!!(model?.preset && model?.connection_type === 'external');
+
 	const modelAccessLabel = (model) => {
 		if (isPublicModel(model)) {
 			return $i18n.t('Public');
@@ -605,6 +608,15 @@
 			: model;
 
 	const openModelHandler = async (model: any) => {
+		if (isExternalPresetModel(model)) {
+			// External preset models are backed by their connection, not a workspace
+			// model row, so the workspace model editor would fail with a 404.
+			toast.error(
+				$i18n.t('This model is provided by an external connection and cannot be edited here.')
+			);
+			return;
+		}
+
 		if (isPresetModel(model)) {
 			showSettings.set(false);
 			await goto(`/workspace/models/edit?id=${encodeURIComponent(model.id)}`);
@@ -1121,29 +1133,31 @@
 										</Tooltip>
 									{/if}
 
-									<button
-										class="hidden sm:flex self-center w-fit text-sm p-1.5 dark:text-gray-300 dark:hover:text-white hover:bg-black/5 dark:hover:bg-white/5 rounded-xl"
-										type="button"
-										aria-label={$i18n.t('Edit')}
-										on:click={() => {
-											openModelHandler(model);
-										}}
-									>
-										<svg
-											xmlns="http://www.w3.org/2000/svg"
-											fill="none"
-											viewBox="0 0 24 24"
-											stroke-width="1.5"
-											stroke="currentColor"
-											class="size-3.5"
+									{#if !isExternalPresetModel(model)}
+										<button
+											class="hidden sm:flex self-center w-fit text-sm p-1.5 dark:text-gray-300 dark:hover:text-white hover:bg-black/5 dark:hover:bg-white/5 rounded-xl"
+											type="button"
+											aria-label={$i18n.t('Edit')}
+											on:click={() => {
+												openModelHandler(model);
+											}}
 										>
-											<path
-												stroke-linecap="round"
-												stroke-linejoin="round"
-												d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L6.832 19.82a4.5 4.5 0 0 1-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 0 1 1.13-1.897L16.863 4.487Zm0 0L19.5 7.125"
-											/>
-										</svg>
-									</button>
+											<svg
+												xmlns="http://www.w3.org/2000/svg"
+												fill="none"
+												viewBox="0 0 24 24"
+												stroke-width="1.5"
+												stroke="currentColor"
+												class="size-3.5"
+											>
+												<path
+													stroke-linecap="round"
+													stroke-linejoin="round"
+													d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L6.832 19.82a4.5 4.5 0 0 1-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 0 1 1.13-1.897L16.863 4.487Zm0 0L19.5 7.125"
+												/>
+											</svg>
+										</button>
+									{/if}
 
 									<ModelMenu
 										user={$user}


### PR DESCRIPTION
### What

External preset models (returned by `/api/v1/models` with `preset: true` and `connection_type: "external"`, e.g. a model exposed by an external OpenAI-compatible connection) are not stored as workspace model rows, but Settings → Models still offered Edit for them and `openModelHandler` routed every preset model to `/workspace/models/edit?id=...`. The edit page then queried `/api/v1/models/model?id=...` and got a 404, which the UI displayed as a misleading "You do not have permission to edit this model" error.

This change:

- adds an `isExternalPresetModel` check and makes `openModelHandler` show a toast instead of navigating to the workspace model editor for those models;
- hides the pencil Edit button for external preset models, per the "should not show an Edit action" option from the issue.

Local preset models (workspace models with a backing row) and regular models keep their existing behavior.

### Why

Reported in #29629 with full reproduction steps and screenshots: clicking Edit on a working external preset model produced a 404 request and a permission error.

### How tested

- The modified `Models.svelte` parses and compiles cleanly with the Svelte 5 compiler (`svelte/compiler` parse + compile).
- Manual reproduction of the reported flow (admin → Settings → Models → external preset model → Edit) before/after: before shows the 404 dialog from the issue; after shows a toast and no navigation. A full `svelte-check` runs in CI.
