### PR TITLE
Document safe voice mode defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,19 @@ OLLAMA_BASE_URL='http://localhost:11434'
 OPENAI_API_BASE_URL=''
 OPENAI_API_KEY=''
 
+# Voice mode (safe local/browser defaults)
+# Empty STT engine uses the bundled faster-whisper backend.
+# The first transcription downloads the model into the persistent data directory.
+AUDIO_STT_ENGINE=''
+WHISPER_MODEL='base'
+WHISPER_COMPUTE_TYPE='int8'
+WHISPER_MODEL_AUTO_UPDATE='true'
+# Leave empty to auto-detect the spoken language, or set an ISO-639-1 code (for example 'ru').
+WHISPER_LANGUAGE=''
+
+# Empty TTS engine uses the browser's Web Speech API; no provider credentials are required.
+AUDIO_TTS_ENGINE=''
+
 # AUTOMATIC1111_BASE_URL="http://localhost:7860"
 
 # For production, you should only need one host as

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ Passionate about open-source AI? [Join our team →](https://careers.openwebui.c
 
 For more information, be sure to check out our [Open WebUI Documentation](https://docs.openwebui.com/).
 
+For a safe local/browser voice setup, see the repository's
+[voice mode guide](./docs/VOICE_MODE.md).
+
 ## Key Features of Open WebUI ⭐
 
 - 🚀 **Effortless Setup**: Install seamlessly via pip, uv, Docker, or Kubernetes (kubectl, kustomize, or helm), with `:ollama` and `:cuda` tagged images available for container deployments.

--- a/docs/VOICE_MODE.md
+++ b/docs/VOICE_MODE.md
@@ -1,0 +1,91 @@
+# Voice mode
+
+Open WebUI includes voice input and response playback without requiring a
+cloud API key. The recommended baseline is:
+
+- **STT:** local `faster-whisper` (`AUDIO_STT_ENGINE=''`)
+- **TTS:** the browser Web Speech API (`AUDIO_TTS_ENGINE=''`)
+
+Audio is still sent to the configured Open WebUI server for local Whisper
+transcription. Browser TTS runs in the user's browser. Browser speech
+recognition (`Web API` in the UI) is an optional alternative, but browser
+support and its privacy behavior depend on the browser vendor.
+
+## Quick start
+
+1. Copy the example environment file and adjust only the values you need:
+
+   ```bash
+   cp .env.example .env
+   ```
+
+   On Windows PowerShell, use:
+
+   ```powershell
+   Copy-Item .env.example .env
+   ```
+
+2. Start Open WebUI using the normal installation method. For a local Python
+   installation:
+
+   ```bash
+   open-webui serve
+   ```
+
+   For Docker, keep the data volume so the Whisper model is retained:
+
+   ```bash
+   docker run -d -p 3000:8080 --env-file .env `
+     -v open-webui:/app/backend/data `
+     --name open-webui --restart always `
+     ghcr.io/open-webui/open-webui:main
+   ```
+
+3. Open `http://localhost:3000` (Docker) or `http://localhost:8080` (Python),
+   sign in as an administrator, and open **Admin Settings → Audio**.
+
+4. Confirm **Speech-to-Text Engine** is **Whisper (Local)** and
+   **Text-to-Speech Engine** is **Web API**, then save. The first local
+   transcription downloads the configured Whisper model; subsequent requests
+   use the cached model.
+
+5. In **Settings → Audio**, choose a microphone, optionally set the language,
+   and enable **Instant Auto-Send After Voice Transcription** or response
+   auto-playback as desired. Allow microphone access when the browser asks.
+
+## Local Whisper options
+
+`WHISPER_MODEL='base'` is a balanced default. Smaller models use less memory
+and are faster; larger models can improve accuracy but require more CPU/GPU
+memory. Set `WHISPER_LANGUAGE` to an ISO-639-1 code such as `ru` or `en` when
+the language is known; leave it empty for automatic detection.
+
+`WHISPER_MODEL_AUTO_UPDATE='true'` permits downloading the model when it is
+not cached. For an offline deployment, pre-populate `WHISPER_MODEL_DIR` in the
+persistent data volume and set `WHISPER_MODEL_AUTO_UPDATE='false'`.
+`WHISPER_COMPUTE_TYPE='int8'` is a CPU-friendly default. CUDA deployments may
+need a different compute type supported by the installed runtime.
+
+## Optional browser/local TTS
+
+The default Web Speech API uses voices supplied by the browser or operating
+system and needs no secret. Users can select a voice in **Settings → Audio**.
+For fully local browser synthesis, users can select **Kokoro.js (Browser)**;
+the model is downloaded and executed in the browser and is cached there.
+
+## Optional online providers
+
+OpenAI-compatible, Azure, ElevenLabs, Deepgram, and Mistral providers can be
+selected in **Admin Settings → Audio**. Configure their credentials only via
+deployment secrets or the admin UI; never commit real keys to `.env.example`,
+documentation, or source control. If an online provider is required, use
+placeholders in deployment configuration, for example:
+
+```dotenv
+AUDIO_STT_ENGINE='openai'
+AUDIO_STT_OPENAI_API_BASE_URL='https://api.example.invalid/v1'
+AUDIO_STT_OPENAI_API_KEY='<set-in-your-secret-store>'
+AUDIO_STT_MODEL='<provider-model>'
+```
+
+Replace the placeholders with provider-specific values outside the repository.

--- a/src/lib/components/chat/MessageInput/VoiceRecording.svelte
+++ b/src/lib/components/chat/MessageInput/VoiceRecording.svelte
@@ -6,6 +6,7 @@
 
 	import { transcribeAudio } from '$lib/apis/audio';
 	import XMark from '$lib/components/icons/XMark.svelte';
+	import Mic from '$lib/components/icons/Mic.svelte';
 
 	import dayjs from 'dayjs';
 	import LocalizedFormat from 'dayjs/plugin/localizedFormat';
@@ -468,6 +469,14 @@
 		: 'bg-indigo-300/10 dark:bg-indigo-500/10 '} rounded-full flex justify-between {className}"
 >
 	<div class="flex items-center mr-1">
+		<div
+			class="flex items-center justify-center rounded-full p-1.5 {loading
+				? 'text-gray-500 dark:text-gray-400'
+				: 'text-indigo-600 dark:text-indigo-300'}"
+			aria-hidden="true"
+		>
+			<Mic className="size-4" />
+		</div>
 		<button
 			type="button"
 			class="p-1.5


### PR DESCRIPTION
## Why

Provide a safe, usable voice-mode setup without committing secrets or requiring an online provider by default.

## What changed

- Document local faster-whisper STT and browser Web Speech API TTS defaults in `.env.example`.
- Add `docs/VOICE_MODE.md` with Python, Docker, Windows PowerShell, offline, and optional provider setup steps.
- Link the voice guide from the README.
- Add a microphone indicator to the active voice-recording control while preserving existing recording behavior.

## Validation

- `git diff --check` passes.
- Secret-like value scan found no credentials in the added configuration or documentation.
- `npm run check` was attempted with portable Node.js; it reports existing project-wide Svelte/type errors unrelated to this change.

No real API keys or dependency lockfile changes were added.