### PR TITLE
Let users with write access manage calendar sharing

### DIFF
--- a/backend/open_webui/routers/calendar.py
+++ b/backend/open_webui/routers/calendar.py
@@ -399,17 +399,10 @@ async def update_calendar(
     request: Request, calendar_id: str, form_data: CalendarUpdateForm, user: UserModel = Depends(get_verified_user)
 ):
     await check_calendar_permission(request, user)
-    cal = await _check_calendar_access(calendar_id, user, 'write')
-
-    # Only owner/admin can change access grants
-    if form_data.access_grants is not None and cal.user_id != user.id and user.role != 'admin':
-        raise HTTPException(status_code=403, detail='Only owner can manage sharing')
+    await _check_calendar_access(calendar_id, user, 'write')
 
     # Strip public/user grants the requesting user is not permitted to assign
-    # (matches the channel/notes/models pattern). The owner-only check above
-    # only restricts WHO can set grants; this filter restricts WHICH grants
-    # they may set, so a non-admin owner cannot make their calendar
-    # publicly readable/writable without the corresponding sharing permission.
+    # (matches the channel/notes/models pattern).
     if form_data.access_grants is not None:
         form_data.access_grants = await filter_allowed_access_grants(
             await Config.get('user.permissions'),


### PR DESCRIPTION
Calendars were the only shared resource where a collaborator with write access could not change who else the resource is shared with. Notes, folders, models, prompts, tools, knowledge and skills all treat a write grant as owner-equivalent and allow it, so a team sharing a calendar had to route every sharing change back through the owner.

The owner-only gate on the update endpoint is removed, which brings calendars in line with the other resources. Deleting a calendar stays owner-and-admin-only, matching folders, and the existing filter still strips public wildcard grants from anyone without the public-sharing permission.

Verified against a running instance: a write-grantee can now update grants and the newly granted user gains access, while a read-only grantee, an ungranted user and a write-grantee attempting deletion are all still refused. Public grants submitted without the permission are still stripped, and calendar and event operations are unchanged.

## Contributor License Agreement

<!--
DO NOT DELETE THIS SECTION.
Your PR will not be reviewed or merged until you check the box below confirming that you have read and agree to the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
