### PR TITLE
fix: wait for the in-flight default tool selection before a URL query submits

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -981,10 +981,11 @@
 		selectedTerminalId.set(null);
 	}
 
-	let settingDefaults = false;
+	let settingDefaults = null;
 	const setDefaults = async () => {
-		if (settingDefaults) return;
-		settingDefaults = true;
+		if (settingDefaults) return settingDefaults;
+		let done;
+		settingDefaults = new Promise((resolve) => (done = resolve));
 
 		try {
 			if (!$tools) {
@@ -1092,7 +1093,8 @@
 				}
 			}
 		} finally {
-			settingDefaults = false;
+			settingDefaults = null;
+			done();
 		}
 	};
 


### PR DESCRIPTION
# Pull Request

## Checklist

- [x] This PR targets the `dev` branch.
- [x] This PR links to a well-described, confirmed Issue or active Discussion: Closes #29666
- [x] A maintainer explicitly asked me to open this PR, or this PR only updates i18n/localization.
- [x] The change is one logical unit with no unrelated commits.
- [x] I matched nearby code patterns and avoided unnecessary new settings, abstractions, or dependencies.
- [x] I manually tested the changed workflow and any nearby behavior that could be affected.
- [ ] I updated relevant docs, including the [Open WebUI Docs Repository](https://github.com/open-webui/docs), if needed.
- [ ] I added screenshots for UI changes, and a recording when motion or interaction matters.
- [x] I reviewed any AI-generated code before submitting it.
- [x] The PR title uses one of the prefixes listed below.

## Summary

Opening `/?model=<id>&q=<text>` directly sends the first message without the model's default tools. Admin tool servers, MCP servers, and the user's default tools are all missing from that first request, and the same question typed as a second message gets them. Related earlier report: #24176.

Two things happen when the page loads with a model in the URL. Changing the selected model fires a reactive `resetInput`, which starts `setDefaults`. On a fresh load, the functions and skills stores are empty, so that run awaits two requests before it reaches the line that seeds the tool selection. `initNewChat` then calls `resetInput` itself, which clears the selection again and calls `setDefaults`, and that call hits the re-entrancy guard and returns at once. `initNewChat` continues to the `?q=` block and submits with an empty selection. The first run finishes shortly after, which is why the second message has the tools.

The guard now hands the in-flight run to the second caller instead of returning early, so `await resetInput()` in `initNewChat` resolves only once the selection is seeded. The body of `setDefaults` is unchanged.

```diff
-	let settingDefaults = false;
+	let settingDefaults = null;
 	const setDefaults = async () => {
-		if (settingDefaults) return;
-		settingDefaults = true;
+		if (settingDefaults) return settingDefaults;
+		let done;
+		settingDefaults = new Promise((resolve) => (done = resolve));

 		try {
 ...
 		} finally {
-			settingDefaults = false;
+			settingDefaults = null;
+			done();
 		}
 	};
```

## Testing

1. A model with at least one default tool, for example an MCP server, set under its edit page. In a fresh tab, load `/?model=<that model>&q=What tools do you have?`. Open the browser's Network panel first and inspect the request to `/api/chat/completions`. Current `dev` sends no `tool_ids` in the first request and the model lists no external tools. This branch sends the default tool ids in the first request and the model lists them.
2. Ask the same question as a second message. Both `dev` and this branch send the tool ids.
3. Switch models mid-chat and send a message. The new model's default tools apply, as before.

I captured the request body of the first message on my instance. The model has two MCP servers as default tools, and the page was loaded from `/?model=<id>&q=What tools do you have?` in a fresh tab:

```
dev:     no "tool_ids" key
branch:  "tool_ids":["server:mcp:deepwiki","server:mcp:astrodocs"]
```

No visual surface changes, so no screenshots.

## Changelog Entry

### Fixed

- Starting a chat from a URL with `?q=` now includes the model's default tools and tool servers in the first message.

## Additional Context

The layout preloads the tools store before the chat mounts but not the functions or skills stores, which is why `setDefaults` has network awaits ahead of the seed on a fresh load only. Preloading those two stores as well would narrow the window without closing it, since the guard would still return early to a concurrent caller.

## Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
