### PR TITLE
fix: allow ask_user questions and options beyond three

### DIFF
--- a/backend/open_webui/tools/builtin.py
+++ b/backend/open_webui/tools/builtin.py
@@ -524,14 +524,14 @@ async def ask_user(
     Ask the user clarifying questions before continuing.
     Use this when the next step depends on user intent, preference, or a tradeoff that cannot be inferred safely.
 
-    :param questions: 1-3 question objects, each with id, header, question, and 2-3 options. Each option needs label and description.
+    :param questions: one or more question objects, each with id, header, question, and one or more options. Each option needs label and description.
     :param allow_other: Whether users may enter a free-form answer instead of choosing one of the options
     :param timeout_ms: How long the browser should keep the prompt open before cancelling it
     :return: JSON with status and answers keyed by question id
     """
     try:
-        if not isinstance(questions, list) or not 1 <= len(questions) <= 3:
-            raise ValueError('ask_user requires 1-3 questions.')
+        if not isinstance(questions, list) or not len(questions) >= 1:
+            raise ValueError('ask_user requires at least one question.')
 
         normalized_questions = []
         seen_ids = set()
@@ -547,8 +547,8 @@ async def ask_user(
             seen_ids.add(question_id)
 
             options = question.get('options')
-            if not isinstance(options, list) or not 2 <= len(options) <= 3:
-                raise ValueError('Each question requires 2-3 options.')
+            if not isinstance(options, list) or not len(options) >= 1:
+                raise ValueError('Each question requires at least one option.')
 
             normalized_options = []
             for option in options:

--- a/backend/open_webui/utils/ask_user.py
+++ b/backend/open_webui/utils/ask_user.py
@@ -24,8 +24,8 @@ def get_ask_user_tool_calls(tool_calls: list[dict]) -> tuple[list[dict], str | N
 
 def normalize_ask_user_request(arguments: dict) -> dict:
     questions = arguments.get('questions')
-    if not isinstance(questions, list) or not 1 <= len(questions) <= 3:
-        raise ValueError('ask_user requires 1-3 questions.')
+    if not isinstance(questions, list) or not len(questions) >= 1:
+        raise ValueError('ask_user requires at least one question.')
 
     normalized_questions = []
     seen_ids = set()
@@ -42,8 +42,8 @@ def normalize_ask_user_request(arguments: dict) -> dict:
         seen_ids.add(question_id)
 
         options = question.get('options')
-        if not isinstance(options, list) or not 2 <= len(options) <= 3:
-            raise ValueError('Each question requires 2-3 options.')
+        if not isinstance(options, list) or not len(options) >= 1:
+            raise ValueError('Each question requires at least one option.')
 
         normalized_options = []
         for option in options:


### PR DESCRIPTION
Closes #29905

## Summary

The `ask_user` tool rejected otherwise valid model output whenever a request contained more than three questions or more than three options. The UI already renders arbitrary counts, so these backend limits caused avoidable tool failures.

## Changes

- Allow one or more questions instead of limiting requests to three.
- Allow one or more options per question instead of limiting each question to three options.
- Update validation messages and the tool description to match the supported behavior.

## Validation

- `python3 -m compileall -q backend/open_webui/utils/ask_user.py backend/open_webui/tools/builtin.py`
- `git diff --check`
