### PR TITLE
fix: skip wasted query generation when rag.bypass_embedding_and_retrieval is on

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -1994,8 +1994,14 @@ async def chat_completion_files_handler(
 
     files = [item for item in (body.get('metadata', {}).get('files', None) or []) if item.get('type') != 'filesystem']
     if files:
-        # Check if all files are in full context mode
-        all_full_context = all(item.get('context') == 'full' for item in files)
+        # Check if all files are in full context mode, or the global bypass flag
+        # is on (which forces full-context injection regardless of per-item flags —
+        # see retrieval/utils.py's get_sources_from_items). Skipping query
+        # generation only when it will actually be used avoids wasting an LLM call.
+        bypass_embedding_and_retrieval = await Config.get('rag.bypass_embedding_and_retrieval')
+        all_full_context = bypass_embedding_and_retrieval or all(
+            item.get('context') == 'full' for item in files
+        )
 
         queries = []
         if not all_full_context:


### PR DESCRIPTION
Fixes #29898

## Problem

When the global admin setting `rag.bypass_embedding_and_retrieval` is enabled,
every chat turn with attached files still triggers an extra LLM call to
generate retrieval queries (`generate_queries`) — and the result of that call
is immediately discarded, because the file-injection step always falls back
to injecting the full document when the global bypass flag is on.

The two decision points disagreed with each other:

- **Skip condition** (`chat_completion_files_handler` in
  `backend/open_webui/utils/middleware.py`) only checked the per-item
  `context == 'full'` flag on each attached file, ignoring the global bypass
  setting entirely.
- **Injection condition** (`get_sources_from_items` in
  `backend/open_webui/retrieval/utils.py`) checks
  `item.get('context') == 'full' or bypass_embedding_and_retrieval` — i.e. it
  *does* account for the global flag.

So with the global bypass flag on: `generate_queries` still ran (an extra,
discarded LLM call on the full conversation history), and its result was
thrown away because the injection step used the global flag to decide to
inject the full document anyway.

**Impact:** one wasted LLM call per turn, on the full conversation history,
for every user who has this global setting enabled and any files attached to
a chat. Worst case (default `task.model.default = ""`, so the chat model
itself serves the task): a full prompt evaluation over the entire
conversation history is wasted on every single turn.

This closes a second gap in the same logic that #22674 (per-item
`context: "full"`) already addressed — same category of fix, not a new
design direction.

## Fix

Make the skip condition in `middleware.py` mirror the injection condition in
`retrieval/utils.py`, by also checking the global bypass flag:

```python
bypass_embedding_and_retrieval = await Config.get('rag.bypass_embedding_and_retrieval')
all_full_context = bypass_embedding_and_retrieval or all(
    item.get('context') == 'full' for item in files
)
```

## Manual testing

No automated test currently covers this path, so this was verified manually
against a local dev instance (backend `./dev.sh` + frontend `npm run dev`),
using Ollama with a local model, by inspecting each chat's stored
`statusHistory` directly in the database after each turn.

| Scenario | Global bypass | Per-item `context` | `queries_generated` fired? | Expected |
|---|---|---|---|---|
| This fix's target case | ON | (default) | No | No — confirms the extra call is skipped |
| Regression check | OFF | (default) | Yes | Yes — normal retrieval path unaffected |
| #22674 precedent (unchanged) | OFF | `"full"` | No | No — still skips generation as before |

All three cases produced the expected result.

## Notes

- No changes to `retrieval/utils.py` — its bypass-flag handling was already
  correct; this fix only aligns `middleware.py`'s skip decision with it.
