### PR TITLE
fix: stop context compaction firing on chats containing a tool image

### DIFF
--- a/backend/open_webui/utils/context_compaction.py
+++ b/backend/open_webui/utils/context_compaction.py
@@ -19,6 +19,8 @@ from open_webui.utils.task import (
 
 log = logging.getLogger(__name__)
 
+IMAGE_TOKEN_ESTIMATE = 1000
+
 DEFAULT_CONTEXT_COMPACTION_PROMPT = """### Task:
 Summarize the conversation history that will be compacted out of the active chat context.
 
@@ -431,15 +433,15 @@ def _estimate_messages_tokens(messages: list[dict]) -> int:
                 if not isinstance(item, dict):
                     total += _estimate_tokens(item)
                 elif item.get('type') in {'image', 'image_url'}:
-                    total += 1000
+                    total += IMAGE_TOKEN_ESTIMATE
                 else:
                     total += _estimate_tokens(item.get('text') or item.get('content') or item)
         else:
             total += _estimate_tokens(content)
 
-        total += _estimate_tokens(message.get('output'))
+        total += _estimate_attachment_tokens(message.get('output'))
         total += _estimate_tokens(message.get('tool_calls'))
-        total += _estimate_tokens(message.get('files'))
+        total += _estimate_attachment_tokens(message.get('files'))
     return total
 
 
@@ -457,3 +459,27 @@ def _estimate_tokens(value: Any) -> int:
         return 0
 
     return max(1, len(value) // 4)
+
+
+def _estimate_attachment_tokens(value: Any) -> int:
+    total = _estimate_tokens(value)
+    pending_items = [value]
+    while pending_items:
+        item = pending_items.pop()
+        if isinstance(item, list):
+            pending_items.extend(item)
+        elif isinstance(item, dict):
+            payload = _inline_attachment_payload(item)
+            if payload:
+                # The estimate above already charged this payload's length, which is no guide to its context cost.
+                total += IMAGE_TOKEN_ESTIMATE - len(payload) // 4
+            else:
+                pending_items.extend(item.values())
+    return total
+
+
+def _inline_attachment_payload(item: dict) -> str | None:
+    payload = item.get('url') or item.get('image_url')
+    if not payload and item.get('type') == 'data':
+        payload = item.get('content')
+    return payload if isinstance(payload, str) and payload.startswith('data:') else None


### PR DESCRIPTION
When a tool returned an image, the base64 data URI was persisted inside the message and the context estimator charged it as text at roughly one token per four characters. A single 3 MB image scored over a million tokens, which is more than most model context windows, so auto-compaction fired on the next request and summarised the conversation away for no reason. The context usage indicator reported the same inflated figure.

The estimator now recognises an inline attachment wherever one is stored and charges it the same flat per-image estimate that an inline image in message content already gets. Everything else is counted exactly as before, so a chat without attachments produces an identical figure and compacts at the same point it did.

Verified against the reported reproduction: a 3 MB image scored 1,030,860 tokens before and 1,062 after, and no longer crosses a 350,000 token threshold.

Fixes #29761

## Contributor License Agreement

<!--
DO NOT DELETE THIS SECTION.
Your PR will not be reviewed or merged until you check the box below confirming that you have read and agree to the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
