### PR TITLE
fix: check Docling conversion status before processing response

### DIFF
--- a/backend/open_webui/retrieval/loaders/main.py
+++ b/backend/open_webui/retrieval/loaders/main.py
@@ -276,9 +276,27 @@ class DoclingLoader:
             )
         if r.ok:
             result = r.json()
+            # Docling returns HTTP 200 even for failed/partial conversions.
+            # Check the top-level "status" field to ensure we only accept
+            # actual successful results.
+            docling_status = result.get('status', '')
+            if docling_status not in ('success', 'partial_success'):
+                errors = result.get('errors', [])
+                error_detail = f' - errors: {errors}' if errors else ''
+                raise Exception(
+                    f'Docling conversion did not succeed '
+                    f'(status={docling_status}){error_detail}'
+                )
+
             document_data = result.get('document', {})
             md_content = document_data.get('md_content', '')
-            text = md_content or '<No text content found>'
+            if not md_content or not md_content.strip():
+                raise Exception(
+                    f'Docling conversion succeeded but returned empty '
+                    f'md_content (status={docling_status})'
+                )
+
+            text = md_content
 
             metadata = {'Content-Type': self.mime_type} if self.mime_type else {}
             if page_break_marker in md_content:


### PR DESCRIPTION
## Checklist
- [x] This PR targets the `dev` branch.
- [x] This PR links to a well-described, confirmed Issue: `Closes #29808`
- [x] A maintainer explicitly asked me to open this PR, or this PR only updates i18n/localization.
- [x] The change is one logical unit with no unrelated commits.
- [x] I matched nearby code patterns and avoided unnecessary new settings, abstractions, or dependencies.
- [x] I manually tested the changed workflow and any nearby behavior that could be affected.
- [x] I updated relevant docs, including the [Open WebUI Docs Repository](https://github.com/open-webui/docs), if needed.
- [ ] I added screenshots for UI changes, and a recording when motion or interaction matters.
- [x] I reviewed any AI-generated code before submitting it.
- [x] The PR title uses one of the prefixes listed below.

## Title Prefix
**fix**: Bug fixes or corrections

## Summary
Fixes #29808

Docling returns HTTP 200 even when conversion fails or is skipped — the HTTP status only indicates the API request was received, not that the file was successfully converted.

Previously, `DoclingLoader.load()` only checked `r.ok` (HTTP 2xx):
- If `status="failure"` with empty `md_content`, it silently returned the placeholder `<No text content found>` which gets embedded/indexed
- If `status="failure"` with `md_content=null`, it raised an unrelated `TypeError` on `.split()`

This change inspects Docling's top-level `status` field and only accepts `"success"` or `"partial_success"`. For `"failure"`, `"skipped"`, or missing/unknown status, raises a clear exception with Docling's error details. Also guards against empty/null `md_content` to prevent the `TypeError`.

## Changelog Entry

### Added
-

### Changed
- DoclingLoader now checks Docling's top-level `status` field before processing response, raising a clear error for failed/skipped conversions

### Fixed
- DoclingLoader no longer silently accepts failed conversions (status='failure' with empty md_content) as valid documents — they previously returned the placeholder `<No text content found>` which got embedded
- Fixed TypeError when Docling returns md_content=null by raising a clear error instead

### Removed
-

### Security
-

### Breaking Changes
-

## Additional Context
Issue #29808 was labeled "confirmed issue" by maintainers. The fix adds proper status validation per Docling's API contract.

## Contributor License Agreement

<!--
DO NOT DELETE THIS SECTION.
Your PR will not be reviewed or merged until you check the box below confirming that you have read and agree to the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
