### PR TITLE
fix: place the memory context ahead of the system prompt

### DIFF
--- a/backend/open_webui/utils/memory.py
+++ b/backend/open_webui/utils/memory.py
@@ -402,7 +402,7 @@ async def add_memory_context(request, form_data: dict, user, model: dict | None 
         return form_data
 
     memory_context = f'{MEMORY_CONTEXT_OPEN}\n{rendered}\n{MEMORY_CONTEXT_CLOSE}'
-    form_data['messages'] = add_or_update_system_message(memory_context, messages, append=True)
+    form_data['messages'] = add_or_update_system_message(memory_context, messages)
     return form_data
 
 


### PR DESCRIPTION
# Pull Request

## Checklist

- [x] This PR targets the `dev` branch.
- [x] This PR links to a well-described, confirmed Issue or active Discussion: Closes #29557
- [x] A maintainer explicitly asked me to open this PR, or this PR only updates i18n/localization.
- [x] The change is one logical unit with no unrelated commits.
- [x] I matched nearby code patterns and avoided unnecessary new settings, abstractions, or dependencies.
- [x] I manually tested the changed workflow and any nearby behavior that could be affected.
- [ ] I updated relevant docs, including the [Open WebUI Docs Repository](https://github.com/open-webui/docs), if needed.
- [ ] I added screenshots for UI changes, and a recording when motion or interaction matters.
- [x] I reviewed any AI-generated code before submitting it.
- [x] The PR title uses one of the prefixes listed below.

## Summary

With Memory on, a system prompt whose last lines ask the model to append a fixed string makes the model print the injected `<memory_context>` block after that string. The stored memories come with it. The issue uses `HELLO, WORLD!` as the string. The block is appended to the system message directly under the user's last line, so the model reads it as more of the text it was told to append.

This places the block ahead of the system prompt instead. The user's instructions stay last in the system message, which is what they were before Memory was enabled, and the block is not adjacent to anything that asks for literal output.

```diff
-    form_data['messages'] = add_or_update_system_message(memory_context, messages, append=True)
+    form_data['messages'] = add_or_update_system_message(memory_context, messages)
```

The default for that helper prepends to the existing system message. The block still lands in the same message, and the code that strips a stale block from that message before re-injecting on later turns finds it wherever it sits.

## Testing

1. Memory on, one memory typed User, system prompt set in Chat Controls to the two lines from the issue, model gpt-5.6-luna over an OpenAI connection. Send "What is 3×3?". Current `dev` replies with `HELLO, WORLD!` followed by the memory block, stored memory visible. This branch replies with `HELLO, WORLD!` and stops.
2. Same setup with a throwaway pipe that echoes its system message. Current `dev` shows the block directly under the prompt. This branch shows the prompt directly under the block, in one system message.
3. Second turn in the same chat, checked with the echo pipe. The block appears once, ahead of the prompt. The same turn on gpt-4.1-mini also ends at `HELLO, WORLD!`.


## Changelog Entry

### Fixed

- The memory context block is placed before the system prompt, so a prompt that asks for trailing output no longer pulls stored memories into the visible response.

## Screenshots

Before is current `dev`, After is this branch.

| Surface | Before | After |
|---|---|---|
| Reply from gpt-5.6-luna to "What is 3×3?" with the append instruction in Chat Controls | <img width="2317" height="1294" alt="image" src="https://github.com/user-attachments/assets/8440a995-1c49-4105-b62a-058beeb18979" /> | <img width="2317" height="1294" alt="image" src="https://github.com/user-attachments/assets/9abf6e8c-37b5-47ba-9769-ee54d5a5bdac" /> |
| System message as received by a throwaway echo pipe, same chat | <img width="2317" height="1294" alt="image" src="https://github.com/user-attachments/assets/f62a0be8-09b5-4677-b9b5-5fe93b8a2512" /> | <img width="2317" height="1294" alt="image" src="https://github.com/user-attachments/assets/067db6aa-50e2-4eae-b240-8956862ff507" /> |

## Additional Context

The memory text has been appended after the prompt since the original `User Context:` block in the middleware. The position carried unchanged into the `<memory_context>` block when the code moved to `utils/memory.py` in dbdcfd8c6. Neither commit states a reason for the position, and nothing reads the block by position.

Anyone unable to reproduce the issue should check for a filter or plugin that inserts its own system message ahead of the prompt. That pushes the block away from the user's last line and hides the behavior, which is how it stayed invisible on my instance until the filter was turned off.

## Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

