### PR TITLE
fix(a11y): improve aria-labels on AppSidebar navigation buttons

### DIFF
--- a/src/lib/components/app/AppSidebar.svelte
+++ b/src/lib/components/app/AppSidebar.svelte
@@ -22,7 +22,7 @@
 
 		<Tooltip content={$i18n.t('Home')} placement="right">
 			<button
-				aria-label={$i18n.t('Home')}
+				aria-label={$i18n.t('Navigate to home')}
 				class=" cursor-pointer {selected === 'home' ? 'rounded-2xl' : 'rounded-full'}"
 				on:click={() => {
 					selected = 'home';
@@ -54,7 +54,7 @@
 			</div>
 		{/if}
 		<button
-			aria-label={$i18n.t('Chat')}
+			aria-label={$i18n.t('Navigate to chat list')}
 			class=" cursor-pointer bg-transparent"
 			on:click={() => {
 				selected = '';


### PR DESCRIPTION
# Pull Request

## Checklist

- [x] This PR targets the `dev` branch.
- [x] A maintainer explicitly asked me to open this PR, or this PR only updates i18n/localization.
- [x] The change is one logical unit with no unrelated commits.
- [x] I matched nearby code patterns and avoided unnecessary new settings, abstractions, or dependencies.
- [x] I manually tested the changed workflow and any nearby behavior that could be affected.
- [x] I updated relevant docs, including the [Open WebUI Docs Repository](https://github.com/open-webui/docs), if needed.
- [x] I reviewed any AI-generated code before submitting it.
- [x] The PR title uses one of the prefixes listed below.

## Summary

Improve screen reader accessibility on `AppSidebar` navigation buttons by replacing generic labels with descriptive action phrases (`Home` → `Navigate to home`, `Chat` → `Navigate to chat list`) while keeping `$i18n.t()` localization and maintaining existing visual tooltip labels.

Related to merged #29160.

## Testing

- Inspected rendered DOM on AppSidebar: verified `aria-label` attributes are properly populated with descriptive navigation text.
- Verified visual Tooltip retains `Home` for desktop hover while screen readers announce the full action.

## Changelog Entry

### Fixed

- Improve aria-labels on AppSidebar navigation buttons for screen reader accessibility (WCAG 4.1.2)

## Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.