### PR TITLE
fix: forward custom headers for Ollama connections

### DIFF
--- a/backend/open_webui/routers/ollama.py
+++ b/backend/open_webui/routers/ollama.py
@@ -70,6 +70,8 @@ async def send_get_request(
     url: str,
     key: str | None = None,
     user: UserModel | None = None,
+    api_config: dict | None = None,
+    request: Request | None = None,
 ):
     """Issue a GET request to an Ollama backend and return JSON, or *None* on failure."""
     try:
@@ -81,6 +83,8 @@ async def send_get_request(
             headers['Authorization'] = f'Bearer {key}'
         if ENABLE_FORWARD_USER_INFO_HEADERS and user:
             headers = include_user_info_headers(headers, user)
+        if api_config and api_config.get('headers'):
+            headers.update(await get_custom_headers(api_config['headers'], user, request=request))
 
         async with session.get(
             url,
@@ -248,10 +252,12 @@ async def get_status() -> dict:
 class ConnectionVerificationForm(BaseModel):
     url: str
     key: str | None = None
+    config: dict | None = None
 
 
 @router.post('/verify')
 async def verify_connection(
+    request: Request,
     form_data: ConnectionVerificationForm,
     user=Depends(get_admin_user),
 ):
@@ -263,6 +269,9 @@ async def verify_connection(
             headers['Authorization'] = f'Bearer {form_data.key}'
         if ENABLE_FORWARD_USER_INFO_HEADERS and user:
             headers = include_user_info_headers(headers, user)
+        api_config = form_data.config or {}
+        if api_config.get('headers'):
+            headers.update(await get_custom_headers(api_config['headers'], user, request=request))
 
         async with session.get(
             f'{form_data.url}/api/version',
@@ -403,9 +412,13 @@ async def get_all_models(request: Request, user: UserModel | None = None):
     for idx, url in enumerate(base_urls):
         api_config = resolve_api_config(api_configs, idx, url)
         if not api_config:
-            tasks.append(send_get_request(f'{url}/api/tags', user=user))
+            tasks.append(send_get_request(f'{url}/api/tags', user=user, request=request))
         elif api_config.get('enable', True):
-            tasks.append(send_get_request(f'{url}/api/tags', api_config.get('key'), user=user))
+            tasks.append(
+                send_get_request(
+                    f'{url}/api/tags', api_config.get('key'), user=user, api_config=api_config, request=request
+                )
+            )
         else:
             tasks.append(asyncio.ensure_future(asyncio.sleep(0, None)))
 
@@ -496,8 +509,11 @@ async def get_ollama_tags(
         result = await get_all_models(request, user=user)
     else:
         url = (await Config.get('ollama.base_urls', []))[url_idx]
-        key = get_api_key(url_idx, url, (await Config.get('ollama.api_configs', {})))
-        result = await send_request(f'{url}/api/tags', 'GET', key=key, user=user)
+        api_configs = await Config.get('ollama.api_configs', {})
+        api_config = resolve_api_config(api_configs, url_idx, url)
+        result = await send_request(
+            f'{url}/api/tags', 'GET', key=get_api_key(url_idx, url, api_configs), user=user, api_config=api_config
+        )
 
     if user.role == 'user' and not BYPASS_MODEL_ACCESS_CONTROL:
         result['models'] = await get_filtered_models(result, user)
@@ -524,9 +540,13 @@ async def get_ollama_loaded_models(
             continue
         api_config = resolve_api_config(api_configs, idx, url)
         if not api_config:
-            tasks.append(send_get_request(f'{url}/api/ps', user=user))
+            tasks.append(send_get_request(f'{url}/api/ps', user=user, request=request))
         elif api_config.get('enable', True):
-            tasks.append(send_get_request(f'{url}/api/ps', api_config.get('key'), user=user))
+            tasks.append(
+                send_get_request(
+                    f'{url}/api/ps', api_config.get('key'), user=user, api_config=api_config, request=request
+                )
+            )
         else:
             tasks.append(asyncio.ensure_future(asyncio.sleep(0, None)))
 
@@ -560,17 +580,31 @@ async def get_ollama_versions(
 
     if url_idx is not None:
         url = (await Config.get('ollama.base_urls', []))[url_idx]
-        return await send_request(f'{url}/api/version', 'GET')
+        api_configs = await Config.get('ollama.api_configs', {})
+        api_config = resolve_api_config(api_configs, url_idx, url)
+        return await send_request(
+            f'{url}/api/version',
+            'GET',
+            key=get_api_key(url_idx, url, api_configs),
+            user=user,
+            api_config=api_config,
+        )
 
     # Fan-out to every enabled backend
     tasks = []
+    api_configs = await Config.get('ollama.api_configs', {})
     for idx, url in enumerate(await Config.get('ollama.base_urls', [])):
-        api_config = (await Config.get('ollama.api_configs', {})).get(
-            str(idx),
-            (await Config.get('ollama.api_configs', {})).get(url, {}),
-        )
+        api_config = resolve_api_config(api_configs, idx, url)
         if api_config.get('enable', True):
-            tasks.append(send_get_request(f'{url}/api/version', api_config.get('key')))
+            tasks.append(
+                send_get_request(
+                    f'{url}/api/version',
+                    api_config.get('key'),
+                    user=user,
+                    api_config=api_config,
+                    request=request,
+                )
+            )
 
     raw = await asyncio.gather(*tasks)
     valid = [r for r in raw if r is not None]

--- a/src/lib/components/AddConnectionModal.svelte
+++ b/src/lib/components/AddConnectionModal.svelte
@@ -77,9 +77,26 @@
 		// remove trailing slash from url
 		url = url.replace(/\/$/, '');
 
+		let _headers = null;
+
+		if (headers) {
+			try {
+				_headers = JSON.parse(headers);
+				if (typeof _headers !== 'object' || Array.isArray(_headers)) {
+					_headers = null;
+					throw new Error('Headers must be a valid JSON object');
+				}
+				headers = JSON.stringify(_headers, null, 2);
+			} catch (error) {
+				toast.error($i18n.t('Headers must be a valid JSON object'));
+				return;
+			}
+		}
+
 		const res = await verifyOllamaConnection(localStorage.token, {
 			url,
-			key
+			key,
+			...(_headers ? { config: { headers: _headers } } : {})
 		}).catch((error) => {
 			toast.error(`${error}`);
 		});


### PR DESCRIPTION
## Summary

Closes #29868.

Ollama connection verification and model discovery did not forward per-connection custom headers. This breaks Ollama backends protected by Cloudflare Access service tokens, even though chat requests already support the configured headers.

This change:
- accepts and forwards custom headers from the Ollama connection verification form;
- forwards each connection's configured headers for `/api/tags`, `/api/ps`, and `/api/version` requests;
- keeps bearer-key and user-info header behavior unchanged.

## Testing

- `python3 -m py_compile backend/open_webui/routers/ollama.py`
- Structural checks for backend header propagation and the Svelte verification payload.
- `git diff --check`

## Changelog Entry

### Fixed

- Forward custom headers for Ollama connection verification and model discovery.

## Additional Context

The linked issue includes a reproducible Cloudflare Access service-token configuration. The change follows the existing `send_request` custom-header behavior and keeps header template expansion available for requests that have a live `Request` object.

## Contributor License Agreement

- [ ] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
