### PR TITLE
fix: report a mid-stream upstream failure in band on the chat completions API path

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -4183,6 +4183,18 @@ async def non_streaming_chat_response_handler(response, ctx):
     return response
 
 
+async def stream_with_error_frame(original_generator):
+    """Raising mid-body truncates the response silently, so report the failure in the stream instead."""
+    try:
+        async for data in original_generator:
+            yield data
+    except Exception as e:
+        log.exception('Chat completion stream failed mid-response: %s', e)
+        # Terminate the event that was cut off, so the error frame is not merged into it.
+        yield f'\n\ndata: {JSONCodec.dumps({"error": {"message": "Chat completion stream failed"}})}\n\n'
+        yield 'data: [DONE]\n\n'
+
+
 async def streaming_chat_response_handler(response, ctx):
     request = ctx['request']
 
@@ -6346,7 +6358,7 @@ async def streaming_chat_response_handler(response, ctx):
                 await outlet_filter_handler(ctx)
 
         return StreamingResponse(
-            stream_wrapper(response.body_iterator, events),
+            stream_with_error_frame(stream_wrapper(response.body_iterator, events)),
             headers=dict(response.headers),
             background=response.background,
         )


### PR DESCRIPTION
When a streamed chat completion fails after the 200 headers have already been sent, the exception escapes the response body iterator. The status can no longer change, so the connection is simply dropped: API clients get a truncated event stream with no error and no [DONE]. Depending on what sits in front of Open WebUI, that surfaces either as a transport-level protocol error or as a completed but empty assistant message, and the real cause is invisible to the caller.

The failure is now reported in the stream instead, as an error event followed by [DONE], so the body terminates normally and the client can surface it and stop reading. Verified against a live instance with the OpenAI SDK: it raises a typed APIError where it previously hit an incomplete-read protocol error. The frame opens with a blank line because the event that was cut off is still missing its terminator, and an SSE parser would otherwise merge the two into one unparseable event.

The chat UI path is deliberately untouched. There the exception already propagates to the chat handler, which persists the error on the message and cancels the pending tasks, so catching it earlier would have marked a truncated response as complete and run title generation on it.

The message sent to the client is fixed text and the exception detail goes to the log only. The wrapper also covers stream filters and pipes, and their exception strings should not reach API callers.

Fixes #29628

## Contributor License Agreement

<!--
DO NOT DELETE THIS SECTION.
Your PR will not be reviewed or merged until you check the box below confirming that you have read and agree to the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
