### PR TITLE
fix: use USER_AGENT env in default web loader

### DIFF
--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -33,6 +33,7 @@ from open_webui.env import (
     ENABLE_FORWARD_USER_INFO_HEADERS,
     ENABLE_RETRIEVAL_UNSCOPED_COLLECTIONS,
     OFFLINE_MODE,
+    USER_AGENT,
 )
 from open_webui.models.access_grants import AccessGrants
 from open_webui.models.chats import Chats
@@ -265,6 +266,8 @@ def _get_content_from_url_sync(request, url: str, loader_config):
     try:
         # Probe through the connect-time SSRF guard; bare requests.get re-resolves (DNS-rebinding gap).
         session = get_ssrf_safe_requests_session()
+        if USER_AGENT:
+            session.headers.update({"User-Agent": USER_AGENT})
         response = session.get(url, stream=True, timeout=30, allow_redirects=AIOHTTP_CLIENT_ALLOW_REDIRECTS)
         response.raise_for_status()
         content_type = response.headers.get('Content-Type', '')

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -58,6 +58,7 @@ from open_webui.env import (
     SENTENCE_TRANSFORMERS_CROSS_ENCODER_MODEL_KWARGS,
     SENTENCE_TRANSFORMERS_CROSS_ENCODER_SIGMOID_ACTIVATION_FUNCTION,
     SENTENCE_TRANSFORMERS_MODEL_KWARGS,
+    USER_AGENT,
 )
 from open_webui.events import EVENTS, publish_event
 from open_webui.internal.db import get_async_db, get_async_session
@@ -2184,7 +2185,10 @@ async def _fetch_url(url: str, max_size_mb: int | str | None) -> dict:
 
     async with get_ssrf_safe_session() as session:
         async with session.get(
-            url, ssl=AIOHTTP_CLIENT_SESSION_SSL, allow_redirects=AIOHTTP_CLIENT_ALLOW_REDIRECTS
+            url,
+            ssl=AIOHTTP_CLIENT_SESSION_SSL,
+            allow_redirects=AIOHTTP_CLIENT_ALLOW_REDIRECTS,
+            headers={"User-Agent": USER_AGENT} if USER_AGENT else None,
         ) as response:
             response.raise_for_status()
 


### PR DESCRIPTION
Closes #29617

Default web loader ignored USER_AGENT env, sending default aiohttp UA which Wikipedia and others reject with 403.

Changes:
- backend/open_webui/routers/retrieval.py _fetch_url: send User-Agent header from env when set
- backend/open_webui/retrieval/utils.py _get_content_from_url_sync probe: same, otherwise it 403s before reaching loader

Verified:
- py_compile OK
- Live check: default UA to en.wikipedia.org = 403, custom USER_AGENT = 200