### PR TITLE
fix: stop forwarding upstream Server and Date headers from the terminal proxy

### DIFF
--- a/backend/open_webui/routers/terminals.py
+++ b/backend/open_webui/routers/terminals.py
@@ -39,7 +39,10 @@ log = logging.getLogger(__name__)
 router = APIRouter()
 
 STREAMING_CONTENT_TYPES = ('application/octet-stream', 'image/', 'application/pdf')
-STRIPPED_RESPONSE_HEADERS = frozenset(('transfer-encoding', 'connection', 'content-encoding', 'content-length'))
+# Drop the upstream's server and date: uvicorn adds its own and forwarding both duplicates them.
+STRIPPED_RESPONSE_HEADERS = frozenset(
+    ('transfer-encoding', 'connection', 'content-encoding', 'content-length', 'server', 'date')
+)
 
 
 def _sanitize_proxy_path(path: str) -> str | None:


### PR DESCRIPTION
Proxied terminal responses (GET /api/v1/terminals/{id}/ports and every other proxied route) went out with two Server and two Date headers: the terminal server's copies, forwarded verbatim, plus uvicorn's own. nginx in front of Open WebUI logs "upstream sent duplicate header line" for both on every request, and the ports route is polled often enough to fill gigabytes of error log per day.

Server and Date belong to whoever terminates the connection, so the proxy now drops the upstream's copies next to the framing headers it already stripped. uvicorn's own values still go out, once. Everything else, including custom upstream headers and TERMINAL_PROXY_HEADERS, passes through unchanged.

The OpenAI and Ollama proxies forward upstream Server and Date the same way and are left for a separate change.

Fixes #29824

## Contributor License Agreement

<!--
DO NOT DELETE THIS SECTION.
Your PR will not be reviewed or merged until you check the box below confirming that you have read and agree to the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
