### PR TITLE
chore: drop the duplicate onnxruntime wasm copies from the frontend build

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"scripts": {
 		"dev": "npm run pyodide:fetch && vite dev --host",
 		"dev:5050": "npm run pyodide:fetch && vite dev --port 5050",
-		"build": "npm run pyodide:fetch && vite build",
+		"build": "npm run pyodide:fetch && vite build && node scripts/drop-duplicate-ort-wasm.js",
 		"build:watch": "npm run pyodide:fetch && vite build --watch",
 		"preview": "vite preview",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",

--- a/scripts/drop-duplicate-ort-wasm.js
+++ b/scripts/drop-duplicate-ort-wasm.js
@@ -1,0 +1,16 @@
+// both kokoro entry points set wasmPaths, so onnxruntime never resolves these hashed copies
+import { readdir, unlink } from 'fs/promises';
+import { join } from 'path';
+
+async function dropDuplicateWasm(dir) {
+	for (const entry of await readdir(dir, { withFileTypes: true })) {
+		const entryPath = join(dir, entry.name);
+		if (entry.isDirectory()) {
+			await dropDuplicateWasm(entryPath);
+		} else if (/^ort-wasm-.*\.wasm$/.test(entry.name)) {
+			await unlink(entryPath);
+		}
+	}
+}
+
+await dropDuplicateWasm('build/_app');


### PR DESCRIPTION
The frontend build gets 43 MB smaller uncompressed (about 10 MB on the compressed pull), in the Docker image and in the PyPI wheel alike. Vite emits two hashed copies of ort-wasm-simd-threaded.jsep.wasm (21.6 MB each) under _app/immutable besides the copy in /wasm/ that viteStaticCopy places.

Both hashed copies are referenced from shipped code, but only from the branch onnxruntime takes when wasmPaths is unset. src/lib/workers/kokoro.worker.ts sets wasmPaths to /wasm/, and the main-thread import in the audio settings relies on the transformers.js default, which points at its CDN. With wasmPaths set, onnxruntime resolves the runtime through that prefix and never through the hashed files, so nothing fetches them.

The delete runs as a Node step at the end of npm run build, after the SvelteKit adapter has written build/, which is the command the Dockerfile, the hatch wheel build and the frontend CI all call. A Rollup hook could drop the asset during the build instead, but the two copies come out of the main bundle and the worker bundle, which register plugins separately, so one post-build step is the smaller change. build:watch is not covered; it never returns, and its output is not shipped.

Part of #29721.

## Contributor License Agreement

<!--
DO NOT DELETE THIS SECTION.
Your PR will not be reviewed or merged until you check the box below confirming that you have read and agree to the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
