### PR TITLE
fix: skip embedded HTML parts and restrict link targets in docx preview

### DIFF
--- a/src/lib/components/common/DocxPreview.svelte
+++ b/src/lib/components/common/DocxPreview.svelte
@@ -116,6 +116,7 @@
 				className: 'docx',
 				ignoreLastRenderedPageBreak: false,
 				inWrapper: true,
+				renderAltChunks: false,
 				renderEndnotes: true,
 				renderFooters: true,
 				renderFootnotes: true,

--- a/src/lib/components/common/DocxPreview.svelte
+++ b/src/lib/components/common/DocxPreview.svelte
@@ -28,6 +28,8 @@
 	let zoomLevel = 1;
 	let resizeObserver: ResizeObserver | null = null;
 
+	const SAFE_LINK_SCHEMES = ['http:', 'https:', 'mailto:', 'tel:'];
+
 	$: docxScale = Math.max(0.25, fitScale * zoomLevel);
 
 	const clearPreview = () => {
@@ -96,6 +98,24 @@
 		(pages[page - 1] as HTMLElement | undefined)?.scrollIntoView({ block: 'start' });
 	};
 
+	const isSafeLinkTarget = (href: string) => {
+		if (!href.trim()) return false;
+
+		try {
+			return SAFE_LINK_SCHEMES.includes(new URL(href, document.baseURI).protocol);
+		} catch {
+			return false;
+		}
+	};
+
+	const stripUnsafeLinkTargets = () => {
+		containerEl.querySelectorAll('a[href]').forEach((link) => {
+			if (!isSafeLinkTarget(link.getAttribute('href') ?? '')) {
+				link.removeAttribute('href');
+			}
+		});
+	};
+
 	const renderDocx = async (arrayBuffer: ArrayBuffer | null) => {
 		const currentRender = ++renderId;
 		clearPreview();
@@ -116,6 +136,7 @@
 				className: 'docx',
 				ignoreLastRenderedPageBreak: false,
 				inWrapper: true,
+				// the renderer would otherwise inline a document-supplied HTML part into a same-origin frame
 				renderAltChunks: false,
 				renderEndnotes: true,
 				renderFooters: true,
@@ -123,6 +144,7 @@
 				renderHeaders: true,
 				useBase64URL: true
 			});
+			stripUnsafeLinkTargets();
 			await tick();
 			updateFitScale();
 			await scrollToTargetPage();


### PR DESCRIPTION
The docx preview rendered two things exactly as the document supplied them: an embedded HTML sub-document, and link targets.

Embedded HTML parts are no longer rendered, so such a part is omitted from the output. Link targets are now checked after rendering and kept only when they resolve to http, https, mailto or tel. Any other target is removed and the link renders as plain text.

Targets resolve against the page URL, so internal bookmark links and relative targets are unaffected. An empty target, which the renderer emits for a hyperlink with no external relationship, is also dropped. Links using file: or Office application schemes no longer resolve.

DOMPurify was not used because running it over the rendered document would strip the renderer's own markup and styling, so the check stays limited to link targets.

## Contributor License Agreement

<!--
DO NOT DELETE THIS SECTION.
Your PR will not be reviewed or merged until you check the box below confirming that you have read and agree to the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
