### PR TITLE
chore: drop python3-dev from the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -128,7 +128,6 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     git build-essential pandoc gcc curl jq ca-certificates \
     libmariadb-dev \
-    python3-dev \
     ffmpeg libsm6 libxext6 zstd \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
The apt layer of the Docker image shrinks by about 60 MB. python3-dev installs Debian's own interpreter with its headers, and nothing in the image uses it.

The image's Python is the /usr/local build from the base image, which ships its own headers, and it is also the interpreter that installs tool and function requirements at runtime, so Debian's headers were never on the include path of anything built in the container. The zlib headers python3-dev pulled in stay through libmariadb-dev, which also brings the OpenSSL headers, so the optional mariadb connector still builds; the only other header package that goes with it is libexpat1-dev, which nothing in the pinned tree builds against.

Part of #29721.

## Contributor License Agreement

<!--
DO NOT DELETE THIS SECTION.
Your PR will not be reviewed or merged until you check the box below confirming that you have read and agree to the CLA.
-->

- [X] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
