### PR TITLE
fix(chats): preserve existing titles on partial updates

### DIFF
--- a/backend/open_webui/models/chats.py
+++ b/backend/open_webui/models/chats.py
@@ -1163,7 +1163,7 @@ class ChatTable:
                 saved_message = self.upsert_message_to_history(history, message_id, message)
                 chat['history'] = history
                 chat_item.chat = chat  # chat is a fresh dict when the column was empty
-                chat_item.title = chat.get('title', 'New Chat')
+                chat_item.title = chat.get('title', chat_item.title)
                 chat_item.current_message_id = self.get_current_message_id(chat)
                 flag_modified(chat_item, 'chat')
 
@@ -1209,7 +1209,7 @@ class ChatTable:
                 deleted_ids = self.delete_message_from_history(history, message_id)
                 if not deleted_ids:
                     chat_item.chat = chat
-                    chat_item.title = chat.get('title', 'New Chat')
+                    chat_item.title = chat.get('title', chat_item.title)
                     chat_item.current_message_id = self.get_current_message_id(chat)
                     flag_modified(chat_item, 'chat')
                     await session.commit()
@@ -1218,7 +1218,7 @@ class ChatTable:
                 messages = history.get('messages') or {}
                 chat['history'] = history
                 chat_item.chat = chat
-                chat_item.title = chat.get('title', 'New Chat')
+                chat_item.title = chat.get('title', chat_item.title)
                 chat_item.current_message_id = self.get_current_message_id(chat)
                 flag_modified(chat_item, 'chat')
                 chat_item.updated_at = int(time.time())
@@ -1260,7 +1260,7 @@ class ChatTable:
 
                 chat['history'] = history
                 chat_item.chat = chat
-                chat_item.title = chat.get('title', 'New Chat')
+                chat_item.title = chat.get('title', chat_item.title)
                 chat_item.current_message_id = self.get_current_message_id(chat)
                 flag_modified(chat_item, 'chat')
                 await session.commit()


### PR DESCRIPTION
# Pull Request

Fixes #29767

## Summary

Preserve the persisted chat title when message and status updates omit the optional 'title' field. The affected model-layer paths now fall back to chat_item.title instead of overwriting a generated title with the literal "New Chat".

## Testing

- ruff format --check backend/open_webui/models/chats.py
- ruff check --select=F --ignore=F401,F403,F405,F541,F811,F841 backend/open_webui/models/chats.py
- python -m py_compile backend/open_webui/models/chats.py
- Verified four affected fallbacks use the persisted title and no legacy chat.get('title', 'New Chat') fallback remains in those paths.
- git diff --check

## Changelog Entry

### Fixed

- Prevent partial message, deletion, and status updates from reverting generated chat titles to "New Chat".

## Additional Context

This is intentionally limited to the four fallbacks called out in #29767. Explicit title values remain unchanged.

## Contributor License Agreement

<!-- DO NOT DELETE THIS SECTION. Your PR will not be reviewed or merged until you check the box below confirming that you have read and agree to the CLA. -->
- [ ] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.