### PR TITLE
fix: apply the selection highlight only when the editor is unfocused and keep it out of the chat input

### DIFF
--- a/src/lib/components/common/RichTextInput.svelte
+++ b/src/lib/components/common/RichTextInput.svelte
@@ -717,9 +717,9 @@
 					props: {
 						decorations: (state) => {
 							const { selection } = state;
-							const { focused } = this.editor;
+							const { isFocused } = this.editor;
 
-							if (focused || selection.empty) {
+							if (isFocused || selection.empty) {
 								return null;
 							}
 
@@ -823,7 +823,7 @@
 				...(messageInput ? [PromptItalic] : []),
 				...(dragHandle ? [ListItemDragHandle] : []),
 				Placeholder.configure({ placeholder: () => _placeholder, showOnlyWhenEditable: false }),
-				SelectionDecoration,
+				...(messageInput ? [] : [SelectionDecoration]),
 
 				...(richText
 					? [


### PR DESCRIPTION
# Pull Request

## Checklist

- [x] This PR targets the `dev` branch.
- [x] This PR links to a well-described, confirmed Issue or active Discussion: Closes #29944
- [x] A maintainer explicitly asked me to open this PR, or this PR only updates i18n/localization.
- [x] The change is one logical unit with no unrelated commits.
- [x] I matched nearby code patterns and avoided unnecessary new settings, abstractions, or dependencies.
- [x] I manually tested the changed workflow and any nearby behavior that could be affected.
- [ ] I updated relevant docs, including the [Open WebUI Docs Repository](https://github.com/open-webui/docs), if needed.
- [x] I added screenshots for UI changes, and a recording when motion or interaction matters.
- [x] I reviewed any AI-generated code before submitting it.
- [x] The PR title uses one of the prefixes listed below.

## Summary

In Chromium browsers, picking a spelling suggestion from the right-click menu in the chat input often does nothing, or the misspelling comes back. Firefox is fine, and typing the correction by hand is fine everywhere.

Chromium keeps its spelling markers on the text node of the word. A probe on the chat input shows what happens on right-click. About twenty milliseconds after the click, the paragraph's single text node is replaced by three nodes. That is the editor rendering an inline decoration over the selected word, and the markers die with the old node. The context menu was built from those markers, so the suggestion it offers has nothing left to replace.

The decoration is the selection highlight added for the notes editor, which should show only while the editor is unfocused. Its check reads `this.editor.focused`, a property the TipTap editor does not have, so the check is always false and the highlight is applied on every non-empty selection, focused or not. Chromium's right-click selects the word, and that is enough to trigger it.

Two lines fix it. The check reads `isFocused`, which the editor does expose, so the highlight appears only when focus has left the editor, as intended for notes. The extension is also left out of the chat input, which has no use for it, so a platform whose context menu takes focus from the page cannot bring the redraw back there.

```diff
-							const { focused } = this.editor;
+							const { isFocused } = this.editor;

-							if (focused || selection.empty) {
+							if (isFocused || selection.empty) {
 ...
-				SelectionDecoration,
+				...(messageInput ? [] : [SelectionDecoration]),
```

## Testing

1. Chrome on Linux, new chat, a sentence with eleven misspelled words, wait for the underlines, right-click each and pick the suggestion. Current `dev` drops the markers on right-click and loses corrections. This branch keeps all eleven. The probe log on this branch shows each right-click followed by no DOM change at all, then one `insertReplacementText` and one text change per correction.
2. Same with Rich Text Input off. Same result on both.
3. Notes editor: select text, open the edit panel so the editor loses focus. The selection highlight appears. Click back into the editor with the selection kept. The highlight goes away.

## Screenshots

Before is current `dev`, After is this branch.

| Surface | Before | After |
|---|---|---|
| Chat input after picking a spelling suggestion from the Chrome context menu | https://github.com/user-attachments/assets/c2be33af-7f06-430b-bb22-312f86f9bafe| https://github.com/user-attachments/assets/d018151b-c229-41d4-80b5-44c51d3e8735 |

## Changelog Entry

### Fixed

- Spelling corrections chosen from the browser's right-click menu now stick in the chat input on Chromium browsers.

## Additional Context

The extension was introduced in 3af2938ef for note selection edits, two days after the move to TipTap 3, and has read the non-existent property since then. Probe log from the chat input on `dev`, right-click on a misspelled word with the underline present:

```
mousedown button=2
focus
contextmenu
DOM childList in <p> added=1 removed=0
DOM childList in <p> added=1 removed=0
DOM childList in <p> added=1 removed=0
DOM childList in <p> added=0 removed=1
```

## Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
