### PR TITLE
feat: Added environment variable config for leaflet map tile server URL

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -1749,6 +1749,13 @@ RESPONSE_WATERMARK = os.getenv('RESPONSE_WATERMARK', '')
 
 IFRAME_CSP = os.getenv('IFRAME_CSP', '')
 
+MAP_TILE_SERVER_URL = os.getenv('MAP_TILE_SERVER_URL', 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png')
+
+MAP_TILE_SERVER_ATTRIBUTION = os.getenv(
+    'MAP_TILE_SERVER_ATTRIBUTION',
+    '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+)
+
 USER_PERMISSIONS_WORKSPACE_MODELS_ACCESS = (
     os.getenv('USER_PERMISSIONS_WORKSPACE_MODELS_ACCESS', 'False').lower() == 'true'
 )

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -59,6 +59,8 @@ from open_webui.config import (
     GOOGLE_DRIVE_API_KEY,
     GOOGLE_DRIVE_CLIENT_ID,
     IFRAME_CSP,
+    MAP_TILE_SERVER_ATTRIBUTION,
+    MAP_TILE_SERVER_URL,
     OAUTH_PROVIDERS,
     ONEDRIVE_CLIENT_ID_BUSINESS,
     ONEDRIVE_CLIENT_ID_PERSONAL,
@@ -2413,6 +2415,8 @@ async def get_app_config(request: Request):
                     'pending_user_overlay_content': config.get('ui.pending_user_overlay_content'),
                     'response_watermark': config.get('ui.watermark'),
                     'iframe_csp': IFRAME_CSP,
+                    'map_tile_server_url': MAP_TILE_SERVER_URL,
+                    'map_tile_server_attribution': MAP_TILE_SERVER_ATTRIBUTION,
                 },
                 'license_metadata': license_metadata,
                 **(

--- a/src/lib/components/common/Valves/MapSelector.svelte
+++ b/src/lib/components/common/Valves/MapSelector.svelte
@@ -1,5 +1,6 @@
 <script>
 	import { onMount, onDestroy } from 'svelte';
+	import { config } from '$lib/stores';
 
 	let map;
 	let mapElement;
@@ -28,10 +29,13 @@
 			];
 		}
 
-		L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-			attribution:
-				'&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-		}).addTo(map);
+		const tileServerUrl = $config?.ui?.map_tile_server_url;
+
+		if (tileServerUrl) {
+			L.tileLayer(tileServerUrl, {
+				attribution: $config?.ui?.map_tile_server_attribution
+			}).addTo(map);
+		}
 
 		const setMarkers = (points) => {
 			if (map) {

--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -375,6 +375,8 @@ type Config = {
 		pending_user_overlay_content?: string;
 		response_watermark?: string;
 		iframe_csp?: string;
+		map_tile_server_url?: string;
+		map_tile_server_attribution?: string;
 	};
 };
 


### PR DESCRIPTION
<!--
Important checks for contributors:
1. Target the `dev` branch. PRs targeting `main` will be closed.
2. Code pull requests are not the default contribution path.
3. Do not open a code PR as the first step. Start with a well-written Issue or Discussion unless a maintainer asked for the PR or the change is only i18n/localization.
4. Do not delete the Contributor License Agreement section at the bottom. The CLA bot requires it.
-->

# Pull Request

Thanks for wanting to improve Open WebUI. The most useful contribution is usually a clear, well-written Issue, not an unsolicited code pull request.

Open a code pull request only when a maintainer asks for one, or when the change is only i18n/localization. For real, reproducible bugs, start with a well-described [Issue](https://github.com/open-webui/open-webui/issues). For feature requests, UI/UX changes, behavior changes, architecture changes, suspected fixes, or unconfirmed approaches, start with an active [Discussion](https://github.com/open-webui/open-webui/discussions).

Before continuing, make sure the linked Issue or Discussion explains the user-facing problem, the expected outcome, the affected workflow, and any examples, logs, screenshots, constraints, or reproduction details needed for maintainers to evaluate it.

If you have implementation notes, include them as reference in the Issue or Discussion. If you want to share code as reference, include it there as a local diff, patch, or branch note. Do not open a pull request for reference code.

Unsolicited PRs may be closed without review, especially when they introduce product, architecture, compatibility, dependency, or maintenance decisions that have not been discussed.

## Checklist

- [x] This PR targets the `dev` branch.
- [x] This PR links to a well-described, confirmed Issue or active Discussion: `Closes #___` / `Relates to #___`.
- [ ] A maintainer explicitly asked me to open this PR, or this PR only updates i18n/localization.
- [x] The change is one logical unit with no unrelated commits.
- [x] I matched nearby code patterns and avoided unnecessary new settings, abstractions, or dependencies.
- [x] I manually tested the changed workflow and any nearby behavior that could be affected.
- [x] I updated relevant docs, including the [Open WebUI Docs Repository](https://github.com/open-webui/docs), if needed.
- [x] I added screenshots for UI changes, and a recording when motion or interaction matters.
- [x] I reviewed any AI-generated code before submitting it.
- [x] The PR title uses one of the prefixes listed below.

## Title Prefix

Use one of the following prefixes:

- **BREAKING CHANGE**: Changes affecting backward compatibility
- **build**: Build system or dependency changes
- **ci**: CI/CD workflow changes
- **chore**: Refactoring, cleanup, or non-functional changes
- **docs**: Documentation additions or updates
- **feat**: New features or enhancements
- **fix**: Bug fixes or corrections
- **i18n**: Internationalization or localization changes
- **perf**: Performance improvements
- **refactor**: Code restructuring

## Summary

This change adds 2 new environment variables to configure the map tile server that Leaflet uses for map type prompt variables: `MAP_TILE_SERVER_URL` and `MAP_TILE_SERVER_ATTRIBUTION`. If they are not set, they default to the standard OpenStreetMap URL. I didn't feel that it was necessary to add controls in the admin panel UI, as environment variables seem sufficient for this.

Closes  #29316 

Corresponding docs PR: https://github.com/open-webui/docs/pull/1389

## Testing

Tested by pointing the map tile server at CARTO:
```
MAP_TILE_SERVER_URL='https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png'
MAP_TILE_SERVER_ATTRIBUTION='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="https://carto.com/attributions">CARTO</a>'
```

Result:

<img width="692" height="567" alt="Screenshot_2026-08-31_19-33-20" src="https://github.com/user-attachments/assets/538829b9-750d-4fb4-9273-1761652330c5" />

Also setting `MAP_TILE_SERVER_URL` to an empty string will result in blank tiles for the map

## Changelog Entry

### Added

- 🗺️ **Map tile server via environment.** Administrators can now point the map at a different tile server through the new "MAP_TILE_SERVER_URL" and "MAP_TILE_SERVER_ATTRIBUTION" environment variables, for deployments that cannot reach OpenStreetMap.

## Additional Context

I understand that this is an unsolicited PR though the changes are so small that this shouldn't be too much trouble to review. I will likely have more contributions to make in the future especially in regards to supporting deployments in air-gapped environments.

## Contributor License Agreement

<!--
DO NOT DELETE THIS SECTION.
Your PR will not be reviewed or merged until you check the box below confirming that you have read and agree to the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
