### PR TITLE
fix: require pipe-label in SKILL_MENTION_STRIP_RE to prevent false-positive stripping

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2290,7 +2290,13 @@ def extract_skill_ids_from_messages(messages: list[dict]) -> set[str]:
     return ids
 
 
-SKILL_MENTION_STRIP_RE = re.compile(r'<(?:\$[a-z0-9_-]+(?:\|([^>]*))?|/[a-z0-9_-]+\|([^>]*))>')
+# Skill mentions always carry a mandatory pipe-separated visible label:
+#   <$skillId|label>  or  </skillId|label>
+# The pipe+label is NOT optional for $-prefixed mentions — requiring it prevents
+# false-positive matches on angle-bracket constructs like Perl's <$fh> or shell
+# redirect syntax, which do not contain a '|' separator.
+# See: https://github.com/open-webui/open-webui/issues/29910
+SKILL_MENTION_STRIP_RE = re.compile(r'<(?:\$[a-z0-9_-]+\|([^>]*)|/[a-z0-9_-]+\|([^>]*))>')
 
 
 def strip_skill_mentions(messages: list[dict]) -> None:


### PR DESCRIPTION
## Summary

Fixes #29910.

The `SKILL_MENTION_STRIP_RE` regex made the pipe-separated label **optional** for `$`-prefixed skill mentions. This caused false-positive matches on any angle-bracket construct containing a `$` variable, such as:

- Perl's filehandle operator: `while (my $line = <$fh>) {` → silently became `while (my $line = ) {`  
- Shell-style variable expansions: `<$var>` → stripped to empty string

**Root cause:** The regex group `(?:\|([^>]*))?` made the pipe+label optional. But real skill mentions are *always* of the form `<$skillId|visible label>` — the pipe separator and label are mandatory parts of the mention format.

## Change

```diff
-SKILL_MENTION_STRIP_RE = re.compile(r'<(?:\$[a-z0-9_-]+(?:\|([^>]*))?|/[a-z0-9_-]+\|([^>]*)>)>')
+SKILL_MENTION_STRIP_RE = re.compile(r'<(?:\$[a-z0-9_-]+\|([^>]*)|/[a-z0-9_-]+\|([^>]*)>)>')
```

**Before:**  
- `<$fh>` → matches ❌ (stripped to empty string)  
- `<$skill-id|My Tool>` → matches ✅ (replaced with label)  

**After:**  
- `<$fh>` → no match ✅ (passed through unchanged)  
- `<$skill-id|My Tool>` → matches ✅ (replaced with label)  

## Testing

Verified with a unit test covering the following cases:
- `<$fh>` — Perl filehandle → no match (fixed)
- `<$var>` — shell variable syntax → no match (fixed)  
- `<$skill-id|My Tool>` — real skill mention → match (preserved)
- `<$tool|>` — skill mention with empty label → match (preserved)

## Related

- Closes #29910
- Related to #24929