### PR TITLE
fix: open the thread when a notification toast for a thread reply is clicked

### DIFF
--- a/src/lib/components/channel/Channel.svelte
+++ b/src/lib/components/channel/Channel.svelte
@@ -3,6 +3,7 @@
 
 	import { onDestroy, onMount, tick } from 'svelte';
 	import { goto } from '$app/navigation';
+	import { page } from '$app/stores';
 	import { v4 as uuidv4 } from 'uuid';
 
 	import {
@@ -46,6 +47,11 @@
 
 	$: if (id) {
 		initHandler();
+	}
+
+	$: if (channel && $page.url.searchParams.get('thread')) {
+		threadId = $page.url.searchParams.get('thread');
+		window.history.replaceState(history.state, '', `/channels/${id}`);
 	}
 
 	const scrollToBottom = () => {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -864,7 +864,9 @@
 				toast.custom(NotificationToast, {
 					componentProps: {
 						onClick: () => {
-							goto(`/channels/${event.channel_id}`);
+							goto(
+								`/channels/${event.channel_id}${data?.parent_id ? `?thread=${data.parent_id}` : ''}`
+							);
 						},
 						content: data?.content,
 						title: `${title}`


### PR DESCRIPTION
# Pull Request

## Checklist

- [x] This PR targets the `dev` branch.
- [x] This PR links to a well-described, confirmed Issue or active Discussion: `Closes #29855`.
- [x] A maintainer explicitly asked me to open this PR, or this PR only updates i18n/localization.
- [x] The change is one logical unit with no unrelated commits.
- [x] I matched nearby code patterns and avoided unnecessary new settings, abstractions, or dependencies.
- [x] I manually tested the changed workflow and any nearby behavior that could be affected.
- [ ] I updated relevant docs, including the [Open WebUI Docs Repository](https://github.com/open-webui/docs), if needed.
- [ ] I added screenshots for UI changes, and a recording when motion or interaction matters.
- [x] I reviewed any AI-generated code before submitting it.
- [x] The PR title uses one of the prefixes listed below.

## Summary

The notification toast for a reply inside a channel thread opened the channel and stopped there. The thread stayed closed and the reply was off screen until you found the thread by hand. A toast for a plain channel message already landed in the right place. Reported in #29855.

The toast's click handler navigated to the channel and nothing else, and the channel page had no way to be told which thread to open. The event behind the toast carries the whole message, including the parent ID for a reply, so the thread was known and dropped.

The fix has two parts. The toast appends a `thread` parameter with the parent ID when the message is a reply, and keeps navigating to the bare channel when it is not. The channel page opens the thread named by that parameter once the channel has loaded, then strips the parameter from the address bar with the same `replaceState` call the chat page uses. Waiting for the channel matters because the thread pane sends you to the home page when it mounts without one.

## Testing

I tested this locally on the branch with two accounts in the same Firefox browser, in both directions. Replying inside a thread from one account and clicking the toast on the other lands in the channel with that thread open in the side pane and a clean address bar. A plain channel message still opens only the channel. Clicking the toast while already in that channel opens the thread too.

Mechanical checks, run at my direction with AI copilot assistance:

| Check | Result |
|---|---|
| `npm run build` | exit 0 |
| `npx prettier --check` on the changed files | already formatted |
| Added code comments, Svelte 5 runes | none |

## Changelog Entry

### Fixed

- Clicking the notification toast for a reply inside a channel thread now opens that thread in the channel, instead of only the channel.

## Additional Context

The browser-level notification created alongside the toast has no click handler and is unchanged here.

This PR was prepared with AI copilot assistance. I have thoroughly reviewed it.

## Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
