### PR TITLE
fix: fail open when the token revocation lookup errors

### DIFF
--- a/backend/open_webui/utils/auth.py
+++ b/backend/open_webui/utils/auth.py
@@ -248,20 +248,32 @@ def decode_token(token: str) -> dict | None:
         return None
 
 
+# This runs on every authenticated request, so a line per failure floods the log.
+# Track the state instead: one when it breaks, one when it recovers.
+_revocation_check_failing = False
+
+
 async def is_valid_token(decoded, redis=None) -> bool:
     """
     Check whether a JWT has been revoked. Two mechanisms:
     1. Per-token (jti) — used by user-initiated sign-out (known jti).
     2. Per-user (revoked_at) — used by password changes and OIDC back-channel
        logout when individual jti values are unknown; rejects tokens with iat <= revoked_at.
+
+    Fails open. It sits in front of every authenticated request and the store only ever
+    holds revocations, so an unreachable store reads as "not revoked". A revoked token
+    living a little longer beats locking everyone out.
     """
-    if redis:
+    global _revocation_check_failing
+
+    if not redis:
+        return True
+
+    try:
         # Per-token revocation
         jti = decoded.get('jti')
-        if jti:
-            revoked = await redis.get(f'{REDIS_KEY_PREFIX}:auth:token:{jti}:revoked')
-            if revoked:
-                return False
+        if jti and await redis.get(f'{REDIS_KEY_PREFIX}:auth:token:{jti}:revoked'):
+            return False
 
         # Per-user revocation (password change, OIDC back-channel logout)
         user_id = decoded.get('id')
@@ -276,6 +288,15 @@ async def is_valid_token(decoded, redis=None) -> bool:
                         return False
                 except (ValueError, TypeError):
                     pass
+    except Exception as e:
+        if not _revocation_check_failing:
+            _revocation_check_failing = True
+            log.warning('Revocation check failed (%s); accepting tokens until it recovers', e)
+        return True
+
+    if _revocation_check_failing:
+        _revocation_check_failing = False
+        log.warning('Revocation check recovered')
 
     return True
 


### PR DESCRIPTION
is_valid_token runs inside get_current_user, in front of every authenticated request, and its two Redis lookups were unguarded. A Redis error propagated out of the dependency into the handler at the bottom of get_current_user, which deletes the token, oauth_id_token and oauth_session_id cookies before re-raising. Since the exception is not an HTTPException it then surfaces as a 500, so a Redis blip did not merely reject requests, it signed every active user out of the instance and returned an error while doing it. The WebSocket handshake path, get_verified_user_by_token, shares the same lookup and failed its connections.

Both lookups are now wrapped and accept the token on error. The store only ever holds the exception, a revocation, never the rule, so an unreachable store is indistinguishable from an absent entry and the safe reading of absence is "not revoked". This matches what the surrounding code already does: the lookups are skipped entirely when Redis is not configured, and revoke_user_tokens logs and returns in that case, leaving existing sessions valid until expiry. The change extends that accepted behaviour from "not configured" to "briefly unreachable".

A malformed revoked_at value now logs instead of passing silently.

## Contributor License Agreement

<!--
DO NOT DELETE THIS SECTION.
Your PR will not be reviewed or merged until you check the box below confirming that you have read and agree to the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
