### PR TITLE
fix: show the right error when a model cannot be loaded for editing

### DIFF
--- a/src/routes/(app)/workspace/models/edit/+page.svelte
+++ b/src/routes/(app)/workspace/models/edit/+page.svelte
@@ -24,6 +24,7 @@
 
 			if (!model) {
 				goto('/workspace/models');
+				return;
 			}
 
 			if (!model?.write_access) {


### PR DESCRIPTION
Opening the workspace model editor with an id that cannot be loaded redirected back to the model list and then fell through into the write-access check on the same empty model, so a plain not-found id produced "You do not have permission to edit this model". The message pointed people at their permissions for something that was never a permission problem.

The editor now stops after the redirect, so that message only appears when the model loaded and the user really cannot edit it.

Refs #29629

## Contributor License Agreement

<!--
DO NOT DELETE THIS SECTION.
Your PR will not be reviewed or merged until you check the box below confirming that you have read and agree to the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
