### PR TITLE
fix: keep the select chevron clear of the text in shrink-to-fit selects

### DIFF
--- a/src/lib/components/AddConnectionModal.svelte
+++ b/src/lib/components/AddConnectionModal.svelte
@@ -625,7 +625,7 @@
 										<select
 											id="provider-select"
 											bind:value={provider}
-											class="text-xs text-gray-700 dark:text-gray-300 bg-transparent outline-hidden"
+											class="text-xs text-gray-700 dark:text-gray-300 bg-transparent pr-5 outline-hidden"
 										>
 											<option value="">{$i18n.t('Default')}</option>
 											<option value="azure">{$i18n.t('Azure OpenAI')}</option>

--- a/src/lib/components/admin/Users/Groups/General.svelte
+++ b/src/lib/components/admin/Users/Groups/General.svelte
@@ -77,7 +77,7 @@
 
 			<div class="flex items-center gap-2 p-1">
 				<select
-					class="text-sm bg-transparent outline-hidden rounded-lg px-2"
+					class="text-sm bg-transparent outline-hidden rounded-lg pl-2 pr-5"
 					value={data?.config?.share ?? 'members'}
 					on:change={(e) => {
 						const value = e.target.value;

--- a/src/lib/components/workspace/common/AccessControl.svelte
+++ b/src/lib/components/workspace/common/AccessControl.svelte
@@ -609,7 +609,7 @@
 						{#if accessRoles.includes('write')}
 							<select
 								aria-label={$i18n.t('Access level')}
-								class="bg-transparent text-sm outline-none"
+								class="bg-transparent text-sm outline-none pr-5"
 								value={writeGroupIds.includes(group.id) ? 'write' : 'read'}
 								on:change={(e) => {
 									if (
@@ -663,7 +663,7 @@
 							{#if accessRoles.includes('write')}
 								<select
 									aria-label={$i18n.t('Access level')}
-									class="bg-transparent text-sm outline-none"
+									class="bg-transparent text-sm outline-none pr-5"
 									value={writeUserIds.includes(user.id) ? 'write' : 'read'}
 									on:change={(e) => {
 										if (


### PR DESCRIPTION
# Pull Request

## Checklist

- [x] This PR targets the `dev` branch.
- [x] This PR links to a well-described, confirmed Issue or active Discussion: `Closes #29865`.
- [x] A maintainer explicitly asked me to open this PR, or this PR only updates i18n/localization.
- [x] The change is one logical unit with no unrelated commits.
- [x] I matched nearby code patterns and avoided unnecessary new settings, abstractions, or dependencies.
- [x] I manually tested the changed workflow and any nearby behavior that could be affected.
- [ ] I updated relevant docs, including the [Open WebUI Docs Repository](https://github.com/open-webui/docs), if needed.
- [x] I added screenshots for UI changes, and a recording when motion or interaction matters.
- [x] I reviewed any AI-generated code before submitting it.
- [x] The PR title uses one of the prefixes listed below.

## Summary

The Read and Write dropdown in the Access List drew its chevron over the last letter of the word, and three other shrink-to-fit selects did the same. Reported in #29865.

Every select hides the browser's arrow and draws a chevron as a background image at its right edge, from the global rule in `app.css`. The rule's own `padding-right` has been commented out since `59c349de00ee8ca413f0c0dd9b46febe25c06fdf` moved the chevron to the edge, so each select brings its own right padding. Four did not, and since they shrink to fit their text, the chevron landed on the text every time.

This PR adds `pr-5` to those four, the value the connection modals already share for their selects. The share select on the group General tab trades its `px-2` for `pl-2 pr-5`. Four class strings change, nothing else.

I did not restore the global padding. That rule sits outside Tailwind's layers, so a padding there would override every `pr-*` and `px-*` utility on every select in Open WebUI.

## Screenshots

| Before | After |
|---|---|
| Read/Write in the Access List on `dev`: chevron over the last letter <img width="2363" height="1011" alt="image" src="https://github.com/user-attachments/assets/8c2c3597-38f2-427e-897c-0de96028b3b8" />| Same dropdown on this branch: chevron beside the word with a small gap, closed and open <img width="2363" height="1011" alt="Image" src="https://github.com/user-attachments/assets/03ea3771-449a-463b-b792-fedca5bda589" />|

## Testing

I tested this locally on the branch. The Read and Write dropdown in the access control modal shows the chevron beside the word with a small gap, closed and open, for a user row. The gap was first set at `pr-8` to match the visibility select in the same modal and read as too wide, so it was brought down to `pr-5`.

Mechanical checks, run at my direction with AI copilot assistance:

| Check | Result |
|---|---|
| `npm run build` | exit 0 |
| `npx prettier --check` on the changed files | already formatted |
| Added code comments, Svelte 5 runes | none |

## Changelog Entry

### Fixed

- The chevron on the Read and Write access dropdown, the group share select and the connection provider select no longer overlaps the selected text.

## Additional Context

Full-width selects were left alone. Their text only reaches the chevron when a label is long enough to fill the row.

This PR was prepared with AI copilot assistance. I have thoroughly reviewed it.

## Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
