### PR TITLE
fix(mcp): follow tools/list pagination so all pages of tools are discovered

### DIFF
--- a/backend/open_webui/utils/mcp/client.py
+++ b/backend/open_webui/utils/mcp/client.py
@@ -89,8 +89,17 @@ class MCPClient:
         if not self.session:
             raise RuntimeError('MCP client is not connected.')
 
-        result = await self.session.list_tools()
-        tools = result.tools
+        # The MCP spec allows tools/list responses to be paginated via
+        # nextCursor. Follow the cursor until the server omits it so every
+        # page of tools is discovered, not just the first one.
+        tools = []
+        cursor = None
+        while True:
+            result = await self.session.list_tools(cursor)
+            tools.extend(result.tools)
+            cursor = result.nextCursor
+            if not cursor:
+                break
 
         tool_specs = []
         for tool in tools:


### PR DESCRIPTION
Fixes #29879.

`MCPClient.list_tool_specs()` called `session.list_tools()` exactly once and discarded the response cursor, so paginated MCP servers only exposed their first page of tools (e.g. 20 of 44). It now follows the MCP-spec `nextCursor` across `tools/list` calls until the server omits it, accumulating every page before building tool specs.

Single-page servers are unaffected: with no cursor returned, exactly one `list_tools` call is made, as before.

Verification: drove the patched `list_tool_specs` against a stubbed session returning the issue repro shape (44 tools in pages of 20/20/4) - all 44 discovered with cursors followed in order; single-page, empty-list, and not-connected cases also checked.