### PR TITLE
fix: let validate_url accept dotless hosts when local web fetch is enabled

### DIFF
--- a/backend/open_webui/retrieval/web/utils.py
+++ b/backend/open_webui/retrieval/web/utils.py
@@ -130,7 +130,7 @@ def _assert_addresses_allowed(addresses: Sequence[str]) -> None:
 
 def validate_url(url: Union[str, Sequence[str]]):
     if isinstance(url, str):
-        if isinstance(validators.url(url), validators.ValidationError):
+        if isinstance(validators.url(url, simple_host=ENABLE_LOCAL_WEB_FETCH), validators.ValidationError):
             raise ValueError(ERROR_MESSAGES.INVALID_URL)
 
         # Reject parser-confusing chars: urlparse and requests/aiohttp split


### PR DESCRIPTION
# Pull Request

## Checklist

- [x] This PR targets the `dev` branch.
- [x] This PR links to a well-described, confirmed Issue or active Discussion: Closes #28161
- [x] A maintainer explicitly asked me to open this PR, or this PR only updates i18n/localization.
- [x] The change is one logical unit with no unrelated commits.
- [x] I matched nearby code patterns and avoided unnecessary new settings, abstractions, or dependencies.
- [x] I manually tested the changed workflow and any nearby behavior that could be affected.
- [ ] I updated relevant docs, including the [Open WebUI Docs Repository](https://github.com/open-webui/docs), if needed.
- [x] I added screenshots for UI changes, and a recording when motion or interaction matters.
- [x] I reviewed any AI-generated code before submitting it.
- [x] The PR title uses one of the prefixes listed below.

## Summary

With `ENABLE_LOCAL_WEB_FETCH` on, a webhook target such as `http://apprise:8000/notify` is still rejected with "The URL you provided is invalid". The same URL with a dot in the host, `http://apprise.local:8000/notify`, is accepted. Internal service names on Docker networks usually have no dot, so the flag that is meant to allow internal targets does not reach them.

The first check in `validate_url` runs the `validators` library with its defaults, which reject any host without a dot. That check comes before the branch that consults the flag, so the flag never gets a say. This passes the flag to the library's `simple_host` option. With the flag off, nothing changes. With it on, dotless hosts get past the syntax check and still go through the scheme, blocklist, hostname, and address checks that follow.

```diff
-        if isinstance(validators.url(url), validators.ValidationError):
+        if isinstance(validators.url(url, simple_host=ENABLE_LOCAL_WEB_FETCH), validators.ValidationError):
```

Every caller of `validate_url` inherits the change. That covers notification targets, Attach Webpage, and the other fetch paths that share it. The separate `validators.url` call in the web search result filter is untouched.

## Testing

1. `ENABLE_LOCAL_WEB_FETCH=true`, User Webhooks on. Settings, Notifications, add a target with `http://localhost:8000/notify`. Current `dev` shows the invalid URL toast and a 400 on `POST /api/v1/notifications/targets`. This branch saves the target.
2. Same steps with `http://apprise:8000/notify`. Same result on both.
3. `ENABLE_LOCAL_WEB_FETCH` unset, backend restarted. The same URLs are rejected on this branch, as on `dev`.

As a supporting check, I called `validate_url` directly from a scratch copy with the flag on and off. Flag on: `http://localhost:8000/notify`, `http://apprise:8000/notify`, `http://apprise.local:8000/notify`, and `https://example.com/hook` pass, while `ftp://apprise:8000/x` and a URL with a backslash before an `@` are rejected. Flag off: only `https://example.com/hook` passes.

## Screenshots

Before is current `dev`, After is this branch.

| Surface | Before | After |
|---|---|---|
| Settings, Notifications, saving a target with `http://localhost:8000/notify` | <img width="2560" height="1296" alt="image" src="https://github.com/user-attachments/assets/e8cc626b-efb2-4c83-9b5a-67e113928680" /> | <img width="2560" height="1296" alt="image" src="https://github.com/user-attachments/assets/ca2a95dc-c1a9-4809-be6e-24a5ee7b3abd" /> |
| Network panel, `POST /api/v1/notifications/targets` | <img width="2560" height="585" alt="image" src="https://github.com/user-attachments/assets/da81dbad-ceba-407a-9557-ffad35429003" /> | <img width="2560" height="587" alt="image" src="https://github.com/user-attachments/assets/bdb161b5-4195-402e-8405-39d8b866cac8" /> |

## Changelog Entry

### Fixed

- With `ENABLE_LOCAL_WEB_FETCH` on, URLs with a dotless internal hostname such as `http://apprise:8000` pass URL validation, so they can be used as notification targets and fetch sources.

## Additional Context

The `validators` check has been the first line of `validate_url` since the function was added in d3d161f72, before the local fetch flag existed in its current form. The pinned `validators==0.35.0` exposes `simple_host` for exactly this case.

## Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
