### PR TITLE
fix: stop streaming the raw reasoning tag into the thinking panel

### DIFF
--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import copy
 import logging
 import random
 import sys
@@ -1005,6 +1006,9 @@ async def _make_channel_emitter(request_info):
 
             if not content and not output and not done:
                 return
+
+            if isinstance(output, list):
+                state['output'] = copy.deepcopy(output)
 
             now = time.time()
             if done or (now - state['last_emit_at']) >= THROTTLE_INTERVAL:

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -5447,6 +5447,8 @@ async def streaming_chat_response_handler(response, ctx):
                                                     }
                                                 ]
 
+                                        pre_tag_item_id = output[-1].get('id')
+
                                         if DETECT_REASONING_TAGS:
                                             output, _ = tag_output_handler(
                                                 'reasoning',
@@ -5487,6 +5489,15 @@ async def streaming_chat_response_handler(response, ctx):
                                             'delta': value,
                                         }
                                         delta_type = delta_event_type
+
+                                        # the raw chunk still carries the tag text: resend the cleaned output instead
+                                        if target_item.get('id') != pre_tag_item_id:
+                                            await flush_pending_delta_data()
+                                            await event_emitter(
+                                                {'type': 'chat:completion', 'data': {'output': full_output()}}
+                                            )
+                                            await save_current_response_stream()
+                                            data = None
 
                                 if delta and data:
                                     await queue_pending_delta_data(data, delta_type)

--- a/src/lib/components/chat/Messages/structuredOutput.ts
+++ b/src/lib/components/chat/Messages/structuredOutput.ts
@@ -626,6 +626,11 @@ export function applyResponseStreamEvent(
 			return nextOutput;
 		}
 
+		if (item.type === 'open_webui:code_interpreter') {
+			item.code = appendDelta(item.code ?? '', event.delta);
+			return nextOutput;
+		}
+
 		const key = deltaType === 'output_text' || deltaType === 'reasoning_text' ? 'text' : deltaType;
 		item.content = [...(item.content ?? [])];
 		const part = ensurePart(item.content, event.content_index ?? 0);


### PR DESCRIPTION
When a model streams its reasoning inline as <think> or <thinking> text, the chunk that opens the block is forwarded to the browser as-is, so the literal tag sits at the top of the thinking panel for as long as the block is open, and the chunk that closes it lands in the answer with the closing tag still in it. Both only clean up when the response finishes and the final output replaces what the browser accumulated. Regressed in v0.11.1 with the per-chunk delta events; v0.10.2 resent the already cleaned output instead.

The backend already strips the tags from its own output items in that same chunk. Now, whenever the tag scanner opens or closes an item, the cleaned output is resent whole (the same snapshot event the handler already sends at the end of a response) instead of the raw delta, so the thinking panel shows clean text from the first chunk and the answer never carries the closing tag. Chunks without a tag transition still stream as plain deltas, unchanged. Channel chats adopt that snapshot too, and the browser now applies text deltas to a code interpreter block's code so it keeps streaming after the tag.

Fixes #29842

## Contributor License Agreement

<!--
DO NOT DELETE THIS SECTION.
Your PR will not be reviewed or merged until you check the box below confirming that you have read and agree to the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
