### PR TITLE
chore: stop duplicating open_webui/static in a second image layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,25 @@ COPY . .
 ENV APP_BUILD_HASH=${BUILD_HASH}
 RUN npm run build
 
+######## WebUI backend sources ########
+FROM python:3.11-slim-bookworm AS backend
+ARG UID
+ARG GID
+
+COPY --chown=$UID:$GID ./backend /app/backend
+
+# The backend rewrites its bundled static assets (favicons, splash, manifest,
+# loader.js, ...) under open_webui/static at startup. Make that directory
+# writable by an arbitrary UID -- which under OpenShift's restricted SCC is
+# always a member of GID 0 -- so those writes don't fail with EACCES and crash
+# the boot log with "[Errno 13] Permission denied". `chmod -R g=u` mirrors the
+# owner bits onto the group (the Red Hat arbitrary-UID idiom). This is applied
+# unconditionally because it targets a directory the app writes on every start;
+# the broader, opt-in USE_PERMISSION_HARDENING in the base stage covers the
+# rest of /app.
+RUN chgrp -R 0 /app/backend/open_webui/static && \
+    chmod -R g=u /app/backend/open_webui/static
+
 ######## WebUI backend ########
 FROM python:3.11-slim-bookworm AS base
 
@@ -187,19 +206,8 @@ COPY --chown=$UID:$GID --from=build /app/build /app/build
 COPY --chown=$UID:$GID --from=build /app/CHANGELOG.md /app/CHANGELOG.md
 COPY --chown=$UID:$GID --from=build /app/package.json /app/package.json
 
-# copy backend files
-COPY --chown=$UID:$GID ./backend .
-
-# The backend rewrites its bundled static assets (favicons, splash, manifest,
-# loader.js, ...) under open_webui/static at startup. Make that directory
-# writable by an arbitrary UID -- which under OpenShift's restricted SCC is
-# always a member of GID 0 -- so those writes don't fail with EACCES and crash
-# the boot log with "[Errno 13] Permission denied". `chmod -R g=u` mirrors the
-# owner bits onto the group (the Red Hat arbitrary-UID idiom). This is applied
-# unconditionally because it targets a directory the app writes on every start;
-# the broader, opt-in USE_PERMISSION_HARDENING below covers the rest of /app.
-RUN chgrp -R 0 /app/backend/open_webui/static && \
-    chmod -R g=u /app/backend/open_webui/static
+# copy backend files (ownership comes from the backend stage, a --chown here would reset static's GID 0)
+COPY --from=backend /app/backend /app/backend
 
 EXPOSE 8080
 


### PR DESCRIPTION
The image gets about 69 MB smaller uncompressed per architecture, about 39 MB off the compressed pull. The chgrp/chmod -R g=u RUN that makes open_webui/static writable for an arbitrary UID (OpenShift) runs after the backend tree is copied in, so overlayfs copies every file in that directory into a new layer: 68.7 MB on the amd64 main image, most of it fonts.

The permission fix now runs in a small backend stage and the prepared tree is copied once. COPY --from preserves ownership and mode bits, so the result is the same as before for the default build and for custom UID/GID builds.

COPY --chmod=g=u, on the static directory alone or with --exclude on the rest of the tree, was rejected after checking BuildKit's copy implementation: a destination directory that does not exist yet is created 0755 and only an octal --chmod reaches it, so the static directory itself would end up 755 instead of 775. A whole-tree --chmod would rewrite modes across all of backend/.

The registry build cache grows by about 73 MB uncompressed (about 40 MB as pushed), the single copied backend tree in the base stage being the new cached content.

Part of #29721.

## Contributor License Agreement

<!--
DO NOT DELETE THIS SECTION.
Your PR will not be reviewed or merged until you check the box below confirming that you have read and agree to the CLA.
-->

- [X] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
