### PR TITLE
fix: ignore unknown IDs in the tools and tool-ids URL parameters

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -2160,13 +2160,13 @@
 				.get('tools')
 				?.split(',')
 				.map((id) => id.trim())
-				.filter((id) => id);
+				.filter((id) => id && ($tools ?? []).find((t) => t.id === id));
 		} else if ($page.url.searchParams.get('tool-ids')) {
 			selectedToolIds = $page.url.searchParams
 				.get('tool-ids')
 				?.split(',')
 				.map((id) => id.trim())
-				.filter((id) => id);
+				.filter((id) => id && ($tools ?? []).find((t) => t.id === id));
 		}
 
 		// Restore tool selection after OAuth redirect


### PR DESCRIPTION
# Pull Request

## Checklist

- [x] This PR targets the `dev` branch.
- [x] This PR links to a well-described, confirmed Issue or active Discussion: `Closes #29802`.
- [x] A maintainer explicitly asked me to open this PR, or this PR only updates i18n/localization.
- [x] The change is one logical unit with no unrelated commits.
- [x] I matched nearby code patterns and avoided unnecessary new settings, abstractions, or dependencies.
- [x] I manually tested the changed workflow and any nearby behavior that could be affected.
- [x] I updated relevant docs, including the [Open WebUI Docs Repository](https://github.com/open-webui/docs), if needed.
- [ ] I added screenshots for UI changes, and a recording when motion or interaction matters.
- [x] I reviewed any AI-generated code before submitting it.
- [x] The PR title uses one of the prefixes listed below.

## Summary

A `tools` or `tool-ids` URL parameter naming an ID Open WebUI does not know showed a wrench with a count of 1 in the chat input, while no tool was selected. The Integrations menu showed every tool off, and opening it made the count vanish. A message sent before that went out without the tool. Reported in #29802.

The URL branches assigned the split parameter straight to the selected tool list without checking any ID against the tools store, and the count in the input is the length of that list. The menu validates on open, which is why the count disappeared only then.

The fix filters the URL IDs against the tools store at the point they are read, using the same lookup `setDefaults` already applies to a model's default tool IDs. Unknown IDs never enter the selection, so the count, the menu and the request agree from the first paint. A known ID still selects its tool, and a tool server connection by its prefixed ID still selects as before.

One consequence for review. The `direct_server:N` IDs, the per-user connections from Settings, are not in the tools store, so a URL naming one is dropped too. The docs never listed that form, and `setDefaults` already strips those IDs when it falls back.

## Screenshots

| Before | After |
|---|---|
| `/?model=gpt-4o&tool-ids=deepwiki` on `dev`: wrench with `1`, no tool selected in Integrations, count gone once the menu opens | Same URL on this branch: no wrench, Integrations shows every tool off |

## Testing

I tested this locally on the branch. `/?model=gpt-4o&tool-ids=deepwikifiewhfiwhfwei` no longer shows the wrench or the count in the chat input. `/?model=gpt-4o&tool-ids=server:oikb` still selects that tool server connection as before.

Mechanical checks, run at my direction with AI copilot assistance:

| Check | Result |
|---|---|
| `npm run build` | exit 0 |
| `npx prettier` on the changed hunk | already formatted |
| Added code comments, Svelte 5 runes | none |

## Changelog Entry

### Fixed

- The `tools` and `tool-ids` URL parameters now ignore IDs that do not match a known tool, so the chat input no longer shows a tool count for a tool that was never selected.

## Additional Context

The companion docs change, open-webui/docs#1386, documents the prefixed IDs tool server connections need in these parameters.

This PR was prepared with AI copilot assistance. I have thoroughly reviewed it.

## Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
