### PR TITLE
fix: persist provider-supplied citation sources

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -3480,6 +3480,14 @@ def get_response_data(response):
     return response, response_data
 
 
+def get_provider_sources(response_data):
+    if not isinstance(response_data, dict):
+        return None
+
+    sources = response_data.get('sources')
+    return sources if isinstance(sources, list) else None
+
+
 def merge_events_into_response(response_data, events):
     if events and isinstance(events, list):
         extra_response = {}
@@ -4021,6 +4029,7 @@ async def non_streaming_chat_response_handler(response, ctx):
     response, response_data = get_response_data(response)
     if response_data is None:
         return response
+    provider_sources = get_provider_sources(response_data)
 
     chat_id = metadata.get('chat_id') or ''
     save_to_chat = is_saved_chat_id(chat_id)
@@ -4170,6 +4179,7 @@ async def non_streaming_chat_response_handler(response, ctx):
                                 'done': True,
                                 'role': 'assistant',
                                 'output': response_output,
+                                **({'sources': provider_sources} if provider_sources is not None else {}),
                                 **({'usage': usage} if usage else {}),
                             },
                         )
@@ -4179,6 +4189,7 @@ async def non_streaming_chat_response_handler(response, ctx):
                     ctx['assistant_message'] = {
                         'content': content,
                         'output': response_output,
+                        **({'sources': provider_sources} if provider_sources is not None else {}),
                         **({'usage': usage} if usage else {}),
                     }
                     await outlet_filter_handler(ctx)
@@ -4218,6 +4229,7 @@ async def non_streaming_chat_response_handler(response, ctx):
         ctx['assistant_message'] = {
             **({'content': content} if content else {}),
             **({'output': output} if output else {}),
+            **({'sources': provider_sources} if provider_sources is not None else {}),
             **({'usage': usage} if usage else {}),
         }
         await outlet_filter_handler(ctx)
@@ -4615,6 +4627,7 @@ async def streaming_chat_response_handler(response, ctx):
                 content_parts = []
 
             usage = None
+            provider_sources = None
             last_response_id = None
 
             def full_output():
@@ -4714,6 +4727,7 @@ async def streaming_chat_response_handler(response, ctx):
 
                 async def stream_body_handler(response, form_data):
                     nonlocal usage
+                    nonlocal provider_sources
                     nonlocal output
                     nonlocal prior_output
                     nonlocal last_response_id
@@ -4895,6 +4909,10 @@ async def streaming_chat_response_handler(response, ctx):
                                     form_data=data,
                                     extra_params=filter_extra_params,
                                 )
+
+                            chunk_sources = get_provider_sources(data)
+                            if provider_sources is None and chunk_sources is not None:
+                                provider_sources = chunk_sources
 
                             if data:
                                 if 'event' in data and not getattr(request.state, 'direct', False):
@@ -6290,6 +6308,7 @@ async def streaming_chat_response_handler(response, ctx):
                     'done': True,
                     'output': current_output,
                     'title': title,
+                    **({'sources': provider_sources} if provider_sources is not None else {}),
                     **({'usage': usage} if usage else {}),
                 }
 
@@ -6302,6 +6321,7 @@ async def streaming_chat_response_handler(response, ctx):
                         {
                             'done': True,
                             'output': current_output,
+                            **({'sources': provider_sources} if provider_sources is not None else {}),
                             **({'usage': usage} if usage else {}),
                         },
                     )
@@ -6328,6 +6348,7 @@ async def streaming_chat_response_handler(response, ctx):
                     if continuing
                     else ''.join(content_parts) or get_output_text(current_output),
                     'output': current_output,
+                    **({'sources': provider_sources} if provider_sources is not None else {}),
                     **({'usage': usage} if usage else {}),
                 }
                 await outlet_filter_handler(ctx)
@@ -6354,6 +6375,7 @@ async def streaming_chat_response_handler(response, ctx):
                             {
                                 'done': True,
                                 'output': full_output(),
+                                **({'sources': provider_sources} if provider_sources is not None else {}),
                             },
                         )
                     await clear_response_stream(request.app.state.redis, response_stream_task_id)


### PR DESCRIPTION
<!--
Important checks for contributors:
1. Target the `dev` branch. PRs targeting `main` will be closed.
2. Code pull requests are not the default contribution path.
3. Do not open a code PR as the first step. Start with a well-written Issue or Discussion unless a maintainer asked for the PR or the change is only i18n/localization.
4. Do not delete the Contributor License Agreement section at the bottom. The CLA bot requires it.
-->

## Checklist

- [✓] This PR targets the `dev` branch.
- [✓ ] This PR links to a well-described, confirmed Issue or active Discussion: `Closes #29715`.
- [  ] A maintainer explicitly asked me to open this PR, or this PR only updates i18n/localization.
- [✓] The change is one logical unit with no unrelated commits.
- [✓] I matched nearby code patterns and avoided unnecessary new settings, abstractions, or dependencies.
- [  ] I manually tested the changed workflow and any nearby behavior that could be affected.
- [✓] I updated relevant docs, including the [Open WebUI Docs Repository](https://github.com/open-webui/docs), if needed.
- [✓] I added screenshots for UI changes, and a recording when motion or interaction matters.
- [  ] I reviewed any AI-generated code before submitting it.
- [✓] The PR title uses one of the prefixes listed below.


# Pull Request

Closes #29715

## Summary

Provider-supplied citation sources were included in streaming completion events, so they appeared while a response was being generated. However, the sources were omitted from the final assistant-message update and disappeared after reloading the chat.

This change:

- Captures list-valued provider sources from streaming responses.
- Persists sources when streaming completes or is cancelled.
- Persists sources for non-streaming responses.
- Includes the persisted sources in the assistant message passed to outlet and background handlers.
- Ignores malformed, non-list source values.

This uses the existing `sources` field on chat messages and requires no database migration.

## Testing

Automated regression coverage was run against the external Open WebUI test suite:

```text
.venv/bin/python -m pytest unit/chat/test_provider_source_persistence.py -q
3 passed
```

## Changelog Entry

### Fixed
- Provider-supplied citation sources disappearing after reloading a chat.
Additional Context
The database model already supports a sources field, so no schema or migration changes are needed.
No frontend, dependency, configuration, or documentation changes are required.
AI usage disclosure: Codex assisted with tracing the streaming and persistence paths, drafting the implementation, and creating regression coverage. The submitted diff and test results were reviewed by the contributor.

## Additional Context

The database model already supports a sources field, so no schema or migration changes are needed.
No frontend, dependency, configuration, or documentation changes are required.
AI usage disclosure: Codex assisted with tracing the streaming and persistence paths, drafting the implementation, and creating regression coverage. The submitted diff and test results were reviewed by the contributor.

## Contributor License Agreement

<!--
DO NOT DELETE THIS SECTION.
Your PR will not be reviewed or merged until you check the box below confirming that you have read and agree to the CLA.
-->

- [✓] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
