### PR TITLE
fix: only log a reranking model change when the request carries one

### DIFF
--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -1215,7 +1215,8 @@ async def update_rag_config(request: Request, form_data: ConfigForm, user=Depend
         else config.RAG_RERANKING_BATCH_SIZE
     )
 
-    log.info('Updating reranking model: %s to %s', config.RAG_RERANKING_MODEL, form_data.RAG_RERANKING_MODEL)
+    if form_data.RAG_RERANKING_MODEL is not None:
+        log.info('Updating reranking model: %s to %s', config.RAG_RERANKING_MODEL, form_data.RAG_RERANKING_MODEL)
     try:
         config.RAG_RERANKING_MODEL = (
             form_data.RAG_RERANKING_MODEL if form_data.RAG_RERANKING_MODEL is not None else config.RAG_RERANKING_MODEL


### PR DESCRIPTION
# Pull Request

## Checklist

- [x] This PR targets the `dev` branch.
- [x] This PR links to a well-described, confirmed Issue or active Discussion: Relates to #29884
- [x] A maintainer explicitly asked me to open this PR, or this PR only updates i18n/localization.
- [x] The change is one logical unit with no unrelated commits.
- [x] I matched nearby code patterns and avoided unnecessary new settings, abstractions, or dependencies.
- [x] I manually tested the changed workflow and any nearby behavior that could be affected.
- [ ] I updated relevant docs, including the [Open WebUI Docs Repository](https://github.com/open-webui/docs), if needed.
- [ ] I added screenshots for UI changes, and a recording when motion or interaction matters.
- [x] I reviewed any AI-generated code before submitting it.
- [x] The PR title uses one of the prefixes listed below.

## Summary

Saving any admin settings page that shares the retrieval config endpoint but does not display the reranking model, such as Web Search, logs `Updating reranking model: <model> to None`. The stored value is not changed. The log line runs before the handler resolves the incoming field, and an omitted field arrives as `None`. #29884 is a report built on that line.

This change logs the line only when the request actually carries a reranking model, so the log reflects what the handler does.

```diff
-    log.info('Updating reranking model: %s to %s', config.RAG_RERANKING_MODEL, form_data.RAG_RERANKING_MODEL)
+    if form_data.RAG_RERANKING_MODEL is not None:
+        log.info('Updating reranking model: %s to %s', config.RAG_RERANKING_MODEL, form_data.RAG_RERANKING_MODEL)
```

## Testing

1. Admin settings, Documents: set a reranking model, save. The log shows `Updating reranking model: <old> to <model>`.
2. Admin settings, Web Search: change any field, save. On `dev`, the log shows `Updating reranking model: <model> to None`. This branch logs nothing for the reranking model. The Documents page still shows the model.
3. Admin settings, Documents: change the reranking model again, save. The log shows the old and new values as before.

No visual surface changes, so no screenshots.

## Changelog Entry

### Fixed

- The retrieval config handler no longer logs a reranking model change to `None` when a save from another settings page omits the field.

## Additional Context

The embedding update endpoint has no equivalent trap. Its form requires the model field, so that log line always prints a real value.

## Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
