### PR TITLE
fix: allow saving personal settings without interface settings permission

### DIFF
--- a/backend/open_webui/routers/users.py
+++ b/backend/open_webui/routers/users.py
@@ -502,14 +502,6 @@ async def update_user_settings_by_session_user(
     user=Depends(get_verified_user),
     db: AsyncSession = Depends(get_async_session),
 ):
-    if user.role != 'admin' and not await has_permission(
-        user.id, 'settings.interface', await Config.get('user.permissions')
-    ):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail=ERROR_MESSAGES.ACCESS_PROHIBITED,
-        )
-
     updated_user_settings = form_data.model_dump(exclude_unset=True)
     ui_settings = updated_user_settings.get('ui')
     if (


### PR DESCRIPTION
The user settings update endpoint rejected the whole request with a 403 whenever the settings.interface permission was off.

INTERFACE DEFAULTS SETTING IS AN AFFORDANCE FLAG.

**Since every personal setting (system prompt, audio, notifications, shortcuts, account) goes through the same endpoint, users who were explicitly granted the system prompt permission could not persist their system prompt.**

This WRONGFULLY blocked system prompt saving.

Interface tab keys are now pinned to their stored values for users without the permission while every other key is saved. The system prompt key is additionally dropped when chat.controls or chat.system_prompt is off, matching the rule the frontend already applies.

## Contributor License Agreement

<!--
DO NOT DELETE THIS SECTION.
Your PR will not be reviewed or merged until you check the box below confirming that you have read and agree to the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
