### PR TITLE
fix: keep line breaks between two single tildes in rendered markdown

### DIFF
--- a/src/lib/utils/marked/strikethrough-extension.ts
+++ b/src/lib/utils/marked/strikethrough-extension.ts
@@ -15,11 +15,11 @@ export const disableSingleTilde = {
 			// 2. Check for single-tilde: ~text~
 			const singleMatch = /^~(?=\S)([\s\S]*?\S)~/.exec(src);
 			if (singleMatch) {
-				// return a plain-text token, NOT del
+				// the rest of the span re-lexes as normal inline markdown
 				return {
 					type: 'text',
-					raw: singleMatch[0],
-					text: singleMatch[0] // include both tildes as literal text
+					raw: '~',
+					text: '~'
 				};
 			}
 


### PR DESCRIPTION
Any text with a single ~ on one line and another one further down lost every line break in between: a thinking block with "~-1ms" timing tokens on each line collapsed into one long line, while lines outside that span kept their breaks. Visible since v0.11.0, where the message container stopped preserving raw newlines in text; before that the CSS masked the missing line breaks.

The tokenizer that keeps single tildes from becoming strikethrough swallowed the whole ~...~ span into one opaque text token, so the line-break tokenizer never saw the newlines inside it. It now emits only the tilde as literal text and lets the rest lex normally. Side effect, and the intended reading of "single tilde is not strikethrough": inline markdown between two single tildes (bold, code, links, a ~~real~~ strikethrough) now renders instead of showing as literal characters. Double-tilde strikethrough is untouched.

Second symptom of #29842.

## Contributor License Agreement

<!--
DO NOT DELETE THIS SECTION.
Your PR will not be reviewed or merged until you check the box below confirming that you have read and agree to the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
