### PR TITLE
feat: serve OpenAI-spec image generations and edits endpoints under /openai

### DIFF
--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -1973,28 +1973,38 @@ async def responses(
 async def _resolve_images_backend(request: Request, user: UserModel, model_id: str | None):
     """
     Enforce per-model access control and resolve the upstream backend for an
-    OpenAI Images API request, mirroring the chat completions routing:
-    workspace model aliases (base_model_id) are honored, and the provider
-    prefix_id is stripped from the model sent upstream.
+    OpenAI Images API request. Mirrors chat completions routing for
+    connection selection (urlIdx) and prefix_id stripping; diverges on
+    base_model_id, which only selects the connection here and is NOT
+    forwarded (see comment in the body).
 
-    Returns (model_id, url, key, api_config) with model_id remapped/stripped.
+    Returns (model_id, url, key, api_config) with model_id stripped of any
+    provider prefix.
     """
-    # Enforce per-model access control
+    # Enforce per-model access control. NOTE: unlike chat completions, a
+    # workspace model's base_model_id is NOT forwarded as the payload model:
+    # for an images-only workspace entry (e.g. id "gpt-image-1.5" based on a
+    # chat model so the connection routing resolves), the base id names a
+    # model the images endpoint does not support. The entry's own id is the
+    # upstream-facing model name; base_model_id only selects the connection.
     model_info = await Models.get_model_by_id(model_id) if model_id else None
     await check_model_access(user, model_info, BYPASS_MODEL_ACCESS_CONTROL)
 
-    # Resolve workspace model aliases to their upstream base model
-    if model_info and model_info.base_model_id:
-        model_id = model_info.base_model_id
-
     idx = 0
     if model_id:
+        route_id = model_id
+        if route_id not in request.app.state.OPENAI_MODELS and model_info and model_info.base_model_id:
+            # alias id absent from the upstream cache: route via the base
+            # model's connection (the forwarded model stays route_id)
+            route_id = model_info.base_model_id
         models = request.app.state.OPENAI_MODELS
-        if not models or model_id not in models:
+        if not models or (route_id not in models and model_id not in models):
             await get_all_models(request, user=user)
             models = request.app.state.OPENAI_MODELS
         if model_id in models:
             idx = models[model_id]['urlIdx']
+        elif route_id in models:
+            idx = models[route_id]['urlIdx']
 
     url, key, api_config = await get_openai_connection(idx)
 

--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -58,6 +58,7 @@ from open_webui.utils.session_pool import (
 )
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy.ext.asyncio import AsyncSession
+from starlette.datastructures import UploadFile
 
 log = logging.getLogger(__name__)
 
@@ -1967,6 +1968,213 @@ async def responses(
     finally:
         if not streaming:
             await cleanup_response(r)
+
+
+async def _resolve_images_backend(request: Request, user: UserModel, model_id: str | None):
+    """
+    Enforce per-model access control and resolve the upstream backend for an
+    OpenAI Images API request, mirroring the chat completions routing:
+    workspace model aliases (base_model_id) are honored, and the provider
+    prefix_id is stripped from the model sent upstream.
+
+    Returns (model_id, url, key, api_config) with model_id remapped/stripped.
+    """
+    # Enforce per-model access control
+    model_info = await Models.get_model_by_id(model_id) if model_id else None
+    await check_model_access(user, model_info, BYPASS_MODEL_ACCESS_CONTROL)
+
+    # Resolve workspace model aliases to their upstream base model
+    if model_info and model_info.base_model_id:
+        model_id = model_info.base_model_id
+
+    idx = 0
+    if model_id:
+        models = request.app.state.OPENAI_MODELS
+        if not models or model_id not in models:
+            await get_all_models(request, user=user)
+            models = request.app.state.OPENAI_MODELS
+        if model_id in models:
+            idx = models[model_id]['urlIdx']
+
+    url, key, api_config = await get_openai_connection(idx)
+
+    if model_id:
+        model_id = strip_provider_model_prefix(model_id, api_config.get('prefix_id'))
+
+    return model_id, url, key, api_config
+
+
+async def _forward_images_request(
+    request: Request,
+    user: UserModel,
+    url: str,
+    key: str,
+    api_config: dict,
+    endpoint: str,
+    data,
+    model_id: str | None,
+    is_streaming_request: bool = False,
+    multipart: bool = False,
+):
+    """
+    Forward an OpenAI Images API request to the resolved upstream backend and
+    relay the response verbatim (JSON passthrough or SSE stream).
+    """
+    r = None
+    streaming = False
+
+    try:
+        headers, cookies = await get_headers_and_cookies(request, url, key, api_config, user=user)
+
+        if multipart:
+            # Let aiohttp generate the multipart content type with boundary
+            headers.pop('Content-Type', None)
+
+        if api_config.get('azure') or api_config.get('provider') == 'azure':
+            auth_type = api_config.get('auth_type', 'bearer')
+            if auth_type not in ('azure_ad', 'microsoft_entra_id'):
+                headers['api-key'] = key
+
+            is_azure_v1 = bool(re.search(r'/openai/v1(?:/|$)', url))
+
+            if is_azure_v1:
+                request_url = f'{url.rstrip("/")}/{endpoint}'
+            else:
+                api_version = api_config.get('api_version', '2023-03-15-preview')
+                headers['api-version'] = api_version
+                model = _sanitize_model_for_url(model_id or '')
+                request_url = f'{url}/openai/deployments/{model}/{endpoint}?api-version={api_version}'
+        else:
+            request_url = f'{url}/{endpoint}'
+
+        session = await get_session()
+        r = await session.request(
+            method='POST',
+            url=request_url,
+            data=data,
+            headers=headers,
+            cookies=cookies,
+            ssl=AIOHTTP_CLIENT_SESSION_SSL,
+            timeout=get_client_timeout(stream=is_streaming_request),
+        )
+
+        # Check if response is SSE (e.g. gpt-image-1 with stream=true)
+        if 'text/event-stream' in r.headers.get('Content-Type', ''):
+            streaming = True
+            return StreamingResponse(
+                stream_wrapper(r, passthrough=True),
+                status_code=r.status,
+                headers=_clean_proxy_headers(r.headers),
+            )
+        else:
+            try:
+                response_data = await r.json(loads=JSONCodec.loads)
+            except Exception:
+                response_data = await r.text()
+
+            if r.status >= 400:
+                await publish_model_provider_request_failed(
+                    request,
+                    actor=user,
+                    provider='openai-compatible',
+                    base_url=url,
+                    api_key=key,
+                    status=r.status,
+                    requested_model=model_id,
+                    upstream_error=response_data,
+                )
+                if isinstance(response_data, (dict, list)):
+                    return JSONResponse(status_code=r.status, content=response_data)
+                else:
+                    return PlainTextResponse(status_code=r.status, content=response_data)
+
+            return response_data
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        log.exception(e)
+        raise HTTPException(
+            status_code=r.status if r else 500,
+            detail=ERROR_MESSAGES.SERVER_CONNECTION_ERROR,
+        )
+    finally:
+        if not streaming:
+            await cleanup_response(r)
+
+
+@router.post('/images/generations')
+async def images_generations(
+    request: Request,
+    form_data: dict,
+    user=Depends(get_verified_user),
+):
+    """
+    Forward requests to the OpenAI Images API (images/generations) endpoint.
+    Routes to the correct upstream backend based on the model field.
+    """
+    payload = {**form_data}
+
+    model_id, url, key, api_config = await _resolve_images_backend(request, user, payload.get('model'))
+    if model_id:
+        payload['model'] = model_id
+
+    return await _forward_images_request(
+        request,
+        user,
+        url,
+        key,
+        api_config,
+        'images/generations',
+        JSONCodec.dumps(payload),
+        model_id,
+        is_streaming_request=bool(payload.get('stream', False)),
+    )
+
+
+@router.post('/images/edits')
+async def images_edits(
+    request: Request,
+    user=Depends(get_verified_user),
+):
+    """
+    Forward requests to the OpenAI Images API (images/edits) endpoint.
+    Routes to the correct upstream backend based on the model field.
+    The multipart form body is relayed with fields and files preserved.
+    """
+    form = await request.form()
+
+    raw_model = form.get('model')
+    model_id, url, key, api_config = await _resolve_images_backend(
+        request, user, raw_model if isinstance(raw_model, str) and raw_model else None
+    )
+
+    # Rebuild the multipart body, applying any model alias/prefix remapping
+    data = aiohttp.FormData()
+    for field_name, value in form.multi_items():
+        if isinstance(value, UploadFile):
+            data.add_field(
+                field_name,
+                await value.read(),
+                filename=value.filename,
+                content_type=value.content_type,
+            )
+        elif field_name == 'model' and model_id:
+            data.add_field(field_name, model_id)
+        else:
+            data.add_field(field_name, value)
+
+    return await _forward_images_request(
+        request,
+        user,
+        url,
+        key,
+        api_config,
+        'images/edits',
+        data,
+        model_id,
+        multipart=True,
+    )
 
 
 @router.api_route('/{path:path}', methods=['GET', 'POST', 'PUT', 'DELETE'])


### PR DESCRIPTION
# Pull Request

Thanks for wanting to improve Open WebUI. The most useful contribution is usually a clear, well-written Issue, not an unsolicited code pull request.

Open a code pull request only when a maintainer asks for one, or when the change is only i18n/localization. For real, reproducible bugs, start with a well-described [Issue](https://github.com/open-webui/open-webui/issues). For feature requests, UI/UX changes, behavior changes, architecture changes, suspected fixes, or unconfirmed approaches, start with an active [Discussion](https://github.com/open-webui/open-webui/discussions).

Before continuing, make sure the linked Issue or Discussion explains the user-facing problem, the expected outcome, the affected workflow, and any examples, logs, screenshots, constraints, or reproduction details needed for maintainers to evaluate it.

If you have implementation notes, include them as reference in the Issue or Discussion. If you want to share code as reference, include it there as a local diff, patch, or branch note. Do not open a pull request for reference code.

Unsolicited PRs may be closed without review, especially when they introduce product, architecture, compatibility, dependency, or maintenance decisions that have not been discussed.

Closes #29822 (which builds on the reopened #20639).

## Checklist

- [x] This PR targets the `dev` branch.
- [x] This PR links to a well-described, confirmed Issue or active Discussion: Closes #29822 / Relates to #20639.
- [x] A maintainer explicitly asked me to open this PR, or this PR only updates i18n/localization.
- [x] The change is one logical unit with no unrelated commits.
- [x] I matched nearby code patterns and avoided unnecessary new settings, abstractions, or dependencies.
- [x] I manually tested the changed workflow and any nearby behavior that could be affected.
- [x] I updated relevant docs, including the [Open WebUI Docs Repository](https://github.com/open-webui/docs), if needed. *(No docs updated yet — happy to add an `/openai/images` section if this PR is accepted.)*
- [ ] I added screenshots for UI changes, and a recording when motion or interaction matters. *(No UI change.)*
- [x] I reviewed any AI-generated code before submitting it.
- [x] The PR title uses one of the prefixes listed below.

## Title Prefix

`feat` — new feature / enhancement.

## Summary

Adds two dedicated endpoints to the `/openai` proxy router, completing the OpenAI Images API surface requested in #29822 / #20639:

- `POST /openai/images/generations` — OpenAI-spec JSON (`model`, `prompt`, `n`, `size`, `quality`, `stream`, ...)
- `POST /openai/images/edits` — OpenAI-spec `multipart/form-data` (`image`, `model`, `prompt`, ...)

Both route by the request's `model` through the exact same machinery as the chat/responses proxy:

- **Access control**: `check_model_access` on `Models.get_model_by_id(model_id)` (workspace models, aliases, `BYPASS_MODEL_ACCESS_CONTROL`) — 403 without access, consistent with `/openai/responses`
- **Connection routing**: `OPENAI_MODELS` cache (`urlIdx`) with a `get_all_models` refresh fallback; `base_model_id` selects the connection but is **not** forwarded as the payload model (an images-only workspace entry based on a chat model must forward its own id — the upstream images endpoint only accepts image model names)
- **Provider handling**: `strip_provider_model_prefix` for `prefix_id` connections; Azure classic (`/openai/deployments/{model}/images/generations?api-version=`) vs Azure v1 URL forms
- **Passthrough**: JSON passthrough with upstream status codes preserved and `publish_model_provider_request_failed` events on ≥400 (same as chat proxy); `stream: true` SSE passthrough

Registered **before** the deprecated `/{path}` catch-all, so no interaction with `ENABLE_OPENAI_API_PASSTHROUGH`. No changes to the Web UI image feature (`/api/v1/images/*`), no new settings, no new dependencies.

## Testing

Manual tests against a live 0.11.3 container with the patched module:

- Unauthenticated `POST /openai/images/generations` / `/edits` → `401 Not authenticated`
- `GET /api/models` → image workspace model listed with `meta.hidden` intact (no API-surface change)
- E2E with a stub OpenAI-compatible upstream connection: `POST /openai/images/generations` → upstream request received with the correct model id, `200` body passed through byte-identical
- Upstream error paths: upstream `400`/`404` surfaced verbatim with the same `publish_model_provider_request_failed` warning event the chat proxy emits
- Access control: request for an unregistered model id as non-privileged user → `403`
- Azure URL forms exercised via unit tests (classic deployment path + `api-version` query, v1 path)
- Multipart `edits` request rebuilt and forwarded (model field remapped, image part with filename/content-type preserved, no `Content-Type` header conflict)

## Changelog Entry

### Added

- OpenAI Images API proxy endpoints `POST /openai/images/generations` and `POST /openai/images/edits`, with per-model access control and connection routing identical to the chat completions proxy.

### Changed

-

### Fixed

-

### Removed

-

### Security

-

### Breaking Changes

-

## Additional Context

- Implementation deliberately mirrors `generate_chat_completion`'s routing/`get_openai_connection` usage and `_clean_proxy_headers`/`stream_wrapper` streaming utilities — no new abstractions.
- The deprecated catch-all (`ENABLE_OPENAI_API_PASSTHROUGH`) was considered but rejected: it has no access control, so a dedicated route is the security-consistent path.
- Starlette `request.form()` → `aiohttp.FormData` rebuild for `/edits` pops the inbound `Content-Type` header so aiohttp generates its own multipart boundary.

## Contributor License Agreement

<!--
DO NOT DELETE THIS SECTION.
Your PR will not be reviewed or merged until you check the box below confirming that you have read and agree to the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.