### PR TITLE
fix: stamp docker builds with the build hash so stale tabs reload

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -23,6 +23,9 @@ const config = {
 				try {
 					return child_process.execSync('git rev-parse HEAD').toString().trim();
 				} catch {
+					if (process.env.APP_BUILD_HASH && process.env.APP_BUILD_HASH !== 'dev-build') {
+						return process.env.APP_BUILD_HASH;
+					}
 					// if git is not available, fallback to package.json version
 					// or current timestamp
 					try {


### PR DESCRIPTION
# Pull Request

## Checklist

- [x] This PR targets the `dev` branch.
- [x] This PR links to a well-described, confirmed Issue or active Discussion: Closes #29831
- [x] A maintainer explicitly asked me to open this PR, or this PR only updates i18n/localization.
- [x] The change is one logical unit with no unrelated commits.
- [x] I matched nearby code patterns and avoided unnecessary new settings, abstractions, or dependencies.
- [x] I manually tested the changed workflow and any nearby behavior that could be affected.
- [ ] I updated relevant docs, including the [Open WebUI Docs Repository](https://github.com/open-webui/docs), if needed.
- [ ] I added screenshots for UI changes, and a recording when motion or interaction matters.
- [x] I reviewed any AI-generated code before submitting it.
- [x] The PR title uses one of the prefixes listed below.

## Summary

After a `dev` Docker image update, an open tab shows "500: Internal Error" on its next navigation instead of reloading itself (#29831). A manual refresh is needed every time.

**Root cause.** SvelteKit reloads a stale tab on a failed navigation only when the server's `_app/version.json` differs from the version built into the tab. Open WebUI stamps that version with `git rev-parse HEAD` in `svelte.config.js`, falling back to the package.json version when git is unavailable ([svelte.config.js L21-L40](https://github.com/open-webui/open-webui/blob/12b14124b9376eccf2ba7cf3dba92bc145493703/svelte.config.js#L21-L40)). Commit cb942bb94 (2026-09-06) added `.git` to `.dockerignore`, so the Docker build stage has no repository and the git call fails. Every `dev` image since then is stamped `0.11.3`. The current `dev` image ships `{"version":"0.11.3"}`, read with `docker run --rm --entrypoint cat ghcr.io/open-webui/open-webui:dev /app/build/_app/version.json`. The stale tab and the new image report the same version, so SvelteKit renders the error page.

**Fix.** The Dockerfile already passes the commit SHA into the build stage as `APP_BUILD_HASH` (the docker workflow sets `BUILD_HASH` to the pushed commit), and vite.config.ts already reads it for `WEBUI_BUILD_HASH`. The version name now uses it when git is unavailable, before falling back to the package.json version. `dev-build` is the Dockerfile's default for builds with no build arg, so it is skipped the same way vite.config.ts treats it.

```diff
 				} catch {
+					if (process.env.APP_BUILD_HASH && process.env.APP_BUILD_HASH !== 'dev-build') {
+						return process.env.APP_BUILD_HASH;
+					}
 					// if git is not available, fallback to package.json version
```

One file, +3.

## Testing

This only shows in a Docker image built twice, so I verified the value that gets stamped. I evaluated `svelte.config.js` from a copy with no git repository, as the Docker build stage sees it, and read `kit.version.name`:

| Build situation | Before | After |
|---|---|---|
| CI image, `APP_BUILD_HASH` set to a commit | `0.11.3` | the commit SHA |
| Local `docker build` with no build arg (`dev-build`) | `0.11.3` | `0.11.3` |
| Local checkout with git available | commit SHA | commit SHA |

The user-facing check is the reporter's flow. After the next `dev` image update, a stale tab reloads on its next navigation instead of showing the error page.

## Changelog Entry

### Fixed

- Docker builds are stamped with the build commit, so a tab left open across a `dev` image update reloads on its next navigation instead of showing "500: Internal Error".

## Additional Context

Anchor commit for the permalink: 12b14124b9376eccf2ba7cf3dba92bc145493703.

Local `docker build` runs with no build arg still stamp the package.json version and keep the old behavior. If self-built images should get a unique version too, the last fallback could be a timestamp instead of the package version. I left that out since it changes the value for everyone building without git.

This PR was prepared with AI copilot assistance. I have thoroughly reviewed it.

## Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
