### PR TITLE
fix: disconnect live socket sessions when tokens are revoked

### DIFF
--- a/backend/open_webui/utils/auth.py
+++ b/backend/open_webui/utils/auth.py
@@ -303,6 +303,12 @@ async def invalidate_token(request, token):
                     ex=ttl,
                 )
 
+                user_id = decoded.get('id')
+                if user_id:
+                    from open_webui.socket.main import disconnect_user_sessions
+
+                    await disconnect_user_sessions(user_id)
+
 
 async def revoke_user_tokens(request, user_id: str):
     """Reject every token already issued to a user. Requires Redis."""
@@ -323,6 +329,10 @@ async def revoke_user_tokens(request, user_id: str):
         str(int(datetime.now(UTC).timestamp())),
         ex=int(expires_delta.total_seconds()) if expires_delta else None,
     )
+
+    from open_webui.socket.main import disconnect_user_sessions
+
+    await disconnect_user_sessions(user_id)
 
 
 def extract_token_from_auth_header(auth_header: str):


### PR DESCRIPTION
Token revocation only took effect at the Socket.IO handshake, so connections established beforehand kept running. Both revocation helpers now drop the user's live sessions after writing the revocation marker, which covers signout, password change, admin user update and OIDC back-channel logout in one place. Clients holding a still-valid token reconnect immediately.

## Contributor License Agreement

<!--
DO NOT DELETE THIS SECTION.
Your PR will not be reviewed or merged until you check the box below confirming that you have read and agree to the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
