### PR TITLE
fix(oauth): accept resource arrays from MCP servers

### DIFF
--- a/backend/open_webui/utils/oauth.py
+++ b/backend/open_webui/utils/oauth.py
@@ -430,7 +430,11 @@ async def get_protected_resource_metadata(server_url: str) -> ProtectedResourceM
                             if resource_response.status == 200:
                                 resource_metadata = await resource_response.json()
 
-                                resource = resource_metadata.get('resource') or None
+                                resource = resource_metadata.get('resource')
+                                if isinstance(resource, list):
+                                    resource = next((value for value in resource if isinstance(value, str)), None)
+                                elif not isinstance(resource, str):
+                                    resource = None
                                 if resource:
                                     log.debug('Discovered resource indicator: %s', resource)
 


### PR DESCRIPTION
# Pull Request

Fixes #29751

## Summary

Accept MCP protected-resource metadata that encodes the resource indicator as a JSON array. GitLab's MCP endpoint returns a one-element array, while Open WebUI's OAuth client model stores a single RFC 8707 resource URI; the first string value is now normalized before Pydantic validation.

Scalar string resource values keep their existing behavior. Empty arrays and unsupported value types are treated as an absent resource indicator.

## Testing

- ruff format --check backend/open_webui/utils/oauth.py
- ruff check --select=F --ignore=F401,F403,F405,F541,F811,F841 backend/open_webui/utils/oauth.py
- python -m py_compile backend/open_webui/utils/oauth.py
- git diff --check

## Changelog Entry

### Fixed

- Allow static MCP OAuth client registration when protected-resource metadata returns resource as an array.

## Additional Context

The normalization is kept at the metadata boundary so the rest of the OAuth flow continues to work with the existing single-resource client contract.

## Contributor License Agreement

<!-- DO NOT DELETE THIS SECTION. Your PR will not be reviewed or merged until you check the box below confirming that you have read and agree to the CLA. -->
- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.