### PR TITLE
fix: close modal shortcut closes only the top modal

### DIFF
--- a/src/lib/components/common/ConfirmDialog.svelte
+++ b/src/lib/components/common/ConfirmDialog.svelte
@@ -3,6 +3,8 @@
 
 	import { onMount, getContext, createEventDispatcher, onDestroy, tick } from 'svelte';
 	import * as FocusTrap from 'focus-trap';
+	import { settings } from '$lib/stores';
+	import { matchKeybinding, Shortcut } from '$lib/shortcuts';
 
 	const i18n = getContext('i18n');
 	const dispatch = createEventDispatcher();
@@ -45,7 +47,10 @@
 	};
 
 	const handleKeyDown = (event: KeyboardEvent) => {
-		if (event.key === 'Escape') {
+		if (
+			event.key === 'Escape' ||
+			($settings?.keyboardShortcuts !== false && matchKeybinding(event) === Shortcut.CLOSE_MODAL)
+		) {
 			cancelHandler();
 		}
 
@@ -113,7 +118,7 @@
 	<!-- svelte-ignore a11y-no-static-element-interactions -->
 	<div
 		bind:this={modalElement}
-		class=" fixed top-0 right-0 left-0 bottom-0 bg-black/60 w-full h-screen max-h-[100dvh] flex justify-center z-99999999 overflow-hidden overscroll-contain"
+		class="modal fixed top-0 right-0 left-0 bottom-0 bg-black/60 w-full h-screen max-h-[100dvh] flex justify-center z-99999999 overflow-hidden overscroll-contain"
 		in:fade={{ duration: 10 }}
 		on:mousedown={() => {
 			cancelHandler();

--- a/src/lib/components/common/Drawer.svelte
+++ b/src/lib/components/common/Drawer.svelte
@@ -2,6 +2,8 @@
 	import { onDestroy, onMount } from 'svelte';
 	import { flyAndScale } from '$lib/utils/transitions';
 	import { fade, fly, slide } from 'svelte/transition';
+	import { settings } from '$lib/stores';
+	import { matchKeybinding, Shortcut } from '$lib/shortcuts';
 
 	export let show = false;
 	export let className = '';
@@ -12,7 +14,12 @@
 	let mounted = false;
 
 	const handleKeyDown = (event: KeyboardEvent) => {
-		if (event.key === 'Escape' && isTopModal()) {
+		if (
+			(event.key === 'Escape' ||
+				($settings?.keyboardShortcuts !== false &&
+					matchKeybinding(event) === Shortcut.CLOSE_MODAL)) &&
+			isTopModal()
+		) {
 			console.log('Escape');
 			show = false;
 		}

--- a/src/lib/components/common/ImagePreview.svelte
+++ b/src/lib/components/common/ImagePreview.svelte
@@ -6,6 +6,8 @@
 	const { saveAs } = fileSaver;
 
 	import { WEBUI_BASE_URL } from '$lib/constants';
+	import { settings } from '$lib/stores';
+	import { matchKeybinding, Shortcut } from '$lib/shortcuts';
 	import PanzoomContainer from '$lib/components/common/PanzoomContainer.svelte';
 	import XMark from '$lib/components/icons/XMark.svelte';
 
@@ -18,7 +20,10 @@
 	let previewElement = null;
 
 	const handleKeyDown = (event: KeyboardEvent) => {
-		if (event.key === 'Escape') {
+		if (
+			event.key === 'Escape' ||
+			($settings?.keyboardShortcuts !== false && matchKeybinding(event) === Shortcut.CLOSE_MODAL)
+		) {
 			console.log('Escape');
 			show = false;
 		}

--- a/src/lib/components/common/Modal.svelte
+++ b/src/lib/components/common/Modal.svelte
@@ -4,6 +4,8 @@
 
 	import { flyAndScale } from '$lib/utils/transitions';
 	import * as FocusTrap from 'focus-trap';
+	import { settings } from '$lib/stores';
+	import { matchKeybinding, Shortcut } from '$lib/shortcuts';
 	export let show = true;
 	export let size = 'md';
 	export let containerClassName = 'p-3';
@@ -40,7 +42,12 @@
 	};
 
 	const handleKeyDown = (event: KeyboardEvent) => {
-		if (event.key === 'Escape' && isTopModal()) {
+		if (
+			(event.key === 'Escape' ||
+				($settings?.keyboardShortcuts !== false &&
+					matchKeybinding(event) === Shortcut.CLOSE_MODAL)) &&
+			isTopModal()
+		) {
 			console.log('Escape');
 			show = false;
 		}

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -328,10 +328,6 @@
 					console.log('Shortcut triggered: SHOW_SHORTCUTS');
 					event.preventDefault();
 					showSettings.set('shortcuts');
-				} else if (shortcut === Shortcut.CLOSE_MODAL) {
-					console.log('Shortcut triggered: CLOSE_MODAL');
-					event.preventDefault();
-					showSettings.set(false);
 				} else if (shortcut === Shortcut.OPEN_MODEL_SELECTOR) {
 					console.log('Shortcut triggered: OPEN_MODEL_SELECTOR');
 					event.preventDefault();


### PR DESCRIPTION
# Pull Request

## Checklist

- [x] This PR targets the `dev` branch.
- [x] This PR links to a well-described, confirmed Issue or active Discussion: Closes #29817
- [x] A maintainer explicitly asked me to open this PR, or this PR only updates i18n/localization.
- [x] The change is one logical unit with no unrelated commits.
- [x] I matched nearby code patterns and avoided unnecessary new settings, abstractions, or dependencies.
- [x] I manually tested the changed workflow and any nearby behavior that could be affected.
- [ ] I updated relevant docs, including the [Open WebUI Docs Repository](https://github.com/open-webui/docs), if needed.
- [x] I added screenshots for UI changes, and a recording when motion or interaction matters.
- [x] I reviewed any AI-generated code before submitting it.
- [x] The PR title uses one of the prefixes listed below.

## Summary

Pressing Escape with two modals stacked (Settings, then Manage Files from the Data Controls tab) closes both at once instead of only the top one. The same happens with the Delete All Chats confirmation on top of Settings, and with the `Close Modal` shortcut rebound to another key.

**Root cause.** Two handlers answer the same keypress. The Modal component checks whether it is the top modal before closing itself, and that part works. The global shortcut handler in the route layout maps `Close Modal` to closing Settings through its store, with no idea what is stacked above it ([+layout.svelte L331-L334](https://github.com/open-webui/open-webui/blob/12b14124b9376eccf2ba7cf3dba92bc145493703/src/routes/(app)/+layout.svelte#L331-L334)). Settings is the bottom of the stack, so it goes, and the Manage Files modal goes with it because it is a child component of Settings. The confirm dialog case has a second cause: ConfirmDialog does not carry the `modal` class, so the Modal under it still sees itself as the top modal.

**Fix.** The `Close Modal` shortcut is handled by the modal components, which know whether they are on top, instead of by the layout:

- Modal, Drawer, ConfirmDialog, and ImagePreview close on Escape or on the configured `Close Modal` binding, using the same store-gated `matchKeybinding` check the chat input already uses for its dictation shortcut. Modal and Drawer keep their existing check for being the top modal.
- The layout's `Close Modal` branch is removed. It was introduced in #18473 (October 2025) to give the newly rebindable shortcut something to close, back when the Shortcuts modal was a separate modal. Settings is itself a Modal, so it now closes through the component like every other modal, and the branch has nothing left to do.
- ConfirmDialog gets the `modal` class so it takes part in the same stack. Nothing else selects `.modal`, so this has no styling effect.

Escape stays hardcoded in the components on purpose. Dialogs closing on Escape is the accessibility baseline, so a rebind adds a second key rather than replacing Escape. The `Enable Keyboard Shortcuts` setting gates the rebound key only.

```diff
 	const handleKeyDown = (event: KeyboardEvent) => {
-		if (event.key === 'Escape' && isTopModal()) {
+		if (
+			(event.key === 'Escape' ||
+				($settings?.keyboardShortcuts !== false &&
+					matchKeybinding(event) === Shortcut.CLOSE_MODAL)) &&
+			isTopModal()
+		) {
 			console.log('Escape');
 			show = false;
 		}
```

```diff
-				} else if (shortcut === Shortcut.CLOSE_MODAL) {
-					console.log('Shortcut triggered: CLOSE_MODAL');
-					event.preventDefault();
-					showSettings.set(false);
 				} else if (shortcut === Shortcut.OPEN_MODEL_SELECTOR) {
```

Five files, +29/-9.

## Testing

Manually on this branch, against the steps in #29817:

1. Settings, Data Controls, Manage Files, press Escape: only the files modal closes. A second Escape closes Settings.
2. Same path with `Close Modal` rebound to `N` in the Shortcuts tab: `N` closes only the files modal, then Settings.
3. Settings, Data Controls, Delete All Chats: Escape and `N` each close only the confirmation dialog.
4. With `Enable Keyboard Shortcuts` off: Escape still closes modals, `N` does not.
5. Image preview and the sidebar drawer still close on Escape.

## Screenshots

| Flow | Before | After |
|---|---|---|
| Settings, Manage Files, Escape | https://github.com/user-attachments/assets/622f591c-d1ae-4716-9f3d-0d67a29c87d8 | https://github.com/user-attachments/assets/17152e95-a60f-4ca3-a519-82986bc4732f|

## Changelog Entry

### Fixed

- Pressing Escape or the `Close Modal` shortcut with stacked modals now closes only the top modal instead of all of them.

## Additional Context

Anchor commit for the permalink: 12b14124b9376eccf2ba7cf3dba92bc145493703.

This PR was prepared with AI copilot assistance. I have thoroughly reviewed and manually tested it.

## Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
