### PR TITLE
perf: send only the current round's output at tool-call boundaries

### DIFF
--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -1019,7 +1019,7 @@ async def _make_channel_emitter(request_info):
             content = get_output_text(state['output'])
 
             now = time.time()
-            if content and (now - state['last_emit_at']) >= THROTTLE_INTERVAL:
+            if state['output'] and (now - state['last_emit_at']) >= THROTTLE_INTERVAL:
                 state['last_emit_at'] = now
                 await _emit_channel_update(content, False, state['output'])
 

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -4778,6 +4778,14 @@ async def streaming_chat_response_handler(response, ctx):
                                 **response_data,
                                 'output_index': response_data['output_index'] + len(prior_output),
                             }
+                        if prior_output and isinstance(response_data.get('response'), dict):
+                            # response.output is this round only; the response.completed reducer drops earlier rounds
+                            return {
+                                **response_data,
+                                'response': {
+                                    key: value for key, value in response_data['response'].items() if key != 'output'
+                                },
+                            }
                         return response_data
 
                     async def flush_pending_delta_data(threshold: int = 0):
@@ -5595,6 +5603,7 @@ async def streaming_chat_response_handler(response, ctx):
                         if responses_api_tool_calls:
                             tool_calls.append(_split_tool_calls(responses_api_tool_calls))
 
+                output_start = len(prior_output)
                 try:
                     await stream_body_handler(response, form_data)
                 finally:
@@ -5625,6 +5634,27 @@ async def streaming_chat_response_handler(response, ctx):
                     original_system_content = (
                         get_content_from_message(original_system_message) if original_system_message else None
                     )
+
+                async def emit_current_response_output_items():
+                    for output_index, item in enumerate(full_output()[output_start:], start=output_start):
+                        if item.get('type') == 'function_call_output':
+                            # input_image parts are base64 data URIs only for the LLM, via convert_output_to_messages
+                            item = {
+                                **item,
+                                'output': [
+                                    part for part in item.get('output', []) if part.get('type') != 'input_image'
+                                ],
+                            }
+                        await event_emitter(
+                            {
+                                'type': 'response:completion',
+                                'data': {
+                                    'type': 'response.output_item.done',
+                                    'output_index': output_index,
+                                    'item': item,
+                                },
+                            }
+                        )
 
                 while tool_calls and (
                     max_tool_call_iterations is None or tool_call_iterations < max_tool_call_iterations
@@ -5693,14 +5723,7 @@ async def streaming_chat_response_handler(response, ctx):
                         )
                         return
 
-                    await event_emitter(
-                        {
-                            'type': 'chat:completion',
-                            'data': {
-                                'output': full_output(),
-                            },
-                        }
-                    )
+                    await emit_current_response_output_items()
 
                     tools = metadata.get('tools', {})
 
@@ -5955,25 +5978,7 @@ async def streaming_chat_response_handler(response, ctx):
                                     )
                         tool_call_sources.clear()
 
-                    # Strip input_image parts (large base64 data URIs) from the
-                    # output sent to the frontend — they're only for LLM consumption
-                    # via convert_output_to_messages.
-                    frontend_output = []
-                    for item in full_output():
-                        if item.get('type') == 'function_call_output':
-                            parts = item.get('output', [])
-                            if any(p.get('type') == 'input_image' for p in parts):
-                                item = {**item, 'output': [p for p in parts if p.get('type') != 'input_image']}
-                        frontend_output.append(item)
-
-                    await event_emitter(
-                        {
-                            'type': 'chat:completion',
-                            'data': {
-                                'output': frontend_output,
-                            },
-                        }
-                    )
+                    await emit_current_response_output_items()
 
                     try:
                         new_form_data = {
@@ -6070,6 +6075,7 @@ async def streaming_chat_response_handler(response, ctx):
                                 if not msg_parts or (len(msg_parts) == 1 and not msg_parts[0].get('text', '').strip()):
                                     prior_output.pop()
                             output = []
+                            output_start = len(prior_output)
                             await stream_body_handler(res, new_form_data)
                             output = full_output()
                             prior_output = []


### PR DESCRIPTION
Every tool-call round re-sent the whole assistant message so far, all earlier rounds' text, reasoning, calls and tool results, twice over the websocket as a chat:completion snapshot, so agentic runs grew with the square of the round count: 45 MB Redis publishes stalling the instance for 400 ms (#29833).

The two boundary emits now send only the items of the response that just ended, one response.output_item.done event each with its absolute index, which the browser and the channel emitter already apply. Earlier rounds never change after their own boundary, so they are never re-sent; the final done snapshot, the approval pauses and the code-interpreter loop keep their snapshots. A continuation round's response.completed drops its round-only output, which wiped the earlier rounds from the channel emitter state, and the channel emitter now writes tool items before the first text token, as the snapshots used to give it.

Boundary payload, 3 tool rounds with 4 calls, chat-completions upstream:

| tool result | before | after |
| --- | --- | --- |
| 4 KiB | 51.6 KiB | 18.7 KiB |
| 400 KiB | 4.30 MiB | 1.18 MiB |

Fixes #29833

## Contributor License Agreement

<!--
DO NOT DELETE THIS SECTION.
Your PR will not be reviewed or merged until you check the box below confirming that you have read and agree to the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
