### PR TITLE
fix: keep stopping the remaining tasks of a chat when one already ended

### DIFF
--- a/backend/open_webui/tasks.py
+++ b/backend/open_webui/tasks.py
@@ -275,9 +275,8 @@ async def stop_item_tasks(redis: Redis, item_id: str):
         return {'status': True, 'message': f'No tasks found for item {item_id}.'}
 
     for task_id in task_ids:
-        result = await stop_task(redis, task_id)
-        if not result['status']:
-            return result  # Return the first failure
+        # Keep going: a task that already ended on its own is not a failure
+        await stop_task(redis, task_id)
 
     return {'status': True, 'message': f'All tasks for item {item_id} stopped.'}
 


### PR DESCRIPTION
Stopping a chat with several running tasks (a multi-model response, or a follow-up sent while a response was still streaming) gave up as soon as one of them could not be found. Without Redis that happens whenever a task finishes on its own while a sibling is still being cancelled: its id is gone by the time the loop reaches it, the loop returned that miss as a failure, and every task after it was left running.

A task that already ended needs no stopping, so the loop now goes on to the next id instead of returning early. No caller ever acted on the early return, so the only visible change is that the later tasks actually stop.

Verified with three tasks on one chat where the middle one completes while the first is unwinding: before the change the third stayed alive and the call reported a not-found failure, after it all tasks are cancelled.

https://github.com/open-webui/open-webui/issues/29816

## Contributor License Agreement

<!--
DO NOT DELETE THIS SECTION.
Your PR will not be reviewed or merged until you check the box below confirming that you have read and agree to the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
