### PR TITLE
fix: drop thinking blocks when converting Anthropic Messages requests to Chat Completions

### DIFF
--- a/backend/open_webui/utils/anthropic.py
+++ b/backend/open_webui/utils/anthropic.py
@@ -202,8 +202,9 @@ def convert_anthropic_to_openai_payload(
                         )
                     )
                 elif block_type in ('thinking', 'redacted_thinking'):
-                    # Thinking blocks have no OpenAI content-part equivalent
-                    pass
+                    # Unsigned thinking cannot be replayed upstream
+                    if block_type == 'redacted_thinking' or block.get('signature'):
+                        openai_content.append(_copy_cache_control(block, dict(block)))
                 elif block_type == 'image':
                     source = block.get('source', {})
                     if source.get('type') == 'base64':

--- a/backend/open_webui/utils/anthropic.py
+++ b/backend/open_webui/utils/anthropic.py
@@ -202,7 +202,8 @@ def convert_anthropic_to_openai_payload(
                         )
                     )
                 elif block_type in ('thinking', 'redacted_thinking'):
-                    openai_content.append(_copy_cache_control(block, dict(block)))
+                    # Thinking blocks have no OpenAI content-part equivalent
+                    pass
                 elif block_type == 'image':
                     source = block.get('source', {})
                     if source.get('type') == 'base64':
@@ -369,7 +370,7 @@ def convert_anthropic_to_openai_payload(
                     msg_dict['content'] = ''
                 msg_dict['tool_calls'] = tool_calls
                 messages.append(msg_dict)
-            elif openai_content:
+            elif openai_content or role == 'assistant':
                 messages.append({'role': role, 'content': _finalize_openai_content(openai_content)})
         else:
             messages.append({'role': role, 'content': str(content) if content else ''})


### PR DESCRIPTION
Claude Code and other Anthropic SDK clients pointed at /api/v1/messages send the assistant's earlier thinking blocks back with every follow-up request. Since 0.11.0 those blocks were copied into the OpenAI assistant message as content parts of type thinking, a part type Chat Completions does not define. Strict OpenAI-compatible servers such as NVIDIA Dynamo reject the whole request with 400 "data did not match any variant of untagged enum ChatCompletionRequestAssistantMessageContent", so a conversation with a reasoning model died on its second turn. The error reports its position at the very end of the body, which made the request look cut off; it was complete.

Thinking and redacted_thinking blocks are now skipped in the conversion, which is what happened before 0.11.0. An assistant turn that held only thinking blocks is kept as an empty assistant message so the turn order survives. Native Anthropic and LiteLLM connections are unaffected because they receive the request untouched, and thinking blocks in responses are still produced.

Fixes #29799

## Contributor License Agreement

<!--
DO NOT DELETE THIS SECTION.
Your PR will not be reviewed or merged until you check the box below confirming that you have read and agree to the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
