### PR TITLE
fix(exa): use highlights instead of full text for snippets

### DIFF
--- a/backend/open_webui/retrieval/web/exa.py
+++ b/backend/open_webui/retrieval/web/exa.py
@@ -9,6 +9,32 @@ log = logging.getLogger(__name__)
 
 EXA_API_BASE = 'https://api.exa.ai'
 
+# Maximum snippet length to prevent context flooding
+MAX_SNIPPET_LENGTH = 4000
+
+
+def _get_highlight_snippet(result: dict) -> str:
+    """Extract a snippet from Exa result highlights, falling back to text.
+
+    Exa's 'highlights' field contains token-efficient summaries suitable for LLM context.
+    It may be a string or a list of strings. Falls back to 'text' (uncapped) if highlights
+    are unavailable.
+    """
+    highlights = result.get('highlights')
+    if highlights:
+        if isinstance(highlights, list):
+            snippet = ' '.join(highlights)
+        else:
+            snippet = highlights
+    else:
+        snippet = result.get('text', '')
+
+    # Truncate to MAX_SNIPPET_LENGTH to prevent context flooding
+    if len(snippet) > MAX_SNIPPET_LENGTH:
+        snippet = snippet[:MAX_SNIPPET_LENGTH]
+
+    return snippet
+
 
 @dataclass
 class ExaResult:
@@ -26,7 +52,7 @@ def search_exa(
     """Search using Exa Search API and return the results as a list of SearchResult objects.
 
     Args:
-        api_key (str): A Exa Search API key
+        api_key (str): An Exa Search API key
         query (str): The query to search for
         count (int): Number of results to return
         filter_list (Optional[list[str]]): List of domains to filter results by
@@ -39,7 +65,9 @@ def search_exa(
         'query': query,
         'numResults': count or 5,
         'includeDomains': filter_list,
-        'contents': {'text': True, 'highlights': True},
+        # Use highlights (token-efficient summaries) instead of full uncapped text.
+        # maxCharacters caps each highlight to MAX_SNIPPET_LENGTH chars to prevent context flooding.
+        'contents': {'highlights': True, 'maxCharacters': MAX_SNIPPET_LENGTH},
         'type': 'auto',  # Use the auto search type (keyword or neural)
     }
 
@@ -48,24 +76,25 @@ def search_exa(
         response.raise_for_status()
         data = response.json()
 
-        results = []
-        for result in data['results']:
-            results.append(
+        raw_results = data.get('results', [])
+        processed_results = []
+        for raw in raw_results:
+            processed_results.append(
                 ExaResult(
-                    url=result['url'],
-                    title=result['title'],
-                    text=result['text'],
+                    url=raw['url'],
+                    title=raw['title'],
+                    text=raw.get('text', ''),
                 )
             )
 
-        log.info('Found %s results', len(results))
+        log.info('Found %s results', len(processed_results))
         return [
             SearchResult(
-                link=result.url,
-                title=result.title,
-                snippet=result.text,
+                link=exaresult.url,
+                title=exaresult.title,
+                snippet=_get_highlight_snippet(raw),
             )
-            for result in results
+            for exaresult, raw in zip(processed_results, raw_results)
         ]
     except Exception as e:
         log.error(f'Error searching Exa: {e}')


### PR DESCRIPTION
## Summary

Fixes [#29702](https://github.com/open-webui/open-webui/issues/29702).

When `BYPASS_WEB_SEARCH_WEB_LOADER` and
`BYPASS_WEB_SEARCH_EMBEDDING_AND_RETRIEVAL` are both enabled, Exa's
`text` field (full uncapped page content) was used as the search result
snippet. This caused individual snippets to reach ~170k characters,
wasting context and API costs.

## Changes

- Use Exa's `highlights` field (token-efficient LLM-friendly summaries)
  instead of `text` for the snippet
- Add `maxCharacters=4000` to the API request to cap each highlight
- Add a `_get_highlight_snippet` helper that handles both string and
  list `highlights` formats, with a fallback to `text` if highlights
  are unavailable
- Add a 4000-character truncation guard as a safety net

## Testing

- Manual: verified with Exa web search + both bypass flags enabled
- Unit: `pytest tests/` (add tests for `_get_highlight_snippet` edge cases)
