### PR TITLE
fix: url-encode {{USER_NAME}} and {{USER_GROUPS}} in custom header templates

### DIFF
--- a/backend/open_webui/utils/headers.py
+++ b/backend/open_webui/utils/headers.py
@@ -141,10 +141,12 @@ def parse_custom_headers(
         '{{FILE_CONTENT_TYPE}}': metadata.get('file_content_type', '') or '',
         '{{TASK}}': metadata.get('task', '') or '',
         '{{USER_ID}}': (user.id if user else '') or '',
-        '{{USER_NAME}}': (user.name.strip() if user else '') or '',
+        '{{USER_NAME}}': quote(user.name.strip(), safe=' ') if user else '',
         '{{USER_EMAIL}}': (user.email.strip() if user else '') or '',
         '{{USER_ROLE}}': (user.role if user else '') or '',
-        '{{USER_GROUPS}}': ','.join(group.name.strip() for group in user_groups) if user_groups else '',
+        '{{USER_GROUPS}}': ','.join(quote(group.name.strip(), safe=' ') for group in user_groups)
+        if user_groups
+        else '',
         '{{USER_GROUP_IDS}}': ','.join(group.id for group in user_groups) if user_groups else '',
         '{{USER_AGENT}}': user_agent,
         '{{AUTH_TYPE}}': getattr(getattr(request, 'state', None), 'auth_type', None) or '',


### PR DESCRIPTION
# Pull Request

## Checklist

- [x] This PR targets the `dev` branch.
- [x] This PR links to a well-described, confirmed Issue or active Discussion: Closes #29907
- [x] A maintainer explicitly asked me to open this PR, or this PR only updates i18n/localization.
- [x] The change is one logical unit with no unrelated commits.
- [x] I matched nearby code patterns and avoided unnecessary new settings, abstractions, or dependencies.
- [x] I manually tested the changed workflow and any nearby behavior that could be affected.
- [ ] I updated relevant docs, including the [Open WebUI Docs Repository](https://github.com/open-webui/docs), if needed.
- [ ] I added screenshots for UI changes, and a recording when motion or interaction matters.
- [x] I reviewed any AI-generated code before submitting it.
- [x] The PR title uses one of the prefixes listed below.

## Summary

A connection whose custom headers use `{{USER_NAME}}` fails for every user whose display name contains a non-ASCII character. The placeholder is replaced with the display name as is, httpx encodes header values as ASCII, and the request never leaves the backend. On an MCP Streamable HTTP tool server, the user sees `Failed to connect to MCP server '<id>'` and the model gets no tools from that server. The same happens on OpenAI and Ollama connections and the external document loader, since they share the same substitution.

The built-in `X-OpenWebUI-User-Name` header already URL-encodes the name with `quote(name, safe=' ')`. This change applies the same encoding to the `{{USER_NAME}}` placeholder and to each group name inside `{{USER_GROUPS}}`. Both paths now produce the same value for the same user. `{{USER_EMAIL}}` is left as is to match the built-in `X-OpenWebUI-User-Email` header, which is also sent unencoded.

```diff
-        '{{USER_NAME}}': (user.name.strip() if user else '') or '',
+        '{{USER_NAME}}': quote(user.name.strip(), safe=' ') if user else '',
...
-        '{{USER_GROUPS}}': ','.join(group.name.strip() for group in user_groups) if user_groups else '',
+        '{{USER_GROUPS}}': ','.join(quote(group.name.strip(), safe=' ') for group in user_groups)
+        if user_groups
+        else '',
```

## Testing

I reproduced the bug on v0.11.3 with one MCP Streamable HTTP connection whose custom headers were `{"X-User-Name": "{{USER_NAME}}"}`, a user with display name `áéáüß`, and any chat with the server enabled. The connect toast appears and the log shows `'ascii' codec can't encode characters in position 0-4`. Removing the custom header connects the same user.

Manual checks on this branch:

1. Same connection, same custom header, same `áéáüß` user, a chat that asks the model to search the Astro docs. The MCP server connects, the model calls `search_astro_docs`, and the reply is grounded in the docs. No connect toast.

As a supporting check, I called the changed function directly against a throwaway sqlite database. A user named `áéáüß` in groups `Équipe Alpha` and `ops` produces `X-User-Name: %C3%A1%C3%A9%C3%A1%C3%BC%C3%9F` and `X-Groups: %C3%89quipe Alpha,ops`. httpx accepts both values, and the `X-User-Name` value is identical to what `include_user_info_headers` sets for the built-in header.

No visual surface changes, so no screenshots.

## Changelog Entry

### Fixed

- Custom header placeholders `{{USER_NAME}}` and `{{USER_GROUPS}}` are now URL-encoded, so connections using them work for users whose display name or group names contain non-ASCII characters.

## Additional Context

Related: #26181 covers whitespace in the same value. `quote(..., safe=' ')` keeps spaces, which matches the built-in header's behavior and does not change that report.

## Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
