### PR TITLE
feat: add model-level reasoning replay toggle

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2152,12 +2152,18 @@ def get_reasoning_format(model: dict) -> str | None:
     """
     Determine how reasoning should be included in reconstructed messages.
 
+    Reasoning replay is disabled by default and can be enabled per model with
+    the ``reinject_reasoning`` model parameter.
+
     Returns:
         'thinking': Ollama expects reasoning in the native thinking field.
-        'think_tags': wrap reasoning in <think> tags inside content.
         'reasoning_content': llama.cpp supports reasoning_content as a top-level field.
         None: skip reasoning (safe default for strict providers).
     """
+    params = model.get('params') or {}
+    if not params.get('reinject_reasoning', True):
+        return None
+
     provider = model.get('provider', '')
     if model.get('owned_by') == 'ollama':
         return 'thinking'

--- a/backend/test_reasoning_format.py
+++ b/backend/test_reasoning_format.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+def _load_get_reasoning_format():
+    source = Path(__file__).parent.joinpath("open_webui/utils/middleware.py").read_text()
+    tree = ast.parse(source)
+    function = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == "get_reasoning_format"
+    )
+    module = ast.Module(body=[function], type_ignores=[])
+    namespace = {}
+    exec(compile(module, "middleware.py", "exec"), namespace)
+    return namespace["get_reasoning_format"]
+
+
+get_reasoning_format = _load_get_reasoning_format()
+
+
+def test_reasoning_replay_preserves_existing_default():
+    assert get_reasoning_format({"owned_by": "ollama"}) == "thinking"
+    assert get_reasoning_format({"provider": "llama.cpp"}) == "reasoning_content"
+
+
+def test_reasoning_replay_can_be_disabled_per_model():
+    disabled = {"params": {"reinject_reasoning": False}}
+    assert get_reasoning_format({**disabled, "owned_by": "ollama"}) is None
+    assert get_reasoning_format({**disabled, "provider": "llama.cpp"}) is None
+
+
+def test_reasoning_replay_can_be_enabled_for_supported_providers():
+    enabled = {"params": {"reinject_reasoning": True}}
+    assert get_reasoning_format({**enabled, "owned_by": "ollama"}) == "thinking"
+    assert get_reasoning_format({**enabled, "provider": "llama.cpp"}) == "reasoning_content"
+
+
+def test_reasoning_replay_stays_disabled_for_unknown_providers():
+    model = {"provider": "openai", "params": {"reinject_reasoning": True}}
+    assert get_reasoning_format(model) is None

--- a/src/lib/components/chat/Settings/Advanced/AdvancedParams.svelte
+++ b/src/lib/components/chat/Settings/Advanced/AdvancedParams.svelte
@@ -21,6 +21,7 @@
 		stream_delta_chunk_size: null, // Set the chunk size for streaming responses
 		compact_token_threshold: null,
 		function_calling: null,
+		reinject_reasoning: true,
 		reasoning_tags: null,
 		seed: null,
 		stop: null,
@@ -271,6 +272,21 @@
 						<span class="ml-2 self-center">{$i18n.t('Default')}</span>
 					{/if}
 				</button>
+			</div>
+		</Tooltip>
+	</div>
+
+	<div>
+		<Tooltip
+			content={$i18n.t(
+				'Include reasoning from previous assistant turns in subsequent model requests. Disabled by default to prevent reasoning-tag imitation and prompt pollution.'
+			)}
+			placement="top-start"
+			className="inline-tooltip"
+		>
+			<div class="py-0.5 flex w-full justify-between">
+				<div class="self-center text-xs">{$i18n.t('Reinject Reasoning')}</div>
+				<Switch bind:state={params.reinject_reasoning} />
 			</div>
 		</Tooltip>
 	</div>

--- a/src/lib/components/chat/Settings/General.svelte
+++ b/src/lib/components/chat/Settings/General.svelte
@@ -36,6 +36,7 @@
 		stream_response: null,
 		stream_delta_chunk_size: null,
 		function_calling: null,
+		reinject_reasoning: true,
 		reasoning_tags: null,
 		seed: null,
 		temperature: null,
@@ -85,6 +86,7 @@
 				stream_delta_chunk_size:
 					params.stream_delta_chunk_size !== null ? params.stream_delta_chunk_size : undefined,
 				function_calling: params.function_calling !== null ? params.function_calling : undefined,
+				reinject_reasoning: params.reinject_reasoning,
 				reasoning_tags: params.reasoning_tags !== null ? params.reasoning_tags : undefined,
 				seed: (params.seed !== null ? params.seed : undefined) ?? undefined,
 				stop: params.stop ? params.stop.split(',').filter((e) => e) : undefined,


### PR DESCRIPTION
## Summary

- add a model-level `reinject_reasoning` toggle
- preserve the existing reasoning replay behavior by default
- allow replay to be disabled for models that prohibit historical thinking content
- cover default, disabled, enabled, and unsupported-provider behavior with focused tests

## Testing

- `python3 -m pytest -q backend/test_reasoning_format.py`
- `python3 -m compileall -q backend/open_webui/utils/middleware.py backend/test_reasoning_format.py`
- `git diff --check`
- Prettier validation passed for both changed Svelte files before the interrupted dependency refresh

The repository-wide `npm run check` currently reports pre-existing diagnostics across hundreds of unrelated files. The changed AdvancedParams component introduced no targeted diagnostic; diagnostics shown for General.svelte were on unchanged lines.

Fixes #23339

### Contributor License Agreement

By submitting my contributions to this repository in any form, I grant Open WebUI Inc. a perpetual, worldwide, irrevocable, royalty-free license, under copyright and patent, to use, modify, distribute, sublicense, and commercialize my work under any terms they choose, both now and in the future.

I represent that my contributions are my original work (or that I have sufficient rights to grant this license) and that I have the authority to enter into this agreement.

To the fullest extent permitted by law, my contributions are provided on an “as is” basis, with no warranties or guarantees of any kind, and I disclaim any liability for any issues or damages arising from their use or incorporation into the project, regardless of the type of legal claim.