### PR TITLE
feat: middle-click a sidebar folder to open it in a new tab

### DIFF
--- a/src/lib/components/layout/Sidebar/RecursiveFolder.svelte
+++ b/src/lib/components/layout/Sidebar/RecursiveFolder.svelte
@@ -613,6 +613,10 @@
 			showSidebar.set(!$showSidebar);
 		}
 	};
+
+	const openFolderInNewTabHandler = () => {
+		window.open(`/folders/${folderId}`, '_blank');
+	};
 	$: if (!open && chats !== null) {
 		chats = null;
 		chatsPage = 1;
@@ -758,6 +762,16 @@
 				}}
 				role="button"
 				tabindex="0"
+				on:mousedown={(e) => {
+					if (e.button === 1) e.preventDefault();
+				}}
+				on:auxclick={(e) => {
+					if (e.button !== 1) return;
+					if (shouldIgnoreRowClick(e.target)) return;
+					e.preventDefault();
+					e.stopPropagation();
+					openFolderInNewTabHandler();
+				}}
 				on:click={async (e) => {
 					e.stopPropagation();
 					if (shouldIgnoreRowClick(e.target)) return;


### PR DESCRIPTION
<!--
Important checks for contributors:
1. Target the `dev` branch. PRs targeting `main` will be closed.
2. Code pull requests are not the default contribution path.
3. Do not open a code PR as the first step. Start with a well-written Issue or Discussion unless a maintainer asked for the PR or the change is only i18n/localization.
4. Do not delete the Contributor License Agreement section at the bottom. The CLA bot requires it.
-->

# Pull Request

Closes #29750

## Checklist

- [x] This PR targets the `dev` branch.
- [x] This PR links to a well-described, confirmed Issue or active Discussion: `Closes #29750`.
- [x] A maintainer explicitly asked me to open this PR, or this PR only updates i18n/localization.
- [x] The change is one logical unit with no unrelated commits.
- [x] I matched nearby code patterns and avoided unnecessary new settings, abstractions, or dependencies.
- [x] I manually tested the changed workflow and any nearby behavior that could be affected.
- [x] I updated relevant docs, including the [Open WebUI Docs Repository](https://github.com/open-webui/docs), if needed. (No docs change required.)
- [x] I added screenshots for UI changes, and a recording when motion or interaction matters.
- [x] I reviewed any AI-generated code before submitting it.
- [x] The PR title uses one of the prefixes listed below.

## Title Prefix

`feat`

## Summary

Chat rows in the sidebar are real `<a href>` elements, so middle-click already opens them in a new browser tab. Folder rows are a `div role="button"` with a JS click handler, so middle-click did nothing.

This adds middle-click → open the folder in a new browser tab for folder rows, for parity:

- `auxclick` (button 1) on the folder row calls `window.open('/folders/<id>', '_blank')` — the same path the row already navigates to via `goto()` on left-click.
- `mousedown` (button 1) calls `preventDefault()` to suppress the browser's autoscroll cursor.
- Middle-clicking the expand chevron or the folder `⋯` menu is ignored via the existing `shouldIgnoreRowClick` guard.
- Left-click, double-click-to-rename, keyboard activation, drag-and-drop, and right-click (context menu) are unchanged.

One file changed: `src/lib/components/layout/Sidebar/RecursiveFolder.svelte` (+14 lines). No new dependencies, settings, or abstractions.

## Testing

Ran with `npm run dev` (frontend) against a local backend on `:8080`.

- Sidebar → expand **Folders** → middle-click a folder row → new tab opens at `/folders/<id>` ✅
- Middle-click the expand chevron and the folder `⋯` menu → no tab opens ✅
- Left-click a folder → still navigates in place; `selectedFolder` still updates ✅
- Double-click a folder → still enters rename mode ✅
- Enter / Space on a focused folder row → still opens the folder in place ✅
- Drag a folder to reorder / drag a chat into a folder → unchanged ✅
- Right-click a folder row → browser context menu still appears (auxclick handler is gated to `button === 1`) ✅
- Verified in Chrome and Firefox.

## Changelog Entry

### Added

- Middle-click a folder in the sidebar to open it in a new browser tab (parity with chat rows).

### Changed

-

### Fixed

-

### Removed

-

### Security

-

### Breaking Changes

-

## Additional Context

`window.open('/folders/<id>')` mirrors the existing `href="/c/<id>"` on chat rows (`ChatItem.svelte`) and the `goto('/folders/<id>')` already used by the row's left-click handler (`openFolderHandler`), so no base-path handling is added that the rest of the sidebar doesn't already assume.

A short screen recording of the interaction will be attached to this PR.

## Contributor License Agreement

<!--
DO NOT DELETE THIS SECTION.
Your PR will not be reviewed or merged until you check the box below confirming that you have read and agree to the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.