### PR TITLE
fix: pass model default terminal to channel responses

### DIFF
--- a/backend/open_webui/routers/channels.py
+++ b/backend/open_webui/routers/channels.py
@@ -1102,7 +1102,7 @@ async def model_response_handler(request, channel, message, user, db=None):
                 # Resolve model config (same path automations use)
                 from open_webui.utils.automations import _resolve_model_defaults
 
-                tool_ids, features, filter_ids, _ = await _resolve_model_defaults(request.app, model_id)
+                tool_ids, features, filter_ids, terminal_id = await _resolve_model_defaults(request.app, model_id)
 
                 # Build full form_data — same shape as frontend POST.
                 # The channel: prefix routes pipeline events to the
@@ -1128,6 +1128,8 @@ async def model_response_handler(request, channel, message, user, db=None):
                     form_data['features'] = features
                 if filter_ids:
                     form_data['filter_ids'] = filter_ids
+                if terminal_id:
+                    form_data['terminal_id'] = terminal_id
 
                 # Call the full chat completion pipeline — streaming,
                 # tools, filters, RAG — everything. The pipeline runs as

--- a/backend/open_webui/utils/automations.py
+++ b/backend/open_webui/utils/automations.py
@@ -436,7 +436,7 @@ async def _execute_channel_automation(
             db,
         )
 
-    tool_ids, features, filter_ids, _ = await _resolve_model_defaults(app, model_id)
+    tool_ids, features, filter_ids, terminal_id = await _resolve_model_defaults(app, model_id)
 
     form_data = {
         'model': model_id,
@@ -460,6 +460,8 @@ async def _execute_channel_automation(
         form_data['features'] = features
     if filter_ids:
         form_data['filter_ids'] = filter_ids
+    if terminal_id:
+        form_data['terminal_id'] = terminal_id
 
     await app.state.CHAT_COMPLETION_HANDLER(request, form_data, user=user)
 


### PR DESCRIPTION
# Pull Request

## Checklist

- [x] This PR targets the `dev` branch.
- [x] This PR links to a well-described, confirmed Issue or active Discussion: Closes #29016
- [x] A maintainer explicitly asked me to open this PR, or this PR only updates i18n/localization.
- [x] The change is one logical unit with no unrelated commits.
- [x] I matched nearby code patterns and avoided unnecessary new settings, abstractions, or dependencies.
- [x] I manually tested the changed workflow and any nearby behavior that could be affected.
- [ ] I updated relevant docs, including the [Open WebUI Docs Repository](https://github.com/open-webui/docs), if needed.
- [x] I added screenshots for UI changes, and a recording when motion or interaction matters.
- [x] I reviewed any AI-generated code before submitting it.
- [x] The PR title uses one of the prefixes listed below.

## Summary

A workspace model with a default terminal gets its Open Terminal tools in a normal chat. It does not get them when it replies in a channel, whether it was mentioned or posted into the channel by an automation. It still has the knowledge tools, so it searches the knowledge base and then tells the user it has no file system tools.

The model's defaults are resolved by one helper for all three server-side reply paths. It returns the tool ids, features, filter ids, and the default terminal id. The direct automation run keeps the terminal id and sets it on the request. The channel mention path and the channel automation path drop it, and the chat pipeline only attaches terminal tools when the request carries one.

This keeps the fourth value in both channel paths and sets it on the request, the same way the direct automation path already does. The commit is the reporter's, cherry-picked from their fork with authorship intact, since PRs on this repository were limited to collaborators at the time.

```diff
-                tool_ids, features, filter_ids, _ = await _resolve_model_defaults(request.app, model_id)
+                tool_ids, features, filter_ids, terminal_id = await _resolve_model_defaults(request.app, model_id)
 ...
                 if filter_ids:
                     form_data['filter_ids'] = filter_ids
+                if terminal_id:
+                    form_data['terminal_id'] = terminal_id
```

The same two lines apply in `utils/automations.py` for the channel automation path.

## Testing

1. Admin Settings, Integrations: an Open Terminal connection. A workspace model with the Terminal capability on and that terminal selected as its default, plus a knowledge base attached so the difference is visible.
2. Normal chat with the model, asked to run `pwd`. The terminal runs it and the model answers `/home/user`. Same on both.
3. A channel, mention the model with the same request. Current `dev` searches the knowledge base and replies that it cannot execute `pwd` and has no persistent file system. This branch calls `run_command` and `get_process_status` and replies with `/home/user`.
4. A reply inside a channel thread with the same mention. This branch runs the command there as well.

## Screenshots

Before is current `dev`, After is this branch.

| Surface | Before | After |
|---|---|---|
| Channel reply from the mentioned model to a request that needs the terminal | <img width="2316" height="1288" alt="image" src="https://github.com/user-attachments/assets/b1542c26-303b-49cc-8d98-5f2e5a54bfdc" /> | <img width="2000" height="1112" alt="image" src="https://github.com/user-attachments/assets/c0aca55b-e1c6-4d1f-a339-bd048676de3b" /> |

## Changelog Entry

### Fixed

- A model's default terminal is applied when it replies in a channel, from a mention or from a channel automation. It now has its Open Terminal tools there as it does in a normal chat.

## Additional Context

The channel reply path builds the request from the same resolver the automation paths use. The terminal id was added to that resolver's return for the direct automation run and the two channel callers were not updated to read it.

## Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.
