### PR TITLE
fix: stop deleting "<$word>" text that names no skill

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2263,14 +2263,20 @@ def extract_skill_ids_from_messages(messages: list[dict]) -> set[str]:
     return ids
 
 
-SKILL_MENTION_STRIP_RE = re.compile(r'<(?:\$[a-z0-9_-]+(?:\|([^>]*))?|/[a-z0-9_-]+\|([^>]*))>')
+SKILL_MENTION_STRIP_RE = re.compile(r'<(?:\$([a-z0-9_-]+)(?:\|([^>]*))?|/[a-z0-9_-]+\|([^>]*))>')
 
 
-def strip_skill_mentions(messages: list[dict]) -> None:
-    """Replace <$skillId|label> and </skillId|label> mention tags with the label in-place."""
+def strip_skill_mentions(messages: list[dict], accessible_skill_ids: set[str]) -> None:
+    """Replace <$skillId|label> and </skillId|label> mention tags with the label in-place.
+
+    A "<$word>" written without a label is only a mention when it names a skill the user can read.
+    """
 
     def label(match):
-        return match.group(1) or match.group(2) or ''
+        mentioned_skill_id, dollar_label, slash_label = match.groups()
+        if dollar_label is None and slash_label is None:
+            return '' if mentioned_skill_id in accessible_skill_ids else match.group(0)
+        return dollar_label or slash_label or ''
 
     for message in messages:
         content = message.get('content')
@@ -2708,6 +2714,7 @@ async def process_chat_payload(request, form_data, user, metadata, model):
         | set(model.get('info', {}).get('meta', {}).get('skillIds', []))
         | mentioned_skill_ids
     )
+    accessible_skills = {}
     available_skills = []
     view_skill_ids = []
     chat = None
@@ -2777,7 +2784,7 @@ async def process_chat_payload(request, form_data, user, metadata, model):
             )
 
     # Strip <$skillId|label> mention tags so the model doesn't see raw markup.
-    strip_skill_mentions(form_data.get('messages', []))
+    strip_skill_mentions(form_data.get('messages', []), set(accessible_skills))
 
     prompt = get_last_user_message(form_data['messages'])
 


### PR DESCRIPTION
Any <$word> with a lowercase id was treated as a skill mention and removed from the message before it reached the model, so Perl's readline operator (<$fh>), shell placeholders and similar text silently disappeared: the model received "while (my $line = ) {".

Requiring the visible label does not work, because a mention only carries one straight from the editor; a draft restore or a message edit re-serializes it as a bare <$id>. A label-less <$word> is now stripped only when it names a skill the user can read, which the request has already resolved at that point. Labelled tags are still replaced by their label unconditionally, where a false positive degrades to the label instead of deleting text.

Fixes #29910

## Contributor License Agreement

<!--
DO NOT DELETE THIS SECTION.
Your PR will not be reviewed or merged until you check the box below confirming that you have read and agree to the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
