### PR TITLE
fix: sanitize user-typed notification target ids the same way generated ones are

### DIFF
--- a/backend/open_webui/utils/notifications.py
+++ b/backend/open_webui/utils/notifications.py
@@ -46,8 +46,8 @@ def _normalize_target(target: dict[str, Any], existing: dict[str, Any] | None = 
 
     target_id = str(target.get('id') or existing.get('id') or '').strip()
     if not target_id:
-        hostname = urlparse(url).hostname or 'webhook'
-        target_id = re.sub(r'[^a-zA-Z0-9_-]+', '-', hostname).strip('-').lower() or 'target'
+        target_id = urlparse(url).hostname or 'webhook'
+    target_id = re.sub(r'[^a-zA-Z0-9_-]+', '-', target_id).strip('-').lower() or 'target'
 
     events = target['events'] if 'events' in target else existing.get('events', [])
     if events is None:


### PR DESCRIPTION
# Pull Request

## Checklist

- [x] This PR targets the `dev` branch.
- [x] This PR links to a well-described, confirmed Issue or active Discussion: Closes #29946
- [x] A maintainer explicitly asked me to open this PR, or this PR only updates i18n/localization.
- [x] The change is one logical unit with no unrelated commits.
- [x] I matched nearby code patterns and avoided unnecessary new settings, abstractions, or dependencies.
- [x] I manually tested the changed workflow and any nearby behavior that could be affected.
- [ ] I updated relevant docs, including the [Open WebUI Docs Repository](https://github.com/open-webui/docs), if needed.
- [ ] I added screenshots for UI changes, and a recording when motion or interaction matters.
- [x] I reviewed any AI-generated code before submitting it.
- [x] The PR title uses one of the prefixes listed below.

## Summary

A notification target saved with a typed ID that contains a slash or a colon can never be edited, tested, made default, or removed. Each of those calls puts the ID into the request path, and a path with an extra slash matches no route, so the UI shows "Method Not Allowed" and the target stays for good.

The backend already turns a generated ID into a safe slug. This applies the same slug step to a typed ID, so the ID that gets stored is always one the per-target routes can address. A clean ID such as `discord-test` is unchanged.

```diff
     target_id = str(target.get('id') or existing.get('id') or '').strip()
     if not target_id:
-        hostname = urlparse(url).hostname or 'webhook'
-        target_id = re.sub(r'[^a-zA-Z0-9_-]+', '-', hostname).strip('-').lower() or 'target'
+        target_id = urlparse(url).hostname or 'webhook'
+    target_id = re.sub(r'[^a-zA-Z0-9_-]+', '-', target_id).strip('-').lower() or 'target'
```

## Testing

1. Settings, Notifications, add a target with the address http://localhost:8000/notify typed into the Target ID field and a valid webhook URL. Current `dev` saves the ID as typed, and Edit, Send Test, Make Default, and Remove all fail with "Method Not Allowed". This branch saves it as `http-localhost-8000-notify`, and all four actions work.
2. Add a target with a plain ID such as `local-test`. Saved unchanged on both.
3. Add a target with the ID field empty. The ID is derived from the webhook hostname, as before.

As a supporting check, I ran the normalizer directly from a scratch copy. The typed address becomes `http-localhost-8000-notify` and `My_Hook` becomes `my_hook`. An empty ID becomes the hostname slug and a value of only slashes becomes `target`. A clean `discord-test` is unchanged.

## Screenshots

Before is current `dev`, After is this branch.

| Surface | Before | After |
|---|---|---|
| Settings, Notifications, the saved target's ID and the result of Remove | <img width="2560" height="1295" alt="image" src="https://github.com/user-attachments/assets/69423f2e-d88a-46ac-8ab8-ad278744e19a" /> | <img width="2560" height="1295" alt="image" src="https://github.com/user-attachments/assets/d52743bd-a2c1-46b2-8483-b82150d857b6" /> |

## Changelog Entry

### Fixed

- A typed notification target ID is stored in the same safe form as a generated one, so targets can always be edited, tested, and removed afterwards.

## Additional Context

A target already stored with a raw ID stays unreachable until it is removed some other way. The issue describes the settings update that clears it.

## Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
