### PR TITLE
refac: validate the citation embed URL before use

### DIFF
--- a/src/lib/components/chat/Messages/Citations.svelte
+++ b/src/lib/components/chat/Messages/Citations.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { getContext } from 'svelte';
 	import { embed, showControls, showEmbeds } from '$lib/stores';
+	import { isValidHttpUrl } from '$lib/utils';
 
 	import CitationModal from './Citations/CitationModal.svelte';
 
@@ -43,7 +44,11 @@
 
 			if (citations[index]?.source?.embed_url) {
 				const embedUrl = citations[index].source.embed_url;
-				if (embedUrl) {
+				// The embed panel renders anything it cannot read as a URL as raw HTML
+				if (
+					typeof embedUrl === 'string' &&
+					(isValidHttpUrl(embedUrl) || embedUrl.startsWith('//'))
+				) {
 					if (readOnly) {
 						// Open in new tab if readOnly
 						window.open(embedUrl, '_blank');


### PR DESCRIPTION
A citation's embed_url now has to be an http or https URL, or protocol-relative, before it is opened or handed to the embed panel. Anything else falls back to the citation modal, which already renders the source.

## Contributor License Agreement

<!--
DO NOT DELETE THIS SECTION.
Your PR will not be reviewed or merged until you check the box below confirming that you have read and agree to the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
