### PR TITLE
fix: send the configured USER_AGENT on the Attach Webpage fetch

### DIFF
--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -59,6 +59,7 @@ from open_webui.env import (
     SENTENCE_TRANSFORMERS_CROSS_ENCODER_SIGMOID_ACTIVATION_FUNCTION,
     SENTENCE_TRANSFORMERS_MODEL_KWARGS,
     USE_SLIM,
+    USER_AGENT,
 )
 from open_webui.events import EVENTS, publish_event
 from open_webui.internal.db import get_async_db, get_async_session
@@ -2235,6 +2236,8 @@ async def _fetch_url(url: str, max_size_mb: int | str | None) -> dict:
             max_bytes = None
 
     async with get_ssrf_safe_session() as session:
+        if USER_AGENT:
+            session.headers['User-Agent'] = USER_AGENT
         async with session.get(
             url, ssl=AIOHTTP_CLIENT_SESSION_SSL, allow_redirects=AIOHTTP_CLIENT_ALLOW_REDIRECTS
         ) as response:


### PR DESCRIPTION
# Pull Request

## Checklist

- [x] This PR targets the `dev` branch.
- [x] This PR links to a well-described, confirmed Issue or active Discussion: Closes #29617
- [x] A maintainer explicitly asked me to open this PR, or this PR only updates i18n/localization.
- [x] The change is one logical unit with no unrelated commits.
- [x] I matched nearby code patterns and avoided unnecessary new settings, abstractions, or dependencies.
- [x] I manually tested the changed workflow and any nearby behavior that could be affected.
- [ ] I updated relevant docs, including the [Open WebUI Docs Repository](https://github.com/open-webui/docs), if needed.
- [ ] I added screenshots for UI changes, and a recording when motion or interaction matters.
- [x] I reviewed any AI-generated code before submitting it.
- [x] The PR title uses one of the prefixes listed below.

## Summary

Attach Webpage fails with `403 Forbidden` on sites that reject the bare aiohttp user agent, Wikipedia among them, even when the operator has set `USER_AGENT`. The web loader honors that variable, but the fetch that runs first to decide whether a URL is a page or a file does not, so the request never reaches the loader.

This sets the configured user agent on that session the same way the loader does, and only when the variable is set. With it unset, nothing changes.

```diff
     async with get_ssrf_safe_session() as session:
+        if USER_AGENT:
+            session.headers['User-Agent'] = USER_AGENT
         async with session.get(
```

## Testing

1. `USER_AGENT` set to a descriptive string, default web loader enabled. Attach `https://en.wikipedia.org/wiki/OpenAI` through Attach Webpage. Current `dev` returns the 403 from the issue. This branch attaches the page.
2. Attach a direct file URL, for example a PDF. It is still detected as a file and attached as one.
3. `USER_AGENT` unset, backend restarted, same Wikipedia URL on this branch. The 403 returns, which shows the change does nothing without the variable.

No visual surface changes, so no screenshots.

## Changelog Entry

### Fixed

- Attach Webpage now sends the configured `USER_AGENT` on its initial fetch, so sites that reject the default aiohttp user agent no longer return 403 when the variable is set.

## Additional Context

The initial fetch was added in 8fbfd14a8 to tell pages from downloadable files before handing off to the loader. It creates its own session, so the loader's user agent setting never applied to it. The loader's own handling is at `retrieval/web/utils.py`, in the `SafeWebBaseLoader` constructor, and this change copies that line.

## Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
