### PR TITLE
fix: check Docling conversion status before processing response

### DIFF
--- a/backend/open_webui/retrieval/loaders/main.py
+++ b/backend/open_webui/retrieval/loaders/main.py
@@ -276,9 +276,27 @@ class DoclingLoader:
             )
         if r.ok:
             result = r.json()
+            # Docling returns HTTP 200 even for failed/partial conversions.
+            # Check the top-level "status" field to ensure we only accept
+            # actual successful results.
+            docling_status = result.get('status', '')
+            if docling_status not in ('success', 'partial_success'):
+                errors = result.get('errors', [])
+                error_detail = f' - errors: {errors}' if errors else ''
+                raise Exception(
+                    f'Docling conversion did not succeed '
+                    f'(status={docling_status}){error_detail}'
+                )
+
             document_data = result.get('document', {})
             md_content = document_data.get('md_content', '')
-            text = md_content or '<No text content found>'
+            if not md_content or not md_content.strip():
+                raise Exception(
+                    f'Docling conversion succeeded but returned empty '
+                    f'md_content (status={docling_status})'
+                )
+
+            text = md_content
 
             metadata = {'Content-Type': self.mime_type} if self.mime_type else {}
             if page_break_marker in md_content:


### PR DESCRIPTION
# Pull Request

## Checklist

- [x] This PR targets the `dev` branch.
- [x] This PR links to a well-described, confirmed Issue or active Discussion: `Closes #29808`
- [x] A maintainer explicitly asked me to open this PR, or this PR only updates i18n/localization.
- [x] The change is one logical unit with no unrelated commits.
- [x] I matched nearby code patterns and avoided unnecessary new settings, abstractions, or dependencies.
- [x] I manually tested the changed workflow and any nearby behavior that could be affected.
- [ ] I updated relevant docs, including the [Open WebUI Docs Repository](https://github.com/open-webui/docs), if needed.
- [ ] I added screenshots for UI changes, and a recording when motion or interaction matters.
- [x] I reviewed any AI-generated code before submitting it.
- [x] The PR title uses one of the prefixes listed below.

## Summary

The Docling loader processes HTTP 200 responses without checking the conversion status field. Docling returns HTTP 200 even for failed/partial conversions, causing the loader to silently return empty or invalid content.

This fix adds status validation before processing the response, raising exceptions with useful error details when conversion fails.

## Testing

- Tested with successful Docling conversion (status=success) → document processed correctly
- Tested with failed conversion (status=error) → exception raised with error details
- Tested with empty md_content → exception raised for empty content
- Tested with partial_success status → document processed correctly

## Changelog Entry

### Fixed

- Docling loader now checks conversion status before processing response
- Docling loader raises exception with error details when conversion fails
- Docling loader raises exception when md_content is empty despite successful status

## Additional Context

This is a backend error-handling fix with no UI changes. The fix ensures Docling conversion errors are properly caught instead of silently returning empty/invalid content.

## Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.