### PR TITLE
fix: log image model connectivity failures without a traceback

### DIFF
--- a/backend/open_webui/routers/images.py
+++ b/backend/open_webui/routers/images.py
@@ -435,6 +435,12 @@ async def get_models(request: Request, user=Depends(get_verified_user)):
                     models,
                 )
             )
+    except (aiohttp.ClientConnectionError, TimeoutError) as e:
+        log.error('Failed to list image generation models: %s', str(e) or type(e).__name__)
+        raise HTTPException(
+            status_code=400,
+            detail=ERROR_MESSAGES.DEFAULT(e, 'Failed to retrieve image generation models'),
+        )
     except Exception as e:
         log.exception(f'Failed to list image generation models: {e}')
         raise HTTPException(


### PR DESCRIPTION
# Pull Request

## Checklist

- [x] This PR targets the `dev` branch.
- [x] This PR links to a well-described, confirmed Issue or active Discussion: Closes #29924
- [x] A maintainer explicitly asked me to open this PR, or this PR only updates i18n/localization.
- [x] The change is one logical unit with no unrelated commits.
- [x] I matched nearby code patterns and avoided unnecessary new settings, abstractions, or dependencies.
- [x] I manually tested the changed workflow and any nearby behavior that could be affected.
- [ ] I updated relevant docs, including the [Open WebUI Docs Repository](https://github.com/open-webui/docs), if needed.
- [ ] I added screenshots for UI changes, and a recording when motion or interaction matters.
- [x] I reviewed any AI-generated code before submitting it.
- [x] The PR title uses one of the prefixes listed below.

## Summary

Opening Admin Settings > Images with the ComfyUI or AUTOMATIC1111 server offline writes a full traceback to the log for an ordinary connection refusal. The UI toast is right. The log entry is noise, about ninety lines through uvicorn, starlette, and aiohttp, repeated on every visit to the tab.

This adds a dedicated handler for connectivity failures ahead of the existing catch-all, logging one line and raising the same 400 as before. It is the same shape as the tool server fetch (#27757) and the terminal proxy (#27755). Any other failure still goes through the catch-all with its traceback.

```diff
+    except (aiohttp.ClientConnectionError, TimeoutError) as e:
+        log.error('Failed to list image generation models: %s', str(e) or type(e).__name__)
+        raise HTTPException(
+            status_code=400,
+            detail=ERROR_MESSAGES.DEFAULT(e, 'Failed to retrieve image generation models'),
+        )
     except Exception as e:
         log.exception(f'Failed to list image generation models: {e}')
```

## Testing

1. I set the image generation engine to ComfyUI with a base URL nothing listens on, then opened Admin Settings > Images. Current `dev` writes the full traceback to the log. This branch writes one line, `Failed to list image generation models: Cannot connect to host ...`, and the toast `Failed to retrieve image generation models` is unchanged.
2. Start ComfyUI and reload the tab. The model list loads as before.

No visual surface changes, so no screenshots.

## Changelog Entry

### Fixed

- An unreachable ComfyUI or AUTOMATIC1111 server no longer writes a full traceback to the log when the image model list is fetched. The failure is logged as a single line.

## Additional Context

The `get_models` handler on `dev` before this change:
https://github.com/open-webui/open-webui/blob/7aaa4a692e949724913834efc47c57572042703b/backend/open_webui/routers/images.py#L438-L443

## Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
