### PR TITLE
fix: show disabled preset models in the admin Models list

### DIFF
--- a/src/lib/apis/models/index.ts
+++ b/src/lib/apis/models/index.ts
@@ -149,6 +149,37 @@ export const importModels = async (token: string, models: object[]) => {
 	return res;
 };
 
+export const exportModels = async (token: string = '') => {
+	let error = null;
+
+	const res = await fetch(`${WEBUI_API_BASE_URL}/models/export`, {
+		method: 'GET',
+		headers: {
+			Accept: 'application/json',
+			'Content-Type': 'application/json',
+			authorization: `Bearer ${token}`
+		}
+	})
+		.then(async (res) => {
+			if (!res.ok) throw await res.json();
+			return res.json();
+		})
+		.then((json) => {
+			return json;
+		})
+		.catch((err) => {
+			error = err;
+			console.error(err);
+			return null;
+		});
+
+	if (error) {
+		throw error;
+	}
+
+	return res;
+};
+
 export const getBaseModels = async (token: string = '', tag: string = '') => {
 	let error = null;
 

--- a/src/lib/components/admin/Settings/Models.svelte
+++ b/src/lib/components/admin/Settings/Models.svelte
@@ -18,6 +18,7 @@
 	import {
 		createNewModel,
 		deleteAllModels,
+		exportModels,
 		getBaseModelTags,
 		getBaseModels,
 		getModelById,
@@ -273,10 +274,13 @@
 		allModels = await getModels(localStorage.token);
 
 		const providerModels = await getModels(localStorage.token, null, true);
+		const presetModels = await exportModels(localStorage.token);
 		const allModelIds = new Set<string>(allModels.map((model: ModelListItem) => model.id));
 		allModels = [
 			...allModels,
-			...providerModels.filter((model: ModelListItem) => !allModelIds.has(model.id))
+			...[...providerModels, ...presetModels].filter(
+				(model: ModelListItem) => !allModelIds.has(model.id)
+			)
 		];
 
 		const baseModelIds = new Set<string>(baseModels.map((model: ModelListItem) => model.id));
@@ -297,7 +301,7 @@
 						id: m.id,
 						name: m.name,
 
-						is_active: true
+						is_active: m.is_active ?? true
 					};
 				}
 			});


### PR DESCRIPTION
# Pull Request

## Checklist

- [x] This PR targets the `dev` branch.
- [x] This PR links to a well-described, confirmed Issue or active Discussion: Closes #29567
- [x] A maintainer explicitly asked me to open this PR, or this PR only updates i18n/localization.
- [x] The change is one logical unit with no unrelated commits.
- [x] I matched nearby code patterns and avoided unnecessary new settings, abstractions, or dependencies.
- [x] I manually tested the changed workflow and any nearby behavior that could be affected.
- [ ] I updated relevant docs, including the [Open WebUI Docs Repository](https://github.com/open-webui/docs), if needed.
- [ ] I added screenshots for UI changes, and a recording when motion or interaction matters.
- [x] I reviewed any AI-generated code before submitting it.
- [x] The PR title uses one of the prefixes listed below.

## Summary

A preset model is one created in Workspace or Admin on top of a base model. Disabling it removes it from Admin Settings, Models. The Disabled and All filters do not show it, and there is no way to enable it again from that page. Disable All Models does this to every preset at once.

#29037 fixed the same disappearance for provider models by merging the provider list into the page. Presets were left out because none of the three sources the page reads returns an inactive preset. The chat model list skips them, the provider list never had them, and the base rows exclude anything with a base model.

This adds the fourth source the page was missing. The admin export endpoint already returns every preset row with its stored state, so the page merges those rows in the same way it merges provider models, and a merged row keeps its own `is_active` instead of being forced to true. The Workspace page shows disabled presets today by reading the same table, so this brings the admin page in line with it. The admin page has its own Workspace Models filter and applies Enable All and Disable All to presets, so a preset that vanishes once disabled leaves those controls with nothing to act on.

```diff
 		const providerModels = await getModels(localStorage.token, null, true);
+		const presetModels = await exportModels(localStorage.token);
 		const allModelIds = new Set<string>(allModels.map((model: ModelListItem) => model.id));
 		allModels = [
 			...allModels,
-			...providerModels.filter((model: ModelListItem) => !allModelIds.has(model.id))
+			...[...providerModels, ...presetModels].filter(
+				(model: ModelListItem) => !allModelIds.has(model.id)
+			)
 		];
 ...
-						is_active: true
+						is_active: m.is_active ?? true
```

The `exportModels` wrapper is new in the frontend. It calls the existing `GET /api/v1/models/export` and is shaped like `getBaseModels` next to it.

## Testing

1. Create a preset in Workspace, Models on top of any base model. Open Admin Settings, Models and confirm it is listed.
2. Toggle it off, reload the page, and switch the filter to Disabled. Current `dev` shows nothing. This branch shows the preset, toggled off.
3. Toggle it back on. It returns to the Enabled filter and to the chat model selector.
4. Disable All Models, reload, and use Enable All Models. Every preset comes back.
5. A provider model toggled off still shows under Disabled, as it did after #29037.

## Screenshots

Before is current `dev`, After is this branch.

| Surface | Before | After |
|---|---|---|
| Admin Settings, Models, Disabled filter with one disabled preset | <img width="1603" height="1087" alt="image" src="https://github.com/user-attachments/assets/d51d4352-aa53-4378-af3c-35b079a92c8f" /> | <img width="1603" height="1087" alt="image" src="https://github.com/user-attachments/assets/2f06f8da-95b8-410b-9cbd-a98722cce85a" /> |

## Changelog Entry

### Fixed

- Disabled preset models stay visible in Admin Settings, Models under the Disabled and All filters, so they can be enabled again.

## Additional Context

#29566 proposed the same outcome with an `include_inactive` flag on `GET /api/models`. This change stays on the page and uses an endpoint that already exists, which is the shape #29037 took for provider models.

## Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
