### PR TITLE
fix: detect actual MIME type and extension for base64 generated images (#29948)

### DIFF
--- a/backend/open_webui/routers/images.py
+++ b/backend/open_webui/routers/images.py
@@ -62,6 +62,8 @@ IMAGE_FILE_EXTENSIONS = {
     'image/mpo': '.jpg',
     'image/png': '.png',
     'image/webp': '.webp',
+    'image/gif': '.gif',
+    'image/bmp': '.bmp',
 }
 
 IMAGE_CONFIG_KEYS = {
@@ -120,7 +122,7 @@ def normalize_openai_edit_image_data_url(data_url: str) -> str:
         return data_url
 
     header, encoded = data_url.split(',', 1)
-    mime_type = header.split(';')[0].lstrip('data:').lower()
+    mime_type = header.split(';')[0].removeprefix('data:').lower()
     if mime_type not in {'image/jpeg', 'image/jpg', 'image/mpo'}:
         return data_url
 
@@ -156,7 +158,7 @@ def normalize_openai_edit_image_data_url(data_url: str) -> str:
 
 def get_image_file_item(base64_string, param_name='image'):
     header, encoded = base64_string.split(',', 1)
-    mime_type = header.split(';')[0].lstrip('data:') or 'image/png'
+    mime_type = header.split(';')[0].removeprefix('data:') or 'image/png'
     image_data = base64.b64decode(encoded)
     extension = IMAGE_FILE_EXTENSIONS.get(mime_type.lower()) or mimetypes.guess_extension(mime_type) or '.png'
     return (
@@ -477,6 +479,34 @@ def _is_same_origin(url: str, base_url: str) -> bool:
     )
 
 
+def sniff_image_mime(data: bytes) -> str:
+    """Sniff the MIME type of image data by checking magic bytes with PIL fallback."""
+    if data.startswith(b'\xff\xd8\xff'):
+        return 'image/jpeg'
+    if data.startswith(b'\x89PNG\r\n\x1a\n') or data.startswith(b'\x89PNG'):
+        return 'image/png'
+    if data.startswith(b'RIFF') and len(data) >= 12 and data[8:12] == b'WEBP':
+        return 'image/webp'
+    if data.startswith(b'GIF87a') or data.startswith(b'GIF89a'):
+        return 'image/gif'
+    if data.startswith(b'BM'):
+        return 'image/bmp'
+    if data.startswith(b'II*\x00') or data.startswith(b'MM\x00*'):
+        return 'image/tiff'
+
+    try:
+        with Image.open(io.BytesIO(data)) as img:
+            if img.format:
+                fmt = img.format.lower()
+                if fmt in ('jpeg', 'jpg'):
+                    return 'image/jpeg'
+                return f'image/{fmt}'
+    except Exception:
+        pass
+
+    return 'image/png'
+
+
 async def get_image_data(data: str, headers=None, trusted_base_url: str | None = None):
     try:
         if data.startswith('http://') or data.startswith('https://'):
@@ -507,11 +537,13 @@ async def get_image_data(data: str, headers=None, trusted_base_url: str | None =
         else:
             if ',' in data:
                 header, encoded = data.split(',', 1)
-                mime_type = header.split(';')[0].lstrip('data:')
+                mime_type = header.split(';')[0].removeprefix('data:').strip().lower()
                 img_data = base64.b64decode(encoded)
+                if not mime_type or mime_type in {'application/octet-stream', 'image/octet-stream'}:
+                    mime_type = sniff_image_mime(img_data)
             else:
-                mime_type = 'image/png'
                 img_data = base64.b64decode(data)
+                mime_type = sniff_image_mime(img_data)
             return img_data, mime_type
     except Exception as e:
         log.exception(f'Error loading image data: {e}')
@@ -521,7 +553,7 @@ async def get_image_data(data: str, headers=None, trusted_base_url: str | None =
 async def upload_image(request, image_data, content_type, metadata, user, db=None):
     if image_data is None or content_type is None:
         raise ValueError('Failed to retrieve image data from the generation backend')
-    image_format = mimetypes.guess_extension(content_type)
+    image_format = IMAGE_FILE_EXTENSIONS.get(content_type.lower()) or mimetypes.guess_extension(content_type) or '.png'
     file = UploadFile(
         file=io.BytesIO(image_data),
         filename=f'generated-image{image_format}',  # will be converted to a unique ID on upload_file


### PR DESCRIPTION
# Pull Request

## Checklist

- [x] This PR targets the `dev` branch.
- [x] This PR links to a well-described, confirmed Issue or active Discussion: `Closes #29948`.
- [x] A maintainer explicitly asked me to open this PR, or this PR only updates i18n/localization.
- [x] The change is one logical unit with no unrelated commits.
- [x] I matched nearby code patterns and avoided unnecessary new settings, abstractions, or dependencies.
- [x] I manually tested the changed workflow and any nearby behavior that could be affected.
- [x] I updated relevant docs, including the [Open WebUI Docs Repository](https://github.com/open-webui/docs), if needed.
- [x] I added screenshots for UI changes, and a recording when motion or interaction matters.
- [x] I reviewed any AI-generated code before submitting it.
- [x] The PR title uses one of the prefixes listed below.

## Title Prefix

- **fix**: Bug fixes or corrections

## Summary

Fixes #29948 where generated images returned as bare base64 (`b64_json` from OpenAI, Gemini `bytesBase64Encoded`, and compatible image generation backends) are always saved as `image/png` and `generated-image.png` regardless of their actual image format.

### Details:
1. Added `sniff_image_mime(data: bytes) -> str` to inspect image magic bytes (JPEG `FF D8 FF`, PNG `89 50 4E 47`, WebP `RIFF....WEBP`, GIF `GIF87a`/`GIF89a`, BMP `BM`, TIFF) with a PIL fallback and safe default to `image/png`.
2. Updated `get_image_data()` to inspect bare base64 decoded bytes using `sniff_image_mime()` instead of unconditionally hardcoding `image/png`. Also added fallback sniffing when data URIs provide generic `octet-stream` headers, and replaced character-stripping `lstrip('data:')` with `removeprefix('data:')` to prevent corrupted MIME strings.
3. Expanded `IMAGE_FILE_EXTENSIONS` to support `.gif` and `.bmp` alongside `.jpg`, `.png`, and `.webp`.
4. Updated `upload_image()` to check `IMAGE_FILE_EXTENSIONS` before `mimetypes.guess_extension()` so that JPEG files are consistently named `.jpg` instead of Python's default `.jpe`.

## Testing

1. Tested `sniff_image_mime` and `get_image_data` locally across JPEG, PNG, WebP, GIF, and BMP test images encoded as bare base64 and data URIs.
2. Verified octet-stream header sniffing and arbitrary binary fallback to `image/png`.
3. Verified extension mappings for all supported formats.
4. Ran `ruff format --check` and `ruff check` matching the repository's GitHub Actions CI workflow (`.github/workflows/backend.yaml`). All checks passed with zero errors.

## Changelog Entry

### Fixed

- Accurately detect and store actual MIME type and file extension for base64 generated images (e.g. JPEG, WebP, GIF) instead of hardcoding `image/png` (#29948).

## Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
