### PR TITLE
fix: keep sticky code block headers at the top of channel scroll containers

### DIFF
--- a/src/lib/components/channel/PinnedMessagesModal.svelte
+++ b/src/lib/components/channel/PinnedMessagesModal.svelte
@@ -94,62 +94,64 @@
 							</div>
 						{:else}
 							<div
-								class="flex flex-col gap-2 max-h-[60vh] overflow-y-auto scrollbar-thin scrollbar-thumb-gray-300 dark:scrollbar-thumb-gray-700 scrollbar-track-transparent pt-7 pb-2"
+								class="max-h-[60vh] overflow-y-auto scrollbar-thin scrollbar-thumb-gray-300 dark:scrollbar-thumb-gray-700 scrollbar-track-transparent pb-2"
 							>
-								{#if pinnedMessages.length === 0}
-									<div class=" text-center text-xs text-gray-500 dark:text-gray-400 py-6">
-										{$i18n.t('No pinned messages')}
-									</div>
-								{:else}
-									{#each pinnedMessages as message, messageIdx (message.id)}
-										<Message
-											id="pinned"
-											className="rounded-xl px-2"
-											{message}
-											{channel}
-											onPin={async (message) => {
-												pinnedMessages = pinnedMessages.filter((m) => m.id !== message.id);
-												onPin(message.id, !message.is_pinned);
+								<div class="flex flex-col gap-2 pt-7">
+									{#if pinnedMessages.length === 0}
+										<div class=" text-center text-xs text-gray-500 dark:text-gray-400 py-6">
+											{$i18n.t('No pinned messages')}
+										</div>
+									{:else}
+										{#each pinnedMessages as message, messageIdx (message.id)}
+											<Message
+												id="pinned"
+												className="rounded-xl px-2"
+												{message}
+												{channel}
+												onPin={async (message) => {
+													pinnedMessages = pinnedMessages.filter((m) => m.id !== message.id);
+													onPin(message.id, !message.is_pinned);
 
-												const updatedMessage = await pinMessage(
-													localStorage.token,
-													message.channel_id,
-													message.id,
-													!message.is_pinned
-												).catch((error) => {
-													toast.error(`${error}`);
-													return null;
-												});
+													const updatedMessage = await pinMessage(
+														localStorage.token,
+														message.channel_id,
+														message.id,
+														!message.is_pinned
+													).catch((error) => {
+														toast.error(`${error}`);
+														return null;
+													});
 
-												init();
-											}}
-											onReaction={false}
-											onThread={false}
-											onReply={false}
-											onEdit={false}
-											onDelete={false}
-										/>
-
-										{#if messageIdx === pinnedMessages.length - 1 && !allItemsLoaded}
-											<Loader
-												on:visible={(e) => {
-													console.log('visible');
-													if (!loading) {
-														page += 1;
-														getPinnedMessages();
-													}
+													init();
 												}}
-											>
-												<div
-													class="w-full flex justify-center py-1 text-xs animate-pulse items-center gap-2"
+												onReaction={false}
+												onThread={false}
+												onReply={false}
+												onEdit={false}
+												onDelete={false}
+											/>
+
+											{#if messageIdx === pinnedMessages.length - 1 && !allItemsLoaded}
+												<Loader
+													on:visible={(e) => {
+														console.log('visible');
+														if (!loading) {
+															page += 1;
+															getPinnedMessages();
+														}
+													}}
 												>
-													<Spinner className=" size-4" />
-													<div class=" ">{$i18n.t('Loading...')}</div>
-												</div>
-											</Loader>
-										{/if}
-									{/each}
-								{/if}
+													<div
+														class="w-full flex justify-center py-1 text-xs animate-pulse items-center gap-2"
+													>
+														<Spinner className=" size-4" />
+														<div class=" ">{$i18n.t('Loading...')}</div>
+													</div>
+												</Loader>
+											{/if}
+										{/each}
+									{/if}
+								</div>
 							</div>
 						{/if}
 					</div>

--- a/src/lib/components/channel/PinnedMessagesModal.svelte
+++ b/src/lib/components/channel/PinnedMessagesModal.svelte
@@ -94,7 +94,7 @@
 							</div>
 						{:else}
 							<div
-								class="max-h-[60vh] overflow-y-auto scrollbar-thin scrollbar-thumb-gray-300 dark:scrollbar-thumb-gray-700 scrollbar-track-transparent pb-2"
+								class="max-h-[60vh] overflow-y-auto will-change-transform scrollbar-thin scrollbar-thumb-gray-300 dark:scrollbar-thumb-gray-700 scrollbar-track-transparent pb-2"
 							>
 								<div class="flex flex-col gap-2 pt-7">
 									{#if pinnedMessages.length === 0}

--- a/src/lib/components/channel/Thread.svelte
+++ b/src/lib/components/channel/Thread.svelte
@@ -188,7 +188,10 @@
 			</div>
 		</div>
 
-		<div class="flex-1 min-h-0 w-full overflow-y-auto" bind:this={messagesContainerElement}>
+		<div
+			class="flex-1 min-h-0 w-full overflow-y-auto will-change-transform"
+			bind:this={messagesContainerElement}
+		>
 			<div class="pt-7">
 				{#if messages !== null}
 					<Messages

--- a/src/lib/components/channel/Thread.svelte
+++ b/src/lib/components/channel/Thread.svelte
@@ -188,43 +188,45 @@
 			</div>
 		</div>
 
-		<div class="flex-1 min-h-0 w-full overflow-y-auto pt-7" bind:this={messagesContainerElement}>
-			{#if messages !== null}
-				<Messages
-					id={threadId}
-					{channel}
-					{top}
-					{messages}
-					{replyToMessage}
-					thread={true}
-					{onPin}
-					onReply={async (message) => {
-						replyToMessage = message;
+		<div class="flex-1 min-h-0 w-full overflow-y-auto" bind:this={messagesContainerElement}>
+			<div class="pt-7">
+				{#if messages !== null}
+					<Messages
+						id={threadId}
+						{channel}
+						{top}
+						{messages}
+						{replyToMessage}
+						thread={true}
+						{onPin}
+						onReply={async (message) => {
+							replyToMessage = message;
 
-						await tick();
-						chatInputElement?.focus();
-					}}
-					onLoad={async () => {
-						const newMessages = await getChannelThreadMessages(
-							localStorage.token,
-							channel.id,
-							threadId,
-							messages.length
-						);
+							await tick();
+							chatInputElement?.focus();
+						}}
+						onLoad={async () => {
+							const newMessages = await getChannelThreadMessages(
+								localStorage.token,
+								channel.id,
+								threadId,
+								messages.length
+							);
 
-						messages = [...messages, ...newMessages];
+							messages = [...messages, ...newMessages];
 
-						if (newMessages.length < 50) {
-							top = true;
-							return;
-						}
-					}}
-				/>
-			{:else}
-				<div class="w-full flex justify-center pt-5 pb-10">
-					<Spinner />
-				</div>
-			{/if}
+							if (newMessages.length < 50) {
+								top = true;
+								return;
+							}
+						}}
+					/>
+				{:else}
+					<div class="w-full flex justify-center pt-5 pb-10">
+						<Spinner />
+					</div>
+				{/if}
+			</div>
 		</div>
 
 		<div class=" pb-[1rem] px-2.5 w-full">

--- a/src/lib/components/chat/Messages/CodeBlock.svelte
+++ b/src/lib/components/chat/Messages/CodeBlock.svelte
@@ -433,7 +433,7 @@
 
 <div>
 	<div
-		class="relative {className} flex flex-col rounded-2xl border border-gray-100/30 dark:border-gray-850/30 my-0.5"
+		class="relative {className} flex flex-col rounded-2xl border border-gray-100/30 dark:border-gray-850/30 my-0.5 overflow-clip"
 		dir="ltr"
 	>
 		{#if ['mermaid', 'vega', 'vega-lite'].includes(lang)}
@@ -457,7 +457,7 @@
 			{/if}
 		{:else}
 			<div
-				class="sticky {stickyButtonsClassName} left-0 right-0 py-1.5 px-3.5 gap-2 flex items-center justify-end w-full z-10 text-xs text-black dark:text-white bg-white dark:bg-black rounded-t-2xl"
+				class="sticky {stickyButtonsClassName} left-0 right-0 py-1.5 px-3.5 gap-2 flex items-center justify-end w-full z-10 text-xs text-black dark:text-white bg-white dark:bg-black"
 			>
 				<div class="flex-1 truncate">
 					<Tooltip content={lang} placement="top-start">


### PR DESCRIPTION
# Pull Request

## Checklist

- [x] This PR targets the `dev` branch.
- [x] This PR links to a well-described, confirmed Issue or active Discussion: Closes #29835
- [x] A maintainer explicitly asked me to open this PR, or this PR only updates i18n/localization.
- [x] The change is one logical unit with no unrelated commits.
- [x] I matched nearby code patterns and avoided unnecessary new settings, abstractions, or dependencies.
- [x] I manually tested the changed workflow and any nearby behavior that could be affected.
- [ ] I updated relevant docs, including the [Open WebUI Docs Repository](https://github.com/open-webui/docs), if needed.
- [x] I added screenshots for UI changes, and a recording when motion or interaction matters.
- [x] I reviewed any AI-generated code before submitting it.
- [x] The PR title uses one of the prefixes listed below.

## Summary

In the Pinned Messages modal and the thread panel, a long code block's sticky header bar parks about 28px below the top of the list and floats over the code (#29835). Its bottom corners are square when it reaches the end of the block, and Firefox draws a strip of code above the bar outside the list. Three commits, one per cause. Two wrappers reindent their contents, so the diff reads best with whitespace hidden.

**The 28px float.** Both scroll containers carry `pt-7` ([PinnedMessagesModal.svelte L97](https://github.com/open-webui/open-webui/blob/12b14124b9376eccf2ba7cf3dba92bc145493703/src/lib/components/channel/PinnedMessagesModal.svelte#L97), [Thread.svelte L191](https://github.com/open-webui/open-webui/blob/12b14124b9376eccf2ba7cf3dba92bc145493703/src/lib/components/channel/Thread.svelte#L191)), added in #27737 as headroom so the first message's hover action row is not clipped. Sticky positioning insets by the scroll container's padding, so the `top-0` header parks 28px down. I measured this in a bare page in both Chromium and Firefox: 28px with the padding on the scroll container, 0px without. The headroom is still needed, so it moves one level down onto an inner wrapper in both files. The scroll containers have no top padding and the first message keeps its 28px.

**The square corners.** The header keeps its own top rounding and nothing clips it, so at the end of the block its square bottom corners sit over the block's rounded ones. The block wrapper now carries `overflow-clip`, which clips children to the wrapper's rounded shape without creating a scroll container, so the header still sticks. The header drops its own `rounded-t-2xl` since the wrapper's corners now shape it at both ends. The body already clips itself and nothing inside the wrapper overflows on purpose, so the only visible change is the header's corners. This applies to every code block, chat included, where the same square corners showed.

**The Firefox strip** appears only while the header is sticky. Firefox paints the scrolled code above the list's top edge, outside its clip. Hit-testing there finds only the modal's title row, so the text is composited, not laid out. I isolated it in the console, scrolling after each change. Making the header static clears it. Neither `isolation: isolate` nor `contain: paint` on the list helps, and `will-change: transform` on the list clears it. The two scroll containers get `will-change-transform`, which gives each list its own composited layer and Firefox then clips it correctly. Nothing fixed-positioned renders inside a channel message (the image preview moves itself to the document body), so the layer cannot capture a fixed descendant. Chrome shows no difference with or without it.

```diff
 	<div
-		class="relative {className} flex flex-col rounded-2xl border border-gray-100/30 dark:border-gray-850/30 my-0.5"
+		class="relative {className} flex flex-col rounded-2xl border border-gray-100/30 dark:border-gray-850/30 my-0.5 overflow-clip"
```

```diff
-		<div class="flex-1 min-h-0 w-full overflow-y-auto pt-7" bind:this={messagesContainerElement}>
+		<div
+			class="flex-1 min-h-0 w-full overflow-y-auto will-change-transform"
+			bind:this={messagesContainerElement}
+		>
+			<div class="pt-7">
```

Four files: the modal, the thread panel, and `CodeBlock.svelte`.

## Testing

Manually on this branch in Firefox and Chrome, with a pinned message holding a code block of 40 or more lines:

1. Pinned Messages modal, block scrolled partly out at the top: the header sits flush with the top edge of the list with no code above it, and `Copy` works from there.
2. The first pinned entry's hover action row is still fully visible, not clipped at the top of the list.
3. Scrolled until the header reaches the end of its block: its bottom corners follow the block's rounded corners.
4. Firefox, block scrolled partly out: no strip of code above the header.
5. The same four checks in a thread panel.
6. A code block in a normal chat, since the wrapper clip and the header corners apply to every block.

Two measurements of mine support the fixes. In both Chromium and Firefox, a sticky child sits 28px down when the scroll container has 28px of top padding and 0px down without it. A static page with the compiled CSS and the modal's element chain kept the header at 0px from the list edge with the wrapper clip applied, and its corners followed the block at the bottom clamp.

## Screenshots

| Surface | Before | After |
|---|---|---|
| Pinned Messages modal, header stuck mid-block | <img width="610" height="895" alt="image" src="https://github.com/user-attachments/assets/20fb1a93-c748-4764-a9cf-9cdf520d42d8" /> | <img width="610" height="895" alt="image" src="https://github.com/user-attachments/assets/edc8fab5-3392-4766-8560-bed225d1acd0" /> |
| Header at the end of its block, corners | <img width="610" height="895" alt="image" src="https://github.com/user-attachments/assets/163cf656-418e-4893-8532-a7ba86e82407" /> | <img width="610" height="895" alt="image" src="https://github.com/user-attachments/assets/269b5255-c143-4d21-a58c-4e05c3a85542" /> |
| Firefox strip above the header | <img width="610" height="895" alt="image" src="https://github.com/user-attachments/assets/a4163254-caee-4174-9d70-43d72be62e4e" /> | <img width="610" height="895" alt="image" src="https://github.com/user-attachments/assets/977259c9-7ade-43be-81e3-f87a9b494730" /> |

Before is current `dev`, After is this branch.

## Changelog Entry

### Fixed

- Sticky code block headers in the Pinned Messages modal and thread panel now stay at the top of the list, keep the block's rounded corners at the end of the block, and no longer leave a strip of code above the bar in Firefox.

## Additional Context

Anchor commit for the permalinks: 12b14124b9376eccf2ba7cf3dba92bc145493703.

The main channel list gives its own scroll container `pt-6`, which would shift a sticky header the same way. I did not see it reported there and left it out of this PR.

This PR was prepared with AI copilot assistance. I have thoroughly reviewed and manually tested it.

## Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
