### PR TITLE
fix: render code blocks in channel model replies with the same editor as other messages

### DIFF
--- a/src/lib/components/channel/Messages/Message.svelte
+++ b/src/lib/components/channel/Messages/Message.svelte
@@ -537,7 +537,6 @@
 									id={renderedMessageId}
 									output={messageOutput}
 									done={message?.meta?.done ?? false}
-									editCodeBlock={false}
 								/>
 							{:else if (message?.content ?? '').trim() === '' && message?.meta?.model_id}
 								<Skeleton />


### PR DESCRIPTION
# Pull Request

## Checklist

- [x] This PR targets the `dev` branch.
- [x] This PR links to a well-described, confirmed Issue or active Discussion: `Closes #29859`.
- [x] A maintainer explicitly asked me to open this PR, or this PR only updates i18n/localization.
- [x] The change is one logical unit with no unrelated commits.
- [x] I matched nearby code patterns and avoided unnecessary new settings, abstractions, or dependencies.
- [x] I manually tested the changed workflow and any nearby behavior that could be affected.
- [ ] I updated relevant docs, including the [Open WebUI Docs Repository](https://github.com/open-webui/docs), if needed.
- [x] I added screenshots for UI changes, and a recording when motion or interaction matters.
- [x] I reviewed any AI-generated code before submitting it.
- [x] The PR title uses one of the prefixes listed below.

## Summary

Code blocks in a model's reply inside a channel rendered as plain highlighted blocks with no line numbers and a different theme. The same content posted by a user rendered with the code editor. Reported in #29859.

Model replies produced through the Responses API store a structured output item, and a channel message with that item renders through `StructuredOutputRenderer`. The channel passed it `editCodeBlock={false}`, which makes every code block inside fall back to the static block instead of `CodeEditor`. The plain `Markdown` path used by every other channel message leaves the prop at its default of true, and so does the chat side, where `ContentRenderer` passes it through unchanged. The channel was the one place switching it off.

This PR removes that one line, so the renderer's default applies and channel model replies get the same code blocks as every other message. The editor's Save button stays hidden, because that is governed by the separate `save` prop, which channels do not set.

The removed line arrived in 498cdab9a548d7d2fd19c389204ee26236fc7efe on 2026-07-27, the refac that added structured output to channel messages together with the socket change that stores the output on model replies. Its commit message is "refac" with no linked issue, so no reason for the flag is on record. If it was meant to make model replies read-only, the path for user messages does not do that either, so this brings the two in line rather than changing a policy.

## Screenshots

| Before | After |
|---|---|
| A model reply in a channel thread on `dev`: plain highlighted block, no line numbers, different theme <img width="422" height="647" alt="image" src="https://github.com/user-attachments/assets/eab40eca-e516-4b81-ac35-8562bd612231" /> | The same reply on this branch: line numbers and the editor theme, matching a user-posted copy <img width="422" height="551" alt="image" src="https://github.com/user-attachments/assets/57721cc5-8dd4-45dc-8562-76dbae768ff0" />|

## Testing

I tested this locally on the branch. A July model reply in a channel thread that used to render plain now shows line numbers and the editor theme, matching the copy of it I had posted as a user message. Channel messages without code and the main channel view are unchanged.

Mechanical checks, run at my direction with AI copilot assistance:

| Check | Result |
|---|---|
| `npm run build` | exit 0 |
| `npx prettier --check` on the changed file | already formatted |
| Added code comments, Svelte 5 runes | none |

## Changelog Entry

### Fixed

- Code blocks in a model's channel reply now render with the same editor, line numbers and theme as every other message.

## Additional Context

This PR was prepared with AI copilot assistance. I have thoroughly reviewed it.

## Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
