### PR TITLE
refac: resolve knowledge file access from the file association

### DIFF
--- a/backend/open_webui/utils/access_control/files.py
+++ b/backend/open_webui/utils/access_control/files.py
@@ -63,28 +63,6 @@ async def has_access_to_file(
         ) and (access_type == 'read' or knowledge_base.user_id == file.user_id):
             return True
 
-    knowledge_base_id = file.meta.get('collection_name') if file.meta else None
-    if knowledge_base_id:
-        # Fetch the one referenced knowledge base instead of listing every
-        # knowledge base the user can access just to scan for this id.
-        knowledge_base = await Knowledges.get_knowledge_by_id(knowledge_base_id, db=db)
-        if (
-            knowledge_base
-            and (access_type == 'read' or knowledge_base.user_id == file.user_id)
-            and (
-                knowledge_base.user_id == user.id
-                or await AccessGrants.has_access(
-                    user_id=user.id,
-                    resource_type='knowledge',
-                    resource_id=knowledge_base.id,
-                    permission=access_type,
-                    user_group_ids=user_group_ids,
-                    db=db,
-                )
-            )
-        ):
-            return True
-
     # Check if the file is associated with any channels the user has access to
     channels = await Channels.get_channels_by_file_id_and_user_id(file_id, user.id, db=db)
     if access_type == 'read' and channels:


### PR DESCRIPTION
`has_access_to_file` now derives knowledge-base access purely from the knowledge-file association, instead of also consulting the `collection_name` value stored on the file record.

## Contributor License Agreement

<!--
DO NOT DELETE THIS SECTION.
Your PR will not be reviewed or merged until you check the box below confirming that you have read and agree to the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
