### PR TITLE
fix: wait for a pending note save before navigating away

### DIFF
--- a/src/lib/components/notes/NoteEditor.svelte
+++ b/src/lib/components/notes/NoteEditor.svelte
@@ -10,7 +10,7 @@
 	import { toast } from 'svelte-sonner';
 	import equal from 'fast-deep-equal';
 
-	import { goto } from '$app/navigation';
+	import { goto, onNavigate } from '$app/navigation';
 
 	import dayjs from '$lib/dayjs';
 	import calendar from 'dayjs/plugin/calendar';
@@ -205,27 +205,46 @@
 
 	let debounceTimeout: NodeJS.Timeout | null = null;
 
+	const saveHandler = async () => {
+		const res = await updateNoteById(localStorage.token, id, {
+			title: note?.title === '' ? $i18n.t('Untitled') : note.title,
+			data: {
+				files: files
+			},
+			access_grants: note?.access_grants ?? []
+		}).catch((e) => {
+			toast.error(`${e}`);
+		});
+
+		if (res) {
+			pinnedNotes.set(await getPinnedNoteList(localStorage.token).catch(() => []));
+		}
+	};
+
 	const changeDebounceHandler = () => {
 		if (debounceTimeout) {
 			clearTimeout(debounceTimeout);
 		}
 
-		debounceTimeout = setTimeout(async () => {
-			const res = await updateNoteById(localStorage.token, id, {
-				title: note?.title === '' ? $i18n.t('Untitled') : note.title,
-				data: {
-					files: files
-				},
-				access_grants: note?.access_grants ?? []
-			}).catch((e) => {
-				toast.error(`${e}`);
-			});
-
-			if (res) {
-				pinnedNotes.set(await getPinnedNoteList(localStorage.token).catch(() => []));
-			}
+		debounceTimeout = setTimeout(() => {
+			debounceTimeout = null;
+			saveHandler();
 		}, 200);
 	};
+
+	onNavigate(() => {
+		if (titleInputFocused) {
+			changeDebounceHandler();
+		}
+
+		if (!debounceTimeout) {
+			return;
+		}
+
+		clearTimeout(debounceTimeout);
+		debounceTimeout = null;
+		return saveHandler();
+	});
 
 	const applyExternalNoteContent = async (_note) => {
 		const incomingContent = _note.data?.content;


### PR DESCRIPTION
# Pull Request

## Checklist

- [x] This PR targets the `dev` branch.
- [x] This PR links to a well-described, confirmed Issue or active Discussion: `Closes #29744`.
- [ ] A maintainer explicitly asked me to open this PR, or this PR only updates i18n/localization.
- [x] The change is one logical unit with no unrelated commits.
- [x] I matched nearby code patterns and avoided unnecessary new settings, abstractions, or dependencies.
- [x] I manually tested the changed workflow and any nearby behavior that could be affected.
- [ ] I updated relevant docs, including the [Open WebUI Docs Repository](https://github.com/open-webui/docs), if needed.
- [ ] I added screenshots for UI changes, and a recording when motion or interaction matters.
- [x] I reviewed any AI-generated code before submitting it.
- [x] The PR title uses one of the prefixes listed below.

## Summary

Editing a note's title and going back to the Notes page showed the old title until a reload, whether you left through the Notes link or the browser's Back button. Nothing was lost. The list was drawn before the save landed. Reported in #29744.

The title saves on the field's blur through a 200 millisecond debounce, and nothing flushed that timer when the page was left. The Notes link blurs the field and navigates at once, so the list mounted and fetched before the save landed. The Back button does not move focus, so with the cursor still in the field the blur only happened when the editor unmounted, and the save landed after the list had fetched.

The fix makes the editor finish a pending save before the next page mounts. It uses SvelteKit's `onNavigate`, which waits for a returned promise before completing a client-side navigation and never cancels or replays the navigation itself. The debounce body becomes a `saveHandler` that the debounce schedules. In `onNavigate`, a title field that still has focus gets its save scheduled, since Back will not blur it. A pending timer is then cleared and the save is returned, so the navigation waits for it. The Notes page therefore fetches after the save has resolved, for the sidebar link, Back and forward alike. Nothing changes when nothing is pending. Full page reloads are untouched, since they cannot be deferred.

## Testing

I tested this locally on the branch. Clearing the title and clicking `Notes` shows `Untitled` in the list without a reload. The same holds with the Back button pressed straight away, without clicking elsewhere first. Typing a new title and leaving immediately keeps the new title. Navigating between notes still works.

Mechanical checks, run at my direction with AI copilot assistance:

| Check | Result |
|---|---|
| `npm run build` | exit 0 |
| `npx prettier --check` on the changed file | already formatted |
| `svelte-check` errors in the changed file | identical to `dev`, message for message (the file's pre-existing ones) |
| Added code comments, Svelte 5 runes | none |

## Changelog Entry

### Fixed

- Leaving a note with a title edit still pending now saves it before the next page loads. The Notes list shows the current title without a reload, for the Notes link and the browser's Back button alike.

## Additional Context

The root layout's `beforeNavigate` is the nearest existing hook, but `beforeNavigate` cannot wait. An earlier attempt cancelled the navigation, awaited the save and re-issued it with `goto`. That misbehaved on Back, because SvelteKit restores the history entry asynchronously and the replay raced it. `onNavigate` is the hook built for waiting.

When a save completes while the editor is still visible, the server's update event applies the saved title back into the field. The field can therefore read `Untitled` for a moment before the page swaps. This already happens on `dev` whenever a save completes with the editor open, and this PR does not change it.

This PR was prepared with AI copilot assistance. I have thoroughly reviewed it.

## Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.




