### PR TITLE
fix: stop the note editor date reading as a button

### DIFF
--- a/src/lib/components/notes/NoteEditor.svelte
+++ b/src/lib/components/notes/NoteEditor.svelte
@@ -1263,7 +1263,7 @@ ${content}
 							<div
 								class="flex gap-0.5 items-center text-xs font-normal text-gray-500 dark:text-gray-500 w-fit"
 							>
-								<button class=" flex items-center gap-1 w-fit py-1 px-1.5 rounded-lg min-w-fit">
+								<div class=" flex items-center gap-1 w-fit py-1 px-1.5 rounded-lg min-w-fit">
 									<!-- check for same date, yesterday, last week, and other -->
 
 									{#if dayjs(note.created_at / 1000000).isSame(dayjs(), 'day')}
@@ -1285,7 +1285,7 @@ ${content}
 									{:else}
 										<span>{dayjs(note.created_at / 1000000).format($i18n.t('DD/MM/YYYY'))}</span>
 									{/if}
-								</button>
+								</div>
 
 								{#if editor}
 									<div class="flex items-center gap-1 px-1 min-w-fit">


### PR DESCRIPTION
# Pull Request

## Checklist

- [x] This PR targets the `dev` branch.
- [x] This PR links to a well-described, confirmed Issue or active Discussion: `Relates to #29642`.
- [ ] A maintainer explicitly asked me to open this PR, or this PR only updates i18n/localization.
- [x] The change is one logical unit with no unrelated commits.
- [x] I matched nearby code patterns and avoided unnecessary new settings, abstractions, or dependencies.
- [x] I manually tested the changed workflow and any nearby behavior that could be affected.
- [ ] I updated relevant docs, including the [Open WebUI Docs Repository](https://github.com/open-webui/docs), if needed.
- [ ] I added screenshots for UI changes, and a recording when motion or interaction matters.
- [x] I reviewed any AI-generated code before submitting it.
- [x] The PR title uses one of the prefixes listed below.

## Summary

The date under a note's title in the note editor shows a hand cursor, but clicking it does nothing. The chip is a bare `<button>` with no handler, and this app gives every `button` a pointer cursor in `src/tailwind.css`, so it reads as clickable without being clickable.

It arrived that way in the styling pass that introduced the row (`11914d20b`, 2025-07), as one of two placeholder chips with no handlers. The other chip was removed later and this one kept its wrapper. The words and characters chip beside it has been a `<div>` since that same commit.

The fix swaps the wrapper for a `<div>` with the same classes:

```diff
-	<button class=" flex items-center gap-1 w-fit py-1 px-1.5 rounded-lg min-w-fit">
+	<div class=" flex items-center gap-1 w-fit py-1 px-1.5 rounded-lg min-w-fit">
```

Nothing moves, since the classes are identical. The cursor goes back to normal because the element is no longer a button. The four date forms (today, yesterday, last week, older) are untouched.

## Testing

I tested this locally on the branch. The pointer is gone over the date, the chip sits where it did next to the words and characters count, and the date forms render as before.

## Changelog Entry

### Fixed

- The creation date shown under a note's title no longer shows a pointer cursor as if it were clickable.

## Screenshots

| State | Before | After |
|---|---|---|
| Cursor over the date under the note title | <img width="431" height="84" alt="image" src="https://github.com/user-attachments/assets/04f7efcc-72a9-487a-92dd-e5a022c4bd6a" /> | <img width="431" height="84" alt="image" src="https://github.com/user-attachments/assets/cb7af05a-6401-4ada-ac16-5b902023278b" /> |

Before is current `dev`, After is this branch.

## Additional Context

Relates to #29642, which is the same page rather than the same defect.

This PR was prepared with AI copilot assistance. I have thoroughly reviewed it.

## Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.


