### PR TITLE
fix: only strip skill mentions that resolve to a skill

### DIFF
--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -2263,14 +2263,16 @@ def extract_skill_ids_from_messages(messages: list[dict]) -> set[str]:
     return ids
 
 
-SKILL_MENTION_STRIP_RE = re.compile(r'<(?:\$[a-z0-9_-]+(?:\|([^>]*))?|/[a-z0-9_-]+\|([^>]*))>')
+SKILL_MENTION_STRIP_RE = re.compile(r'<(?:\$([a-z0-9_-]+)(?:\|([^>]*))?|/([a-z0-9_-]+)\|([^>]*))>')
 
 
-def strip_skill_mentions(messages: list[dict]) -> None:
+def strip_skill_mentions(messages: list[dict], skill_ids: set[str]) -> None:
     """Replace <$skillId|label> and </skillId|label> mention tags with the label in-place."""
 
     def label(match):
-        return match.group(1) or match.group(2) or ''
+        if (match.group(1) or match.group(3)) not in skill_ids:
+            return match.group(0)
+        return match.group(2) or match.group(4) or ''
 
     for message in messages:
         content = message.get('content')
@@ -2709,6 +2711,7 @@ async def process_chat_payload(request, form_data, user, metadata, model):
         | mentioned_skill_ids
     )
     available_skills = []
+    accessible_skills = {}
     view_skill_ids = []
     chat = None
     if is_saved_chat_id(metadata.get('chat_id')):
@@ -2777,7 +2780,7 @@ async def process_chat_payload(request, form_data, user, metadata, model):
             )
 
     # Strip <$skillId|label> mention tags so the model doesn't see raw markup.
-    strip_skill_mentions(form_data.get('messages', []))
+    strip_skill_mentions(form_data.get('messages', []), set(accessible_skills))
 
     prompt = get_last_user_message(form_data['messages'])
 


### PR DESCRIPTION
# Pull Request

## Checklist

- [x] This PR targets the `dev` branch.
- [x] This PR links to a well-described, confirmed Issue or active Discussion: Closes #29910
- [x] A maintainer explicitly asked me to open this PR, or this PR only updates i18n/localization.
- [x] The change is one logical unit with no unrelated commits.
- [x] I matched nearby code patterns and avoided unnecessary new settings, abstractions, or dependencies.
- [x] I manually tested the changed workflow and any nearby behavior that could be affected.
- [ ] I updated relevant docs, including the [Open WebUI Docs Repository](https://github.com/open-webui/docs), if needed.
- [x] I added screenshots for UI changes, and a recording when motion or interaction matters.
- [x] I reviewed any AI-generated code before submitting it.
- [x] The PR title uses one of the prefixes listed below.

## Summary

Any `<$word>` in a chat message is deleted before the request reaches the model, because it is treated as a skill mention. Perl's readline operator `<$fh>` is the reported case. #29051 narrowed the accepted characters, which stopped the earlier report, but any lowercase word still matches.

The label cannot be made mandatory to fix this. The editor serializes a skill mention as a bare `<$id>` with no label (the turndown rule in `RichTextInput.svelte`), in both rich text modes, so `<$fh>` and a real mention have the same shape.

This change strips a mention only when its id resolved to a skill the user can reach. The handler already looks those skills up a few lines earlier, so the strip is handed that set. Anything else is left in the message exactly as typed. Real mentions still become their label, or disappear when there is none, as before.

```diff
-SKILL_MENTION_STRIP_RE = re.compile(r'<(?:\$[a-z0-9_-]+(?:\|([^>]*))?|/[a-z0-9_-]+\|([^>]*))>')
+SKILL_MENTION_STRIP_RE = re.compile(r'<(?:\$([a-z0-9_-]+)(?:\|([^>]*))?|/([a-z0-9_-]+)\|([^>]*))>')

-def strip_skill_mentions(messages: list[dict]) -> None:
+def strip_skill_mentions(messages: list[dict], skill_ids: set[str]) -> None:
     def label(match):
-        return match.group(1) or match.group(2) or ''
+        if (match.group(1) or match.group(3)) not in skill_ids:
+            return match.group(0)
+        return match.group(2) or match.group(4) or ''

     available_skills = []
+    accessible_skills = {}
     view_skill_ids = []

-    strip_skill_mentions(form_data.get('messages', []))
+    strip_skill_mentions(form_data.get('messages', []), set(accessible_skills))
```

## Testing

1. Send `Give me this text exactly: <$fh>` to any model. Current `dev` delivers `Give me this text exactly:` and the model answers with nothing. This branch delivers the full text and the model echoes `<$fh>`.
2. Send the Perl snippet from the issue. This branch delivers it to the model unchanged.
3. Mention a real skill with `$` in the editor and send. The skill content is injected and the model does not see the raw tag, the same as on `dev`.

As a supporting check, I called the changed function directly from a scratch copy with eight text cases and one multipart case. They cover an unknown `<$fh>`, a known id with and without a label, the `</id|label>` form known and unknown, and a mixed message with one known and one unknown id. All produce the expected output.

No visual surface changes, so no screenshots.

## Changelog Entry

### Fixed

- Text such as `<$fh>` in a chat message is no longer deleted as a skill mention. Only mentions that match a skill the user can access are replaced.

## Screenshots

Before is current `dev`, After is this branch.

| Surface | Before | After |
|---|---|---|
| Model reply to `Give me this text exactly: <$fh>` | <img width="1710" height="336" alt="image" src="https://github.com/user-attachments/assets/49d0edd9-4a40-44be-acef-a8078db14208" /> | <img width="1710" height="336" alt="image" src="https://github.com/user-attachments/assets/7f9a3c21-2133-465d-99b7-ce680c00a68b" /> |

## Additional Context

The `$` form of the regex accepted an optional label since it was introduced in 9a49b271a, because the editor emits `<$id>` without one. The `</id|label>` form keeps its mandatory label.

## Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

