### PR TITLE
fix: reposition the model selector dropdown when its content changes size

### DIFF
--- a/src/lib/components/chat/ModelSelector/Selector.svelte
+++ b/src/lib/components/chat/ModelSelector/Selector.svelte
@@ -209,6 +209,7 @@
 			updatePosition();
 			await tick();
 			updatePosition();
+			scheduleSettledPositionUpdates();
 			for (const delay of [0, 50, 150]) {
 				window.setTimeout(focusSearchInput, delay);
 			}
@@ -960,6 +961,21 @@
 		};
 	};
 
+	const trackContentSize = (node: HTMLElement) => {
+		if (!('ResizeObserver' in window)) {
+			return { destroy() {} };
+		}
+
+		const observer = new ResizeObserver(schedulePositionUpdate);
+		observer.observe(node);
+
+		return {
+			destroy() {
+				observer.disconnect();
+			}
+		};
+	};
+
 	$: visibleStart = Math.max(0, Math.floor(listScrollTop / ITEM_HEIGHT) - OVERSCAN);
 	$: visibleEnd = Math.min(
 		filteredItems.length,
@@ -1027,6 +1043,7 @@
 		>
 			<div
 				bind:this={panelElement}
+				use:trackContentSize
 				class="z-40 {className ??
 					'w-[20rem]'} max-w-[calc(100vw-1rem)] justify-start rounded-xl border border-gray-100 bg-white p-0.5 shadow-lg outline-hidden dark:border-gray-800 dark:bg-gray-850 dark:text-white flex flex-col overflow-hidden"
 				style={dropdownPosition.maxHeight ? `max-height: ${dropdownPosition.maxHeight}px;` : ''}


### PR DESCRIPTION
# Pull Request

## Checklist

- [x] This PR targets the `dev` branch.
- [x] This PR links to a well-described, confirmed Issue or active Discussion: `Closes #29852`.
- [x] A maintainer explicitly asked me to open this PR, or this PR only updates i18n/localization.
- [x] The change is one logical unit with no unrelated commits.
- [x] I matched nearby code patterns and avoided unnecessary new settings, abstractions, or dependencies.
- [x] I manually tested the changed workflow and any nearby behavior that could be affected.
- [ ] I updated relevant docs, including the [Open WebUI Docs Repository](https://github.com/open-webui/docs), if needed.
- [x] I added screenshots for UI changes, and a recording when motion or interaction matters.
- [x] I reviewed any AI-generated code before submitting it.
- [x] The PR title uses one of the prefixes listed below.

## Summary

Opening a chat URL whose model ID is no longer on the instance makes the New Chat page open the model selector with that ID in the search box. That is so the model can be pulled. That selector rendered cut off at the bottom of the window, with the Download rows and Set as default below the edge. Closing and reopening it by hand put it in the right place. Reported in #29852.

The selector computes its position twice when it opens and then only on window scroll or a visual viewport resize. On the auto-open path, the panel changes height three times right after opening. The search text goes in, the list empties, and the Download rows arrive once the Ollama and llama.cpp lookups return. The panel grew past the position it was given. A manual open starts from the full list, which gets clamped, so later changes only shrink it.

The fix adds the two pieces `Dropdown.svelte` received in #27460 for the same defect. A `ResizeObserver` on the panel calls the existing `schedulePositionUpdate` whenever the panel's size changes, in the same action shape the file already uses for its list viewport. `toggleOpen` also calls the file's existing `scheduleSettledPositionUpdates` after its two initial updates, which covers the trigger settling on a fresh page load.

## Screenshots

| Before | After |
|---|---|
| `/?model=llama-3.3-70b-versatile` on `dev`: selector opens above the input with the search filled, Download rows cut off by the window edge <img width="2560" height="278" alt="image" src="https://github.com/user-attachments/assets/58bcc37e-4650-4322-aee6-aa1a3e714d8f" />| Same URL on this branch: selector fits, both Download rows and Set as default visible <img width="2560" height="278" alt="image" src="https://github.com/user-attachments/assets/bd651cce-55f3-4655-bd91-bc0eb8dfb760" />|

## Testing

I tested this locally on the branch. Opening a new tab with a chat URL naming a model that is not on the instance now shows the selector fully inside the window with the Download rows visible. Clicking a mention of a removed model in a channel message behaves the same. Opening the selector by hand, typing a search that narrows to nothing, clearing it, and resizing the window with it open all keep it positioned.

Mechanical checks, run at my direction with AI copilot assistance:

| Check | Result |
|---|---|
| `npm run build` | exit 0 |
| `npx prettier --check` on the changed file | already formatted |
| `svelte-check` on the changed lines | no findings |
| Added code comments, Svelte 5 runes | none |

## Changelog Entry

### Fixed

- The model selector no longer renders cut off when it is opened automatically for a model ID that is not on the instance. It repositions itself whenever its content changes size.

## Additional Context

The same class of defect was fixed for the shared dropdown component in #27460. The model selector has its own positioning code, which that change did not reach.

This PR was prepared with AI copilot assistance. I have thoroughly reviewed it.

## Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
