### PR TITLE
fix: check Docling conversion status before processing response

### DIFF
--- a/backend/open_webui/retrieval/loaders/main.py
+++ b/backend/open_webui/retrieval/loaders/main.py
@@ -273,9 +273,27 @@ class DoclingLoader:
             )
         if r.ok:
             result = r.json()
+            # Docling returns HTTP 200 even for failed/partial conversions.
+            # Check the top-level "status" field to ensure we only accept
+            # actual successful results.
+            docling_status = result.get('status', '')
+            if docling_status not in ('success', 'partial_success'):
+                errors = result.get('errors', [])
+                error_detail = f' - errors: {errors}' if errors else ''
+                raise Exception(
+                    f'Docling conversion did not succeed '
+                    f'(status={docling_status}){error_detail}'
+                )
+
             document_data = result.get('document', {})
             md_content = document_data.get('md_content', '')
-            text = md_content or '<No text content found>'
+            if not md_content or not md_content.strip():
+                raise Exception(
+                    f'Docling conversion succeeded but returned empty '
+                    f'md_content (status={docling_status})'
+                )
+
+            text = md_content
 
             metadata = {'Content-Type': self.mime_type} if self.mime_type else {}
             if page_break_marker in md_content:


### PR DESCRIPTION
Fixes #29808

## Problem
Docling returns HTTP 200 even when conversion fails or is skipped — the HTTP status only indicates the API request was received, not that the file was successfully converted.

Previously, `DoclingLoader.load()` only checked `r.ok` (HTTP 2xx):
- If `status="failure"` with empty `md_content`, it silently returned the placeholder `<No text content found>` which gets embedded/indexed
- If `status="failure"` with `md_content=null`, it raised an unrelated `TypeError` on `.split()`

## Fix
Inspects Docling's top-level `status` field and only accepts `"success"` or `"partial_success"`. For `"failure"`, `"skipped"`, or missing/unknown status, raises a clear exception with Docling's error details. Also guards against empty/null `md_content` to prevent the `TypeError`.

**Files changed:** `backend/open_webui/retrieval/loaders/main.py`
